### PR TITLE
print out data2 for Event::ERROR_NETWORK as well

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -36,7 +36,7 @@ fn cb(_ctx: *mut dc_context_t, event: Event, data1: u64, data2: u64) -> u64 {
                 }
             }
         }
-        Event::INFO | Event::WARNING | Event::ERROR => {
+        Event::INFO | Event::WARNING | Event::ERROR | Event::ERROR_NETWORK => {
             println!(
                 "  {}",
                 unsafe { CStr::from_ptr(data2 as *const _) }


### PR DESCRIPTION
E.g.

```
[ERROR_NETWORK]   
  Could not connect to IMAP-server imap.deltachat.net:993 using SSL. (Error #43)
```