### PR TITLE
chore: fix compiler warnings (mut + unused assignments)

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -196,9 +196,9 @@ unsafe extern "C" fn poke_spec(
     let mut real_spec: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut suffix: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut dir: *mut DIR = 0 as *mut DIR;
-    let mut dir_entry: *mut dirent = 0 as *mut dirent;
+    let mut dir_entry: *mut dirent;
     let mut read_cnt: libc::c_int = 0i32;
-    let mut name: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut name: *mut libc::c_char;
     if 0 == dc_sqlite3_is_open(&context.sql.clone().read().unwrap()) {
         dc_log_error(
             context,
@@ -390,7 +390,6 @@ unsafe extern "C" fn log_msglist(mut context: &dc_context_t, mut msglist: *mut d
     let mut i: libc::c_int = 0;
     let mut cnt: libc::c_int = dc_array_get_cnt(msglist) as libc::c_int;
     let mut lines_out: libc::c_int = 0i32;
-    i = 0i32;
     while i < cnt {
         let mut msg_id: uint32_t = dc_array_get_id(msglist, i as size_t);
         if msg_id == 9i32 as libc::c_uint {
@@ -421,7 +420,7 @@ unsafe extern "C" fn log_msglist(mut context: &dc_context_t, mut msglist: *mut d
     };
 }
 unsafe extern "C" fn log_contactlist(mut context: &dc_context_t, mut contacts: *mut dc_array_t) {
-    let mut contact: *mut dc_contact_t = 0 as *mut dc_contact_t;
+    let mut contact: *mut dc_contact_t;
     let mut peerstate: *mut dc_apeerstate_t = dc_apeerstate_new(context);
     if 0 == dc_array_search_id(contacts, 1i32 as uint32_t, 0 as *mut size_t) {
         dc_array_add_id(contacts, 1i32 as uint32_t);
@@ -429,7 +428,7 @@ unsafe extern "C" fn log_contactlist(mut context: &dc_context_t, mut contacts: *
     let mut i = 0;
     while i < dc_array_get_cnt(contacts) {
         let mut contact_id: uint32_t = dc_array_get_id(contacts, i as size_t);
-        let mut line: *mut libc::c_char = 0 as *mut libc::c_char;
+        let mut line: *mut libc::c_char;
         let mut line2: *mut libc::c_char = 0 as *mut libc::c_char;
         contact = dc_get_contact(context, contact_id);
         if !contact.is_null() {
@@ -462,7 +461,7 @@ unsafe extern "C" fn log_contactlist(mut context: &dc_context_t, mut contacts: *
             let mut peerstate_ok: libc::c_int =
                 dc_apeerstate_load_by_addr(peerstate, &context.sql.clone().read().unwrap(), addr);
             if 0 != peerstate_ok && contact_id != 1i32 as libc::c_uint {
-                let mut pe: *mut libc::c_char = 0 as *mut libc::c_char;
+                let mut pe: *mut libc::c_char;
                 match (*peerstate).prefer_encrypt {
                     1 => pe = dc_strdup(b"mutual\x00" as *const u8 as *const libc::c_char),
                     0 => pe = dc_strdup(b"no-preference\x00" as *const u8 as *const libc::c_char),
@@ -521,8 +520,8 @@ pub unsafe extern "C" fn dc_cmdline(
     context: &mut dc_context_t,
     cmdline: &str,
 ) -> *mut libc::c_char {
-    let mut cmd = 0 as *mut libc::c_char;
-    let mut arg1: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut cmd: *mut libc::c_char;
+    let mut arg1: *mut libc::c_char;
     let mut ret: *mut libc::c_char = 1i32 as *mut libc::c_char;
     let mut sel_chat: *mut dc_chat_t = 0 as *mut dc_chat_t;
 
@@ -699,7 +698,7 @@ pub unsafe extern "C" fn dc_cmdline(
             b"%s/autocrypt-setup-message.html\x00" as *const u8 as *const libc::c_char,
             context.get_blobdir(),
         );
-        let mut file_content: *mut libc::c_char = 0 as *mut libc::c_char;
+        let mut file_content: *mut libc::c_char;
         file_content = dc_render_setup_file(&context, setup_code_0);
         if !file_content.is_null()
             && 0 != dc_write_file(
@@ -799,7 +798,7 @@ pub unsafe extern "C" fn dc_cmdline(
         let mut chatlist: *mut dc_chatlist_t =
             dc_get_chatlist(&context, listflags, arg1, 0i32 as uint32_t);
         if !chatlist.is_null() {
-            let mut i: libc::c_int = 0;
+            let mut i: libc::c_int;
             let mut cnt: libc::c_int = dc_chatlist_get_cnt(chatlist) as libc::c_int;
             if cnt > 0i32 {
                 dc_log_info(&context, 0i32,
@@ -1347,7 +1346,7 @@ pub unsafe extern "C" fn dc_cmdline(
         if !sel_chat.is_null() {
             let mut images: *mut dc_array_t =
                 dc_get_chat_media(&context, dc_chat_get_id(sel_chat), 20i32, 21i32, 50i32);
-            let mut i_0: libc::c_int = 0;
+            let mut i_0: libc::c_int;
             let mut icnt: libc::c_int = dc_array_get_cnt(images) as libc::c_int;
             ret = dc_mprintf(
                 b"%i images or videos: \x00" as *const u8 as *const libc::c_char,
@@ -1707,7 +1706,6 @@ pub unsafe extern "C" fn dc_cmdline(
     }
     if !sel_chat.is_null() {
         dc_chat_unref(sel_chat);
-        sel_chat = 0 as *mut dc_chat_t
     }
     free(cmd as *mut libc::c_void);
     return ret;

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -11,7 +11,6 @@
     non_camel_case_types,
     non_snake_case,
     non_upper_case_globals,
-    unused_assignments,
     unused_mut,
     unused_attributes,
     non_upper_case_globals,

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -293,7 +293,7 @@ unsafe fn start_threads(
         }
     });
 
-    let context = c.clone();
+    let _context = c.clone();
     let h2 = std::thread::spawn(move || {
         // let ctx = context.clone();
         // let context = ctx.read().unwrap();
@@ -305,7 +305,7 @@ unsafe fn start_threads(
         // }
     });
 
-    let context = c.clone();
+    let _context = c.clone();
     let h3 = std::thread::spawn(move || {
         // let ctx = context.clone();
         // let context = ctx.read().unwrap();
@@ -317,7 +317,7 @@ unsafe fn start_threads(
         // }
     });
 
-    let context = c.clone();
+    let _context = c.clone();
     let h4 = std::thread::spawn(move || {
         // let ctx = context.clone();
         // let context = ctx.read().unwrap();

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -514,7 +514,6 @@ unsafe fn main_0(mut argc: libc::c_int, mut argv: *mut *mut libc::c_char) -> lib
         let mut ctx = ctx.write().unwrap();
         free(cmd as *mut libc::c_void);
         stop_threads(&ctx, handles);
-        handles = None;
         dc_close(&mut ctx);
         dc_context_unref(&mut ctx);
     }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,6 +2,7 @@ extern crate deltachat;
 
 use std::ffi::{CStr, CString};
 use std::sync::Arc;
+use std::{thread,time};
 use tempfile::tempdir;
 
 use deltachat::constants::Event;
@@ -58,20 +59,21 @@ fn main() {
         let ctx = dc_context_new(cb, std::ptr::null_mut(), std::ptr::null_mut());
         let info = dc_get_info(&ctx);
         let info_s = CStr::from_ptr(info);
+        let duration = time::Duration::from_millis(4000);
         println!("info: {}", info_s.to_str().unwrap());
 
         let ctx = Arc::new(ctx);
         let ctx1 = ctx.clone();
-        let t1 = std::thread::spawn(move || loop {
+        let t1 = thread::spawn(move || loop {
             dc_perform_imap_jobs(&ctx1);
             dc_perform_imap_fetch(&ctx1);
-            std::thread::sleep_ms(1000);
+            thread::sleep(duration);
 
             // dc_perform_imap_idle(&ctx1);
         });
 
         let ctx1 = ctx.clone();
-        let t2 = std::thread::spawn(move || loop {
+        let t2 = thread::spawn(move || loop {
             dc_perform_smtp_jobs(&ctx1);
             dc_perform_smtp_idle(&ctx1);
         });
@@ -97,7 +99,7 @@ fn main() {
         );
         dc_configure(&ctx);
 
-        std::thread::sleep_ms(4000);
+        thread::sleep(duration);
 
         let email = CString::new("dignifiedquire@gmail.com").unwrap();
         println!("sending a message");

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,7 +2,7 @@ extern crate deltachat;
 
 use std::ffi::{CStr, CString};
 use std::sync::Arc;
-use std::{thread,time};
+use std::{thread, time};
 use tempfile::tempdir;
 
 use deltachat::constants::Event;

--- a/src/dc_aheader.rs
+++ b/src/dc_aheader.rs
@@ -34,7 +34,7 @@ pub unsafe fn dc_aheader_new_from_imffields(
     mut wanted_from: *const libc::c_char,
     mut header: *const mailimf_fields,
 ) -> *mut dc_aheader_t {
-    let mut cur = 0 as *mut clistiter;
+    let mut cur;
     let mut fine_header = 0 as *mut dc_aheader_t;
 
     if wanted_from.is_null() || header.is_null() {
@@ -105,10 +105,10 @@ pub unsafe fn dc_aheader_set_from_string(
     (b) for the key, non-base64-characters are ignored and
     (c) for parsing, we ignore `\r\n` as well as tabs for spaces */
     let mut header_str = 0 as *mut libc::c_char;
-    let mut p = 0 as *mut libc::c_char;
-    let mut beg_attr_name = 0 as *mut libc::c_char;
-    let mut after_attr_name = 0 as *mut libc::c_char;
-    let mut beg_attr_value = 0 as *mut libc::c_char;
+    let mut p;
+    let mut beg_attr_name;
+    let mut after_attr_name;
+    let mut beg_attr_value;
     let mut success: libc::c_int = 0;
 
     dc_aheader_empty(aheader);

--- a/src/dc_apeerstate.rs
+++ b/src/dc_apeerstate.rs
@@ -11,7 +11,7 @@ use crate::types::*;
 use crate::x::*;
 
 /* prefer-encrypt states */
-/* *
+/**
  * @class dc_apeerstate_t
  * Library-internal.
  */
@@ -36,20 +36,22 @@ pub struct dc_apeerstate_t<'a> {
 
 /* the returned pointer is ref'd and must be unref'd after usage */
 pub unsafe fn dc_apeerstate_new<'a>(context: &'a dc_context_t) -> *mut dc_apeerstate_t<'a> {
-    let mut peerstate: *mut dc_apeerstate_t = 0 as *mut dc_apeerstate_t;
+    let mut peerstate: *mut dc_apeerstate_t;
     peerstate = calloc(1, ::std::mem::size_of::<dc_apeerstate_t>()) as *mut dc_apeerstate_t;
     if peerstate.is_null() {
         exit(43i32);
     }
     (*peerstate).context = context;
 
-    return peerstate;
+    peerstate
 }
+
 pub unsafe fn dc_apeerstate_unref(mut peerstate: *mut dc_apeerstate_t) {
     dc_apeerstate_empty(peerstate);
     free(peerstate as *mut libc::c_void);
 }
-/* ******************************************************************************
+
+/*******************************************************************************
  * dc_apeerstate_t represents the state of an Autocrypt peer - Load/save
  ******************************************************************************/
 unsafe fn dc_apeerstate_empty(mut peerstate: *mut dc_apeerstate_t) {
@@ -77,6 +79,8 @@ unsafe fn dc_apeerstate_empty(mut peerstate: *mut dc_apeerstate_t) {
     (*peerstate).verified_key = 0 as *mut dc_key_t;
     (*peerstate).degrade_event = 0i32;
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_apeerstate_init_from_header(
     mut peerstate: *mut dc_apeerstate_t,
     mut header: *const dc_aheader_t,
@@ -94,8 +98,11 @@ pub unsafe fn dc_apeerstate_init_from_header(
     (*peerstate).public_key = dc_key_new();
     dc_key_set_from_key((*peerstate).public_key, (*header).public_key);
     dc_apeerstate_recalc_fingerprint(peerstate);
-    return 1i32;
+
+    1
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_apeerstate_recalc_fingerprint(mut peerstate: *mut dc_apeerstate_t) -> libc::c_int {
     let mut success: libc::c_int = 0i32;
     let mut old_public_fingerprint: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -139,10 +146,14 @@ pub unsafe fn dc_apeerstate_recalc_fingerprint(mut peerstate: *mut dc_apeerstate
         }
         success = 1i32
     }
+
     free(old_public_fingerprint as *mut libc::c_void);
     free(old_gossip_fingerprint as *mut libc::c_void);
-    return success;
+
+    success
 }
+
+// TODO should return bool /rtn
 pub unsafe extern "C" fn dc_apeerstate_init_from_gossip(
     mut peerstate: *mut dc_apeerstate_t,
     mut gossip_header: *const dc_aheader_t,
@@ -158,8 +169,11 @@ pub unsafe extern "C" fn dc_apeerstate_init_from_gossip(
     (*peerstate).gossip_key = dc_key_new();
     dc_key_set_from_key((*peerstate).gossip_key, (*gossip_header).public_key);
     dc_apeerstate_recalc_fingerprint(peerstate);
-    return 1i32;
+
+    1
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_apeerstate_degrade_encryption(
     mut peerstate: *mut dc_apeerstate_t,
     mut message_time: time_t,
@@ -173,8 +187,10 @@ pub unsafe fn dc_apeerstate_degrade_encryption(
     (*peerstate).prefer_encrypt = 20i32;
     (*peerstate).last_seen = message_time;
     (*peerstate).to_save |= 0x2i32;
-    return 1i32;
+
+    1
 }
+
 pub unsafe fn dc_apeerstate_apply_header(
     mut peerstate: *mut dc_apeerstate_t,
     mut header: *const dc_aheader_t,
@@ -212,6 +228,7 @@ pub unsafe fn dc_apeerstate_apply_header(
         }
     };
 }
+
 pub unsafe fn dc_apeerstate_apply_gossip(
     mut peerstate: *mut dc_apeerstate_t,
     mut gossip_header: *const dc_aheader_t,
@@ -239,6 +256,7 @@ pub unsafe fn dc_apeerstate_apply_gossip(
         }
     };
 }
+
 pub unsafe fn dc_apeerstate_render_gossip_header(
     mut peerstate: *const dc_apeerstate_t,
     mut min_verified: libc::c_int,
@@ -252,8 +270,9 @@ pub unsafe fn dc_apeerstate_render_gossip_header(
         ret = dc_aheader_render(autocryptheader)
     }
     dc_aheader_unref(autocryptheader);
-    return ret;
+    ret
 }
+
 pub unsafe fn dc_apeerstate_peek_key(
     mut peerstate: *const dc_apeerstate_t,
     mut min_verified: libc::c_int,
@@ -277,8 +296,10 @@ pub unsafe fn dc_apeerstate_peek_key(
     if !(*peerstate).public_key.is_null() {
         return (*peerstate).public_key;
     }
-    return (*peerstate).gossip_key;
+    (*peerstate).gossip_key
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_apeerstate_set_verified(
     mut peerstate: *mut dc_apeerstate_t,
     mut which_key: libc::c_int,
@@ -310,8 +331,11 @@ pub unsafe fn dc_apeerstate_set_verified(
             success = 1i32
         }
     }
-    return success;
+
+    success
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_apeerstate_load_by_addr(
     mut peerstate: *mut dc_apeerstate_t,
     mut sql: &dc_sqlite3_t,
@@ -334,8 +358,9 @@ pub unsafe fn dc_apeerstate_load_by_addr(
         }
     }
     sqlite3_finalize(stmt);
-    return success;
+    success
 }
+
 unsafe fn dc_apeerstate_set_from_stmt(
     mut peerstate: *mut dc_apeerstate_t,
     mut stmt: *mut sqlite3_stmt,
@@ -364,6 +389,8 @@ unsafe fn dc_apeerstate_set_from_stmt(
         dc_key_set_from_stmt((*peerstate).verified_key, stmt, 9i32, 0i32);
     };
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_apeerstate_load_by_fingerprint(
     mut peerstate: *mut dc_apeerstate_t,
     mut sql: &dc_sqlite3_t,
@@ -388,8 +415,10 @@ pub unsafe fn dc_apeerstate_load_by_fingerprint(
         }
     }
     sqlite3_finalize(stmt);
-    return success;
+    success
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_apeerstate_save_to_db(
     mut peerstate: *const dc_apeerstate_t,
     mut sql: &dc_sqlite3_t,
@@ -522,8 +551,11 @@ pub unsafe fn dc_apeerstate_save_to_db(
         _ => {}
     }
     sqlite3_finalize(stmt);
-    return success;
+
+    success
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_apeerstate_has_verified_key(
     mut peerstate: *const dc_apeerstate_t,
     mut fingerprints: *const dc_hash_t,
@@ -542,5 +574,6 @@ pub unsafe fn dc_apeerstate_has_verified_key(
     {
         return 1i32;
     }
-    return 0i32;
+
+    0
 }

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -220,9 +220,7 @@ pub unsafe fn dc_array_get_marker(
     {
         return 0 as *mut libc::c_char;
     }
-    dc_strdup_keep_null(
-        (*(*(*array).array.offset(index as isize) as *mut _dc_location)).marker,
-    )
+    dc_strdup_keep_null((*(*(*array).array.offset(index as isize) as *mut _dc_location)).marker)
 }
 
 /**

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -16,7 +16,7 @@ pub struct dc_array_t {
     pub array: *mut uintptr_t,
 }
 
-/* *
+/**
  * @class dc_array_t
  *
  * An object containing a simple array.
@@ -35,6 +35,7 @@ pub unsafe fn dc_array_unref(mut array: *mut dc_array_t) {
     (*array).magic = 0i32 as uint32_t;
     free(array as *mut libc::c_void);
 }
+
 pub unsafe fn dc_array_free_ptr(mut array: *mut dc_array_t) {
     if array.is_null() || (*array).magic != 0xa11aai32 as libc::c_uint {
         return;
@@ -52,6 +53,7 @@ pub unsafe fn dc_array_free_ptr(mut array: *mut dc_array_t) {
         i = i.wrapping_add(1)
     }
 }
+
 pub unsafe fn dc_array_add_uint(mut array: *mut dc_array_t, mut item: uintptr_t) {
     if array.is_null() || (*array).magic != 0xa11aai32 as libc::c_uint {
         return;
@@ -70,24 +72,29 @@ pub unsafe fn dc_array_add_uint(mut array: *mut dc_array_t, mut item: uintptr_t)
     *(*array).array.offset((*array).count as isize) = item;
     (*array).count = (*array).count.wrapping_add(1);
 }
+
 pub unsafe fn dc_array_add_id(mut array: *mut dc_array_t, mut item: uint32_t) {
     dc_array_add_uint(array, item as uintptr_t);
 }
+
 pub unsafe fn dc_array_add_ptr(mut array: *mut dc_array_t, mut item: *mut libc::c_void) {
     dc_array_add_uint(array, item as uintptr_t);
 }
+
 pub unsafe fn dc_array_get_cnt(mut array: *const dc_array_t) -> size_t {
     if array.is_null() || (*array).magic != 0xa11aai32 as libc::c_uint {
         return 0i32 as size_t;
     }
-    return (*array).count;
+    (*array).count
 }
+
 pub unsafe fn dc_array_get_uint(mut array: *const dc_array_t, mut index: size_t) -> uintptr_t {
     if array.is_null() || (*array).magic != 0xa11aai32 as libc::c_uint || index >= (*array).count {
         return 0i32 as uintptr_t;
     }
-    return *(*array).array.offset(index as isize);
+    *(*array).array.offset(index as isize)
 }
+
 pub unsafe fn dc_array_get_id(mut array: *const dc_array_t, mut index: size_t) -> uint32_t {
     if array.is_null() || (*array).magic != 0xa11aai32 as libc::c_uint || index >= (*array).count {
         return 0i32 as uint32_t;
@@ -95,8 +102,9 @@ pub unsafe fn dc_array_get_id(mut array: *const dc_array_t, mut index: size_t) -
     if (*array).type_0 == 1i32 {
         return (*(*(*array).array.offset(index as isize) as *mut _dc_location)).location_id;
     }
-    return *(*array).array.offset(index as isize) as uint32_t;
+    *(*array).array.offset(index as isize) as uint32_t
 }
+
 pub unsafe fn dc_array_get_ptr(
     mut array: *const dc_array_t,
     mut index: size_t,
@@ -104,8 +112,9 @@ pub unsafe fn dc_array_get_ptr(
     if array.is_null() || (*array).magic != 0xa11aai32 as libc::c_uint || index >= (*array).count {
         return 0 as *mut libc::c_void;
     }
-    return *(*array).array.offset(index as isize) as *mut libc::c_void;
+    *(*array).array.offset(index as isize) as *mut libc::c_void
 }
+
 pub unsafe fn dc_array_get_latitude(
     mut array: *const dc_array_t,
     mut index: size_t,
@@ -118,8 +127,9 @@ pub unsafe fn dc_array_get_latitude(
     {
         return 0i32 as libc::c_double;
     }
-    return (*(*(*array).array.offset(index as isize) as *mut _dc_location)).latitude;
+    (*(*(*array).array.offset(index as isize) as *mut _dc_location)).latitude
 }
+
 pub unsafe fn dc_array_get_longitude(
     mut array: *const dc_array_t,
     mut index: size_t,
@@ -132,8 +142,9 @@ pub unsafe fn dc_array_get_longitude(
     {
         return 0i32 as libc::c_double;
     }
-    return (*(*(*array).array.offset(index as isize) as *mut _dc_location)).longitude;
+    (*(*(*array).array.offset(index as isize) as *mut _dc_location)).longitude
 }
+
 pub unsafe fn dc_array_get_accuracy(
     mut array: *const dc_array_t,
     mut index: size_t,
@@ -146,8 +157,9 @@ pub unsafe fn dc_array_get_accuracy(
     {
         return 0i32 as libc::c_double;
     }
-    return (*(*(*array).array.offset(index as isize) as *mut _dc_location)).accuracy;
+    (*(*(*array).array.offset(index as isize) as *mut _dc_location)).accuracy
 }
+
 pub unsafe fn dc_array_get_timestamp(mut array: *const dc_array_t, mut index: size_t) -> time_t {
     if array.is_null()
         || (*array).magic != 0xa11aai32 as libc::c_uint
@@ -157,8 +169,9 @@ pub unsafe fn dc_array_get_timestamp(mut array: *const dc_array_t, mut index: si
     {
         return 0i32 as time_t;
     }
-    return (*(*(*array).array.offset(index as isize) as *mut _dc_location)).timestamp;
+    (*(*(*array).array.offset(index as isize) as *mut _dc_location)).timestamp
 }
+
 pub unsafe fn dc_array_get_chat_id(mut array: *const dc_array_t, mut index: size_t) -> uint32_t {
     if array.is_null()
         || (*array).magic != 0xa11aai32 as libc::c_uint
@@ -168,8 +181,9 @@ pub unsafe fn dc_array_get_chat_id(mut array: *const dc_array_t, mut index: size
     {
         return 0i32 as uint32_t;
     }
-    return (*(*(*array).array.offset(index as isize) as *mut _dc_location)).chat_id;
+    (*(*(*array).array.offset(index as isize) as *mut _dc_location)).chat_id
 }
+
 pub unsafe fn dc_array_get_contact_id(mut array: *const dc_array_t, mut index: size_t) -> uint32_t {
     if array.is_null()
         || (*array).magic != 0xa11aai32 as libc::c_uint
@@ -179,8 +193,9 @@ pub unsafe fn dc_array_get_contact_id(mut array: *const dc_array_t, mut index: s
     {
         return 0i32 as uint32_t;
     }
-    return (*(*(*array).array.offset(index as isize) as *mut _dc_location)).contact_id;
+    (*(*(*array).array.offset(index as isize) as *mut _dc_location)).contact_id
 }
+
 pub unsafe fn dc_array_get_msg_id(mut array: *const dc_array_t, mut index: size_t) -> uint32_t {
     if array.is_null()
         || (*array).magic != 0xa11aai32 as libc::c_uint
@@ -190,8 +205,9 @@ pub unsafe fn dc_array_get_msg_id(mut array: *const dc_array_t, mut index: size_
     {
         return 0i32 as uint32_t;
     }
-    return (*(*(*array).array.offset(index as isize) as *mut _dc_location)).msg_id;
+    (*(*(*array).array.offset(index as isize) as *mut _dc_location)).msg_id
 }
+
 pub unsafe fn dc_array_get_marker(
     mut array: *const dc_array_t,
     mut index: size_t,
@@ -204,9 +220,9 @@ pub unsafe fn dc_array_get_marker(
     {
         return 0 as *mut libc::c_char;
     }
-    return dc_strdup_keep_null(
+    dc_strdup_keep_null(
         (*(*(*array).array.offset(index as isize) as *mut _dc_location)).marker,
-    );
+    )
 }
 
 /**
@@ -232,6 +248,7 @@ pub unsafe fn dc_array_is_independent(array: *const dc_array_t, index: size_t) -
     (*(*(*array).array.offset(index as isize) as *mut _dc_location)).independent as libc::c_int
 }
 
+// TODO should return bool /rtn
 pub unsafe fn dc_array_search_id(
     mut array: *const dc_array_t,
     mut needle: uint32_t,
@@ -243,7 +260,6 @@ pub unsafe fn dc_array_search_id(
     let mut data: *mut uintptr_t = (*array).array;
     let mut i: size_t = 0;
     let mut cnt: size_t = (*array).count;
-    i = 0i32 as size_t;
     while i < cnt {
         if *data.offset(i as isize) == needle as size_t {
             if !ret_index.is_null() {
@@ -253,14 +269,16 @@ pub unsafe fn dc_array_search_id(
         }
         i = i.wrapping_add(1)
     }
-    return 0i32;
+    0
 }
+
 pub unsafe fn dc_array_get_raw(mut array: *const dc_array_t) -> *const uintptr_t {
     if array.is_null() || (*array).magic != 0xa11aai32 as libc::c_uint {
         return 0 as *const uintptr_t;
     }
-    return (*array).array;
+    (*array).array
 }
+
 pub unsafe fn dc_array_new(initsize: size_t) -> *mut dc_array_t {
     dc_array_new_typed(0, initsize)
 }
@@ -269,7 +287,7 @@ pub unsafe extern "C" fn dc_array_new_typed(
     mut type_0: libc::c_int,
     mut initsize: size_t,
 ) -> *mut dc_array_t {
-    let mut array: *mut dc_array_t = 0 as *mut dc_array_t;
+    let mut array: *mut dc_array_t;
     array = calloc(1, ::std::mem::size_of::<dc_array_t>()) as *mut dc_array_t;
     if array.is_null() {
         exit(47i32);
@@ -295,8 +313,9 @@ pub unsafe fn dc_array_empty(mut array: *mut dc_array_t) {
     }
     (*array).count = 0i32 as size_t;
 }
+
 pub unsafe fn dc_array_duplicate(mut array: *const dc_array_t) -> *mut dc_array_t {
-    let mut ret: *mut dc_array_t = 0 as *mut dc_array_t;
+    let mut ret: *mut dc_array_t;
     if array.is_null() || (*array).magic != 0xa11aai32 as libc::c_uint {
         return 0 as *mut dc_array_t;
     }
@@ -309,8 +328,9 @@ pub unsafe fn dc_array_duplicate(mut array: *const dc_array_t) -> *mut dc_array_
             .count
             .wrapping_mul(::std::mem::size_of::<uintptr_t>()),
     );
-    return ret;
+    ret
 }
+
 pub unsafe fn dc_array_sort_ids(mut array: *mut dc_array_t) {
     if array.is_null() || (*array).magic != 0xa11aai32 as libc::c_uint || (*array).count <= 1 {
         return;
@@ -322,6 +342,7 @@ pub unsafe fn dc_array_sort_ids(mut array: *mut dc_array_t) {
         Some(cmp_intptr_t),
     );
 }
+
 unsafe extern "C" fn cmp_intptr_t(
     mut p1: *const libc::c_void,
     mut p2: *const libc::c_void,
@@ -336,6 +357,7 @@ unsafe extern "C" fn cmp_intptr_t(
         0i32
     };
 }
+
 pub unsafe fn dc_array_sort_strings(mut array: *mut dc_array_t) {
     if array.is_null() || (*array).magic != 0xa11aai32 as libc::c_uint || (*array).count <= 1 {
         return;
@@ -347,19 +369,22 @@ pub unsafe fn dc_array_sort_strings(mut array: *mut dc_array_t) {
         Some(cmp_strings_t),
     );
 }
+
 unsafe extern "C" fn cmp_strings_t(
     mut p1: *const libc::c_void,
     mut p2: *const libc::c_void,
 ) -> libc::c_int {
     let mut v1: *const libc::c_char = *(p1 as *mut *const libc::c_char);
     let mut v2: *const libc::c_char = *(p2 as *mut *const libc::c_char);
-    return strcmp(v1, v2);
+
+    strcmp(v1, v2)
 }
+
 pub unsafe fn dc_array_get_string(
     mut array: *const dc_array_t,
     mut sep: *const libc::c_char,
 ) -> *mut libc::c_char {
-    let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut ret: *mut libc::c_char;
     if array.is_null() || (*array).magic != 0xa11aai32 as libc::c_uint || sep.is_null() {
         return dc_strdup(b"\x00" as *const u8 as *const libc::c_char);
     }
@@ -374,7 +399,6 @@ pub unsafe fn dc_array_get_string(
         exit(35i32);
     }
     *ret.offset(0isize) = 0i32 as libc::c_char;
-    i = 0;
     while i < (*array).count {
         if 0 != i {
             strcat(ret, sep);
@@ -386,19 +410,21 @@ pub unsafe fn dc_array_get_string(
         );
         i += 1
     }
-    return ret;
+
+    ret
 }
+
 pub unsafe fn dc_arr_to_string(
     mut arr: *const uint32_t,
     mut cnt: libc::c_int,
 ) -> *mut libc::c_char {
     /* return comma-separated value-string from integer array */
-    let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut ret: *mut libc::c_char;
     let mut sep: *const libc::c_char = b",\x00" as *const u8 as *const libc::c_char;
     if arr.is_null() || cnt <= 0i32 {
         return dc_strdup(b"\x00" as *const u8 as *const libc::c_char);
     }
-    let mut i: libc::c_int = 0;
+    let mut i: libc::c_int;
     ret = malloc(
         (cnt as usize)
             .wrapping_mul((11usize).wrapping_add(strlen(sep)))
@@ -420,5 +446,6 @@ pub unsafe fn dc_arr_to_string(
         );
         i += 1
     }
-    return ret;
+
+    ret
 }

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -64,9 +64,10 @@ pub unsafe fn dc_create_chat_by_msg_id(
             0i32 as uintptr_t,
         );
     }
-    return chat_id;
+    chat_id
 }
-/* *
+
+/**
  * @class dc_chat_t
  *
  * An object representing a single chat in memory.
@@ -82,14 +83,15 @@ pub unsafe fn dc_create_chat_by_msg_id(
 // only an indicator in a chatlist
 // larger chat IDs are "real" chats, their messages are "real" messages.
 pub unsafe fn dc_chat_new<'a>(context: &'a dc_context_t) -> *mut dc_chat_t<'a> {
-    let mut chat: *mut dc_chat_t = 0 as *mut dc_chat_t;
+    let mut chat: *mut dc_chat_t;
     chat = calloc(1, ::std::mem::size_of::<dc_chat_t>()) as *mut dc_chat_t;
     (*chat).magic = 0xc4a7c4a7u32;
     (*chat).context = context;
     (*chat).type_0 = 0i32;
     (*chat).param = dc_param_new();
-    return chat;
+    chat
 }
+
 pub unsafe fn dc_chat_unref(mut chat: *mut dc_chat_t) {
     if chat.is_null() || (*chat).magic != 0xc4a7c4a7u32 {
         return;
@@ -99,6 +101,7 @@ pub unsafe fn dc_chat_unref(mut chat: *mut dc_chat_t) {
     (*chat).magic = 0i32 as uint32_t;
     free(chat as *mut libc::c_void);
 }
+
 pub unsafe fn dc_chat_empty(mut chat: *mut dc_chat_t) {
     if chat.is_null() || (*chat).magic != 0xc4a7c4a7u32 {
         return;
@@ -113,15 +116,17 @@ pub unsafe fn dc_chat_empty(mut chat: *mut dc_chat_t) {
     (*chat).gossiped_timestamp = 0i32 as time_t;
     dc_param_set_packed((*chat).param, 0 as *const libc::c_char);
 }
+
 pub unsafe fn dc_unblock_chat(mut context: &dc_context_t, mut chat_id: uint32_t) {
     dc_block_chat(context, chat_id, 0i32);
 }
+
 pub unsafe fn dc_block_chat(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
     mut new_blocking: libc::c_int,
 ) {
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut stmt: *mut sqlite3_stmt;
     stmt = dc_sqlite3_prepare(
         context,
         &context.sql.clone().read().unwrap(),
@@ -132,6 +137,8 @@ pub unsafe fn dc_block_chat(
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_chat_load_from_db(mut chat: *mut dc_chat_t, mut chat_id: uint32_t) -> libc::c_int {
     let mut success: libc::c_int = 0i32;
     let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
@@ -152,8 +159,9 @@ pub unsafe fn dc_chat_load_from_db(mut chat: *mut dc_chat_t, mut chat_id: uint32
         }
     }
     sqlite3_finalize(stmt);
-    return success;
+    success
 }
+
 unsafe fn set_from_stmt(mut chat: *mut dc_chat_t, mut row: *mut sqlite3_stmt) -> libc::c_int {
     let mut row_offset: libc::c_int = 0i32;
     if chat.is_null() || (*chat).magic != 0xc4a7c4a7u32 || row.is_null() {
@@ -211,8 +219,9 @@ unsafe fn set_from_stmt(mut chat: *mut dc_chat_t, mut row: *mut sqlite3_stmt) ->
         free((*chat).name as *mut libc::c_void);
         (*chat).name = dc_stock_str((*chat).context, 2i32)
     }
-    return row_offset;
+    row_offset
 }
+
 pub unsafe fn dc_create_chat_by_contact_id(
     mut context: &dc_context_t,
     mut contact_id: uint32_t,
@@ -257,8 +266,9 @@ pub unsafe fn dc_create_chat_by_contact_id(
             0i32 as uintptr_t,
         );
     }
-    return chat_id;
+    chat_id
 }
+
 pub unsafe fn dc_create_or_lookup_nchat_by_contact_id(
     mut context: &dc_context_t,
     mut contact_id: uint32_t,
@@ -268,8 +278,8 @@ pub unsafe fn dc_create_or_lookup_nchat_by_contact_id(
 ) {
     let mut chat_id: uint32_t = 0i32 as uint32_t;
     let mut chat_blocked: libc::c_int = 0i32;
-    let mut contact: *mut dc_contact_t = 0 as *mut dc_contact_t;
-    let mut chat_name: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut contact: *mut dc_contact_t;
+    let mut chat_name: *mut libc::c_char;
     let mut q: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
     if !ret_chat_id.is_null() {
@@ -338,9 +348,7 @@ pub unsafe fn dc_create_or_lookup_nchat_by_contact_id(
                     (*contact).addr,
                 );
                 sqlite3_free(q as *mut libc::c_void);
-                q = 0 as *mut libc::c_char;
                 sqlite3_finalize(stmt);
-                stmt = 0 as *mut sqlite3_stmt;
                 q = sqlite3_mprintf(
                     b"INSERT INTO chats_contacts (chat_id, contact_id) VALUES(%i, %i)\x00"
                         as *const u8 as *const libc::c_char,
@@ -367,6 +375,7 @@ pub unsafe fn dc_create_or_lookup_nchat_by_contact_id(
         *ret_chat_blocked = create_blocked
     };
 }
+
 pub unsafe fn dc_lookup_real_nchat_by_contact_id(
     mut context: &dc_context_t,
     mut contact_id: uint32_t,
@@ -374,7 +383,7 @@ pub unsafe fn dc_lookup_real_nchat_by_contact_id(
     mut ret_chat_blocked: *mut libc::c_int,
 ) {
     /* checks for "real" chats or self-chat */
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut stmt: *mut sqlite3_stmt;
     if !ret_chat_id.is_null() {
         *ret_chat_id = 0i32 as uint32_t
     }
@@ -401,6 +410,7 @@ pub unsafe fn dc_lookup_real_nchat_by_contact_id(
     }
     sqlite3_finalize(stmt);
 }
+
 pub unsafe fn dc_get_chat_id_by_contact_id(
     mut context: &dc_context_t,
     mut contact_id: uint32_t,
@@ -414,6 +424,7 @@ pub unsafe fn dc_get_chat_id_by_contact_id(
         chat_id
     };
 }
+
 pub unsafe fn dc_prepare_msg<'a>(
     mut context: &'a dc_context_t,
     mut chat_id: uint32_t,
@@ -432,6 +443,7 @@ pub unsafe fn dc_prepare_msg<'a>(
     );
     return msg_id;
 }
+
 unsafe fn prepare_msg_common<'a>(
     mut context: &'a dc_context_t,
     mut chat_id: uint32_t,
@@ -528,16 +540,18 @@ unsafe fn prepare_msg_common<'a>(
     /* potential error already logged */
     dc_chat_unref(chat);
     free(pathNfilename as *mut libc::c_void);
-    return (*msg).id;
+
+    (*msg).id
 }
+
 unsafe fn prepare_msg_raw(
     mut context: &dc_context_t,
     mut chat: *mut dc_chat_t,
     mut msg: *const dc_msg_t,
     mut timestamp: time_t,
 ) -> uint32_t {
-    let mut do_guarantee_e2ee: libc::c_int = 0;
-    let mut e2ee_enabled: libc::c_int = 0;
+    let mut do_guarantee_e2ee: libc::c_int;
+    let mut e2ee_enabled: libc::c_int;
     let mut current_block: u64;
     let mut parent_rfc724_mid: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut parent_references: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -677,7 +691,6 @@ unsafe fn prepare_msg_raw(
                             }
                         }
                         sqlite3_finalize(stmt);
-                        stmt = 0 as *mut sqlite3_stmt;
                         if 0 != can_encrypt {
                             if 0 != all_mutual {
                                 do_guarantee_e2ee = 1i32
@@ -710,7 +723,7 @@ unsafe fn prepare_msg_raw(
                             new_in_reply_to = dc_strdup(parent_rfc724_mid)
                         }
                         if !parent_references.is_null() {
-                            let mut space: *mut libc::c_char = 0 as *mut libc::c_char;
+                            let mut space: *mut libc::c_char;
                             space = strchr(parent_references, ' ' as i32);
                             if !space.is_null() {
                                 *space = 0i32 as libc::c_char
@@ -781,7 +794,6 @@ unsafe fn prepare_msg_raw(
                         );
                         sqlite3_step(stmt);
                         sqlite3_finalize(stmt);
-                        stmt = 0 as *mut sqlite3_stmt;
 
                         location_id = dc_sqlite3_get_rowid2(
                             context,
@@ -853,8 +865,11 @@ unsafe fn prepare_msg_raw(
     free(new_in_reply_to as *mut libc::c_void);
     free(new_references as *mut libc::c_void);
     sqlite3_finalize(stmt);
-    return msg_id;
+
+    msg_id
 }
+
+// TODO should return bool /rtn
 unsafe fn get_parent_mime_headers(
     mut chat: *const dc_chat_t,
     mut parent_rfc724_mid: *mut *mut libc::c_char,
@@ -903,17 +918,20 @@ unsafe fn get_parent_mime_headers(
         }
     }
     sqlite3_finalize(stmt);
-    return success;
+    success
 }
+
 pub unsafe fn dc_chat_is_self_talk(mut chat: *const dc_chat_t) -> libc::c_int {
     if chat.is_null() || (*chat).magic != 0xc4a7c4a7u32 {
         return 0i32;
     }
-    return dc_param_exists((*chat).param, 'K' as i32);
+    dc_param_exists((*chat).param, 'K' as i32)
 }
-/* ******************************************************************************
+
+/*******************************************************************************
  * Sending messages
  ******************************************************************************/
+// TODO should return bool /rtn
 unsafe fn last_msg_in_chat_encrypted(
     context: &dc_context_t,
     sql: &dc_sqlite3_t,
@@ -938,10 +956,12 @@ unsafe fn last_msg_in_chat_encrypted(
         dc_param_unref(msg_param);
     }
     sqlite3_finalize(stmt);
-    return last_is_encrypted;
+    last_is_encrypted
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_chat_update_param(mut chat: *mut dc_chat_t) -> libc::c_int {
-    let mut success: libc::c_int = 0i32;
+    let mut success: libc::c_int;
     let mut stmt: *mut sqlite3_stmt = dc_sqlite3_prepare(
         (*chat).context,
         &mut (*chat).context.sql.clone().read().unwrap(),
@@ -955,8 +975,9 @@ pub unsafe fn dc_chat_update_param(mut chat: *mut dc_chat_t) -> libc::c_int {
         0i32
     };
     sqlite3_finalize(stmt);
-    return success;
+    success
 }
+
 pub unsafe fn dc_is_contact_in_chat(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
@@ -964,8 +985,8 @@ pub unsafe fn dc_is_contact_in_chat(
 ) -> libc::c_int {
     /* this function works for group and for normal chats, however, it is more useful for group chats.
     DC_CONTACT_ID_SELF may be used to check, if the user itself is in a group chat (DC_CONTACT_ID_SELF is not added to normal chats) */
-    let mut ret: libc::c_int = 0i32;
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut ret: libc::c_int;
+    let mut stmt: *mut sqlite3_stmt;
 
     stmt = dc_sqlite3_prepare(
         context,
@@ -995,6 +1016,7 @@ pub unsafe fn dc_unarchive_chat(mut context: &dc_context_t, mut chat_id: uint32_
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
 }
+
 pub unsafe fn dc_send_msg<'a>(
     mut context: &'a dc_context_t,
     mut chat_id: uint32_t,
@@ -1050,8 +1072,10 @@ pub unsafe fn dc_send_msg<'a>(
         }
         free(forwards as *mut libc::c_void);
     }
-    return (*msg).id;
+
+    (*msg).id
 }
+
 pub unsafe fn dc_send_text_msg(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
@@ -1064,8 +1088,9 @@ pub unsafe fn dc_send_text_msg(
         ret = dc_send_msg(context, chat_id, msg)
     }
     dc_msg_unref(msg);
-    return ret;
+    ret
 }
+
 pub unsafe fn dc_set_draft(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
@@ -1083,6 +1108,8 @@ pub unsafe fn dc_set_draft(
         );
     };
 }
+
+// TODO should return bool /rtn
 unsafe fn set_draft_raw(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
@@ -1092,7 +1119,7 @@ unsafe fn set_draft_raw(
     // similar to as dc_set_draft() but does not emit an event
     let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
     let mut pathNfilename: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut prev_draft_msg_id: uint32_t = 0i32 as uint32_t;
+    let mut prev_draft_msg_id: uint32_t;
     let mut sth_changed: libc::c_int = 0i32;
     prev_draft_msg_id = get_draft_msg_id(context, chat_id);
     if 0 != prev_draft_msg_id {
@@ -1165,8 +1192,9 @@ unsafe fn set_draft_raw(
     }
     sqlite3_finalize(stmt);
     free(pathNfilename as *mut libc::c_void);
-    return sth_changed;
+    sth_changed
 }
+
 unsafe fn get_draft_msg_id(mut context: &dc_context_t, mut chat_id: uint32_t) -> uint32_t {
     let mut draft_msg_id: uint32_t = 0i32 as uint32_t;
     let mut stmt: *mut sqlite3_stmt = dc_sqlite3_prepare(
@@ -1180,11 +1208,12 @@ unsafe fn get_draft_msg_id(mut context: &dc_context_t, mut chat_id: uint32_t) ->
         draft_msg_id = sqlite3_column_int(stmt, 0i32) as uint32_t
     }
     sqlite3_finalize(stmt);
-    return draft_msg_id;
+    draft_msg_id
 }
+
 pub unsafe fn dc_get_draft(mut context: &dc_context_t, mut chat_id: uint32_t) -> *mut dc_msg_t {
-    let mut draft_msg_id: uint32_t = 0i32 as uint32_t;
-    let mut draft_msg: *mut dc_msg_t = 0 as *mut dc_msg_t;
+    let mut draft_msg_id: uint32_t;
+    let mut draft_msg: *mut dc_msg_t;
     if chat_id <= 9i32 as libc::c_uint {
         return 0 as *mut dc_msg_t;
     }
@@ -1197,8 +1226,10 @@ pub unsafe fn dc_get_draft(mut context: &dc_context_t, mut chat_id: uint32_t) ->
         dc_msg_unref(draft_msg);
         return 0 as *mut dc_msg_t;
     }
-    return draft_msg;
+
+    draft_msg
 }
+
 pub unsafe fn dc_get_chat_msgs(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
@@ -1209,9 +1240,9 @@ pub unsafe fn dc_get_chat_msgs(
     let mut success: libc::c_int = 0i32;
     let mut ret: *mut dc_array_t = dc_array_new(512i32 as size_t);
     let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
-    let mut curr_id: uint32_t = 0;
-    let mut curr_local_timestamp: time_t = 0;
-    let mut curr_day: libc::c_int = 0;
+    let mut curr_id: uint32_t;
+    let mut curr_local_timestamp: time_t;
+    let mut curr_day: libc::c_int;
     let mut last_day: libc::c_int = 0i32;
     let mut cnv_to_local: libc::c_long = dc_gm2local_offset();
     if !ret.is_null() {
@@ -1269,9 +1300,10 @@ pub unsafe fn dc_get_chat_msgs(
         return 0 as *mut dc_array_t;
     };
 }
+
 pub unsafe fn dc_get_msg_cnt(mut context: &dc_context_t, mut chat_id: uint32_t) -> libc::c_int {
     let mut ret: libc::c_int = 0i32;
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut stmt: *mut sqlite3_stmt;
     stmt = dc_sqlite3_prepare(
         context,
         &context.sql.clone().read().unwrap(),
@@ -1283,14 +1315,15 @@ pub unsafe fn dc_get_msg_cnt(mut context: &dc_context_t, mut chat_id: uint32_t) 
     }
 
     sqlite3_finalize(stmt);
-    return ret;
+    ret
 }
+
 pub unsafe fn dc_get_fresh_msg_cnt(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
 ) -> libc::c_int {
     let mut ret: libc::c_int = 0i32;
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut stmt: *mut sqlite3_stmt;
     stmt = dc_sqlite3_prepare(
         context,
         &context.sql.clone().read().unwrap(),
@@ -1302,10 +1335,11 @@ pub unsafe fn dc_get_fresh_msg_cnt(
         ret = sqlite3_column_int(stmt, 0i32);
     }
     sqlite3_finalize(stmt);
-    return ret;
+    ret
 }
+
 pub unsafe fn dc_marknoticed_chat(mut context: &dc_context_t, mut chat_id: uint32_t) {
-    let mut check: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut check: *mut sqlite3_stmt;
     let mut update: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
 
     check = dc_sqlite3_prepare(
@@ -1335,8 +1369,9 @@ pub unsafe fn dc_marknoticed_chat(mut context: &dc_context_t, mut chat_id: uint3
     sqlite3_finalize(check);
     sqlite3_finalize(update);
 }
+
 pub unsafe fn dc_marknoticed_all_chats(mut context: &dc_context_t) {
-    let mut check: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut check: *mut sqlite3_stmt;
     let mut update: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
 
     check = dc_sqlite3_prepare(
@@ -1362,6 +1397,7 @@ pub unsafe fn dc_marknoticed_all_chats(mut context: &dc_context_t) {
     sqlite3_finalize(check);
     sqlite3_finalize(update);
 }
+
 pub unsafe fn dc_get_chat_media(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
@@ -1399,8 +1435,9 @@ pub unsafe fn dc_get_chat_media(
         dc_array_add_id(ret, sqlite3_column_int(stmt, 0i32) as uint32_t);
     }
     sqlite3_finalize(stmt);
-    return ret;
+    ret
 }
+
 pub unsafe fn dc_get_next_media(
     mut context: &dc_context_t,
     mut curr_msg_id: uint32_t,
@@ -1412,8 +1449,8 @@ pub unsafe fn dc_get_next_media(
     let mut ret_msg_id: uint32_t = 0i32 as uint32_t;
     let mut msg: *mut dc_msg_t = dc_msg_new_untyped(context);
     let mut list: *mut dc_array_t = 0 as *mut dc_array_t;
-    let mut i: libc::c_int = 0i32;
-    let mut cnt: libc::c_int = 0i32;
+    let mut i: libc::c_int;
+    let mut cnt: libc::c_int;
 
     if !(0 == dc_msg_load_from_db(msg, context, curr_msg_id)) {
         list = dc_get_chat_media(
@@ -1451,8 +1488,9 @@ pub unsafe fn dc_get_next_media(
 
     dc_array_unref(list);
     dc_msg_unref(msg);
-    return ret_msg_id;
+    ret_msg_id
 }
+
 pub unsafe fn dc_archive_chat(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
@@ -1488,6 +1526,7 @@ pub unsafe fn dc_archive_chat(
         0i32 as uintptr_t,
     );
 }
+
 pub unsafe fn dc_delete_chat(mut context: &dc_context_t, mut chat_id: uint32_t) {
     /* Up to 2017-11-02 deleting a group also implied leaving it, see above why we have changed this. */
     let mut obj: *mut dc_chat_t = dc_chat_new(context);
@@ -1501,14 +1540,12 @@ pub unsafe fn dc_delete_chat(mut context: &dc_context_t, mut chat_id: uint32_t) 
             );
             if !(0 == dc_sqlite3_execute(context, &context.sql.clone().read().unwrap(), q3)) {
                 sqlite3_free(q3 as *mut libc::c_void);
-                q3 = 0 as *mut libc::c_char;
                 q3 = sqlite3_mprintf(
                     b"DELETE FROM msgs WHERE chat_id=%i;\x00" as *const u8 as *const libc::c_char,
                     chat_id,
                 );
                 if !(0 == dc_sqlite3_execute(context, &context.sql.clone().read().unwrap(), q3)) {
                     sqlite3_free(q3 as *mut libc::c_void);
-                    q3 = 0 as *mut libc::c_char;
                     q3 = sqlite3_mprintf(
                         b"DELETE FROM chats_contacts WHERE chat_id=%i;\x00" as *const u8
                             as *const libc::c_char,
@@ -1517,7 +1554,6 @@ pub unsafe fn dc_delete_chat(mut context: &dc_context_t, mut chat_id: uint32_t) 
                     if !(0 == dc_sqlite3_execute(context, &context.sql.clone().read().unwrap(), q3))
                     {
                         sqlite3_free(q3 as *mut libc::c_void);
-                        q3 = 0 as *mut libc::c_char;
                         q3 = sqlite3_mprintf(
                             b"DELETE FROM chats WHERE id=%i;\x00" as *const u8
                                 as *const libc::c_char,
@@ -1549,6 +1585,7 @@ pub unsafe fn dc_delete_chat(mut context: &dc_context_t, mut chat_id: uint32_t) 
     dc_chat_unref(obj);
     sqlite3_free(q3 as *mut libc::c_void);
 }
+
 pub unsafe fn dc_get_chat_contacts(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
@@ -1572,8 +1609,9 @@ pub unsafe fn dc_get_chat_contacts(
     }
 
     sqlite3_finalize(stmt);
-    return ret;
+    ret
 }
+
 pub unsafe fn dc_get_chat(mut context: &dc_context_t, mut chat_id: uint32_t) -> *mut dc_chat_t {
     let mut success: libc::c_int = 0i32;
     let mut obj: *mut dc_chat_t = dc_chat_new(context);
@@ -1589,6 +1627,7 @@ pub unsafe fn dc_get_chat(mut context: &dc_context_t, mut chat_id: uint32_t) -> 
         return 0 as *mut dc_chat_t;
     };
 }
+
 // handle group chats
 pub unsafe fn dc_create_group_chat(
     mut context: &dc_context_t,
@@ -1596,10 +1635,10 @@ pub unsafe fn dc_create_group_chat(
     mut chat_name: *const libc::c_char,
 ) -> uint32_t {
     let mut chat_id: uint32_t = 0i32 as uint32_t;
-    let mut draft_txt: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut draft_txt: *mut libc::c_char;
     let mut draft_msg: *mut dc_msg_t = 0 as *mut dc_msg_t;
-    let mut grpid: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut grpid: *mut libc::c_char;
+    let mut stmt: *mut sqlite3_stmt;
     if chat_name.is_null() || *chat_name.offset(0isize) as libc::c_int == 0i32 {
         return 0i32 as uint32_t;
     }
@@ -1642,17 +1681,20 @@ pub unsafe fn dc_create_group_chat(
             0i32 as uintptr_t,
         );
     }
-    return chat_id;
+
+    chat_id
 }
+
 /* you MUST NOT modify this or the following strings */
 // Context functions to work with chats
+// TODO should return bool /rtn
 pub unsafe fn dc_add_to_chat_contacts_table(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
     mut contact_id: uint32_t,
 ) -> libc::c_int {
     /* add a contact to a chat; the function does not check the type or if any of the record exist or are already added to the chat! */
-    let mut ret: libc::c_int = 0i32;
+    let mut ret: libc::c_int;
     let mut stmt: *mut sqlite3_stmt = dc_sqlite3_prepare(
         context,
         &context.sql.clone().read().unwrap(),
@@ -1667,15 +1709,18 @@ pub unsafe fn dc_add_to_chat_contacts_table(
         0i32
     };
     sqlite3_finalize(stmt);
-    return ret;
+    ret
 }
+
 pub unsafe fn dc_add_contact_to_chat(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
     mut contact_id: uint32_t,
 ) -> libc::c_int {
-    return dc_add_contact_to_chat_ex(context, chat_id, contact_id, 0i32);
+    dc_add_contact_to_chat_ex(context, chat_id, contact_id, 0i32)
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_add_contact_to_chat_ex(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
@@ -1794,11 +1839,14 @@ pub unsafe fn dc_add_contact_to_chat_ex(
     dc_contact_unref(contact);
     dc_msg_unref(msg);
     free(self_addr as *mut libc::c_void);
-    return success;
+
+    success
 }
+
+// TODO should return bool /rtn
 unsafe fn real_group_exists(mut context: &dc_context_t, mut chat_id: uint32_t) -> libc::c_int {
     // check if a group or a verified group exists under the given ID
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut stmt: *mut sqlite3_stmt;
     let mut ret: libc::c_int = 0i32;
     if (*context.sql.clone().read().unwrap()).cobj.is_null() || chat_id <= 9i32 as libc::c_uint {
         return 0i32;
@@ -1814,17 +1862,19 @@ unsafe fn real_group_exists(mut context: &dc_context_t, mut chat_id: uint32_t) -
         ret = 1i32
     }
     sqlite3_finalize(stmt);
-    return ret;
+    ret
 }
+
 pub unsafe fn dc_reset_gossiped_timestamp(mut context: &dc_context_t, mut chat_id: uint32_t) {
     dc_set_gossiped_timestamp(context, chat_id, 0i32 as time_t);
 }
+
 pub unsafe fn dc_set_gossiped_timestamp(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
     mut timestamp: time_t,
 ) {
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut stmt: *mut sqlite3_stmt;
     if 0 != chat_id {
         dc_log_info(
             context,
@@ -1858,6 +1908,8 @@ pub unsafe fn dc_set_gossiped_timestamp(
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_remove_contact_from_chat(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
@@ -1940,8 +1992,10 @@ pub unsafe fn dc_remove_contact_from_chat(
     dc_chat_unref(chat);
     dc_contact_unref(contact);
     dc_msg_unref(msg);
-    return success;
+
+    success
 }
+
 pub unsafe fn dc_set_group_explicitly_left(
     mut context: &dc_context_t,
     mut grpid: *const libc::c_char,
@@ -1957,6 +2011,8 @@ pub unsafe fn dc_set_group_explicitly_left(
         sqlite3_finalize(stmt);
     };
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_is_group_explicitly_left(
     mut context: &dc_context_t,
     mut grpid: *const libc::c_char,
@@ -1969,8 +2025,10 @@ pub unsafe fn dc_is_group_explicitly_left(
     sqlite3_bind_text(stmt, 1i32, grpid, -1i32, None);
     let mut ret: libc::c_int = (sqlite3_step(stmt) == 100i32) as libc::c_int;
     sqlite3_finalize(stmt);
-    return ret;
+    ret
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_set_chat_name(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
@@ -2037,11 +2095,15 @@ pub unsafe fn dc_set_chat_name(
             }
         }
     }
+
     sqlite3_free(q3 as *mut libc::c_void);
     dc_chat_unref(chat);
     dc_msg_unref(msg);
-    return success;
+
+    success
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_set_chat_profile_image(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
@@ -2117,11 +2179,14 @@ pub unsafe fn dc_set_chat_profile_image(
             }
         }
     }
+
     dc_chat_unref(chat);
     dc_msg_unref(msg);
     free(new_image_rel as *mut libc::c_void);
-    return success;
+
+    success
 }
+
 pub unsafe fn dc_forward_msgs(
     mut context: &dc_context_t,
     mut msg_ids: *const uint32_t,
@@ -2135,7 +2200,7 @@ pub unsafe fn dc_forward_msgs(
     let mut idsstr: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut q3: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
-    let mut curr_timestamp: time_t = 0i32 as time_t;
+    let mut curr_timestamp: time_t;
     let mut original_param: *mut dc_param_t = dc_param_new();
     if !(msg_ids.is_null() || msg_cnt <= 0i32 || chat_id <= 9i32 as libc::c_uint) {
         dc_unarchive_chat(context, chat_id);
@@ -2163,7 +2228,7 @@ pub unsafe fn dc_forward_msgs(
                 dc_param_set((*msg).param, 'c' as i32, 0 as *const libc::c_char);
                 dc_param_set((*msg).param, 'u' as i32, 0 as *const libc::c_char);
                 dc_param_set((*msg).param, 'S' as i32, 0 as *const libc::c_char);
-                let mut new_msg_id: uint32_t = 0;
+                let mut new_msg_id: uint32_t;
                 if (*msg).state == 18i32 {
                     let fresh9 = curr_timestamp;
                     curr_timestamp = curr_timestamp + 1;
@@ -2228,24 +2293,28 @@ pub unsafe fn dc_forward_msgs(
     sqlite3_free(q3 as *mut libc::c_void);
     dc_param_unref(original_param);
 }
+
 pub unsafe fn dc_chat_get_id(mut chat: *const dc_chat_t) -> uint32_t {
     if chat.is_null() || (*chat).magic != 0xc4a7c4a7u32 {
         return 0i32 as uint32_t;
     }
-    return (*chat).id;
+    (*chat).id
 }
+
 pub unsafe fn dc_chat_get_type(mut chat: *const dc_chat_t) -> libc::c_int {
     if chat.is_null() || (*chat).magic != 0xc4a7c4a7u32 {
         return 0i32;
     }
-    return (*chat).type_0;
+    (*chat).type_0
 }
+
 pub unsafe fn dc_chat_get_name(mut chat: *const dc_chat_t) -> *mut libc::c_char {
     if chat.is_null() || (*chat).magic != 0xc4a7c4a7u32 {
         return dc_strdup(b"Err\x00" as *const u8 as *const libc::c_char);
     }
-    return dc_strdup((*chat).name);
+    dc_strdup((*chat).name)
 }
+
 pub unsafe extern "C" fn dc_chat_get_subtitle(mut chat: *const dc_chat_t) -> *mut libc::c_char {
     /* returns either the address or the number of chat members */
     let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -2255,7 +2324,7 @@ pub unsafe extern "C" fn dc_chat_get_subtitle(mut chat: *const dc_chat_t) -> *mu
     if (*chat).type_0 == 100i32 && 0 != dc_param_exists((*chat).param, 'K' as i32) {
         ret = dc_stock_str((*chat).context, 50i32)
     } else if (*chat).type_0 == 100i32 {
-        let mut r: libc::c_int = 0;
+        let mut r: libc::c_int;
         let mut stmt: *mut sqlite3_stmt =
             dc_sqlite3_prepare(
                 (*chat).context,&mut (*chat).context.sql.clone().read().unwrap(),
@@ -2268,7 +2337,7 @@ pub unsafe extern "C" fn dc_chat_get_subtitle(mut chat: *const dc_chat_t) -> *mu
         }
         sqlite3_finalize(stmt);
     } else if (*chat).type_0 == 120i32 || (*chat).type_0 == 130i32 {
-        let mut cnt: libc::c_int = 0i32;
+        let mut cnt: libc::c_int;
         if (*chat).id == 1i32 as libc::c_uint {
             ret = dc_stock_str((*chat).context, 8i32)
         } else {
@@ -2282,6 +2351,7 @@ pub unsafe extern "C" fn dc_chat_get_subtitle(mut chat: *const dc_chat_t) -> *mu
         dc_strdup(b"Err\x00" as *const u8 as *const libc::c_char)
     };
 }
+
 pub unsafe fn dc_get_chat_contact_cnt(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
@@ -2298,8 +2368,9 @@ pub unsafe fn dc_get_chat_contact_cnt(
         ret = sqlite3_column_int(stmt, 0i32)
     }
     sqlite3_finalize(stmt);
-    return ret;
+    ret
 }
+
 pub unsafe fn dc_chat_get_profile_image(mut chat: *const dc_chat_t) -> *mut libc::c_char {
     let mut image_rel: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut image_abs: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -2320,11 +2391,14 @@ pub unsafe fn dc_chat_get_profile_image(mut chat: *const dc_chat_t) -> *mut libc
             }
         }
     }
+
     free(image_rel as *mut libc::c_void);
     dc_array_unref(contacts);
     dc_contact_unref(contact);
-    return image_abs;
+
+    image_abs
 }
+
 pub unsafe fn dc_chat_get_color(mut chat: *const dc_chat_t) -> uint32_t {
     let mut color: uint32_t = 0i32 as uint32_t;
     let mut contacts: *mut dc_array_t = 0 as *mut dc_array_t;
@@ -2343,34 +2417,45 @@ pub unsafe fn dc_chat_get_color(mut chat: *const dc_chat_t) -> uint32_t {
             color = dc_str_to_color((*chat).name) as uint32_t
         }
     }
+
     dc_array_unref(contacts);
     dc_contact_unref(contact);
-    return color;
+
+    color
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_chat_get_archived(mut chat: *const dc_chat_t) -> libc::c_int {
     if chat.is_null() || (*chat).magic != 0xc4a7c4a7u32 {
         return 0i32;
     }
-    return (*chat).archived;
+    (*chat).archived
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_chat_is_unpromoted(mut chat: *const dc_chat_t) -> libc::c_int {
     if chat.is_null() || (*chat).magic != 0xc4a7c4a7u32 {
         return 0i32;
     }
-    return dc_param_get_int((*chat).param, 'U' as i32, 0i32);
+    dc_param_get_int((*chat).param, 'U' as i32, 0i32)
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_chat_is_verified(mut chat: *const dc_chat_t) -> libc::c_int {
     if chat.is_null() || (*chat).magic != 0xc4a7c4a7u32 {
         return 0i32;
     }
-    return ((*chat).type_0 == 130i32) as libc::c_int;
+    ((*chat).type_0 == 130i32) as libc::c_int
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_chat_is_sending_locations(mut chat: *const dc_chat_t) -> libc::c_int {
     if chat.is_null() || (*chat).magic != 0xc4a7c4a7u32 {
         return 0i32;
     }
-    return (*chat).is_sending_locations;
+    (*chat).is_sending_locations
 }
+
 pub unsafe fn dc_get_chat_cnt(mut context: &dc_context_t) -> size_t {
     let mut ret: size_t = 0i32 as size_t;
     let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
@@ -2387,8 +2472,9 @@ pub unsafe fn dc_get_chat_cnt(mut context: &dc_context_t) -> size_t {
         }
     }
     sqlite3_finalize(stmt);
-    return ret;
+    ret
 }
+
 pub unsafe fn dc_get_chat_id_by_grpid(
     mut context: &dc_context_t,
     mut grpid: *const libc::c_char,
@@ -2396,7 +2482,7 @@ pub unsafe fn dc_get_chat_id_by_grpid(
     mut ret_verified: *mut libc::c_int,
 ) -> uint32_t {
     let mut chat_id: uint32_t = 0i32 as uint32_t;
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut stmt: *mut sqlite3_stmt;
     if !ret_blocked.is_null() {
         *ret_blocked = 0i32
     }
@@ -2422,14 +2508,15 @@ pub unsafe fn dc_get_chat_id_by_grpid(
     }
 
     sqlite3_finalize(stmt);
-    return chat_id;
+    chat_id
 }
+
 pub unsafe fn dc_add_device_msg(
     mut context: &dc_context_t,
     mut chat_id: uint32_t,
     mut text: *const libc::c_char,
 ) {
-    let mut msg_id: uint32_t = 0i32 as uint32_t;
+    let mut msg_id: uint32_t;
     let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
     let mut rfc724_mid: *mut libc::c_char = dc_create_outgoing_rfc724_mid(
         0 as *const libc::c_char,

--- a/src/dc_chatlist.rs
+++ b/src/dc_chatlist.rs
@@ -43,7 +43,8 @@ pub unsafe fn dc_get_chatlist<'a>(
         return 0 as *mut dc_chatlist_t;
     };
 }
-/* *
+
+/**
  * @class dc_chatlist_t
  *
  * An object representing a single chatlist in memory.
@@ -82,7 +83,7 @@ pub unsafe fn dc_get_chatlist<'a>(
  * would not add extra work in the UI then.
  */
 pub unsafe fn dc_chatlist_new(mut context: &dc_context_t) -> *mut dc_chatlist_t {
-    let mut chatlist: *mut dc_chatlist_t = 0 as *mut dc_chatlist_t;
+    let mut chatlist: *mut dc_chatlist_t;
     chatlist = calloc(1, ::std::mem::size_of::<dc_chatlist_t>()) as *mut dc_chatlist_t;
     if chatlist.is_null() {
         exit(20i32);
@@ -93,8 +94,9 @@ pub unsafe fn dc_chatlist_new(mut context: &dc_context_t) -> *mut dc_chatlist_t 
     if (*chatlist).chatNlastmsg_ids.is_null() {
         exit(32i32);
     }
-    return chatlist;
+    chatlist
 }
+
 pub unsafe fn dc_chatlist_unref(mut chatlist: *mut dc_chatlist_t) {
     if chatlist.is_null() || (*chatlist).magic != 0xc4a71157u32 {
         return;
@@ -104,6 +106,7 @@ pub unsafe fn dc_chatlist_unref(mut chatlist: *mut dc_chatlist_t) {
     (*chatlist).magic = 0i32 as uint32_t;
     free(chatlist as *mut libc::c_void);
 }
+
 pub unsafe fn dc_chatlist_empty(mut chatlist: *mut dc_chatlist_t) {
     if chatlist.is_null() || (*chatlist).magic != 0xc4a71157u32 {
         return;
@@ -111,11 +114,13 @@ pub unsafe fn dc_chatlist_empty(mut chatlist: *mut dc_chatlist_t) {
     (*chatlist).cnt = 0i32 as size_t;
     dc_array_empty((*chatlist).chatNlastmsg_ids);
 }
-/* *
+
+/**
  * Load a chatlist from the database to the chatlist object.
  *
  * @private @memberof dc_chatlist_t
  */
+// TODO should return bool /rtn
 unsafe fn dc_chatlist_load_from_db(
     mut chatlist: *mut dc_chatlist_t,
     mut listflags: libc::c_int,
@@ -226,8 +231,9 @@ unsafe fn dc_chatlist_load_from_db(
     sqlite3_finalize(stmt);
     free(query as *mut libc::c_void);
     free(strLikeCmd as *mut libc::c_void);
-    return success;
+    success
 }
+
 // Context functions to work with chatlist
 pub unsafe fn dc_get_archived_cnt(mut context: &dc_context_t) -> libc::c_int {
     let mut ret: libc::c_int = 0i32;
@@ -241,11 +247,12 @@ pub unsafe fn dc_get_archived_cnt(mut context: &dc_context_t) -> libc::c_int {
         ret = sqlite3_column_int(stmt, 0i32)
     }
     sqlite3_finalize(stmt);
-    return ret;
+    ret
 }
+
 unsafe fn get_last_deaddrop_fresh_msg(mut context: &dc_context_t) -> uint32_t {
     let mut ret: uint32_t = 0i32 as uint32_t;
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut stmt: *mut sqlite3_stmt;
     stmt =
         dc_sqlite3_prepare(
             context,
@@ -257,14 +264,16 @@ unsafe fn get_last_deaddrop_fresh_msg(mut context: &dc_context_t) -> uint32_t {
         ret = sqlite3_column_int(stmt, 0i32) as uint32_t
     }
     sqlite3_finalize(stmt);
-    return ret;
+    ret
 }
+
 pub unsafe fn dc_chatlist_get_cnt(mut chatlist: *const dc_chatlist_t) -> size_t {
     if chatlist.is_null() || (*chatlist).magic != 0xc4a71157u32 {
         return 0i32 as size_t;
     }
-    return (*chatlist).cnt;
+    (*chatlist).cnt
 }
+
 pub unsafe fn dc_chatlist_get_chat_id(
     mut chatlist: *const dc_chatlist_t,
     mut index: size_t,
@@ -276,8 +285,9 @@ pub unsafe fn dc_chatlist_get_chat_id(
     {
         return 0i32 as uint32_t;
     }
-    return dc_array_get_id((*chatlist).chatNlastmsg_ids, index.wrapping_mul(2));
+    dc_array_get_id((*chatlist).chatNlastmsg_ids, index.wrapping_mul(2))
 }
+
 pub unsafe fn dc_chatlist_get_msg_id(
     mut chatlist: *const dc_chatlist_t,
     mut index: size_t,
@@ -289,11 +299,12 @@ pub unsafe fn dc_chatlist_get_msg_id(
     {
         return 0i32 as uint32_t;
     }
-    return dc_array_get_id(
+    dc_array_get_id(
         (*chatlist).chatNlastmsg_ids,
         index.wrapping_mul(2).wrapping_add(1),
-    );
+    )
 }
+
 pub unsafe fn dc_chatlist_get_summary<'a>(
     mut chatlist: *const dc_chatlist_t<'a>,
     mut index: size_t,
@@ -307,7 +318,7 @@ pub unsafe fn dc_chatlist_get_summary<'a>(
     message. */
     /* the function never returns NULL */
     let mut ret: *mut dc_lot_t = dc_lot_new();
-    let mut lastmsg_id: uint32_t = 0i32 as uint32_t;
+    let mut lastmsg_id: uint32_t;
     let mut lastmsg: *mut dc_msg_t = 0 as *mut dc_msg_t;
     let mut lastcontact: *mut dc_contact_t = 0 as *mut dc_contact_t;
     let mut chat_to_delete: *mut dc_chat_t = 0 as *mut dc_chat_t;
@@ -364,5 +375,5 @@ pub unsafe fn dc_chatlist_get_summary<'a>(
     dc_msg_unref(lastmsg);
     dc_contact_unref(lastcontact);
     dc_chat_unref(chat_to_delete);
-    return ret;
+    ret
 }

--- a/src/dc_configure.rs
+++ b/src/dc_configure.rs
@@ -114,7 +114,7 @@ pub unsafe fn dc_stop_ongoing_process(context: &dc_context_t) {
 }
 // the other dc_job_do_DC_JOB_*() functions are declared static in the c-file
 pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &dc_context_t, _job: *mut dc_job_t) {
-    let mut flags: libc::c_int = 0;
+    let mut flags: libc::c_int;
     let mut current_block: u64;
     let mut success: libc::c_int = 0i32;
     let mut imap_connected_here: libc::c_int = 0i32;
@@ -123,7 +123,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &dc_context_t, _job: *mut
     let mut mvbox_folder: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut param: *mut dc_loginparam_t = 0 as *mut dc_loginparam_t;
     /* just a pointer inside param, must not be freed! */
-    let mut param_domain: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut param_domain: *mut libc::c_char;
     let mut param_addr_urlencoded: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut param_autoconfig: *mut dc_loginparam_t = 0 as *mut dc_loginparam_t;
 
@@ -1313,7 +1313,7 @@ pub unsafe fn dc_free_ongoing(context: &dc_context_t) {
 
 unsafe fn free_folders(mut folders: *mut clist) {
     if !folders.is_null() {
-        let mut iter1: *mut clistiter = 0 as *mut clistiter;
+        let mut iter1: *mut clistiter;
         iter1 = (*folders).first;
         while !iter1.is_null() {
             let mut ret_folder: *mut dc_imapfolder_t = (if !iter1.is_null() {
@@ -1339,14 +1339,9 @@ unsafe fn moz_autoconfigure(
     mut url: *const libc::c_char,
     mut param_in: *const dc_loginparam_t,
 ) -> *mut dc_loginparam_t {
-    let mut p: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut saxparser: dc_saxparser_t = dc_saxparser_t {
-        starttag_cb: None,
-        endtag_cb: None,
-        text_cb: None,
-        userdata: 0 as *mut libc::c_void,
-    };
-    let mut xml_raw: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut p: *mut libc::c_char;
+    let mut saxparser: dc_saxparser_t;
+    let mut xml_raw: *mut libc::c_char;
     let mut moz_ac: moz_autoconfigure_t = moz_autoconfigure_t {
         in_0: 0 as *const dc_loginparam_t,
         in_emaildomain: 0 as *mut libc::c_char,
@@ -1564,7 +1559,7 @@ unsafe fn read_autoconf_file(
     mut context: &dc_context_t,
     mut url: *const libc::c_char,
 ) -> *mut libc::c_char {
-    let mut filecontent: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut filecontent: *mut libc::c_char;
     dc_log_info(
         context,
         0i32,
@@ -1606,7 +1601,6 @@ unsafe fn outlk_autodiscover(
         redirect: 0 as *mut libc::c_char,
     };
     let mut i: libc::c_int = 0;
-    i = 0i32;
     loop {
         if !(i < 10i32) {
             current_block = 11584701595673473500;
@@ -1683,7 +1677,6 @@ unsafe fn outlk_autodiscover(
 }
 unsafe fn outlk_clean_config(mut outlk_ad: *mut outlk_autodiscover_t) {
     let mut i: libc::c_int = 0;
-    i = 0i32;
     while i < 6i32 {
         free((*outlk_ad).config[i as usize] as *mut libc::c_void);
         (*outlk_ad).config[i as usize] = 0 as *mut libc::c_char;

--- a/src/dc_context.rs
+++ b/src/dc_context.rs
@@ -205,7 +205,7 @@ unsafe fn cb_precheck_imf(
     server_uid: uint32_t,
 ) -> libc::c_int {
     let mut rfc724_mid_exists: libc::c_int = 0i32;
-    let mut msg_id: uint32_t = 0i32 as uint32_t;
+    let mut msg_id: uint32_t;
     let mut old_server_folder: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut old_server_uid: uint32_t = 0i32 as uint32_t;
     let mut mark_seen: libc::c_int = 0i32;
@@ -253,6 +253,7 @@ unsafe fn cb_precheck_imf(
     free(old_server_folder as *mut libc::c_void);
     return rfc724_mid_exists;
 }
+
 unsafe fn cb_set_config(
     context: &dc_context_t,
     key: *const libc::c_char,
@@ -260,6 +261,7 @@ unsafe fn cb_set_config(
 ) {
     dc_sqlite3_set_config(context, &context.sql.clone().read().unwrap(), key, value);
 }
+
 /* *
  * The following three callback are given to dc_imap_new() to read/write configuration
  * and to handle received messages. As the imap-functions are typically used in
@@ -615,30 +617,30 @@ unsafe fn get_config_keys_str() -> *mut libc::c_char {
 
 pub unsafe fn dc_get_info(context: &dc_context_t) -> *mut libc::c_char {
     let mut unset = b"0\x00" as *const u8 as *const libc::c_char;
-    let mut displayname = 0 as *mut libc::c_char;
-    let mut temp = 0 as *mut libc::c_char;
-    let mut l_readable_str = 0 as *mut libc::c_char;
-    let mut l2_readable_str = 0 as *mut libc::c_char;
-    let mut fingerprint_str = 0 as *mut libc::c_char;
-    let mut l = 0 as *mut dc_loginparam_t;
-    let mut l2 = 0 as *mut dc_loginparam_t;
-    let mut inbox_watch = 0;
-    let mut sentbox_watch = 0;
-    let mut mvbox_watch = 0;
-    let mut mvbox_move = 0;
-    let mut folders_configured = 0;
-    let mut configured_sentbox_folder = 0 as *mut libc::c_char;
-    let mut configured_mvbox_folder = 0 as *mut libc::c_char;
-    let mut contacts = 0;
-    let mut chats = 0;
-    let mut real_msgs = 0;
-    let mut deaddrop_msgs = 0;
-    let mut is_configured = 0;
-    let mut dbversion = 0;
-    let mut mdns_enabled = 0;
-    let mut e2ee_enabled = 0;
-    let mut prv_key_cnt = 0;
-    let mut pub_key_cnt = 0;
+    let mut displayname;
+    let mut temp;
+    let mut l_readable_str;
+    let mut l2_readable_str;
+    let mut fingerprint_str;
+    let mut l;
+    let mut l2;
+    let mut inbox_watch;
+    let mut sentbox_watch;
+    let mut mvbox_watch;
+    let mut mvbox_move;
+    let mut folders_configured;
+    let mut configured_sentbox_folder;
+    let mut configured_mvbox_folder;
+    let mut contacts;
+    let mut chats;
+    let mut real_msgs;
+    let mut deaddrop_msgs;
+    let mut is_configured;
+    let mut dbversion;
+    let mut mdns_enabled;
+    let mut e2ee_enabled;
+    let mut prv_key_cnt;
+    let mut pub_key_cnt;
     let mut self_public = dc_key_new();
     let mut rpgp_enabled = 1;
 

--- a/src/dc_e2ee.rs
+++ b/src/dc_e2ee.rs
@@ -42,13 +42,13 @@ pub unsafe fn dc_e2ee_encrypt(
     mut in_out_message: *mut mailmime,
     mut helper: *mut dc_e2ee_helper_t,
 ) {
-    let mut p_0: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut p_0: *mut libc::c_char;
     let mut current_block: u64;
     let mut col: libc::c_int = 0i32;
     let mut do_encrypt: libc::c_int = 0i32;
     let mut autocryptheader: *mut dc_aheader_t = dc_aheader_new();
     /*just a pointer into mailmime structure, must not be freed*/
-    let mut imffields_unprotected: *mut mailimf_fields = 0 as *mut mailimf_fields;
+    let mut imffields_unprotected: *mut mailimf_fields;
     let mut keyring: *mut dc_keyring_t = dc_keyring_new();
     let mut sign_key: *mut dc_key_t = dc_key_new();
     let mut plain: *mut MMAPString = mmap_string_new(b"\x00" as *const u8 as *const libc::c_char);
@@ -99,7 +99,7 @@ pub unsafe fn dc_e2ee_encrypt(
                 /*only for random-seed*/
                 if (*autocryptheader).prefer_encrypt == 1i32 || 0 != e2ee_guaranteed {
                     do_encrypt = 1i32;
-                    let mut iter1: *mut clistiter = 0 as *mut clistiter;
+                    let mut iter1: *mut clistiter;
                     iter1 = (*recipients_addr).first;
                     while !iter1.is_null() {
                         let mut recipient_addr: *const libc::c_char = (if !iter1.is_null() {
@@ -394,7 +394,8 @@ pub unsafe fn dc_e2ee_encrypt(
     }
     dc_array_unref(peerstates);
 }
-/* ******************************************************************************
+
+/*******************************************************************************
  * Tools
  ******************************************************************************/
 unsafe fn new_data_part(
@@ -405,15 +406,15 @@ unsafe fn new_data_part(
 ) -> *mut mailmime {
     let mut current_block: u64;
     //char basename_buf[PATH_MAX];
-    let mut encoding: *mut mailmime_mechanism = 0 as *mut mailmime_mechanism;
-    let mut content: *mut mailmime_content = 0 as *mut mailmime_content;
-    let mut mime: *mut mailmime = 0 as *mut mailmime;
+    let mut encoding: *mut mailmime_mechanism;
+    let mut content: *mut mailmime_content;
+    let mut mime: *mut mailmime;
     //int r;
     //char * dup_filename;
-    let mut mime_fields: *mut mailmime_fields = 0 as *mut mailmime_fields;
-    let mut encoding_type: libc::c_int = 0;
-    let mut content_type_str: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut do_encoding: libc::c_int = 0;
+    let mut mime_fields: *mut mailmime_fields;
+    let mut encoding_type: libc::c_int;
+    let mut content_type_str: *mut libc::c_char;
+    let mut do_encoding: libc::c_int;
     encoding = 0 as *mut mailmime_mechanism;
     if default_content_type.is_null() {
         content_type_str =
@@ -427,7 +428,7 @@ unsafe fn new_data_part(
     } else {
         do_encoding = 1i32;
         if (*(*content).ct_type).tp_type == MAILMIME_TYPE_COMPOSITE_TYPE as libc::c_int {
-            let mut composite: *mut mailmime_composite_type = 0 as *mut mailmime_composite_type;
+            let mut composite: *mut mailmime_composite_type;
             composite = (*(*content).ct_type).tp_data.tp_composite_type;
             match (*composite).ct_type {
                 1 => {
@@ -502,9 +503,11 @@ unsafe fn new_data_part(
     }
     return 0 as *mut mailmime;
 }
-/* ******************************************************************************
+
+/*******************************************************************************
  * Generate Keypairs
  ******************************************************************************/
+// TODO should return bool /rtn
 unsafe fn load_or_generate_self_public_key(
     mut context: &dc_context_t,
     mut public_key: *mut dc_key_t,
@@ -514,7 +517,7 @@ unsafe fn load_or_generate_self_public_key(
     let mut current_block: u64;
     /* avoid double creation (we unlock the database during creation) */
     static mut s_in_key_creation: libc::c_int = 0i32;
-    let mut key_created: libc::c_int = 0i32;
+    let mut key_created: libc::c_int;
     let mut success: libc::c_int = 0i32;
     let mut key_creation_here: libc::c_int = 0i32;
     if !public_key.is_null() {
@@ -531,7 +534,7 @@ unsafe fn load_or_generate_self_public_key(
                 key_creation_here = 1i32;
                 s_in_key_creation = 1i32;
                 if !random_data_mime.is_null() {
-                    let mut random_data_mmap: *mut MMAPString = 0 as *mut MMAPString;
+                    let mut random_data_mmap: *mut MMAPString;
                     let mut col: libc::c_int = 0i32;
                     random_data_mmap = mmap_string_new(b"\x00" as *const u8 as *const libc::c_char);
                     if random_data_mmap.is_null() {
@@ -619,15 +622,17 @@ unsafe fn load_or_generate_self_public_key(
     if 0 != key_creation_here {
         s_in_key_creation = 0i32
     }
-    return success;
+
+    success
 }
+
 /* returns 1 if sth. was decrypted, 0 in other cases */
 pub unsafe fn dc_e2ee_decrypt(
     mut context: &dc_context_t,
     mut in_out_message: *mut mailmime,
     mut helper: *mut dc_e2ee_helper_t,
 ) {
-    let mut iterations: libc::c_int = 0;
+    let mut iterations: libc::c_int;
     /* return values: 0=nothing to decrypt/cannot decrypt, 1=sth. decrypted
     (to detect parts that could not be decrypted, simply look for left "multipart/encrypted" MIME types */
     /*just a pointer into mailmime structure, must not be freed*/
@@ -761,13 +766,14 @@ pub unsafe fn dc_e2ee_decrypt(
     free(from as *mut libc::c_void);
     free(self_addr as *mut libc::c_void);
 }
+
 unsafe fn update_gossip_peerstates(
     mut context: &dc_context_t,
     mut message_time: time_t,
     mut imffields: *mut mailimf_fields,
     mut gossip_headers: *const mailimf_fields,
 ) -> *mut dc_hash_t {
-    let mut cur1: *mut clistiter = 0 as *mut clistiter;
+    let mut cur1: *mut clistiter;
     let mut recipients: *mut dc_hash_t = 0 as *mut dc_hash_t;
     let mut gossipped_addr: *mut dc_hash_t = 0 as *mut dc_hash_t;
     cur1 = (*(*gossip_headers).fld_list).first;
@@ -859,8 +865,11 @@ unsafe fn update_gossip_peerstates(
         dc_hash_clear(recipients);
         free(recipients as *mut libc::c_void);
     }
-    return gossipped_addr;
+
+    gossipped_addr
 }
+
+// TODO should return bool /rtn
 unsafe fn decrypt_recursive(
     mut context: &dc_context_t,
     mut mime: *mut mailmime,
@@ -870,8 +879,8 @@ unsafe fn decrypt_recursive(
     mut ret_gossip_headers: *mut *mut mailimf_fields,
     mut ret_has_unencrypted_parts: *mut libc::c_int,
 ) -> libc::c_int {
-    let mut ct: *mut mailmime_content = 0 as *mut mailmime_content;
-    let mut cur: *mut clistiter = 0 as *mut clistiter;
+    let mut ct: *mut mailmime_content;
+    let mut cur: *mut clistiter;
     if mime.is_null() {
         return 0i32;
     }
@@ -964,8 +973,10 @@ unsafe fn decrypt_recursive(
     } else {
         *ret_has_unencrypted_parts = 1i32
     }
-    return 0i32;
+
+    0
 }
+
 unsafe fn decrypt_part(
     mut context: &dc_context_t,
     mut mime: *mut mailmime,
@@ -974,9 +985,9 @@ unsafe fn decrypt_part(
     mut ret_valid_signatures: *mut dc_hash_t,
     mut ret_decrypted_mime: *mut *mut mailmime,
 ) -> libc::c_int {
-    let mut add_signatures: *mut dc_hash_t = 0 as *mut dc_hash_t;
+    let mut add_signatures: *mut dc_hash_t;
     let mut current_block: u64;
-    let mut mime_data: *mut mailmime_data = 0 as *mut mailmime_data;
+    let mut mime_data: *mut mailmime_data;
     let mut mime_transfer_encoding: libc::c_int = MAILMIME_MECHANISM_BINARY as libc::c_int;
     /* mmap_string_unref()'d if set */
     let mut transfer_decoding_buffer: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -994,7 +1005,7 @@ unsafe fn decrypt_part(
         || (*mime_data).dt_data.dt_text.dt_length <= 0)
     {
         if !(*mime).mm_mime_fields.is_null() {
-            let mut cur: *mut clistiter = 0 as *mut clistiter;
+            let mut cur: *mut clistiter;
             cur = (*(*(*mime).mm_mime_fields).fld_list).first;
             while !cur.is_null() {
                 let mut field: *mut mailmime_field = (if !cur.is_null() {
@@ -1030,7 +1041,7 @@ unsafe fn decrypt_part(
                 current_block = 4488286894823169796;
             }
         } else {
-            let mut r: libc::c_int = 0;
+            let mut r: libc::c_int;
             let mut current_index: size_t = 0i32 as size_t;
             r = mailmime_part_parse(
                 (*mime_data).dt_data.dt_text.dt_data,
@@ -1105,11 +1116,14 @@ unsafe fn decrypt_part(
     if !transfer_decoding_buffer.is_null() {
         mmap_string_unref(transfer_decoding_buffer);
     }
-    return sth_decrypted;
+
+    sth_decrypted
 }
-/* ******************************************************************************
+
+/*******************************************************************************
  * Decrypt
  ******************************************************************************/
+// TODO should return bool /rtn
 unsafe fn has_decrypted_pgp_armor(
     mut str__: *const libc::c_char,
     mut str_bytes: libc::c_int,
@@ -1133,9 +1147,11 @@ unsafe fn has_decrypted_pgp_armor(
     {
         return 1;
     }
-    return 0;
+
+    0
 }
-/* *
+
+/**
  * Check if a MIME structure contains a multipart/report part.
  *
  * As reports are often unencrypted, we do not reset the Autocrypt header in
@@ -1149,6 +1165,7 @@ unsafe fn has_decrypted_pgp_armor(
  * @param mime The mime struture to check
  * @return 1=multipart/report found in MIME, 0=no multipart/report found
  */
+// TODO should return bool /rtn
 unsafe fn contains_report(mut mime: *mut mailmime) -> libc::c_int {
     if (*mime).mm_type == MAILMIME_MULTIPLE as libc::c_int {
         if (*(*(*mime).mm_content_type).ct_type).tp_type
@@ -1165,7 +1182,7 @@ unsafe fn contains_report(mut mime: *mut mailmime) -> libc::c_int {
         {
             return 1i32;
         }
-        let mut cur: *mut clistiter = 0 as *mut clistiter;
+        let mut cur: *mut clistiter;
         cur = (*(*mime).mm_data.mm_multipart.mm_mp_list).first;
         while !cur.is_null() {
             if 0 != contains_report(
@@ -1188,8 +1205,10 @@ unsafe fn contains_report(mut mime: *mut mailmime) -> libc::c_int {
             return 1i32;
         }
     }
-    return 0i32;
+
+    0
 }
+
 /* frees data referenced by "mailmime" but not freed by mailmime_free(). After calling this function, in_out_message cannot be used any longer! */
 pub unsafe fn dc_e2ee_thanks(mut helper: *mut dc_e2ee_helper_t) {
     if helper.is_null() {
@@ -1208,7 +1227,9 @@ pub unsafe fn dc_e2ee_thanks(mut helper: *mut dc_e2ee_helper_t) {
         (*helper).signatures = 0 as *mut dc_hash_t
     };
 }
+
 /* makes sure, the private key exists, needed only for exporting keys and the case no message was sent before */
+// TODO should return bool /rtn
 pub unsafe fn dc_ensure_secret_key_exists(mut context: &dc_context_t) -> libc::c_int {
     /* normally, the key is generated as soon as the first mail is send
     (this is to gain some extra-random-seed by the message content and the timespan between program start and message sending) */
@@ -1238,5 +1259,6 @@ pub unsafe fn dc_ensure_secret_key_exists(mut context: &dc_context_t) -> libc::c
     }
     dc_key_unref(public_key);
     free(self_addr as *mut libc::c_void);
-    return success;
+
+    success
 }

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -39,14 +39,15 @@ pub unsafe fn dc_imex(
     dc_job_add(context, 910i32, 0i32, (*param).packed, 0i32);
     dc_param_unref(param);
 }
+
 pub unsafe fn dc_imex_has_backup(
     mut context: &dc_context_t,
     mut dir_name: *const libc::c_char,
 ) -> *mut libc::c_char {
     let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut ret_backup_time: time_t = 0i32 as time_t;
-    let mut dir_handle: *mut DIR = 0 as *mut DIR;
-    let mut dir_entry: *mut dirent = 0 as *mut dirent;
+    let mut dir_handle: *mut DIR;
+    let mut dir_entry: *mut dirent;
     let mut prefix_len = strlen(b"delta-chat\x00" as *const u8 as *const libc::c_char);
     let mut suffix_len = strlen(b"bak\x00" as *const u8 as *const libc::c_char);
     let mut curr_pathNfilename: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -148,17 +149,19 @@ pub unsafe fn dc_check_password(
     }
 
     dc_loginparam_unref(loginparam);
-    return success;
+
+    success
 }
+
 pub unsafe fn dc_initiate_key_transfer(mut context: &dc_context_t) -> *mut libc::c_char {
     let mut current_block: u64;
     let mut success: libc::c_int = 0i32;
-    let mut setup_code: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut setup_code: *mut libc::c_char;
     let mut setup_file_content: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut setup_file_name: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut chat_id: uint32_t = 0i32 as uint32_t;
+    let mut chat_id: uint32_t;
     let mut msg: *mut dc_msg_t = 0 as *mut dc_msg_t;
-    let mut msg_id: uint32_t = 0i32 as uint32_t;
+    let mut msg_id: uint32_t;
     if 0 == dc_alloc_ongoing(context) {
         return 0 as *mut libc::c_char;
     }
@@ -273,8 +276,10 @@ pub unsafe fn dc_initiate_key_transfer(mut context: &dc_context_t) -> *mut libc:
     free(setup_file_content as *mut libc::c_void);
     dc_msg_unref(msg);
     dc_free_ongoing(context);
-    return setup_code;
+
+    setup_code
 }
+
 pub unsafe extern "C" fn dc_render_setup_file(
     mut context: &dc_context_t,
     mut passphrase: *const libc::c_char,
@@ -364,11 +369,13 @@ pub unsafe extern "C" fn dc_render_setup_file(
     dc_key_unref(curr_private_key);
     free(encr_string as *mut libc::c_void);
     free(self_addr as *mut libc::c_void);
-    return ret_setupfilecontent;
+
+    ret_setupfilecontent
 }
+
 pub unsafe fn dc_create_setup_code(_context: &dc_context_t) -> *mut libc::c_char {
-    let mut random_val: uint16_t = 0i32 as uint16_t;
-    let mut i: libc::c_int = 0i32;
+    let mut random_val: uint16_t;
+    let mut i: libc::c_int;
     let mut ret: dc_strbuilder_t = dc_strbuilder_t {
         buf: 0 as *mut libc::c_char,
         allocated: 0,
@@ -398,8 +405,11 @@ pub unsafe fn dc_create_setup_code(_context: &dc_context_t) -> *mut libc::c_char
         );
         i += 1
     }
-    return ret.buf;
+
+    ret.buf
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_continue_key_transfer(
     mut context: &dc_context_t,
     mut msg_id: uint32_t,
@@ -473,15 +483,18 @@ pub unsafe fn dc_continue_key_transfer(
     free(filename as *mut libc::c_void);
     dc_msg_unref(msg);
     free(norm_sc as *mut libc::c_void);
-    return success;
+
+    success
 }
+
+// TODO should return bool /rtn
 unsafe fn set_self_key(
     mut context: &dc_context_t,
     mut armored: *const libc::c_char,
     mut set_default: libc::c_int,
 ) -> libc::c_int {
     let mut success: libc::c_int = 0i32;
-    let mut buf: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut buf: *mut libc::c_char;
     // pointer inside buf, MUST NOT be free()'d
     let mut buf_headerline: *const libc::c_char = 0 as *const libc::c_char;
     //   - " -
@@ -597,14 +610,16 @@ unsafe fn set_self_key(
     free(self_addr as *mut libc::c_void);
     dc_key_unref(private_key);
     dc_key_unref(public_key);
-    return success;
+
+    success
 }
+
 pub unsafe fn dc_decrypt_setup_file(
     mut context: &dc_context_t,
     mut passphrase: *const libc::c_char,
     mut filecontent: *const libc::c_char,
 ) -> *mut libc::c_char {
-    let mut fc_buf: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut fc_buf: *mut libc::c_char;
     let mut fc_headerline: *const libc::c_char = 0 as *const libc::c_char;
     let mut fc_base64: *const libc::c_char = 0 as *const libc::c_char;
     let mut binary: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -661,8 +676,10 @@ pub unsafe fn dc_decrypt_setup_file(
     if !binary.is_null() {
         mmap_string_unref(binary);
     }
-    return payload;
+
+    payload
 }
+
 pub unsafe fn dc_normalize_setup_code(
     _context: &dc_context_t,
     in_0: *const libc::c_char,
@@ -677,7 +694,7 @@ pub unsafe fn dc_normalize_setup_code(
         eos: 0 as *mut libc::c_char,
     };
     dc_strbuilder_init(&mut out, 0i32);
-    let mut outlen: libc::c_int = 0i32;
+    let mut outlen: libc::c_int;
     let mut p1: *const libc::c_char = in_0;
     while 0 != *p1 {
         if *p1 as libc::c_int >= '0' as i32 && *p1 as libc::c_int <= '9' as i32 {
@@ -701,13 +718,15 @@ pub unsafe fn dc_normalize_setup_code(
         }
         p1 = p1.offset(1isize)
     }
-    return out.buf;
+
+    out.buf
 }
+
 pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(mut context: &dc_context_t, mut job: *mut dc_job_t) {
     let mut current_block: u64;
     let mut success: libc::c_int = 0i32;
     let mut ongoing_allocated_here: libc::c_int = 0i32;
-    let mut what: libc::c_int = 0i32;
+    let mut what: libc::c_int;
     let mut param1: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut param2: *mut libc::c_char = 0 as *mut libc::c_char;
     if !(0 == dc_alloc_ongoing(context)) {
@@ -957,9 +976,12 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(mut context: &dc_context_t, mut job: *m
         0i32 as uintptr_t,
     );
 }
-/* ******************************************************************************
+
+/*******************************************************************************
  * Import backup
  ******************************************************************************/
+
+// TODO should return bool /rtn
 unsafe fn import_backup(
     mut context: &dc_context_t,
     mut backup_to_import: *const libc::c_char,
@@ -967,7 +989,7 @@ unsafe fn import_backup(
     let mut current_block: u64;
     let mut success: libc::c_int = 0i32;
     let mut processed_files_cnt: libc::c_int = 0i32;
-    let mut total_files_cnt: libc::c_int = 0i32;
+    let mut total_files_cnt: libc::c_int;
     let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
     let mut pathNfilename: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut repl_from: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -1016,7 +1038,6 @@ unsafe fn import_backup(
                 sqlite3_step(stmt);
                 total_files_cnt = sqlite3_column_int(stmt, 0i32);
                 sqlite3_finalize(stmt);
-                stmt = 0 as *mut sqlite3_stmt;
                 stmt = dc_sqlite3_prepare(
                     context,
                     &context.sql.clone().read().unwrap(),
@@ -1112,34 +1133,37 @@ unsafe fn import_backup(
     free(repl_from as *mut libc::c_void);
     free(repl_to as *mut libc::c_void);
     sqlite3_finalize(stmt);
-    return success;
+
+    success
 }
-/* ******************************************************************************
+
+/*******************************************************************************
  * Export backup
  ******************************************************************************/
 /* the FILE_PROGRESS macro calls the callback with the permille of files processed.
 The macro avoids weird values of 0% or 100% while still working. */
+// TODO should return bool /rtn
 unsafe fn export_backup(mut context: &dc_context_t, mut dir: *const libc::c_char) -> libc::c_int {
     let mut current_block: u64;
     let mut success: libc::c_int = 0i32;
     let mut closed: libc::c_int = 0i32;
-    let mut dest_pathNfilename: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut dest_pathNfilename: *mut libc::c_char;
     let mut now = time(0 as *mut time_t);
     let mut dir_handle: *mut DIR = 0 as *mut DIR;
-    let mut dir_entry: *mut dirent = 0 as *mut dirent;
+    let mut dir_entry: *mut dirent;
     let mut prefix_len = strlen(b"delta-chat\x00" as *const u8 as *const libc::c_char);
     let mut suffix_len = strlen(b"bak\x00" as *const u8 as *const libc::c_char);
     let mut curr_pathNfilename: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut buf: *mut libc::c_void = 0 as *mut libc::c_void;
     let mut buf_bytes: size_t = 0i32 as size_t;
     let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
-    let mut total_files_cnt: libc::c_int = 0i32;
+    let mut total_files_cnt: libc::c_int;
     let mut processed_files_cnt: libc::c_int = 0i32;
     let mut delete_dest_file: libc::c_int = 0i32;
     let mut dest_sql: Option<dc_sqlite3_t> = None;
     /* get a fine backup file name (the name includes the date so that multiple backup instances are possible)
     FIXME: we should write to a temporary file first and rename it on success. this would guarantee the backup is complete. however, currently it is not clear it the import exists in the long run (may be replaced by a restore-from-imap)*/
-    let mut timeinfo: *mut tm = 0 as *mut tm;
+    let mut timeinfo: *mut tm;
     let mut buffer: [libc::c_char; 256] = [0; 256];
     timeinfo = localtime(&mut now);
     strftime(
@@ -1410,9 +1434,11 @@ unsafe fn export_backup(mut context: &dc_context_t, mut dir: *const libc::c_char
     free(dest_pathNfilename as *mut libc::c_void);
     free(curr_pathNfilename as *mut libc::c_void);
     free(buf);
-    return success;
+
+    success
 }
-/* ******************************************************************************
+
+/*******************************************************************************
  * Classic key import
  ******************************************************************************/
 unsafe fn import_self_keys(
@@ -1427,14 +1453,14 @@ unsafe fn import_self_keys(
     (currently, the last imported key is the standard key unless it contains the string "legacy" in its name) */
     let mut imported_cnt: libc::c_int = 0i32;
     let mut dir_handle = 0 as *mut DIR;
-    let mut dir_entry: *mut dirent = 0 as *mut dirent;
+    let mut dir_entry: *mut dirent;
     let mut suffix: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut path_plus_name: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut set_default: libc::c_int = 0i32;
+    let mut set_default: libc::c_int;
     let mut buf: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut buf_bytes: size_t = 0i32 as size_t;
     // a pointer inside buf, MUST NOT be free()'d
-    let mut private_key: *const libc::c_char = 0 as *const libc::c_char;
+    let mut private_key: *const libc::c_char;
     let mut buf2: *mut libc::c_char = 0 as *mut libc::c_char;
     // a pointer inside buf2, MUST NOT be free()'d
     let mut buf2_headerline: *const libc::c_char = 0 as *const libc::c_char;
@@ -1544,16 +1570,19 @@ unsafe fn import_self_keys(
     free(path_plus_name as *mut libc::c_void);
     free(buf as *mut libc::c_void);
     free(buf2 as *mut libc::c_void);
-    return imported_cnt;
+
+    imported_cnt
 }
+
+// TODO should return bool /rtn
 unsafe fn export_self_keys(
     mut context: &dc_context_t,
     mut dir: *const libc::c_char,
 ) -> libc::c_int {
     let mut success: libc::c_int = 0i32;
     let mut export_errors: libc::c_int = 0i32;
-    let mut id: libc::c_int = 0i32;
-    let mut is_default: libc::c_int = 0i32;
+    let mut id: libc::c_int;
+    let mut is_default: libc::c_int;
     let mut public_key: *mut dc_key_t = dc_key_new();
     let mut private_key: *mut dc_key_t = dc_key_new();
     let stmt = dc_sqlite3_prepare(
@@ -1582,11 +1611,14 @@ unsafe fn export_self_keys(
     sqlite3_finalize(stmt);
     dc_key_unref(public_key);
     dc_key_unref(private_key);
-    return success;
+
+    success
 }
-/* ******************************************************************************
+
+/*******************************************************************************
  * Classic key export
  ******************************************************************************/
+// TODO should return bool /rtn
 unsafe fn export_key_to_asc_file(
     mut context: &dc_context_t,
     mut dir: *const libc::c_char,
@@ -1595,7 +1627,7 @@ unsafe fn export_key_to_asc_file(
     mut is_default: libc::c_int,
 ) -> libc::c_int {
     let mut success: libc::c_int = 0i32;
-    let mut file_name = 0 as *mut libc::c_char;
+    let mut file_name;
     if 0 != is_default {
         file_name = dc_mprintf(
             b"%s/%s-key-default.asc\x00" as *const u8 as *const libc::c_char,
@@ -1642,5 +1674,6 @@ unsafe fn export_key_to_asc_file(
         success = 1i32
     }
     free(file_name as *mut libc::c_void);
-    return success;
+
+    success
 }

--- a/src/dc_job.rs
+++ b/src/dc_job.rs
@@ -69,7 +69,7 @@ unsafe fn dc_job_perform(
     mut probe_network: libc::c_int,
 ) {
     println!("perform job");
-    let mut select_stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut select_stmt: *mut sqlite3_stmt;
     let mut job: dc_job_t = dc_job_t {
         job_id: 0,
         action: 0,
@@ -556,7 +556,7 @@ unsafe fn dc_job_do_DC_JOB_MOVE_MSG(mut context: &dc_context_t, mut job: *mut dc
  * IMAP-jobs
  ******************************************************************************/
 unsafe fn connect_to_inbox(context: &dc_context_t, inbox: &dc_imap_t) -> libc::c_int {
-    let mut ret_connected: libc::c_int = 0i32;
+    let mut ret_connected: libc::c_int;
 
     ret_connected = dc_connect_to_configured_imap(context, inbox);
     if !(0 == ret_connected) {
@@ -813,7 +813,7 @@ unsafe fn dc_add_smtp_job(
     mut action: libc::c_int,
     mut mimefactory: *mut dc_mimefactory_t,
 ) -> libc::c_int {
-    let mut pathNfilename: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut pathNfilename: *mut libc::c_char;
     let mut success: libc::c_int = 0i32;
     let mut recipients: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut param: *mut dc_param_t = dc_param_new();
@@ -880,8 +880,8 @@ pub unsafe fn dc_job_add(
     mut delay_seconds: libc::c_int,
 ) {
     let mut timestamp: time_t = time(0 as *mut time_t);
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
-    let mut thread: libc::c_int = 0i32;
+    let mut stmt: *mut sqlite3_stmt;
+    let mut thread: libc::c_int;
     if action >= 100i32 && action < 100i32 + 1000i32 {
         thread = 100i32
     } else if action >= 5000i32 && action < 5000i32 + 1000i32 {
@@ -1285,8 +1285,8 @@ pub unsafe fn dc_job_action_exists(
     mut context: &dc_context_t,
     mut action: libc::c_int,
 ) -> libc::c_int {
-    let mut job_exists: libc::c_int = 0i32;
-    let mut stmt = 0 as *mut sqlite3_stmt;
+    let mut job_exists: libc::c_int;
+    let mut stmt;
     stmt = dc_sqlite3_prepare(
         context,
         &context.sql.clone().read().unwrap(),

--- a/src/dc_jobthread.rs
+++ b/src/dc_jobthread.rs
@@ -119,7 +119,7 @@ pub unsafe fn dc_jobthread_fetch(
     jobthread: &mut dc_jobthread_t,
     use_network: libc::c_int,
 ) {
-    let mut start = 0;
+    let mut start;
 
     {
         let &(ref lock, _) = &*jobthread.state.clone();
@@ -171,7 +171,7 @@ pub unsafe fn dc_jobthread_fetch(
  ******************************************************************************/
 
 unsafe fn connect_to_imap(context: &dc_context_t, jobthread: &mut dc_jobthread_t) -> libc::c_int {
-    let mut ret_connected: libc::c_int = 0i32;
+    let mut ret_connected: libc::c_int;
     let mut mvbox_name: *mut libc::c_char = 0 as *mut libc::c_char;
 
     if jobthread.imap.lock().unwrap().is_connected() {

--- a/src/dc_jsmn.rs
+++ b/src/dc_jsmn.rs
@@ -68,6 +68,7 @@ pub struct jsmn_parser {
     pub toknext: libc::c_uint,
     pub toksuper: libc::c_int,
 }
+
 /* *
  * Create JSON parser over an array of tokens
  */
@@ -76,6 +77,7 @@ pub unsafe fn jsmn_init(mut parser: *mut jsmn_parser) {
     (*parser).toknext = 0i32 as libc::c_uint;
     (*parser).toksuper = -1i32;
 }
+
 /* *
  * Run JSON parser. It parses a JSON data string into and array of tokens, each describing
  * a single JSON object.
@@ -87,15 +89,15 @@ pub unsafe fn jsmn_parse(
     mut tokens: *mut jsmntok_t,
     mut num_tokens: libc::c_uint,
 ) -> libc::c_int {
-    let mut r: libc::c_int = 0;
-    let mut i: libc::c_int = 0;
-    let mut token: *mut jsmntok_t = 0 as *mut jsmntok_t;
+    let mut r: libc::c_int;
+    let mut i: libc::c_int;
+    let mut token: *mut jsmntok_t;
     let mut count: libc::c_int = (*parser).toknext as libc::c_int;
     while (*parser).pos < len as libc::c_uint
         && *js.offset((*parser).pos as isize) as libc::c_int != '\u{0}' as i32
     {
-        let mut c: libc::c_char = 0;
-        let mut type_0: jsmntype_t = JSMN_UNDEFINED;
+        let mut c: libc::c_char;
+        let mut type_0: jsmntype_t;
         c = *js.offset((*parser).pos as isize);
         match c as libc::c_int {
             123 | 91 => {
@@ -222,8 +224,10 @@ pub unsafe fn jsmn_parse(
             i -= 1
         }
     }
-    return count;
+
+    count
 }
+
 /* *
  * Fills next available token with JSON primitive.
  */
@@ -234,8 +238,8 @@ unsafe fn jsmn_parse_primitive(
     mut tokens: *mut jsmntok_t,
     mut num_tokens: size_t,
 ) -> libc::c_int {
-    let mut token: *mut jsmntok_t = 0 as *mut jsmntok_t;
-    let mut start: libc::c_int = 0;
+    let mut token: *mut jsmntok_t;
+    let mut start: libc::c_int;
     start = (*parser).pos as libc::c_int;
     while (*parser).pos < len as libc::c_uint
         && *js.offset((*parser).pos as isize) as libc::c_int != '\u{0}' as i32
@@ -265,8 +269,10 @@ unsafe fn jsmn_parse_primitive(
     }
     jsmn_fill_token(token, JSMN_PRIMITIVE, start, (*parser).pos as libc::c_int);
     (*parser).pos = (*parser).pos.wrapping_sub(1);
-    return 0i32;
+
+    0
 }
+
 /* *
  * Fills token type and boundaries.
  */
@@ -281,6 +287,7 @@ unsafe fn jsmn_fill_token(
     (*token).end = end;
     (*token).size = 0i32;
 }
+
 /*
 Copyright (c) 2010 Serge A. Zaitsev
 
@@ -302,6 +309,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
+
 /* *
  * Allocates a fresh unused token from the token pool.
  */
@@ -310,7 +318,7 @@ unsafe fn jsmn_alloc_token(
     mut tokens: *mut jsmntok_t,
     mut num_tokens: size_t,
 ) -> *mut jsmntok_t {
-    let mut tok: *mut jsmntok_t = 0 as *mut jsmntok_t;
+    let mut tok: *mut jsmntok_t;
     if (*parser).toknext as size_t >= num_tokens {
         return 0 as *mut jsmntok_t;
     }
@@ -320,8 +328,10 @@ unsafe fn jsmn_alloc_token(
     (*tok).end = -1i32;
     (*tok).start = (*tok).end;
     (*tok).size = 0i32;
-    return tok;
+
+    tok
 }
+
 /* *
  * Fills next token with JSON string.
  */
@@ -332,7 +342,7 @@ unsafe fn jsmn_parse_string(
     mut tokens: *mut jsmntok_t,
     mut num_tokens: size_t,
 ) -> libc::c_int {
-    let mut token: *mut jsmntok_t = 0 as *mut jsmntok_t;
+    let mut token: *mut jsmntok_t;
     let mut start: libc::c_int = (*parser).pos as libc::c_int;
     (*parser).pos = (*parser).pos.wrapping_add(1);
     while ((*parser).pos as size_t) < len
@@ -357,7 +367,7 @@ unsafe fn jsmn_parse_string(
             return 0i32;
         }
         if c as libc::c_int == '\\' as i32 && ((*parser).pos.wrapping_add(1) as size_t) < len {
-            let mut i: libc::c_int = 0;
+            let mut i: libc::c_int;
             (*parser).pos = (*parser).pos.wrapping_add(1);
             match *js.offset((*parser).pos as isize) as libc::c_int {
                 34 | 47 | 92 | 98 | 102 | 114 | 110 | 116 => {}
@@ -392,5 +402,6 @@ unsafe fn jsmn_parse_string(
         (*parser).pos = (*parser).pos.wrapping_add(1)
     }
     (*parser).pos = start as libc::c_uint;
-    return JSMN_ERROR_PART as libc::c_int;
+
+    JSMN_ERROR_PART as libc::c_int
 }

--- a/src/dc_key.rs
+++ b/src/dc_key.rs
@@ -26,21 +26,25 @@ pub unsafe fn toupper(mut _c: libc::c_int) -> libc::c_int {
 }
 
 pub unsafe fn dc_key_new() -> *mut dc_key_t {
-    let mut key: *mut dc_key_t = 0 as *mut dc_key_t;
+    let mut key: *mut dc_key_t;
     key = calloc(1, ::std::mem::size_of::<dc_key_t>()) as *mut dc_key_t;
     if key.is_null() {
         exit(44i32);
     }
     (*key)._m_heap_refcnt = 1i32;
-    return key;
+
+    key
 }
+
 pub unsafe fn dc_key_ref(mut key: *mut dc_key_t) -> *mut dc_key_t {
     if key.is_null() {
         return 0 as *mut dc_key_t;
     }
     (*key)._m_heap_refcnt += 1;
-    return key;
+
+    key
 }
+
 pub unsafe fn dc_key_unref(mut key: *mut dc_key_t) {
     if key.is_null() {
         return;
@@ -52,6 +56,7 @@ pub unsafe fn dc_key_unref(mut key: *mut dc_key_t) {
     dc_key_empty(key);
     free(key as *mut libc::c_void);
 }
+
 unsafe fn dc_key_empty(mut key: *mut dc_key_t) {
     if key.is_null() {
         return;
@@ -64,12 +69,15 @@ unsafe fn dc_key_empty(mut key: *mut dc_key_t) {
     (*key).bytes = 0i32;
     (*key).type_0 = 0i32;
 }
+
 pub unsafe fn dc_wipe_secret_mem(mut buf: *mut libc::c_void, mut buf_bytes: size_t) {
     if buf.is_null() || buf_bytes <= 0 {
         return;
     }
     memset(buf, 0i32, buf_bytes);
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_key_set_from_binary(
     mut key: *mut dc_key_t,
     mut data: *const libc::c_void,
@@ -87,15 +95,20 @@ pub unsafe fn dc_key_set_from_binary(
     memcpy((*key).binary, data, bytes as size_t);
     (*key).bytes = bytes;
     (*key).type_0 = type_0;
-    return 1i32;
+
+    1
 }
+
 pub unsafe fn dc_key_set_from_key(mut key: *mut dc_key_t, mut o: *const dc_key_t) -> libc::c_int {
     dc_key_empty(key);
     if key.is_null() || o.is_null() {
         return 0i32;
     }
-    return dc_key_set_from_binary(key, (*o).binary, (*o).bytes, (*o).type_0);
+
+    dc_key_set_from_binary(key, (*o).binary, (*o).bytes, (*o).type_0)
 }
+
+// TODO should return bool /rtn
 pub unsafe extern "C" fn dc_key_set_from_stmt(
     mut key: *mut dc_key_t,
     mut stmt: *mut sqlite3_stmt,
@@ -106,13 +119,16 @@ pub unsafe extern "C" fn dc_key_set_from_stmt(
     if key.is_null() || stmt.is_null() {
         return 0i32;
     }
-    return dc_key_set_from_binary(
+
+    dc_key_set_from_binary(
         key,
         sqlite3_column_blob(stmt, index) as *mut libc::c_uchar as *const libc::c_void,
         sqlite3_column_bytes(stmt, index),
         type_0,
-    );
+    )
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_key_set_from_base64(
     mut key: *mut dc_key_t,
     mut base64: *const libc::c_char,
@@ -144,8 +160,11 @@ pub unsafe fn dc_key_set_from_base64(
         type_0,
     );
     mmap_string_unref(result);
-    return 1i32;
+
+    1
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_key_equals(mut key: *const dc_key_t, mut o: *const dc_key_t) -> libc::c_int {
     if key.is_null()
         || o.is_null()
@@ -169,6 +188,8 @@ pub unsafe fn dc_key_equals(mut key: *const dc_key_t, mut o: *const dc_key_t) ->
         0
     }
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_key_save_self_keypair(
     context: &dc_context_t,
     public_key: *const dc_key_t,
@@ -207,8 +228,11 @@ pub unsafe fn dc_key_save_self_keypair(
         }
     }
     sqlite3_finalize(stmt);
-    return success;
+
+    success
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_key_load_self_public(
     context: &dc_context_t,
     key: *mut dc_key_t,
@@ -232,8 +256,11 @@ pub unsafe fn dc_key_load_self_public(
         }
     }
     sqlite3_finalize(stmt);
-    return success;
+
+    success
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_key_load_self_private(
     context: &dc_context_t,
     key: *mut dc_key_t,
@@ -253,12 +280,14 @@ pub unsafe fn dc_key_load_self_private(
         sqlite3_bind_text(stmt, 1i32, self_addr, -1i32, None);
         if !(sqlite3_step(stmt) != 100i32) {
             dc_key_set_from_stmt(key, stmt, 0i32, 1i32);
-            success = 1i32
+            success = 1i32;
         }
     }
     sqlite3_finalize(stmt);
-    return success;
+
+    success
 }
+
 /* the result must be freed */
 pub unsafe fn dc_render_base64(
     mut buf: *const libc::c_void,
@@ -296,9 +325,11 @@ pub unsafe fn dc_render_base64(
             }
         }
     }
-    return ret;
+
+    ret
 }
-/* ******************************************************************************
+
+/*******************************************************************************
  * Render keys
  ******************************************************************************/
 unsafe fn crc_octets(mut octets: *const libc::c_uchar, mut len: size_t) -> libc::c_long {
@@ -321,8 +352,10 @@ unsafe fn crc_octets(mut octets: *const libc::c_uchar, mut len: size_t) -> libc:
             i += 1
         }
     }
-    return crc & 0xffffff;
+
+    crc & 0xffffff
 }
+
 /* the result must be freed */
 pub unsafe fn dc_key_render_base64(
     mut key: *const dc_key_t,
@@ -333,14 +366,16 @@ pub unsafe fn dc_key_render_base64(
     if key.is_null() {
         return 0 as *mut libc::c_char;
     }
-    return dc_render_base64(
+
+    dc_render_base64(
         (*key).binary,
         (*key).bytes as size_t,
         break_every,
         break_chars,
         add_checksum,
-    );
+    )
 }
+
 /* each header line must be terminated by \r\n, the result must be freed */
 pub unsafe fn dc_key_render_asc(
     mut key: *const dc_key_t,
@@ -384,8 +419,11 @@ pub unsafe fn dc_key_render_asc(
         }
     }
     free(base64 as *mut libc::c_void);
-    return ret;
+
+    ret
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_key_render_asc_to_file(
     mut key: *const dc_key_t,
     mut file: *const libc::c_char,
@@ -414,8 +452,10 @@ pub unsafe fn dc_key_render_asc_to_file(
         }
     }
     free(file_content as *mut libc::c_void);
-    return success;
+
+    success
 }
+
 pub unsafe fn dc_format_fingerprint(mut fingerprint: *const libc::c_char) -> *mut libc::c_char {
     let mut i: libc::c_int = 0i32;
     let mut fingerprint_len: libc::c_int = strlen(fingerprint) as libc::c_int;
@@ -441,8 +481,10 @@ pub unsafe fn dc_format_fingerprint(mut fingerprint: *const libc::c_char) -> *mu
             }
         }
     }
-    return ret.buf;
+
+    ret.buf
 }
+
 pub unsafe fn dc_normalize_fingerprint(mut in_0: *const libc::c_char) -> *mut libc::c_char {
     if in_0.is_null() {
         return 0 as *mut libc::c_char;
@@ -468,8 +510,10 @@ pub unsafe fn dc_normalize_fingerprint(mut in_0: *const libc::c_char) -> *mut li
         }
         p1 = p1.offset(1isize)
     }
-    return out.buf;
+
+    out.buf
 }
+
 pub unsafe fn dc_key_get_fingerprint(
     context: &dc_context_t,
     key: *const dc_key_t,
@@ -491,6 +535,7 @@ pub unsafe fn dc_key_get_fingerprint(
         dc_strdup(0 as *const libc::c_char)
     };
 }
+
 pub unsafe fn dc_key_get_formatted_fingerprint(
     context: &dc_context_t,
     key: *const dc_key_t,
@@ -498,5 +543,6 @@ pub unsafe fn dc_key_get_formatted_fingerprint(
     let mut rawhex: *mut libc::c_char = dc_key_get_fingerprint(context, key);
     let mut formatted: *mut libc::c_char = dc_format_fingerprint(rawhex);
     free(rawhex as *mut libc::c_void);
-    return formatted;
+
+    formatted
 }

--- a/src/dc_keyring.rs
+++ b/src/dc_keyring.rs
@@ -15,13 +15,15 @@ pub struct dc_keyring_t {
 }
 
 pub unsafe fn dc_keyring_new() -> *mut dc_keyring_t {
-    let mut keyring: *mut dc_keyring_t = 0 as *mut dc_keyring_t;
+    let mut keyring: *mut dc_keyring_t;
     keyring = calloc(1, ::std::mem::size_of::<dc_keyring_t>()) as *mut dc_keyring_t;
     if keyring.is_null() {
         exit(42i32);
     }
-    return keyring;
+
+    keyring
 }
+
 pub unsafe fn dc_keyring_unref(mut keyring: *mut dc_keyring_t) {
     if keyring.is_null() {
         return;
@@ -34,6 +36,7 @@ pub unsafe fn dc_keyring_unref(mut keyring: *mut dc_keyring_t) {
     free((*keyring).keys as *mut libc::c_void);
     free(keyring as *mut libc::c_void);
 }
+
 /* the reference counter of the key is increased by one */
 pub unsafe fn dc_keyring_add(mut keyring: *mut dc_keyring_t, mut to_add: *mut dc_key_t) {
     if keyring.is_null() || to_add.is_null() {
@@ -54,12 +57,15 @@ pub unsafe fn dc_keyring_add(mut keyring: *mut dc_keyring_t, mut to_add: *mut dc
     *fresh0 = dc_key_ref(to_add);
     (*keyring).count += 1;
 }
+
+// TODO should return bool? /rtn
 pub unsafe fn dc_keyring_load_self_private_for_decrypting(
     context: &dc_context_t,
     keyring: *mut dc_keyring_t,
     self_addr: *const libc::c_char,
     sql: &dc_sqlite3_t,
 ) -> libc::c_int {
+    // Can we prevent keyring and self_addr to be null?
     if keyring.is_null() || self_addr.is_null() {
         return 0i32;
     }
@@ -78,5 +84,6 @@ pub unsafe fn dc_keyring_load_self_private_for_decrypting(
         dc_key_unref(key);
     }
     sqlite3_finalize(stmt);
-    return 1i32;
+
+    1
 }

--- a/src/dc_log.rs
+++ b/src/dc_log.rs
@@ -15,6 +15,7 @@ pub unsafe extern "C" fn dc_log_event(
 ) {
     log_vprintf(context, event_code, data1, msg, va);
 }
+
 /* Asynchronous "Thread-errors" are reported by the dc_log_error()
 function.  These errors must be shown to the user by a bubble or so.
 
@@ -29,7 +30,7 @@ unsafe fn log_vprintf(
     mut msg_format: *const libc::c_char,
     mut va_0: ::std::ffi::VaList,
 ) {
-    let mut msg: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut msg: *mut libc::c_char;
     if !msg_format.is_null() {
         let mut tempbuf: [libc::c_char; 1025] = [0; 1025];
         vsnprintf(
@@ -48,6 +49,7 @@ unsafe fn log_vprintf(
     ((*context).cb)(context, event, data1 as uintptr_t, msg as uintptr_t);
     free(msg as *mut libc::c_void);
 }
+
 pub unsafe extern "C" fn dc_log_event_seq(
     mut context: &dc_context_t,
     mut event_code: Event,
@@ -61,6 +63,7 @@ pub unsafe extern "C" fn dc_log_event_seq(
     log_vprintf(context, event_code, *sequence_start, msg, va_0);
     *sequence_start = 0i32;
 }
+
 pub unsafe extern "C" fn dc_log_error(
     mut context: &dc_context_t,
     mut data1: libc::c_int,
@@ -69,6 +72,7 @@ pub unsafe extern "C" fn dc_log_error(
 ) {
     log_vprintf(context, Event::ERROR, data1, msg, va_1);
 }
+
 pub unsafe extern "C" fn dc_log_warning(
     mut context: &dc_context_t,
     mut data1: libc::c_int,
@@ -77,6 +81,7 @@ pub unsafe extern "C" fn dc_log_warning(
 ) {
     log_vprintf(context, Event::WARNING, data1, msg, va_2);
 }
+
 pub unsafe extern "C" fn dc_log_info(
     mut context: &dc_context_t,
     mut data1: libc::c_int,

--- a/src/dc_loginparam.rs
+++ b/src/dc_loginparam.rs
@@ -23,13 +23,15 @@ pub struct dc_loginparam_t {
 }
 
 pub unsafe fn dc_loginparam_new() -> *mut dc_loginparam_t {
-    let mut loginparam: *mut dc_loginparam_t = 0 as *mut dc_loginparam_t;
+    let mut loginparam: *mut dc_loginparam_t;
     loginparam = calloc(1, ::std::mem::size_of::<dc_loginparam_t>()) as *mut dc_loginparam_t;
     if loginparam.is_null() {
         exit(22i32);
     }
-    return loginparam;
+
+    loginparam
 }
+
 pub unsafe fn dc_loginparam_unref(mut loginparam: *mut dc_loginparam_t) {
     if loginparam.is_null() {
         return;
@@ -37,6 +39,7 @@ pub unsafe fn dc_loginparam_unref(mut loginparam: *mut dc_loginparam_t) {
     dc_loginparam_empty(loginparam);
     free(loginparam as *mut libc::c_void);
 }
+
 /* clears all data and frees its memory. All pointers are NULL after this function is called. */
 pub unsafe fn dc_loginparam_empty(mut loginparam: *mut dc_loginparam_t) {
     if loginparam.is_null() {
@@ -60,6 +63,7 @@ pub unsafe fn dc_loginparam_empty(mut loginparam: *mut dc_loginparam_t) {
     (*loginparam).send_pw = 0 as *mut libc::c_char;
     (*loginparam).server_flags = 0i32;
 }
+
 pub unsafe fn dc_loginparam_read(
     context: &dc_context_t,
     loginparam: *mut dc_loginparam_t,
@@ -140,6 +144,7 @@ pub unsafe fn dc_loginparam_read(
     (*loginparam).server_flags = dc_sqlite3_get_config_int(context, sql, key, 0i32);
     sqlite3_free(key as *mut libc::c_void);
 }
+
 pub unsafe fn dc_loginparam_write(
     context: &dc_context_t,
     loginparam: *const dc_loginparam_t,
@@ -219,6 +224,7 @@ pub unsafe fn dc_loginparam_write(
     dc_sqlite3_set_config_int(context, sql, key, (*loginparam).server_flags);
     sqlite3_free(key as *mut libc::c_void);
 }
+
 pub unsafe fn dc_loginparam_get_readable(
     mut loginparam: *const dc_loginparam_t,
 ) -> *mut libc::c_char {
@@ -270,8 +276,10 @@ pub unsafe fn dc_loginparam_get_readable(
         flags_readable,
     );
     free(flags_readable as *mut libc::c_void);
-    return ret;
+
+    ret
 }
+
 unsafe fn get_readable_flags(mut flags: libc::c_int) -> *mut libc::c_char {
     let mut strbuilder: dc_strbuilder_t = dc_strbuilder_t {
         buf: 0 as *mut libc::c_char,
@@ -358,5 +366,6 @@ unsafe fn get_readable_flags(mut flags: libc::c_int) -> *mut libc::c_char {
         );
     }
     dc_trim(strbuilder.buf);
-    return strbuilder.buf;
+
+    strbuilder.buf
 }

--- a/src/dc_lot.rs
+++ b/src/dc_lot.rs
@@ -36,15 +36,17 @@ pub struct dc_lot_t {
  * NB: _Lot_ is used in the meaning _heap_ here.
  */
 pub unsafe fn dc_lot_new() -> *mut dc_lot_t {
-    let mut lot: *mut dc_lot_t = 0 as *mut dc_lot_t;
+    let mut lot: *mut dc_lot_t;
     lot = calloc(1, ::std::mem::size_of::<dc_lot_t>()) as *mut dc_lot_t;
     if lot.is_null() {
         exit(27i32);
     }
     (*lot).magic = 0x107107i32 as uint32_t;
     (*lot).text1_meaning = 0i32;
-    return lot;
+
+    lot
 }
+
 pub unsafe fn dc_lot_empty(mut lot: *mut dc_lot_t) {
     if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint {
         return;
@@ -64,6 +66,7 @@ pub unsafe fn dc_lot_empty(mut lot: *mut dc_lot_t) {
     (*lot).state = 0i32;
     (*lot).id = 0i32 as uint32_t;
 }
+
 pub unsafe fn dc_lot_unref(mut set: *mut dc_lot_t) {
     if set.is_null() || (*set).magic != 0x107107i32 as libc::c_uint {
         return;
@@ -72,42 +75,55 @@ pub unsafe fn dc_lot_unref(mut set: *mut dc_lot_t) {
     (*set).magic = 0i32 as uint32_t;
     free(set as *mut libc::c_void);
 }
+
 pub unsafe fn dc_lot_get_text1(mut lot: *const dc_lot_t) -> *mut libc::c_char {
     if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint {
         return 0 as *mut libc::c_char;
     }
-    return dc_strdup_keep_null((*lot).text1);
+
+    dc_strdup_keep_null((*lot).text1)
 }
+
 pub unsafe fn dc_lot_get_text2(mut lot: *const dc_lot_t) -> *mut libc::c_char {
     if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint {
         return 0 as *mut libc::c_char;
     }
-    return dc_strdup_keep_null((*lot).text2);
+
+    dc_strdup_keep_null((*lot).text2)
 }
+
 pub unsafe fn dc_lot_get_text1_meaning(mut lot: *const dc_lot_t) -> libc::c_int {
     if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint {
         return 0i32;
     }
-    return (*lot).text1_meaning;
+
+    (*lot).text1_meaning
 }
+
 pub unsafe fn dc_lot_get_state(mut lot: *const dc_lot_t) -> libc::c_int {
     if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint {
         return 0i32;
     }
-    return (*lot).state;
+
+    (*lot).state
 }
+
 pub unsafe fn dc_lot_get_id(mut lot: *const dc_lot_t) -> uint32_t {
     if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint {
         return 0i32 as uint32_t;
     }
-    return (*lot).id;
+
+    (*lot).id
 }
+
 pub unsafe fn dc_lot_get_timestamp(mut lot: *const dc_lot_t) -> time_t {
     if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint {
         return 0i32 as time_t;
     }
-    return (*lot).timestamp;
+
+    (*lot).timestamp
 }
+
 /* library-internal */
 /* in practice, the user additionally cuts the string himself pixel-accurate */
 pub unsafe fn dc_lot_fill(

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -58,13 +58,15 @@ pub struct dc_mimeparser_t<'a> {
 pub unsafe fn dc_no_compound_msgs() {
     s_generate_compound_msgs = 0i32;
 }
+
 // deprecated: flag to switch generation of compound messages on and off.
 static mut s_generate_compound_msgs: libc::c_int = 1i32;
+
 pub unsafe fn dc_mimeparser_new(
     blobdir: *const libc::c_char,
     context: &dc_context_t,
 ) -> *mut dc_mimeparser_t {
-    let mut mimeparser: *mut dc_mimeparser_t = 0 as *mut dc_mimeparser_t;
+    let mut mimeparser: *mut dc_mimeparser_t;
     mimeparser = calloc(1, ::std::mem::size_of::<dc_mimeparser_t>()) as *mut dc_mimeparser_t;
     if mimeparser.is_null() {
         exit(30i32);
@@ -76,8 +78,10 @@ pub unsafe fn dc_mimeparser_new(
     (*mimeparser).e2ee_helper =
         calloc(1, ::std::mem::size_of::<dc_e2ee_helper_t>()) as *mut dc_e2ee_helper_t;
     dc_hash_init(&mut (*mimeparser).header, 3i32, 0i32);
-    return mimeparser;
+
+    mimeparser
 }
+
 pub unsafe fn dc_mimeparser_unref(mut mimeparser: *mut dc_mimeparser_t) {
     if mimeparser.is_null() {
         return;
@@ -98,7 +102,7 @@ pub unsafe fn dc_mimeparser_empty(mut mimeparser: *mut dc_mimeparser_t) {
         return;
     }
     if !(*mimeparser).parts.is_null() {
-        let mut i: libc::c_int = 0;
+        let mut i: libc::c_int;
         let mut cnt: libc::c_int = carray_count((*mimeparser).parts) as libc::c_int;
         i = 0i32;
         while i < cnt {
@@ -150,14 +154,15 @@ unsafe fn dc_mimepart_unref(mut mimepart: *mut dc_mimepart_t) {
     dc_param_unref((*mimepart).param);
     free(mimepart as *mut libc::c_void);
 }
+
 pub unsafe fn dc_mimeparser_parse(
     mut mimeparser: *mut dc_mimeparser_t,
     mut body_not_terminated: *const libc::c_char,
     mut body_bytes: size_t,
 ) {
-    let mut r: libc::c_int = 0i32;
+    let mut r: libc::c_int;
     let mut index: size_t = 0i32 as size_t;
-    let mut optional_field: *mut mailimf_optional_field = 0 as *mut mailimf_optional_field;
+    let mut optional_field: *mut mailimf_optional_field;
     dc_mimeparser_empty(mimeparser);
     r = mailmime_parse(
         body_not_terminated,
@@ -194,7 +199,7 @@ pub unsafe fn dc_mimeparser_parse(
         )
         .is_null()
         {
-            let mut i: libc::c_int = 0;
+            let mut i: libc::c_int;
             let mut has_setup_file: libc::c_int = 0i32;
             i = 0i32;
             while (i as libc::c_uint) < carray_count((*mimeparser).parts) {
@@ -303,7 +308,7 @@ pub unsafe fn dc_mimeparser_parse(
                 }
                 dc_trim(subj);
                 if 0 != *subj.offset(0isize) {
-                    let mut i_0: libc::c_int = 0;
+                    let mut i_0: libc::c_int;
                     let mut icnt: libc::c_int = carray_count((*mimeparser).parts) as libc::c_int;
                     i_0 = 0i32;
                     while i_0 < icnt {
@@ -328,7 +333,7 @@ pub unsafe fn dc_mimeparser_parse(
             }
         }
         if 0 != (*mimeparser).is_forwarded {
-            let mut i_1: libc::c_int = 0;
+            let mut i_1: libc::c_int;
             let mut icnt_0: libc::c_int = carray_count((*mimeparser).parts) as libc::c_int;
             i_1 = 0i32;
             while i_1 < icnt_0 {
@@ -430,24 +435,26 @@ pub unsafe fn dc_mimeparser_parse(
         );
     };
 }
-/* ******************************************************************************
+
+/*******************************************************************************
  * a MIME part
  ******************************************************************************/
 unsafe fn dc_mimepart_new() -> *mut dc_mimepart_t {
-    let mut mimepart: *mut dc_mimepart_t = 0 as *mut dc_mimepart_t;
+    let mut mimepart: *mut dc_mimepart_t;
     mimepart = calloc(1, ::std::mem::size_of::<dc_mimepart_t>()) as *mut dc_mimepart_t;
     if mimepart.is_null() {
         exit(33i32);
     }
     (*mimepart).type_0 = 0i32;
     (*mimepart).param = dc_param_new();
-    return mimepart;
+    mimepart
 }
+
 pub unsafe fn dc_mimeparser_get_last_nonmeta(
     mut mimeparser: *mut dc_mimeparser_t,
 ) -> *mut dc_mimepart_t {
     if !mimeparser.is_null() && !(*mimeparser).parts.is_null() {
-        let mut i: libc::c_int = 0;
+        let mut i: libc::c_int;
         let mut icnt: libc::c_int = carray_count((*mimeparser).parts) as libc::c_int;
         i = icnt - 1i32;
         while i >= 0i32 {
@@ -459,8 +466,10 @@ pub unsafe fn dc_mimeparser_get_last_nonmeta(
             i -= 1
         }
     }
-    return 0 as *mut dc_mimepart_t;
+
+    0 as *mut dc_mimepart_t
 }
+
 /*the result must be freed*/
 pub unsafe fn mailimf_find_first_addr(
     mut mb_list: *const mailimf_mailbox_list,
@@ -484,19 +493,22 @@ pub unsafe fn mailimf_find_first_addr(
             0 as *mut clistcell_s
         }
     }
-    return 0 as *mut libc::c_char;
+
+    0 as *mut libc::c_char
 }
+
 /* the following functions can be used only after a call to dc_mimeparser_parse() */
 pub unsafe fn dc_mimeparser_lookup_field(
     mut mimeparser: *mut dc_mimeparser_t,
     mut field_name: *const libc::c_char,
 ) -> *mut mailimf_field {
-    return dc_hash_find(
+    dc_hash_find(
         &mut (*mimeparser).header,
         field_name as *const libc::c_void,
         strlen(field_name) as libc::c_int,
-    ) as *mut mailimf_field;
+    ) as *mut mailimf_field
 }
+
 pub unsafe fn dc_mimeparser_lookup_optional_field(
     mut mimeparser: *mut dc_mimeparser_t,
     mut field_name: *const libc::c_char,
@@ -509,14 +521,16 @@ pub unsafe fn dc_mimeparser_lookup_optional_field(
     if !field.is_null() && (*field).fld_type == MAILIMF_FIELD_OPTIONAL_FIELD as libc::c_int {
         return (*field).fld_data.fld_optional_field;
     }
-    return 0 as *mut mailimf_optional_field;
+
+    0 as *mut mailimf_optional_field
 }
+
 unsafe fn dc_mimeparser_parse_mime_recursive(
     mut mimeparser: *mut dc_mimeparser_t,
     mut mime: *mut mailmime,
 ) -> libc::c_int {
     let mut any_part_added: libc::c_int = 0i32;
-    let mut cur: *mut clistiter = 0 as *mut clistiter;
+    let mut cur: *mut clistiter;
     if mimeparser.is_null() || mime.is_null() {
         return 0i32;
     }
@@ -577,6 +591,7 @@ unsafe fn dc_mimeparser_parse_mime_recursive(
         }
     }
     match (*mime).mm_type {
+        // TODO match on enums /rtn
         1 => any_part_added = dc_mimeparser_add_single_part_if_known(mimeparser, mime),
         2 => {
             match mailmime_get_mime_type(mime, 0 as *mut libc::c_int, 0 as *mut *mut libc::c_char) {
@@ -812,8 +827,10 @@ unsafe fn dc_mimeparser_parse_mime_recursive(
         }
         _ => {}
     }
-    return any_part_added;
+
+    any_part_added
 }
+
 unsafe fn hash_header(out: *mut dc_hash_t, in_0: *const mailimf_fields, _context: &dc_context_t) {
     if in_0.is_null() {
         return;
@@ -826,6 +843,7 @@ unsafe fn hash_header(out: *mut dc_hash_t, in_0: *const mailimf_fields, _context
             0 as *mut libc::c_void
         }) as *mut mailimf_field;
         let mut key: *const libc::c_char = 0 as *const libc::c_char;
+        // TODO match on enums /rtn
         match (*field).fld_type {
             1 => key = b"Return-Path\x00" as *const u8 as *const libc::c_char,
             9 => key = b"Date\x00" as *const u8 as *const libc::c_char,
@@ -879,6 +897,7 @@ unsafe fn hash_header(out: *mut dc_hash_t, in_0: *const mailimf_fields, _context
         }
     }
 }
+
 unsafe fn mailmime_get_mime_type(
     mut mime: *mut mailmime,
     mut msg_type: *mut libc::c_int,
@@ -893,6 +912,7 @@ unsafe fn mailmime_get_mime_type(
     if c.is_null() || (*c).ct_type.is_null() {
         return 0i32;
     }
+    // TODO match on enums /rtn
     match (*(*c).ct_type).tp_type {
         1 => match (*(*(*c).ct_type).tp_data.tp_discrete_type).dt_type {
             1 => {
@@ -1047,8 +1067,10 @@ unsafe fn mailmime_get_mime_type(
         }
         _ => {}
     }
-    return 0i32;
+
+    0
 }
+
 unsafe fn reconcat_mime(
     mut raw_mime: *mut *mut libc::c_char,
     mut type_0: *const libc::c_char,
@@ -1070,6 +1092,7 @@ unsafe fn reconcat_mime(
         )
     };
 }
+
 unsafe fn mailmime_is_attachment_disposition(mut mime: *mut mailmime) -> libc::c_int {
     if !(*mime).mm_mime_fields.is_null() {
         let mut cur: *mut clistiter = (*(*(*mime).mm_mime_fields).fld_list).first;
@@ -1097,8 +1120,10 @@ unsafe fn mailmime_is_attachment_disposition(mut mime: *mut mailmime) -> libc::c
             }
         }
     }
-    return 0i32;
+
+    0
 }
+
 /* low-level-tools for working with mailmime structures directly */
 pub unsafe fn mailmime_find_ct_parameter(
     mut mime: *mut mailmime,
@@ -1111,7 +1136,7 @@ pub unsafe fn mailmime_find_ct_parameter(
     {
         return 0 as *mut mailmime_parameter;
     }
-    let mut cur: *mut clistiter = 0 as *mut clistiter;
+    let mut cur: *mut clistiter;
     cur = (*(*(*mime).mm_content_type).ct_parameters).first;
     while !cur.is_null() {
         let mut param: *mut mailmime_parameter = (if !cur.is_null() {
@@ -1130,8 +1155,10 @@ pub unsafe fn mailmime_find_ct_parameter(
             0 as *mut clistcell_s
         }
     }
-    return 0 as *mut mailmime_parameter;
+
+    0 as *mut mailmime_parameter
 }
+
 unsafe fn dc_mimeparser_add_single_part_if_known(
     mut mimeparser: *mut dc_mimeparser_t,
     mut mime: *mut mailmime,
@@ -1139,8 +1166,8 @@ unsafe fn dc_mimeparser_add_single_part_if_known(
     let mut current_block: u64;
     let mut part: *mut dc_mimepart_t = 0 as *mut dc_mimepart_t;
     let mut old_part_count: libc::c_int = carray_count((*mimeparser).parts) as libc::c_int;
-    let mut mime_type: libc::c_int = 0;
-    let mut mime_data: *mut mailmime_data = 0 as *mut mailmime_data;
+    let mut mime_type: libc::c_int;
+    let mut mime_data: *mut mailmime_data;
     let mut file_suffix: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut desired_filename: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut msg_type: libc::c_int = 0i32;
@@ -1183,6 +1210,7 @@ unsafe fn dc_mimeparser_add_single_part_if_known(
                         } else {
                             current_block = 13797916685926291137;
                         }
+                        // TODO match on enums /rtn
                         match current_block {
                             8795901732489102124 => {}
                             _ => {
@@ -1474,6 +1502,7 @@ unsafe fn dc_mimeparser_add_single_part_if_known(
         0i32
     };
 }
+
 unsafe fn do_add_single_file_part(
     mut parser: *mut dc_mimeparser_t,
     mut msg_type: libc::c_int,
@@ -1484,7 +1513,7 @@ unsafe fn do_add_single_file_part(
     mut desired_filename: *const libc::c_char,
 ) {
     let mut part: *mut dc_mimepart_t = 0 as *mut dc_mimepart_t;
-    let mut pathNfilename: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut pathNfilename: *mut libc::c_char;
     /* create a free file name to use */
     pathNfilename = dc_get_fine_pathNfilename(
         (*parser).context,
@@ -1526,6 +1555,7 @@ unsafe fn do_add_single_file_part(
     free(pathNfilename as *mut libc::c_void);
     dc_mimepart_unref(part);
 }
+
 unsafe fn do_add_single_part(mut parser: *mut dc_mimeparser_t, mut part: *mut dc_mimepart_t) {
     if 0 != (*(*parser).e2ee_helper).encrypted
         && (*(*(*parser).e2ee_helper).signatures).count > 0i32
@@ -1540,6 +1570,8 @@ unsafe fn do_add_single_part(mut parser: *mut dc_mimeparser_t, mut part: *mut dc
         0 as *mut libc::c_uint,
     );
 }
+
+// TODO should return bool /rtn
 pub unsafe fn mailmime_transfer_decode(
     mut mime: *mut mailmime,
     mut ret_decoded_data: *mut *const libc::c_char,
@@ -1547,9 +1579,9 @@ pub unsafe fn mailmime_transfer_decode(
     mut ret_to_mmap_string_unref: *mut *mut libc::c_char,
 ) -> libc::c_int {
     let mut mime_transfer_encoding: libc::c_int = MAILMIME_MECHANISM_BINARY as libc::c_int;
-    let mut mime_data: *mut mailmime_data = 0 as *mut mailmime_data;
+    let mut mime_data: *mut mailmime_data;
     /* must not be free()'d */
-    let mut decoded_data: *const libc::c_char = 0 as *const libc::c_char;
+    let mut decoded_data: *const libc::c_char;
     let mut decoded_data_bytes: size_t = 0i32 as size_t;
     /* mmap_string_unref()'d if set */
     let mut transfer_decoding_buffer: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -1565,7 +1597,7 @@ pub unsafe fn mailmime_transfer_decode(
     }
     mime_data = (*mime).mm_data.mm_single;
     if !(*mime).mm_mime_fields.is_null() {
-        let mut cur: *mut clistiter = 0 as *mut clistiter;
+        let mut cur: *mut clistiter;
         cur = (*(*(*mime).mm_mime_fields).fld_list).first;
         while !cur.is_null() {
             let mut field: *mut mailmime_field = (if !cur.is_null() {
@@ -1598,7 +1630,7 @@ pub unsafe fn mailmime_transfer_decode(
             return 0i32;
         }
     } else {
-        let mut r: libc::c_int = 0;
+        let mut r: libc::c_int;
         let mut current_index: size_t = 0i32 as size_t;
         r = mailmime_part_parse(
             (*mime_data).dt_data.dt_text.dt_data,
@@ -1619,8 +1651,11 @@ pub unsafe fn mailmime_transfer_decode(
     *ret_decoded_data = decoded_data;
     *ret_decoded_data_bytes = decoded_data_bytes;
     *ret_to_mmap_string_unref = transfer_decoding_buffer;
-    return 1i32;
+
+    1
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_mimeparser_is_mailinglist_message(
     mut mimeparser: *mut dc_mimeparser_t,
 ) -> libc::c_int {
@@ -1652,15 +1687,17 @@ pub unsafe fn dc_mimeparser_is_mailinglist_message(
             return 1i32;
         }
     }
-    return 0i32;
+
+    0
 }
+
 pub unsafe fn dc_mimeparser_sender_equals_recipient(
     mut mimeparser: *mut dc_mimeparser_t,
 ) -> libc::c_int {
     let mut sender_equals_recipient: libc::c_int = 0i32;
-    let mut fld: *const mailimf_field = 0 as *const mailimf_field;
+    let mut fld: *const mailimf_field;
     let mut fld_from: *const mailimf_from = 0 as *const mailimf_from;
-    let mut mb: *mut mailimf_mailbox = 0 as *mut mailimf_mailbox;
+    let mut mb: *mut mailimf_mailbox;
     let mut from_addr_norm: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut recipients: *mut dc_hash_t = 0 as *mut dc_hash_t;
     if !(mimeparser.is_null() || (*mimeparser).header_root.is_null()) {
@@ -1700,14 +1737,16 @@ pub unsafe fn dc_mimeparser_sender_equals_recipient(
     dc_hash_clear(recipients);
     free(recipients as *mut libc::c_void);
     free(from_addr_norm as *mut libc::c_void);
-    return sender_equals_recipient;
+
+    sender_equals_recipient
 }
+
 pub unsafe fn mailimf_get_recipients(mut imffields: *mut mailimf_fields) -> *mut dc_hash_t {
     /* the returned value must be dc_hash_clear()'d and free()'d. returned addresses are normalized. */
     let mut recipients: *mut dc_hash_t =
         malloc(::std::mem::size_of::<dc_hash_t>()) as *mut dc_hash_t;
     dc_hash_init(recipients, 3i32, 1i32);
-    let mut cur1: *mut clistiter = 0 as *mut clistiter;
+    let mut cur1: *mut clistiter;
     cur1 = (*(*imffields).fld_list).first;
     while !cur1.is_null() {
         let mut fld: *mut mailimf_field = (if !cur1.is_null() {
@@ -1715,9 +1754,10 @@ pub unsafe fn mailimf_get_recipients(mut imffields: *mut mailimf_fields) -> *mut
         } else {
             0 as *mut libc::c_void
         }) as *mut mailimf_field;
-        let mut fld_to: *mut mailimf_to = 0 as *mut mailimf_to;
-        let mut fld_cc: *mut mailimf_cc = 0 as *mut mailimf_cc;
+        let mut fld_to: *mut mailimf_to;
+        let mut fld_cc: *mut mailimf_cc;
         let mut addr_list: *mut mailimf_address_list = 0 as *mut mailimf_address_list;
+        // TODO match on enums /rtn
         match (*fld).fld_type {
             13 => {
                 fld_to = (*fld).fld_data.fld_to;
@@ -1734,7 +1774,7 @@ pub unsafe fn mailimf_get_recipients(mut imffields: *mut mailimf_fields) -> *mut
             _ => {}
         }
         if !addr_list.is_null() {
-            let mut cur2: *mut clistiter = 0 as *mut clistiter;
+            let mut cur2: *mut clistiter;
             cur2 = (*(*addr_list).ad_list).first;
             while !cur2.is_null() {
                 let mut adr: *mut mailimf_address = (if !cur2.is_null() {
@@ -1748,7 +1788,7 @@ pub unsafe fn mailimf_get_recipients(mut imffields: *mut mailimf_fields) -> *mut
                     } else if (*adr).ad_type == MAILIMF_ADDRESS_GROUP as libc::c_int {
                         let mut group: *mut mailimf_group = (*adr).ad_data.ad_group;
                         if !group.is_null() && !(*group).grp_mb_list.is_null() {
-                            let mut cur3: *mut clistiter = 0 as *mut clistiter;
+                            let mut cur3: *mut clistiter;
                             cur3 = (*(*(*group).grp_mb_list).mb_list).first;
                             while !cur3.is_null() {
                                 mailimf_get_recipients__add_addr(
@@ -1781,8 +1821,10 @@ pub unsafe fn mailimf_get_recipients(mut imffields: *mut mailimf_fields) -> *mut
             0 as *mut clistcell_s
         }
     }
-    return recipients;
+
+    recipients
 }
+
 /* ******************************************************************************
  * debug output
  ******************************************************************************/
@@ -1805,6 +1847,7 @@ unsafe fn mailimf_get_recipients__add_addr(
         free(addr_norm as *mut libc::c_void);
     };
 }
+
 /*the result is a pointer to mime, must not be freed*/
 pub unsafe fn mailimf_find_field(
     mut header: *mut mailimf_fields,
@@ -1831,14 +1874,16 @@ pub unsafe fn mailimf_find_field(
             0 as *mut clistcell_s
         }
     }
-    return 0 as *mut mailimf_field;
+
+    0 as *mut mailimf_field
 }
+
 pub unsafe fn dc_mimeparser_repl_msg_by_error(
     mut mimeparser: *mut dc_mimeparser_t,
     mut error_msg: *const libc::c_char,
 ) {
-    let mut part: *mut dc_mimepart_t = 0 as *mut dc_mimepart_t;
-    let mut i: libc::c_int = 0i32;
+    let mut part: *mut dc_mimepart_t;
+    let mut i: libc::c_int;
     if mimeparser.is_null()
         || (*mimeparser).parts.is_null()
         || carray_count((*mimeparser).parts) <= 0i32 as libc::c_uint
@@ -1859,11 +1904,13 @@ pub unsafe fn dc_mimeparser_repl_msg_by_error(
     }
     carray_set_size((*mimeparser).parts, 1i32 as libc::c_uint);
 }
+
 /*the result is a pointer to mime, must not be freed*/
 pub unsafe fn mailmime_find_mailimf_fields(mut mime: *mut mailmime) -> *mut mailimf_fields {
     if mime.is_null() {
         return 0 as *mut mailimf_fields;
     }
+    // TODO match on enums
     match (*mime).mm_type {
         2 => {
             let mut cur: *mut clistiter = (*(*mime).mm_data.mm_multipart.mm_mp_list).first;
@@ -1888,8 +1935,10 @@ pub unsafe fn mailmime_find_mailimf_fields(mut mime: *mut mailmime) -> *mut mail
         3 => return (*mime).mm_data.mm_message.mm_fields,
         _ => {}
     }
-    return 0 as *mut mailimf_fields;
+
+    0 as *mut mailimf_fields
 }
+
 pub unsafe fn mailimf_find_optional_field(
     mut header: *mut mailimf_fields,
     mut wanted_fld_name: *const libc::c_char,
@@ -1921,5 +1970,6 @@ pub unsafe fn mailimf_find_optional_field(
             0 as *mut clistcell_s
         }
     }
-    return 0 as *mut mailimf_optional_field;
+
+    0 as *mut mailimf_optional_field
 }

--- a/src/dc_oauth2.rs
+++ b/src/dc_oauth2.rs
@@ -51,8 +51,10 @@ pub unsafe fn dc_get_oauth2_url(
         }
     }
     free(oauth2 as *mut libc::c_void);
-    return oauth2_url;
+
+    oauth2_url
 }
+
 unsafe fn replace_in_uri(
     mut uri: *mut *mut libc::c_char,
     mut key: *const libc::c_char,
@@ -64,10 +66,11 @@ unsafe fn replace_in_uri(
         free(value_urlencoded as *mut libc::c_void);
     };
 }
+
 unsafe fn get_info(mut addr: *const libc::c_char) -> *mut oauth2_t {
     let mut oauth2: *mut oauth2_t = 0 as *mut oauth2_t;
-    let mut addr_normalized: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut domain: *const libc::c_char = 0 as *const libc::c_char;
+    let mut addr_normalized: *mut libc::c_char;
+    let mut domain: *const libc::c_char;
     addr_normalized = dc_addr_normalize(addr);
     domain = strchr(addr_normalized, '@' as i32);
     if !(domain.is_null() || *domain.offset(0isize) as libc::c_int == 0i32) {
@@ -116,8 +119,10 @@ unsafe fn get_info(mut addr: *const libc::c_char) -> *mut oauth2_t {
         }
     }
     free(addr_normalized as *mut libc::c_void);
-    return oauth2;
+
+    oauth2
 }
+
 // the following function may block due http-requests;
 // must not be called from the main thread or by the ui!
 pub unsafe fn dc_get_oauth2_access_token(
@@ -150,7 +155,7 @@ pub unsafe fn dc_get_oauth2_access_token(
         end: 0,
         size: 0,
     }; 128];
-    let mut tok_cnt: libc::c_int = 0i32;
+    let mut tok_cnt: libc::c_int;
     if code.is_null() || *code.offset(0isize) as libc::c_int == 0i32 {
         dc_log_warning(
             context,
@@ -452,6 +457,7 @@ pub unsafe fn dc_get_oauth2_access_token(
         dc_strdup(0 as *const libc::c_char)
     };
 }
+
 unsafe fn jsondup(mut json: *const libc::c_char, mut tok: *mut jsmntok_t) -> *mut libc::c_char {
     if (*tok).type_0 as libc::c_uint == JSMN_STRING as libc::c_int as libc::c_uint
         || (*tok).type_0 as libc::c_uint == JSMN_PRIMITIVE as libc::c_int as libc::c_uint
@@ -461,8 +467,10 @@ unsafe fn jsondup(mut json: *const libc::c_char, mut tok: *mut jsmntok_t) -> *mu
             ((*tok).end - (*tok).start) as libc::c_ulong,
         );
     }
-    return strdup(b"\x00" as *const u8 as *const libc::c_char);
+
+    strdup(b"\x00" as *const u8 as *const libc::c_char)
 }
+
 unsafe extern "C" fn jsoneq(
     mut json: *const libc::c_char,
     mut tok: *mut jsmntok_t,
@@ -478,8 +486,11 @@ unsafe extern "C" fn jsoneq(
     {
         return 0i32;
     }
-    return -1i32;
+
+    -1
 }
+
+// TODO should return bool /rtn
 unsafe fn is_expired(mut context: &dc_context_t) -> libc::c_int {
     let mut expire_timestamp: time_t = dc_sqlite3_get_config_int64(
         context,
@@ -493,8 +504,10 @@ unsafe fn is_expired(mut context: &dc_context_t) -> libc::c_int {
     if expire_timestamp > time(0 as *mut time_t) {
         return 0i32;
     }
-    return 1i32;
+
+    1
 }
+
 pub unsafe fn dc_get_oauth2_addr(
     mut context: &dc_context_t,
     mut addr: *const libc::c_char,
@@ -502,7 +515,7 @@ pub unsafe fn dc_get_oauth2_addr(
 ) -> *mut libc::c_char {
     let mut access_token: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut addr_out: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut oauth2: *mut oauth2_t = 0 as *mut oauth2_t;
+    let mut oauth2: *mut oauth2_t;
     if !({
         oauth2 = get_info(addr);
         oauth2.is_null()
@@ -518,8 +531,10 @@ pub unsafe fn dc_get_oauth2_addr(
     }
     free(access_token as *mut libc::c_void);
     free(oauth2 as *mut libc::c_void);
-    return addr_out;
+
+    addr_out
 }
+
 unsafe fn get_oauth2_addr(
     mut context: &dc_context_t,
     mut oauth2: *const oauth2_t,
@@ -540,7 +555,7 @@ unsafe fn get_oauth2_addr(
         end: 0,
         size: 0,
     }; 128];
-    let mut tok_cnt: libc::c_int = 0i32;
+    let mut tok_cnt: libc::c_int;
     if !(access_token.is_null()
         || *access_token.offset(0isize) as libc::c_int == 0i32
         || oauth2.is_null())
@@ -608,5 +623,6 @@ unsafe fn get_oauth2_addr(
     }
     free(userinfo_url as *mut libc::c_void);
     free(json as *mut libc::c_void);
-    return addr_out;
+
+    addr_out
 }

--- a/src/dc_param.rs
+++ b/src/dc_param.rs
@@ -94,8 +94,8 @@ unsafe extern "C" fn find_param(
     mut key: libc::c_int,
     mut ret_p2: *mut *mut libc::c_char,
 ) -> *mut libc::c_char {
-    let mut p1: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut p2: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut p1: *mut libc::c_char;
+    let mut p2: *mut libc::c_char;
     p1 = haystack;
     loop {
         if p1.is_null() || *p1 as libc::c_int == 0i32 {
@@ -115,18 +115,20 @@ unsafe extern "C" fn find_param(
         p2 = &mut *p1.offset(strlen(p1) as isize) as *mut libc::c_char
     }
     *ret_p2 = p2;
-    return p1;
+
+    p1
 }
+
 /* the value may be an empty string, "def" is returned only if the value unset.  The result must be free()'d in any case. */
 pub unsafe fn dc_param_get(
     param: *const dc_param_t,
     key: libc::c_int,
     def: *const libc::c_char,
 ) -> *mut libc::c_char {
-    let mut p1: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut p1: *mut libc::c_char;
     let mut p2: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut bak: libc::c_char = 0i32 as libc::c_char;
-    let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut bak: libc::c_char;
+    let mut ret: *mut libc::c_char;
     if param.is_null() || key == 0i32 {
         return if !def.is_null() {
             dc_strdup(def)
@@ -148,8 +150,10 @@ pub unsafe fn dc_param_get(
     ret = dc_strdup(p1);
     dc_rtrim(ret);
     *p2 = bak;
-    return ret;
+
+    ret
 }
+
 pub unsafe fn dc_param_get_int(
     mut param: *const dc_param_t,
     mut key: libc::c_int,
@@ -164,7 +168,8 @@ pub unsafe fn dc_param_get_int(
     }
     let mut ret: int32_t = atol(str) as int32_t;
     free(str as *mut libc::c_void);
-    return ret;
+
+    ret
 }
 
 /**
@@ -201,16 +206,16 @@ pub unsafe fn dc_param_set(
     mut key: libc::c_int,
     mut value: *const libc::c_char,
 ) {
-    let mut old1: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut old2: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut new1: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut old1: *mut libc::c_char;
+    let mut old2: *mut libc::c_char;
+    let mut new1: *mut libc::c_char;
     if param.is_null() || key == 0i32 {
         return;
     }
     old1 = (*param).packed;
     old2 = 0 as *mut libc::c_char;
     if !old1.is_null() {
-        let mut p1: *mut libc::c_char = 0 as *mut libc::c_char;
+        let mut p1: *mut libc::c_char;
         let mut p2: *mut libc::c_char = 0 as *mut libc::c_char;
         p1 = find_param(old1, key, &mut p2);
         if !p1.is_null() {
@@ -277,6 +282,7 @@ pub unsafe fn dc_param_set(
     free((*param).packed as *mut libc::c_void);
     (*param).packed = new1;
 }
+
 pub unsafe fn dc_param_set_int(
     mut param: *mut dc_param_t,
     mut key: libc::c_int,
@@ -295,22 +301,26 @@ pub unsafe fn dc_param_set_int(
     dc_param_set(param, key, value_str);
     free(value_str as *mut libc::c_void);
 }
+
 /* library-private */
 pub unsafe fn dc_param_new() -> *mut dc_param_t {
-    let mut param: *mut dc_param_t = 0 as *mut dc_param_t;
+    let mut param: *mut dc_param_t;
     param = calloc(1, ::std::mem::size_of::<dc_param_t>()) as *mut dc_param_t;
     if param.is_null() {
         exit(28i32);
     }
     (*param).packed = calloc(1, 1) as *mut libc::c_char;
-    return param;
+
+    param
 }
+
 pub unsafe fn dc_param_empty(mut param: *mut dc_param_t) {
     if param.is_null() {
         return;
     }
     *(*param).packed.offset(0isize) = 0i32 as libc::c_char;
 }
+
 pub unsafe fn dc_param_unref(mut param: *mut dc_param_t) {
     if param.is_null() {
         return;
@@ -319,6 +329,7 @@ pub unsafe fn dc_param_unref(mut param: *mut dc_param_t) {
     free((*param).packed as *mut libc::c_void);
     free(param as *mut libc::c_void);
 }
+
 pub unsafe fn dc_param_set_packed(mut param: *mut dc_param_t, mut packed: *const libc::c_char) {
     if param.is_null() {
         return;
@@ -329,6 +340,7 @@ pub unsafe fn dc_param_set_packed(mut param: *mut dc_param_t, mut packed: *const
         (*param).packed = dc_strdup(packed)
     };
 }
+
 pub unsafe fn dc_param_set_urlencoded(
     mut param: *mut dc_param_t,
     mut urlencoded: *const libc::c_char,

--- a/src/dc_pgp.rs
+++ b/src/dc_pgp.rs
@@ -12,6 +12,7 @@ use crate::x::*;
 
 pub unsafe fn dc_pgp_exit() {}
 
+// TODO should return bool /rtn
 pub unsafe fn dc_split_armored_data(
     mut buf: *mut libc::c_char,
     mut ret_headerline: *mut *const libc::c_char,
@@ -23,7 +24,7 @@ pub unsafe fn dc_split_armored_data(
     let mut line_chars: size_t = 0i32 as size_t;
     let mut line: *mut libc::c_char = buf;
     let mut p1: *mut libc::c_char = buf;
-    let mut p2: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut p2: *mut libc::c_char;
     let mut headerline: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut base64: *mut libc::c_char = 0 as *mut libc::c_char;
     if !ret_headerline.is_null() {
@@ -126,9 +127,12 @@ pub unsafe fn dc_split_armored_data(
             }
         }
     }
-    return success;
+
+    success
 }
+
 /* public key encryption */
+// TODO should return bool /rtn
 pub unsafe fn dc_pgp_create_keypair(
     mut context: &dc_context_t,
     mut addr: *const libc::c_char,
@@ -136,11 +140,11 @@ pub unsafe fn dc_pgp_create_keypair(
     mut ret_private_key: *mut dc_key_t,
 ) -> libc::c_int {
     let mut success: libc::c_int = 0i32;
-    let mut skey: *mut rpgp::signed_secret_key = 0 as *mut rpgp::signed_secret_key;
+    let mut skey: *mut rpgp::signed_secret_key;
     let mut pkey: *mut rpgp::signed_public_key = 0 as *mut rpgp::signed_public_key;
     let mut skey_bytes: *mut rpgp::cvec = 0 as *mut rpgp::cvec;
     let mut pkey_bytes: *mut rpgp::cvec = 0 as *mut rpgp::cvec;
-    let mut user_id: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut user_id: *mut libc::c_char;
     user_id = dc_mprintf(b"<%s>\x00" as *const u8 as *const libc::c_char, addr);
     skey = rpgp::rpgp_create_rsa_skey(2048i32 as uint32_t, user_id);
     if !(0 != dc_pgp_handle_rpgp_error(context)) {
@@ -187,12 +191,15 @@ pub unsafe fn dc_pgp_create_keypair(
     if !user_id.is_null() {
         free(user_id as *mut libc::c_void);
     }
-    return success;
+
+    success
 }
+
 /* returns 0 if there is no error, otherwise logs the error if a context is provided and returns 1*/
+// TODO should return bool /rtn
 pub unsafe fn dc_pgp_handle_rpgp_error(mut context: &dc_context_t) -> libc::c_int {
     let mut success: libc::c_int = 0i32;
-    let mut len: libc::c_int = 0i32;
+    let mut len: libc::c_int;
     let mut msg: *mut libc::c_char = 0 as *mut libc::c_char;
     len = rpgp::rpgp_last_error_length();
     if !(len == 0i32) {
@@ -208,8 +215,11 @@ pub unsafe fn dc_pgp_handle_rpgp_error(mut context: &dc_context_t) -> libc::c_in
     if !msg.is_null() {
         rpgp::rpgp_string_drop(msg);
     }
-    return success;
+
+    success
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_pgp_is_valid_key(
     mut context: &dc_context_t,
     mut raw_key: *const dc_key_t,
@@ -233,8 +243,11 @@ pub unsafe fn dc_pgp_is_valid_key(
     if !key.is_null() {
         rpgp::rpgp_key_drop(key);
     }
-    return key_is_valid;
+
+    key_is_valid
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_pgp_calc_fingerprint(
     context: &dc_context_t,
     raw_key: *const dc_key_t,
@@ -276,8 +289,11 @@ pub unsafe fn dc_pgp_calc_fingerprint(
     if !fingerprint.is_null() {
         rpgp::rpgp_cvec_drop(fingerprint);
     }
-    return success;
+
+    success
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_pgp_split_key(
     mut context: &dc_context_t,
     mut private_in: *const dc_key_t,
@@ -325,8 +341,11 @@ pub unsafe fn dc_pgp_split_key(
     if !buf.is_null() {
         rpgp::rpgp_cvec_drop(buf);
     }
-    return success;
+
+    success
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_pgp_pk_encrypt(
     mut context: &dc_context_t,
     mut plain_text: *const libc::c_void,
@@ -338,7 +357,7 @@ pub unsafe fn dc_pgp_pk_encrypt(
     mut ret_ctext_bytes: *mut size_t,
 ) -> libc::c_int {
     let mut current_block: u64;
-    let mut i: libc::c_int = 0i32;
+    let mut i: libc::c_int;
     let mut success: libc::c_int = 0i32;
     let mut public_keys_len: libc::c_int = 0i32;
     let mut public_keys: *mut *mut rpgp::signed_public_key = 0 as *mut *mut rpgp::signed_public_key;
@@ -406,7 +425,7 @@ pub unsafe fn dc_pgp_pk_encrypt(
                     2132137392766895896 => {}
                     _ => {
                         /* sign & encrypt */
-                        let mut op_clocks: libc::clock_t = 0i32 as libc::clock_t;
+                        let mut op_clocks: libc::clock_t;
                         let mut start: libc::clock_t = clock();
                         if private_key.is_null() {
                             encrypted = rpgp::rpgp_encrypt_bytes_to_keys(
@@ -493,8 +512,11 @@ pub unsafe fn dc_pgp_pk_encrypt(
     if !encrypted.is_null() {
         rpgp::rpgp_msg_drop(encrypted);
     }
-    return success;
+
+    success
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_pgp_pk_decrypt(
     mut context: &dc_context_t,
     mut ctext: *const libc::c_void,
@@ -507,7 +529,7 @@ pub unsafe fn dc_pgp_pk_decrypt(
     mut ret_signature_fingerprints: *mut dc_hash_t,
 ) -> libc::c_int {
     let mut current_block: u64;
-    let mut i: libc::c_int = 0i32;
+    let mut i: libc::c_int;
     let mut success: libc::c_int = 0i32;
     let mut encrypted: *mut rpgp::Message = 0 as *mut rpgp::Message;
     let mut decrypted: *mut rpgp::message_decrypt_result = 0 as *mut rpgp::message_decrypt_result;
@@ -654,9 +676,12 @@ pub unsafe fn dc_pgp_pk_decrypt(
     if !decrypted.is_null() {
         rpgp::rpgp_message_decrypt_result_drop(decrypted);
     }
-    return success;
+
+    success
 }
+
 /* symm. encryption */
+// TODO should return bool /rtn
 pub unsafe fn dc_pgp_symm_encrypt(
     mut context: &dc_context_t,
     mut passphrase: *const libc::c_char,
@@ -686,8 +711,11 @@ pub unsafe fn dc_pgp_symm_encrypt(
     if !decrypted.is_null() {
         rpgp::rpgp_msg_drop(decrypted);
     }
-    return success;
+
+    success
 }
+
+// TODO should return bool /rtn
 pub unsafe fn dc_pgp_symm_decrypt(
     mut context: &dc_context_t,
     mut passphrase: *const libc::c_char,
@@ -696,9 +724,9 @@ pub unsafe fn dc_pgp_symm_decrypt(
     mut ret_plain_text: *mut *mut libc::c_void,
     mut ret_plain_bytes: *mut size_t,
 ) -> libc::c_int {
-    let mut decrypted_bytes: *mut rpgp::cvec = 0 as *mut rpgp::cvec;
+    let mut decrypted_bytes: *mut rpgp::cvec;
     let mut success: libc::c_int = 0i32;
-    let mut encrypted: *mut rpgp::Message = 0 as *mut rpgp::Message;
+    let mut encrypted: *mut rpgp::Message;
     let mut decrypted: *mut rpgp::Message = 0 as *mut rpgp::Message;
     encrypted = rpgp::rpgp_msg_from_bytes(ctext as *const uint8_t, ctext_bytes as usize);
     if !(0 != dc_pgp_handle_rpgp_error(context)) {
@@ -719,5 +747,6 @@ pub unsafe fn dc_pgp_symm_decrypt(
     if !decrypted.is_null() {
         rpgp::rpgp_msg_drop(decrypted);
     }
-    return success;
+
+    success
 }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -36,28 +36,28 @@ pub unsafe fn dc_receive_imf(
     /* the function returns the number of created messages in the database */
     let mut incoming: libc::c_int = 1i32;
     let mut incoming_origin: libc::c_int = 0i32;
-    let mut to_ids: *mut dc_array_t = 0 as *mut dc_array_t;
+    let mut to_ids: *mut dc_array_t;
     let mut to_self: libc::c_int = 0i32;
     let mut from_id: uint32_t = 0i32 as uint32_t;
     let mut from_id_blocked: libc::c_int = 0i32;
     let mut to_id: uint32_t = 0i32 as uint32_t;
     let mut chat_id: uint32_t = 0i32 as uint32_t;
     let mut chat_id_blocked: libc::c_int = 0i32;
-    let mut state: libc::c_int = 0i32;
+    let mut state: libc::c_int;
     let mut hidden: libc::c_int = 0i32;
-    let mut msgrmsg: libc::c_int = 0i32;
+    let mut msgrmsg: libc::c_int;
     let mut add_delete_job: libc::c_int = 0i32;
     let mut insert_msg_id: uint32_t = 0i32 as uint32_t;
     let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
-    let mut i: size_t = 0i32 as size_t;
-    let mut icnt: size_t = 0i32 as size_t;
+    let mut i: size_t;
+    let mut icnt: size_t;
     /* Message-ID from the header */
     let mut rfc724_mid: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut sort_timestamp: time_t = -1i32 as time_t;
     let mut sent_timestamp: time_t = -1i32 as time_t;
     let mut rcvd_timestamp: time_t = -1i32 as time_t;
     let mut mime_parser: *mut dc_mimeparser_t = dc_mimeparser_new(context.get_blobdir(), context);
-    let mut field: *const mailimf_field = 0 as *const mailimf_field;
+    let mut field: *const mailimf_field;
     let mut mime_in_reply_to: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut mime_references: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut created_db_entries: *mut carray = carray_new(16i32 as libc::c_uint);
@@ -470,7 +470,7 @@ pub unsafe fn dc_receive_imf(
                             );
                             let mut header_bytes: libc::c_int = imf_raw_bytes as libc::c_int;
                             if 0 != save_mime_headers {
-                                let mut p: *mut libc::c_char = 0 as *mut libc::c_char;
+                                let mut p: *mut libc::c_char;
                                 p = strstr(
                                     imf_raw_not_terminated,
                                     b"\r\n\r\n\x00" as *const u8 as *const libc::c_char,
@@ -1001,7 +1001,6 @@ pub unsafe fn dc_receive_imf(
         if let Some(create_event_to_send) = create_event_to_send {
             let mut i_0: size_t = 0;
             let mut icnt_0: size_t = carray_count(created_db_entries) as size_t;
-            i_0 = 0i32 as size_t;
             while i_0 < icnt_0 {
                 ((*context).cb)(
                     context,
@@ -1016,7 +1015,7 @@ pub unsafe fn dc_receive_imf(
         carray_free(created_db_entries);
     }
     if !rr_event_to_send.is_null() {
-        let mut i_1: size_t = 0;
+        let mut i_1: size_t;
         let mut icnt_1: size_t = carray_count(rr_event_to_send) as size_t;
         i_1 = 0i32 as size_t;
         while i_1 < icnt_1 {
@@ -1098,15 +1097,15 @@ unsafe fn create_or_lookup_group(
     mut ret_chat_id: *mut uint32_t,
     mut ret_chat_id_blocked: *mut libc::c_int,
 ) {
-    let mut group_explicitly_left: libc::c_int = 0;
+    let mut group_explicitly_left: libc::c_int;
     let mut current_block: u64;
     let mut chat_id: uint32_t = 0i32 as uint32_t;
     let mut chat_id_blocked: libc::c_int = 0i32;
     let mut chat_id_verified: libc::c_int = 0i32;
     let mut grpid: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut grpname: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
-    let mut i: libc::c_int = 0i32;
+    let mut stmt: *mut sqlite3_stmt;
+    let mut i: libc::c_int;
     let mut to_ids_cnt: libc::c_int = dc_array_get_cnt(to_ids) as libc::c_int;
     let mut self_addr: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut recreate_member_list: libc::c_int = 0i32;
@@ -1130,8 +1129,8 @@ unsafe fn create_or_lookup_group(
     }
     set_better_msg(mime_parser, &mut better_msg);
     /* search the grpid in the header */
-    let mut field: *mut mailimf_field = 0 as *mut mailimf_field;
-    let mut optional_field: *mut mailimf_optional_field = 0 as *mut mailimf_optional_field;
+    let mut field: *mut mailimf_field;
+    let mut optional_field: *mut mailimf_optional_field;
     optional_field = dc_mimeparser_lookup_optional_field(
         mime_parser,
         b"Chat-Group-ID\x00" as *const u8 as *const libc::c_char,
@@ -1361,7 +1360,6 @@ unsafe fn create_or_lookup_group(
                         create_verified,
                     );
                     chat_id_blocked = create_blocked;
-                    chat_id_verified = create_verified;
                     recreate_member_list = 1i32;
                     current_block = 200744462051969938;
                 }
@@ -1573,7 +1571,7 @@ unsafe fn create_or_lookup_adhoc_group(
     let mut member_ids: *mut dc_array_t = 0 as *mut dc_array_t;
     let mut chat_id: uint32_t = 0i32 as uint32_t;
     let mut chat_id_blocked = 0;
-    let mut i = 0;
+    let mut i;
     let mut chat_ids: *mut dc_array_t = 0 as *mut dc_array_t;
     let mut chat_ids_str: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut q3: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -1679,7 +1677,7 @@ unsafe fn create_group_record(
     mut create_verified: libc::c_int,
 ) -> uint32_t {
     let mut chat_id: uint32_t = 0i32 as uint32_t;
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut stmt: *mut sqlite3_stmt;
     stmt = dc_sqlite3_prepare(
         context,
         &context.sql.clone().read().unwrap(),
@@ -1719,11 +1717,11 @@ unsafe fn create_adhoc_grp_id(
     let mut member_addrs: *mut dc_array_t = dc_array_new(23i32 as size_t);
     let mut member_ids_str: *mut libc::c_char =
         dc_array_get_string(member_ids, b",\x00" as *const u8 as *const libc::c_char);
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
-    let mut q3: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut addr: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut i: libc::c_int = 0i32;
-    let mut iCnt: libc::c_int = 0i32;
+    let mut stmt: *mut sqlite3_stmt;
+    let mut q3: *mut libc::c_char;
+    let mut addr: *mut libc::c_char;
+    let mut i: libc::c_int;
+    let mut iCnt: libc::c_int;
     let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut member_cs: dc_strbuilder_t = dc_strbuilder_t {
         buf: 0 as *mut libc::c_char,
@@ -1804,7 +1802,7 @@ unsafe fn search_chat_ids_by_contact_ids(
     let mut chat_ids: *mut dc_array_t = dc_array_new(23i32 as size_t);
 
     /* copy array, remove duplicates and SELF, sort by ID */
-    let mut i: libc::c_int = 0;
+    let mut i: libc::c_int;
     let mut iCnt: libc::c_int = dc_array_get_cnt(unsorted_contact_ids) as libc::c_int;
     if !(iCnt <= 0i32) {
         i = 0i32;
@@ -2036,7 +2034,7 @@ unsafe fn dc_is_reply_to_known_message(
 ) -> libc::c_int {
     /* check if the message is a reply to a known message; the replies are identified by the Message-ID from
     `In-Reply-To`/`References:` (to support non-Delta-Clients) or from `Chat-Predecessor:` (Delta clients, see comment in dc_chat.c) */
-    let mut optional_field: *mut mailimf_optional_field = 0 as *mut mailimf_optional_field;
+    let mut optional_field: *mut mailimf_optional_field;
     optional_field = dc_mimeparser_lookup_optional_field(
         mime_parser,
         b"Chat-Predecessor\x00" as *const u8 as *const libc::c_char,
@@ -2046,7 +2044,7 @@ unsafe fn dc_is_reply_to_known_message(
             return 1i32;
         }
     }
-    let mut field: *mut mailimf_field = 0 as *mut mailimf_field;
+    let mut field: *mut mailimf_field;
     field = dc_mimeparser_lookup_field(
         mime_parser,
         b"In-Reply-To\x00" as *const u8 as *const libc::c_char,
@@ -2084,7 +2082,7 @@ unsafe fn is_known_rfc724_mid_in_list(
     mut mid_list: *const clist,
 ) -> libc::c_int {
     if !mid_list.is_null() {
-        let mut cur: *mut clistiter = 0 as *mut clistiter;
+        let mut cur: *mut clistiter;
         cur = (*mid_list).first;
         while !cur.is_null() {
             if 0 != is_known_rfc724_mid(
@@ -2136,7 +2134,7 @@ unsafe fn dc_is_reply_to_messenger_message(
     - checks also if any of the referenced IDs are send by a messenger
     - it is okay, if the referenced messages are moved to trash here
     - no check for the Chat-* headers (function is only called if it is no messenger message itself) */
-    let mut field: *mut mailimf_field = 0 as *mut mailimf_field;
+    let mut field: *mut mailimf_field;
     field = dc_mimeparser_lookup_field(
         mime_parser,
         b"In-Reply-To\x00" as *const u8 as *const libc::c_char,

--- a/src/dc_saxparser.rs
+++ b/src/dc_saxparser.rs
@@ -31,6 +31,7 @@ pub unsafe extern "C" fn dc_saxparser_init(
     (*saxparser).endtag_cb = Some(def_endtag_cb);
     (*saxparser).text_cb = Some(def_text_cb);
 }
+
 unsafe fn def_text_cb(_userdata: *mut libc::c_void, _text: *const libc::c_char, _len: libc::c_int) {
 }
 
@@ -65,6 +66,7 @@ pub unsafe fn dc_saxparser_set_tag_handler(
         Some(def_endtag_cb)
     };
 }
+
 pub unsafe fn dc_saxparser_set_text_handler(
     mut saxparser: *mut dc_saxparser_t,
     mut text_cb: dc_saxparser_text_cb_t,
@@ -78,15 +80,16 @@ pub unsafe fn dc_saxparser_set_text_handler(
         Some(def_text_cb)
     };
 }
+
 pub unsafe fn dc_saxparser_parse(
     mut saxparser: *mut dc_saxparser_t,
     mut buf_start__: *const libc::c_char,
 ) {
     let mut current_block: u64;
-    let mut bak: libc::c_char = 0i32 as libc::c_char;
-    let mut buf_start: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut last_text_start: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut p: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut bak: libc::c_char;
+    let mut buf_start: *mut libc::c_char;
+    let mut last_text_start: *mut libc::c_char;
+    let mut p: *mut libc::c_char;
     /* attributes per tag - a fixed border here is a security feature, not a limit */
     /* attributes as key/value pairs, +1 for terminating the list */
     let mut attr: [*mut libc::c_char; 202] = [0 as *mut libc::c_char; 202];
@@ -214,7 +217,7 @@ pub unsafe fn dc_saxparser_parse(
                         {
                             let mut beg_attr_name: *mut libc::c_char = p;
                             let mut beg_attr_value: *mut libc::c_char = 0 as *mut libc::c_char;
-                            let mut beg_attr_value_new: *mut libc::c_char = 0 as *mut libc::c_char;
+                            let mut beg_attr_value_new: *mut libc::c_char;
                             if '=' as i32 == *beg_attr_name as libc::c_int {
                                 p = p.offset(1isize)
                             } else {
@@ -356,6 +359,7 @@ pub unsafe fn dc_saxparser_parse(
     do_free_attr(attr.as_mut_ptr(), free_attr.as_mut_ptr());
     free(buf_start as *mut libc::c_void);
 }
+
 unsafe fn do_free_attr(mut attr: *mut *mut libc::c_char, mut free_attr: *mut libc::c_int) {
     /* "attr" are key/value pairs; the function frees the data if the corresponding bit in "free_attr" is set.
     (we need this as we try to use the strings from the "main" document instead of allocating small strings) */
@@ -376,6 +380,7 @@ unsafe fn do_free_attr(mut attr: *mut *mut libc::c_char, mut free_attr: *mut lib
     let ref mut fresh0 = *attr.offset(0isize);
     *fresh0 = 0 as *mut libc::c_char;
 }
+
 unsafe fn call_text_cb(
     mut saxparser: *mut dc_saxparser_t,
     mut text: *mut libc::c_char,
@@ -384,7 +389,7 @@ unsafe fn call_text_cb(
 ) {
     if !text.is_null() && 0 != len {
         let mut bak: libc::c_char = *text.offset(len as isize);
-        let mut text_new: *mut libc::c_char = 0 as *mut libc::c_char;
+        let mut text_new: *mut libc::c_char;
         *text.offset(len as isize) = '\u{0}' as i32 as libc::c_char;
         text_new = xml_decode(text, type_0);
         (*saxparser).text_cb.expect("non-null function pointer")(
@@ -398,6 +403,7 @@ unsafe fn call_text_cb(
         *text.offset(len as isize) = bak
     };
 }
+
 /* Convert entities as &auml; to UTF-8 characters.
 
 - The first strings MUST NOT start with `&` and MUST end with `;`.
@@ -421,10 +427,10 @@ unsafe fn xml_decode(mut s: *mut libc::c_char, mut type_0: libc::c_char) -> *mut
     let mut e: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut r: *mut libc::c_char = s;
     let mut original_buf: *const libc::c_char = s;
-    let mut b = 0;
-    let mut c: isize = 0;
-    let mut d: isize = 0;
-    let mut l: isize = 0;
+    let mut b;
+    let mut c: isize;
+    let mut d: isize;
+    let mut l: isize;
     while 0 != *s {
         while *s as libc::c_int == '\r' as i32 {
             let fresh1 = s;
@@ -547,8 +553,10 @@ unsafe fn xml_decode(mut s: *mut libc::c_char, mut type_0: libc::c_char) -> *mut
             s = s.offset(1isize)
         }
     }
-    return r;
+
+    r
 }
+
 /* dc_saxparser_t parses XML and HTML files that may not be wellformed
 and spits out all text and tags found.
 
@@ -1077,6 +1085,7 @@ static mut s_ent: [*const libc::c_char; 508] = [
     0 as *const libc::c_char,
     0 as *const libc::c_char,
 ];
+
 pub unsafe fn dc_attr_find(
     mut attr: *mut *mut libc::c_char,
     mut key: *const libc::c_char,
@@ -1090,5 +1099,6 @@ pub unsafe fn dc_attr_find(
             return *attr.offset((i + 1i32) as isize);
         }
     }
-    return 0 as *const libc::c_char;
+
+    0 as *const libc::c_char
 }

--- a/src/dc_securejoin.rs
+++ b/src/dc_securejoin.rs
@@ -34,13 +34,13 @@ pub unsafe fn dc_get_securejoin_qr(
     ====   Step 1 in "Setup verified contact" protocol   ====
     ========================================================= */
     let mut qr: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut self_addr: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut self_addr: *mut libc::c_char;
     let mut self_addr_urlencoded: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut self_name: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut self_name_urlencoded: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut fingerprint: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut invitenumber: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut auth: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut invitenumber: *mut libc::c_char;
+    let mut auth: *mut libc::c_char;
     let mut chat: *mut dc_chat_t = 0 as *mut dc_chat_t;
     let mut group_name: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut group_name_urlencoded: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -148,7 +148,7 @@ pub unsafe fn dc_get_securejoin_qr(
 }
 
 unsafe fn get_self_fingerprint(mut context: &dc_context_t) -> *mut libc::c_char {
-    let mut self_addr: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut self_addr: *mut libc::c_char;
     let mut self_key: *mut dc_key_t = dc_key_new();
     let mut fingerprint: *mut libc::c_char = 0 as *mut libc::c_char;
     self_addr = dc_sqlite3_get_config(
@@ -170,8 +170,10 @@ unsafe fn get_self_fingerprint(mut context: &dc_context_t) -> *mut libc::c_char 
     }
     free(self_addr as *mut libc::c_void);
     dc_key_unref(self_key);
-    return fingerprint;
+
+    fingerprint
 }
+
 pub unsafe fn dc_join_securejoin(
     mut context: &dc_context_t,
     mut qr: *const libc::c_char,
@@ -181,7 +183,7 @@ pub unsafe fn dc_join_securejoin(
     ====   Step 2 in "Setup verified contact" protocol   =====
     ========================================================== */
     let mut ret_chat_id: libc::c_int = 0i32;
-    let mut ongoing_allocated: libc::c_int = 0i32;
+    let mut ongoing_allocated: libc::c_int;
     let mut contact_chat_id: uint32_t = 0i32 as uint32_t;
     let mut join_vg: libc::c_int = 0i32;
     let mut qr_scan: *mut dc_lot_t = 0 as *mut dc_lot_t;
@@ -341,6 +343,7 @@ unsafe fn send_handshake_msg(
     dc_send_msg(context, contact_chat_id, msg);
     dc_msg_unref(msg);
 }
+
 unsafe fn chat_id_2_contact_id(
     mut context: &dc_context_t,
     mut contact_chat_id: uint32_t,
@@ -351,8 +354,10 @@ unsafe fn chat_id_2_contact_id(
         contact_id = dc_array_get_id(contacts, 0i32 as size_t)
     }
     dc_array_unref(contacts);
-    return contact_id;
+
+    contact_id
 }
+
 unsafe fn fingerprint_equals_sender(
     mut context: &dc_context_t,
     mut fingerprint: *const libc::c_char,
@@ -385,8 +390,10 @@ unsafe fn fingerprint_equals_sender(
     free(fingerprint_normalized as *mut libc::c_void);
     dc_contact_unref(contact);
     dc_array_unref(contacts);
-    return fingerprint_equal;
+
+    fingerprint_equal
 }
+
 /* library private: secure-join */
 pub unsafe fn dc_handle_securejoin_handshake(
     context: &dc_context_t,
@@ -394,8 +401,8 @@ pub unsafe fn dc_handle_securejoin_handshake(
     contact_id: uint32_t,
 ) -> libc::c_int {
     let mut current_block: u64;
-    let mut step: *const libc::c_char = 0 as *const libc::c_char;
-    let mut join_vg: libc::c_int = 0i32;
+    let mut step: *const libc::c_char;
+    let mut join_vg: libc::c_int;
     let mut scanned_fingerprint_of_alice: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut auth: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut own_fingerprint: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -441,7 +448,7 @@ pub unsafe fn dc_handle_securejoin_handshake(
                 // it just ensures, we have Bobs key now. If we do _not_ have the key because eg. MitM has removed it,
                 // send_message() will fail with the error "End-to-end-encryption unavailable unexpectedly.", so, there is no additional check needed here.
                 // verify that the `Secure-Join-Invitenumber:`-header matches invitenumber written to the QR code
-                let mut invitenumber: *const libc::c_char = 0 as *const libc::c_char;
+                let mut invitenumber: *const libc::c_char;
                 invitenumber = lookup_field(
                     mimeparser,
                     b"Secure-Join-Invitenumber\x00" as *const u8 as *const libc::c_char,
@@ -588,7 +595,7 @@ pub unsafe fn dc_handle_securejoin_handshake(
                 ====  Step 6 in "Out-of-band verified groups" protocol  ====
                 ============================================================ */
                 // verify that Secure-Join-Fingerprint:-header matches the fingerprint of Bob
-                let mut fingerprint: *const libc::c_char = 0 as *const libc::c_char;
+                let mut fingerprint: *const libc::c_char;
                 fingerprint = lookup_field(
                     mimeparser,
                     b"Secure-Join-Fingerprint\x00" as *const u8 as *const libc::c_char,
@@ -622,7 +629,7 @@ pub unsafe fn dc_handle_securejoin_handshake(
                         b"Fingerprint verified.\x00" as *const u8 as *const libc::c_char,
                     );
                     // verify that the `Secure-Join-Auth:`-header matches the secret written to the QR code
-                    let mut auth_0: *const libc::c_char = 0 as *const libc::c_char;
+                    let mut auth_0: *const libc::c_char;
                     auth_0 = lookup_field(
                         mimeparser,
                         b"Secure-Join-Auth\x00" as *const u8 as *const libc::c_char,
@@ -896,12 +903,15 @@ pub unsafe fn dc_handle_securejoin_handshake(
     free(auth as *mut libc::c_void);
     free(own_fingerprint as *mut libc::c_void);
     free(grpid as *mut libc::c_void);
-    return ret;
+
+    ret
 }
+
 unsafe fn end_bobs_joining(context: &dc_context_t, status: libc::c_int) {
     context.bob.clone().write().unwrap().status = status;
     dc_stop_ongoing_process(context);
 }
+
 unsafe fn secure_connection_established(mut context: &dc_context_t, mut contact_chat_id: uint32_t) {
     let mut contact_id: uint32_t = chat_id_2_contact_id(context, contact_chat_id);
     let mut contact: *mut dc_contact_t = dc_get_contact(context, contact_id);
@@ -924,6 +934,7 @@ unsafe fn secure_connection_established(mut context: &dc_context_t, mut contact_
     free(msg as *mut libc::c_void);
     dc_contact_unref(contact);
 }
+
 unsafe fn lookup_field(
     mut mimeparser: *mut dc_mimeparser_t,
     mut key: *const libc::c_char,
@@ -940,8 +951,10 @@ unsafe fn lookup_field(
     {
         return 0 as *const libc::c_char;
     }
-    return value;
+
+    value
 }
+
 unsafe fn could_not_establish_secure_connection(
     context: &dc_context_t,
     contact_chat_id: uint32_t,
@@ -969,6 +982,7 @@ unsafe fn could_not_establish_secure_connection(
     free(msg as *mut libc::c_void);
     dc_contact_unref(contact);
 }
+
 unsafe fn mark_peer_as_verified(
     context: &dc_context_t,
     fingerprint: *const libc::c_char,
@@ -990,11 +1004,15 @@ unsafe fn mark_peer_as_verified(
         }
     }
     dc_apeerstate_unref(peerstate);
-    return success;
+
+    success
 }
+
 /* ******************************************************************************
  * Tools: Misc.
  ******************************************************************************/
+
+// TODO should return bool
 unsafe fn encrypted_and_signed(
     mut mimeparser: *mut dc_mimeparser_t,
     mut expected_fingerprint: *const libc::c_char,
@@ -1039,14 +1057,16 @@ unsafe fn encrypted_and_signed(
         );
         return 0i32;
     }
-    return 1i32;
+
+    1
 }
+
 pub unsafe fn dc_handle_degrade_event(
     mut context: &dc_context_t,
     mut peerstate: *mut dc_apeerstate_t,
 ) {
-    let mut stmt = 0 as *mut sqlite3_stmt;
-    let mut contact_id: uint32_t = 0i32 as uint32_t;
+    let mut stmt;
+    let mut contact_id: uint32_t;
     let mut contact_chat_id: uint32_t = 0i32 as uint32_t;
     if !peerstate.is_null() {
         // - we do not issue an warning for DC_DE_ENCRYPTION_PAUSED as this is quite normal

--- a/src/dc_simplify.rs
+++ b/src/dc_simplify.rs
@@ -15,19 +15,22 @@ pub struct dc_simplify_t {
 }
 
 pub unsafe fn dc_simplify_new() -> *mut dc_simplify_t {
-    let mut simplify: *mut dc_simplify_t = 0 as *mut dc_simplify_t;
+    let mut simplify: *mut dc_simplify_t;
     simplify = calloc(1, ::std::mem::size_of::<dc_simplify_t>()) as *mut dc_simplify_t;
     if simplify.is_null() {
         exit(31i32);
     }
-    return simplify;
+
+    simplify
 }
+
 pub unsafe fn dc_simplify_unref(mut simplify: *mut dc_simplify_t) {
     if simplify.is_null() {
         return;
     }
     free(simplify as *mut libc::c_void);
 }
+
 /* Simplify and normalise text: Remove quotes, signatures, unnecessary
 lineends etc.
 The data returned from Simplify() must be free()'d when no longer used, private */
@@ -39,8 +42,8 @@ pub unsafe fn dc_simplify_simplify(
     mut is_msgrmsg: libc::c_int,
 ) -> *mut libc::c_char {
     /* create a copy of the given buffer */
-    let mut out: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut temp: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut out: *mut libc::c_char;
+    let mut temp: *mut libc::c_char;
     if simplify.is_null() || in_unterminated.is_null() || in_bytes <= 0i32 {
         return dc_strdup(b"\x00" as *const u8 as *const libc::c_char);
     }
@@ -68,8 +71,10 @@ pub unsafe fn dc_simplify_simplify(
         out = temp
     }
     dc_remove_cr_chars(out);
-    return out;
+
+    out
 }
+
 /* ******************************************************************************
  * Simplify Plain Text
  ******************************************************************************/
@@ -85,12 +90,12 @@ unsafe fn dc_simplify_simplify_plain_text(
     ... remove a non-empty line before the removed quote (contains sth. like "On 2.9.2016, Bjoern wrote:" in different formats and lanugages) */
     /* split the given buffer into lines */
     let mut lines: *mut carray = dc_split_into_lines(buf_terminated);
-    let mut l: libc::c_int = 0i32;
+    let mut l: libc::c_int;
     let mut l_first: libc::c_int = 0i32;
     /* if l_last is -1, there are no lines */
     let mut l_last: libc::c_int =
         carray_count(lines).wrapping_sub(1i32 as libc::c_uint) as libc::c_int;
-    let mut line: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut line: *mut libc::c_char;
     let mut footer_mark: libc::c_int = 0i32;
     l = l_first;
     while l <= l_last {
@@ -246,11 +251,14 @@ unsafe fn dc_simplify_simplify_plain_text(
         dc_strbuilder_cat(&mut ret, b" [...]\x00" as *const u8 as *const libc::c_char);
     }
     dc_free_splitted_lines(lines);
-    return ret.buf;
+
+    ret.buf
 }
+
 /* ******************************************************************************
  * Tools
  ******************************************************************************/
+// TODO should return bool /rtn
 unsafe fn is_empty_line(mut buf: *const libc::c_char) -> libc::c_int {
     /* force unsigned - otherwise the `> ' '` comparison will fail */
     let mut p1: *const libc::c_uchar = buf as *const libc::c_uchar;
@@ -260,8 +268,11 @@ unsafe fn is_empty_line(mut buf: *const libc::c_char) -> libc::c_int {
         }
         p1 = p1.offset(1isize)
     }
-    return 1i32;
+
+    1
 }
+
+// TODO should return bool /rtn
 unsafe fn is_quoted_headline(mut buf: *const libc::c_char) -> libc::c_int {
     /* This function may be called for the line _directly_ before a quote.
     The function checks if the line contains sth. like "On 01.02.2016, xy@z wrote:" in various languages.
@@ -274,11 +285,15 @@ unsafe fn is_quoted_headline(mut buf: *const libc::c_char) -> libc::c_int {
     if buf_len > 0i32 && *buf.offset((buf_len - 1i32) as isize) as libc::c_int == ':' as i32 {
         return 1i32;
     }
-    return 0i32;
+
+    0
 }
+
+// TODO should return bool /rtn
 unsafe fn is_plain_quote(mut buf: *const libc::c_char) -> libc::c_int {
     if *buf.offset(0isize) as libc::c_int == '>' as i32 {
         return 1i32;
     }
-    return 0i32;
+
+    0
 }

--- a/src/dc_sqlite3.rs
+++ b/src/dc_sqlite3.rs
@@ -10,7 +10,6 @@ use crate::types::*;
 use crate::x::*;
 
 const DC_OPEN_READONLY: usize = 0x01;
-const DC_HOUSEKEEPING_DELAY_SEC: usize = 10;
 
 /// A simple wrapper around the underlying Sqlite3 object.
 #[repr(C)]

--- a/src/dc_sqlite3.rs
+++ b/src/dc_sqlite3.rs
@@ -900,7 +900,6 @@ pub unsafe fn dc_sqlite3_open(
                                 b"ALTER TABLE locations ADD COLUMN independent INTEGER DEFAULT 0;\x00" as *const u8 as *const libc::c_char
                             );
 
-                            dbversion = 55;
                             dc_sqlite3_set_config_int(
                                 context,
                                 sql,
@@ -1018,8 +1017,8 @@ pub unsafe fn dc_sqlite3_set_config(
     key: *const libc::c_char,
     value: *const libc::c_char,
 ) -> libc::c_int {
-    let mut state = 0;
-    let mut stmt = 0 as *mut sqlite3_stmt;
+    let mut state;
+    let mut stmt;
     if key.is_null() {
         dc_log_error(
             context,
@@ -1135,7 +1134,7 @@ pub unsafe extern "C" fn dc_sqlite3_log_error(
     msg_format: *const libc::c_char,
     va: ...
 ) {
-    let mut msg = 0 as *mut libc::c_char;
+    let mut msg;
     if msg_format.is_null() {
         return;
     }
@@ -1174,7 +1173,7 @@ pub unsafe fn dc_sqlite3_get_config(
     key: *const libc::c_char,
     def: *const libc::c_char,
 ) -> *mut libc::c_char {
-    let mut stmt = 0 as *mut sqlite3_stmt;
+    let mut stmt;
     if 0 == dc_sqlite3_is_open(sql) || key.is_null() {
         return dc_strdup_keep_null(def);
     }
@@ -1202,7 +1201,7 @@ pub unsafe fn dc_sqlite3_execute(
     querystr: *const libc::c_char,
 ) -> libc::c_int {
     let mut success = 0;
-    let mut sqlState = 0;
+    let mut sqlState;
     let stmt = dc_sqlite3_prepare(context, sql, querystr);
     if !stmt.is_null() {
         sqlState = sqlite3_step(stmt);
@@ -1262,7 +1261,7 @@ pub unsafe fn dc_sqlite3_table_exists(
 ) -> libc::c_int {
     let mut ret = 0;
     let mut stmt = 0 as *mut sqlite3_stmt;
-    let mut sqlState = 0;
+    let mut sqlState;
 
     let querystr = sqlite3_mprintf(
         b"PRAGMA table_info(%s)\x00" as *const u8 as *const libc::c_char,
@@ -1339,7 +1338,7 @@ pub unsafe fn dc_sqlite3_try_execute(
 ) -> libc::c_int {
     // same as dc_sqlite3_execute() but does not pass error to ui
     let mut success = 0;
-    let mut sql_state = 0;
+    let mut sql_state;
     let stmt = dc_sqlite3_prepare(context, sql, querystr);
     if !stmt.is_null() {
         sql_state = sqlite3_step(stmt);
@@ -1416,9 +1415,9 @@ pub unsafe fn dc_sqlite3_get_rowid2(
 }
 
 pub unsafe fn dc_housekeeping(context: &dc_context_t) {
-    let mut stmt = 0 as *mut sqlite3_stmt;
-    let mut dir_handle = 0 as *mut DIR;
-    let mut dir_entry = 0 as *mut dirent;
+    let mut stmt;
+    let mut dir_handle;
+    let mut dir_entry;
     let mut files_in_use = dc_hash_t {
         keyClass: 0,
         copyKey: 0,

--- a/src/dc_stock.rs
+++ b/src/dc_stock.rs
@@ -18,7 +18,7 @@ unsafe fn get_string(
     mut id: libc::c_int,
     mut qty: libc::c_int,
 ) -> *mut libc::c_char {
-    let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut ret: *mut libc::c_char;
 
     ret = ((*context).cb)(
         context,
@@ -30,12 +30,15 @@ unsafe fn get_string(
     if ret.is_null() {
         ret = default_string(id)
     }
-    return ret;
+
+    ret
 }
+
 /* Add translated strings that are used by the messager backend.
 As the logging functions may use these strings, do not log any
 errors from here. */
 unsafe fn default_string(mut id: libc::c_int) -> *mut libc::c_char {
+    // TODO match on enum values /rtn
     match id {
         1 => {
             return dc_strdup(b"No messages.\x00" as *const u8 as
@@ -208,8 +211,10 @@ unsafe fn default_string(mut id: libc::c_int) -> *mut libc::c_char {
         }
         _ => { }
     }
-    return dc_strdup(b"ErrStr\x00" as *const u8 as *const libc::c_char);
+
+    dc_strdup(b"ErrStr\x00" as *const u8 as *const libc::c_char)
 }
+
 /* Replaces the first `%1$s` in the given String-ID by the given value.
 The result must be free()'d! */
 pub unsafe fn dc_stock_str_repl_string(
@@ -228,8 +233,10 @@ pub unsafe fn dc_stock_str_repl_string(
         b"%1$d\x00" as *const u8 as *const libc::c_char,
         to_insert,
     );
-    return ret;
+
+    ret
 }
+
 pub unsafe fn dc_stock_str_repl_int(
     mut context: &dc_context_t,
     mut id: libc::c_int,
@@ -251,8 +258,10 @@ pub unsafe fn dc_stock_str_repl_int(
         to_insert_str,
     );
     free(to_insert_str as *mut libc::c_void);
-    return ret;
+
+    ret
 }
+
 /* Replaces the first `%1$s` and `%2$s` in the given String-ID by the two given strings.
 The result must be free()'d! */
 pub unsafe fn dc_stock_str_repl_string2(
@@ -282,8 +291,10 @@ pub unsafe fn dc_stock_str_repl_string2(
         b"%2$d\x00" as *const u8 as *const libc::c_char,
         to_insert2,
     );
-    return ret;
+
+    ret
 }
+
 /* Misc. */
 pub unsafe fn dc_stock_system_msg(
     mut context: &dc_context_t,
@@ -292,7 +303,7 @@ pub unsafe fn dc_stock_system_msg(
     mut param2: *const libc::c_char,
     mut from_id: uint32_t,
 ) -> *mut libc::c_char {
-    let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut ret: *mut libc::c_char;
     let mut mod_contact: *mut dc_contact_t = 0 as *mut dc_contact_t;
     let mut mod_displayname: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut from_contact: *mut dc_contact_t = 0 as *mut dc_contact_t;
@@ -332,5 +343,6 @@ pub unsafe fn dc_stock_system_msg(
     free(mod_displayname as *mut libc::c_void);
     dc_contact_unref(from_contact);
     dc_contact_unref(mod_contact);
-    return ret;
+
+    ret
 }

--- a/src/dc_strencode.rs
+++ b/src/dc_strencode.rs
@@ -70,8 +70,10 @@ pub unsafe extern "C" fn dc_urlencode(mut to_encode: *const libc::c_char) -> *mu
         pstr = pstr.offset(1isize)
     }
     *pbuf = '\u{0}' as i32 as libc::c_char;
-    return buf;
+
+    buf
 }
+
 /* ******************************************************************************
  * URL encoding and decoding, RFC 3986
  ******************************************************************************/
@@ -79,8 +81,10 @@ unsafe fn int_2_uppercase_hex(mut code: libc::c_char) -> libc::c_char {
     static mut hex: [libc::c_char; 17] = [
         48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 65, 66, 67, 68, 69, 70, 0,
     ];
-    return hex[(code as libc::c_int & 15i32) as usize];
+
+    hex[(code as libc::c_int & 15i32) as usize]
 }
+
 pub unsafe fn dc_urldecode(mut to_decode: *const libc::c_char) -> *mut libc::c_char {
     let mut pstr: *const libc::c_char = to_decode;
     if to_decode.is_null() {
@@ -114,8 +118,10 @@ pub unsafe fn dc_urldecode(mut to_decode: *const libc::c_char) -> *mut libc::c_c
         pstr = pstr.offset(1isize)
     }
     *pbuf = '\u{0}' as i32 as libc::c_char;
-    return buf;
+
+    buf
 }
+
 unsafe fn hex_2_int(mut ch: libc::c_char) -> libc::c_char {
     return (if 0 != isdigit(ch as libc::c_int) {
         ch as libc::c_int - '0' as i32
@@ -123,6 +129,7 @@ unsafe fn hex_2_int(mut ch: libc::c_char) -> libc::c_char {
         tolower(ch as libc::c_int) - 'a' as i32 + 10i32
     }) as libc::c_char;
 }
+
 pub unsafe fn dc_encode_header_words(mut to_encode: *const libc::c_char) -> *mut libc::c_char {
     let mut current_block: u64;
     let mut ret_str: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -143,10 +150,10 @@ pub unsafe fn dc_encode_header_words(mut to_encode: *const libc::c_char) -> *mut
             }
             _ => {
                 if *cur as libc::c_int != '\u{0}' as i32 {
-                    let mut begin: *const libc::c_char = 0 as *const libc::c_char;
-                    let mut end: *const libc::c_char = 0 as *const libc::c_char;
-                    let mut do_quote: libc::c_int = 0;
-                    let mut quote_words: libc::c_int = 0;
+                    let mut begin: *const libc::c_char;
+                    let mut end: *const libc::c_char;
+                    let mut do_quote: libc::c_int;
+                    let mut quote_words: libc::c_int;
                     begin = cur;
                     end = begin;
                     quote_words = 0i32;
@@ -218,15 +225,18 @@ pub unsafe fn dc_encode_header_words(mut to_encode: *const libc::c_char) -> *mut
             }
         }
     }
-    return ret_str;
+
+    ret_str
 }
+
+// TODO return bool /rtn
 unsafe fn quote_word(
     mut display_charset: *const libc::c_char,
     mut mmapstr: *mut MMAPString,
     mut word: *const libc::c_char,
     mut size: size_t,
 ) -> libc::c_int {
-    let mut cur: *const libc::c_char = 0 as *const libc::c_char;
+    let mut cur: *const libc::c_char;
     let mut i: size_t = 0i32 as size_t;
     let mut hex: [libc::c_char; 4] = [0; 4];
     // let mut col: libc::c_int = 0i32;
@@ -241,10 +251,8 @@ unsafe fn quote_word(
     }
     // col = (*mmapstr).len as libc::c_int;
     cur = word;
-    i = 0i32 as size_t;
     while i < size {
         let mut do_quote_char: libc::c_int = 0;
-        do_quote_char = 0i32;
         match *cur as libc::c_int {
             44 | 58 | 33 | 34 | 35 | 36 | 64 | 91 | 92 | 93 | 94 | 96 | 123 | 124 | 125 | 126
             | 61 | 63 | 95 => do_quote_char = 1i32,
@@ -281,12 +289,14 @@ unsafe fn quote_word(
     if mmap_string_append(mmapstr, b"?=\x00" as *const u8 as *const libc::c_char).is_null() {
         return 0i32;
     }
-    return 1i32;
+
+    1
 }
+
 unsafe fn get_word(
     mut begin: *const libc::c_char,
     mut pend: *mut *const libc::c_char,
-    mut pto_be_quoted: *mut libc::c_int,
+    mut pto_be_quoted: *mut libc::c_int, // TODO should be bool /rtn
 ) {
     let mut cur: *const libc::c_char = begin;
     while *cur as libc::c_int != ' ' as i32
@@ -301,14 +311,16 @@ unsafe fn get_word(
     );
     *pend = cur;
 }
+
 /* ******************************************************************************
  * Encode/decode header words, RFC 2047
  ******************************************************************************/
+
 /* see comment below */
+// TODO should be bool /rtn
 unsafe fn to_be_quoted(mut word: *const libc::c_char, mut size: size_t) -> libc::c_int {
     let mut cur: *const libc::c_char = word;
     let mut i: size_t = 0i32 as size_t;
-    i = 0i32 as size_t;
     while i < size {
         match *cur as libc::c_int {
             44 | 58 | 33 | 34 | 35 | 36 | 64 | 91 | 92 | 93 | 94 | 96 | 123 | 124 | 125 | 126
@@ -322,8 +334,10 @@ unsafe fn to_be_quoted(mut word: *const libc::c_char, mut size: size_t) -> libc:
         cur = cur.offset(1isize);
         i = i.wrapping_add(1)
     }
-    return 0i32;
+
+    0
 }
+
 pub unsafe fn dc_decode_header_words(mut in_0: *const libc::c_char) -> *mut libc::c_char {
     if in_0.is_null() {
         return 0 as *mut libc::c_char;
@@ -341,22 +355,24 @@ pub unsafe fn dc_decode_header_words(mut in_0: *const libc::c_char) -> *mut libc
     if r != MAILIMF_NO_ERROR as libc::c_int || out.is_null() {
         out = dc_strdup(in_0)
     }
-    return out;
+
+    out
 }
+
 pub unsafe fn dc_encode_modified_utf7(
     mut to_encode: *const libc::c_char,
     mut change_spaces: libc::c_int,
 ) -> *mut libc::c_char {
-    let mut utf8pos: libc::c_uint = 0i32 as libc::c_uint;
-    let mut utf8total: libc::c_uint = 0i32 as libc::c_uint;
-    let mut c: libc::c_uint = 0i32 as libc::c_uint;
-    let mut utf7mode: libc::c_uint = 0i32 as libc::c_uint;
-    let mut bitstogo: libc::c_uint = 0i32 as libc::c_uint;
-    let mut utf16flag: libc::c_uint = 0i32 as libc::c_uint;
+    let mut utf8pos: libc::c_uint;
+    let mut utf8total: libc::c_uint;
+    let mut c: libc::c_uint;
+    let mut utf7mode: libc::c_uint;
+    let mut bitstogo: libc::c_uint;
+    let mut utf16flag: libc::c_uint;
     let mut ucs4: libc::c_ulong = 0;
     let mut bitbuf: libc::c_ulong = 0;
-    let mut dst: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut res: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut dst: *mut libc::c_char;
+    let mut res: *mut libc::c_char;
     if to_encode.is_null() {
         return dc_strdup(b"\x00" as *const u8 as *const libc::c_char);
     }
@@ -479,31 +495,35 @@ pub unsafe fn dc_encode_modified_utf7(
         *fresh16 = '-' as i32 as libc::c_char
     }
     *dst = '\u{0}' as i32 as libc::c_char;
-    return res;
+
+    res
 }
+
 /* ******************************************************************************
  * Encode/decode modified UTF-7 as needed for IMAP, see RFC 2192
  ******************************************************************************/
+
 // UTF7 modified base64 alphabet
 static mut base64chars: [libc::c_char; 65] = [
     65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88,
     89, 90, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114,
     115, 116, 117, 118, 119, 120, 121, 122, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 43, 44, 0,
 ];
+
 pub unsafe fn dc_decode_modified_utf7(
     mut to_decode: *const libc::c_char,
     mut change_spaces: libc::c_int,
 ) -> *mut libc::c_char {
-    let mut c: libc::c_uint = 0i32 as libc::c_uint;
-    let mut i: libc::c_uint = 0i32 as libc::c_uint;
-    let mut bitcount: libc::c_uint = 0i32 as libc::c_uint;
-    let mut ucs4: libc::c_ulong = 0;
-    let mut utf16: libc::c_ulong = 0;
-    let mut bitbuf: libc::c_ulong = 0;
+    let mut c: libc::c_uint;
+    let mut i: libc::c_uint;
+    let mut bitcount: libc::c_uint;
+    let mut ucs4: libc::c_ulong;
+    let mut utf16: libc::c_ulong;
+    let mut bitbuf: libc::c_ulong;
     let mut base64: [libc::c_uchar; 256] = [0; 256];
-    let mut src: *const libc::c_char = 0 as *const libc::c_char;
-    let mut dst: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut res: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut src: *const libc::c_char;
+    let mut dst: *mut libc::c_char;
+    let mut res: *mut libc::c_char;
     if to_decode.is_null() {
         return dc_strdup(b"\x00" as *const u8 as *const libc::c_char);
     }
@@ -599,8 +619,11 @@ pub unsafe fn dc_decode_modified_utf7(
         }
     }
     *dst = '\u{0}' as i32 as libc::c_char;
-    return res;
+
+    res
 }
+
+// TODO should be bool /rtn
 pub unsafe fn dc_needs_ext_header(mut to_check: *const libc::c_char) -> libc::c_int {
     if !to_check.is_null() {
         while 0 != *to_check {
@@ -615,8 +638,10 @@ pub unsafe fn dc_needs_ext_header(mut to_check: *const libc::c_char) -> libc::c_
             to_check = to_check.offset(1isize)
         }
     }
-    return 0i32;
+
+    0
 }
+
 pub unsafe fn dc_encode_ext_header(mut to_encode: *const libc::c_char) -> *mut libc::c_char {
     let mut pstr: *const libc::c_char = to_encode;
     if to_encode.is_null() {
@@ -657,12 +682,14 @@ pub unsafe fn dc_encode_ext_header(mut to_encode: *const libc::c_char) -> *mut l
         pstr = pstr.offset(1isize)
     }
     *pbuf = '\u{0}' as i32 as libc::c_char;
-    return buf;
+
+    buf
 }
+
 pub unsafe fn dc_decode_ext_header(mut to_decode: *const libc::c_char) -> *mut libc::c_char {
     let mut decoded: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut charset: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut p2: *const libc::c_char = 0 as *const libc::c_char;
+    let mut p2: *const libc::c_char;
     if !to_decode.is_null() {
         // get char set
         p2 = strchr(to_decode, '\'' as i32);

--- a/src/dc_token.rs
+++ b/src/dc_token.rs
@@ -39,8 +39,8 @@ pub unsafe fn dc_token_lookup(
     mut namespc: dc_tokennamespc_t,
     mut foreign_id: uint32_t,
 ) -> *mut libc::c_char {
-    let mut token: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
+    let mut token: *mut libc::c_char;
+    let mut stmt: *mut sqlite3_stmt;
     stmt = dc_sqlite3_prepare(
         context,
         &context.sql.clone().read().unwrap(),

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -18,10 +18,11 @@ no references to dc_context_t and other "larger" classes here. */
 pub unsafe fn dc_exactly_one_bit_set(mut v: libc::c_int) -> libc::c_int {
     return (0 != v && 0 == v & v - 1i32) as libc::c_int;
 }
+
 /* string tools */
 /* dc_strdup() returns empty string if NULL is given, never returns NULL (exits on errors) */
 pub unsafe fn dc_strdup(mut s: *const libc::c_char) -> *mut libc::c_char {
-    let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut ret: *mut libc::c_char;
     if !s.is_null() {
         ret = strdup(s);
         if ret.is_null() {
@@ -33,8 +34,10 @@ pub unsafe fn dc_strdup(mut s: *const libc::c_char) -> *mut libc::c_char {
             exit(17i32);
         }
     }
-    return ret;
+
+    ret
 }
+
 /* strdup(NULL) is undefined, safe_strdup_keep_null(NULL) returns NULL in this case */
 pub unsafe fn dc_strdup_keep_null(mut s: *const libc::c_char) -> *mut libc::c_char {
     return if !s.is_null() {
@@ -43,9 +46,11 @@ pub unsafe fn dc_strdup_keep_null(mut s: *const libc::c_char) -> *mut libc::c_ch
         0 as *mut libc::c_char
     };
 }
+
 pub unsafe fn dc_atoi_null_is_0(mut s: *const libc::c_char) -> libc::c_int {
     return if !s.is_null() { atoi(s) } else { 0i32 };
 }
+
 pub unsafe fn dc_atof(mut str: *const libc::c_char) -> libc::c_double {
     // hack around atof() that may accept only `,` as decimal point on mac
     let mut test: *mut libc::c_char =
@@ -60,8 +65,10 @@ pub unsafe fn dc_atof(mut str: *const libc::c_char) -> libc::c_double {
     let mut f: libc::c_double = atof(str_locale);
     free(test as *mut libc::c_void);
     free(str_locale as *mut libc::c_void);
-    return f;
+
+    f
 }
+
 pub unsafe fn dc_str_replace(
     mut haystack: *mut *mut libc::c_char,
     mut needle: *const libc::c_char,
@@ -69,8 +76,8 @@ pub unsafe fn dc_str_replace(
 ) -> libc::c_int {
     let mut replacements: libc::c_int = 0i32;
     let mut start_search_pos: libc::c_int = 0i32;
-    let mut needle_len: libc::c_int = 0i32;
-    let mut replacement_len: libc::c_int = 0i32;
+    let mut needle_len: libc::c_int;
+    let mut replacement_len: libc::c_int;
     if haystack.is_null()
         || (*haystack).is_null()
         || needle.is_null()
@@ -108,7 +115,8 @@ pub unsafe fn dc_str_replace(
         *haystack = new_string;
         replacements += 1
     }
-    return replacements;
+
+    replacements
 }
 
 pub unsafe fn dc_ftoa(mut f: libc::c_double) -> *mut libc::c_char {
@@ -123,12 +131,13 @@ pub unsafe fn dc_ftoa(mut f: libc::c_double) -> *mut libc::c_char {
         b".\x00" as *const u8 as *const libc::c_char,
     );
     free(test as *mut libc::c_void);
-    return str;
+
+    str
 }
 
 pub unsafe fn dc_ltrim(mut buf: *mut libc::c_char) {
-    let mut len: size_t = 0i32 as size_t;
-    let mut cur: *const libc::c_uchar = 0 as *const libc::c_uchar;
+    let mut len: size_t;
+    let mut cur: *const libc::c_uchar;
     if !buf.is_null() && 0 != *buf as libc::c_int {
         len = strlen(buf);
         cur = buf as *const libc::c_uchar;
@@ -147,8 +156,8 @@ pub unsafe fn dc_ltrim(mut buf: *mut libc::c_char) {
 }
 
 pub unsafe fn dc_rtrim(mut buf: *mut libc::c_char) {
-    let mut len: size_t = 0i32 as size_t;
-    let mut cur: *mut libc::c_uchar = 0 as *mut libc::c_uchar;
+    let mut len: size_t;
+    let mut cur: *mut libc::c_uchar;
     if !buf.is_null() && 0 != *buf as libc::c_int {
         len = strlen(buf);
         cur = (buf as *mut libc::c_uchar)
@@ -181,8 +190,10 @@ pub unsafe fn dc_strlower(mut in_0: *const libc::c_char) -> *mut libc::c_char {
         *p = tolower(*p as libc::c_int) as libc::c_char;
         p = p.offset(1isize)
     }
-    return out;
+
+    out
 }
+
 pub unsafe fn dc_strlower_in_place(mut in_0: *mut libc::c_char) {
     let mut p: *mut libc::c_char = in_0;
     while 0 != *p {
@@ -190,6 +201,7 @@ pub unsafe fn dc_strlower_in_place(mut in_0: *mut libc::c_char) {
         p = p.offset(1isize)
     }
 }
+
 pub unsafe fn dc_str_contains(
     mut haystack: *const libc::c_char,
     mut needle: *const libc::c_char,
@@ -209,8 +221,10 @@ pub unsafe fn dc_str_contains(
     };
     free(haystack_lower as *mut libc::c_void);
     free(needle_lower as *mut libc::c_void);
-    return ret;
+
+    ret
 }
+
 /* the result must be free()'d */
 pub unsafe fn dc_null_terminate(
     mut in_0: *const libc::c_char,
@@ -224,11 +238,13 @@ pub unsafe fn dc_null_terminate(
         strncpy(out, in_0, bytes as usize);
     }
     *out.offset(bytes as isize) = 0i32 as libc::c_char;
-    return out;
+
+    out
 }
+
 pub unsafe fn dc_binary_to_uc_hex(mut buf: *const uint8_t, mut bytes: size_t) -> *mut libc::c_char {
     let mut hex: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut i = 0;
+    let mut i;
     if !(buf.is_null() || bytes <= 0) {
         hex = calloc(
             ::std::mem::size_of::<libc::c_char>(),
@@ -247,8 +263,10 @@ pub unsafe fn dc_binary_to_uc_hex(mut buf: *const uint8_t, mut bytes: size_t) ->
             }
         }
     }
-    return hex;
+
+    hex
 }
+
 /* remove all \r characters from string */
 pub unsafe extern "C" fn dc_remove_cr_chars(mut buf: *mut libc::c_char) {
     /* search for first `\r` */
@@ -270,9 +288,11 @@ pub unsafe extern "C" fn dc_remove_cr_chars(mut buf: *mut libc::c_char) {
     }
     *p2 = 0i32 as libc::c_char;
 }
+
 pub unsafe fn dc_unify_lineends(mut buf: *mut libc::c_char) {
     dc_remove_cr_chars(buf);
 }
+
 /* replace bad UTF-8 characters by sequences of `_` (to avoid problems in filenames, we do not use eg. `?`) the function is useful if strings are unexpectingly encoded eg. as ISO-8859-1 */
 pub unsafe fn dc_replace_bad_utf8_chars(mut buf: *mut libc::c_char) {
     let mut current_block: u64;
@@ -282,11 +302,11 @@ pub unsafe fn dc_replace_bad_utf8_chars(mut buf: *mut libc::c_char) {
     /* force unsigned - otherwise the `> ' '` comparison will fail */
     let mut p1: *mut libc::c_uchar = buf as *mut libc::c_uchar;
     let mut p1len: libc::c_int = strlen(buf) as libc::c_int;
-    let mut c: libc::c_int = 0i32;
-    let mut i: libc::c_int = 0i32;
-    let mut ix: libc::c_int = 0i32;
-    let mut n: libc::c_int = 0i32;
-    let mut j: libc::c_int = 0i32;
+    let mut c: libc::c_int;
+    let mut i: libc::c_int;
+    let mut ix: libc::c_int;
+    let mut n: libc::c_int;
+    let mut j: libc::c_int;
     i = 0i32;
     ix = p1len;
     's_36: loop {
@@ -341,6 +361,7 @@ pub unsafe fn dc_replace_bad_utf8_chars(mut buf: *mut libc::c_char) {
         }
     };
 }
+
 pub unsafe fn dc_utf8_strlen(mut s: *const libc::c_char) -> size_t {
     if s.is_null() {
         return 0i32 as size_t;
@@ -353,8 +374,10 @@ pub unsafe fn dc_utf8_strlen(mut s: *const libc::c_char) -> size_t {
         }
         i = i.wrapping_add(1)
     }
-    return j;
+
+    j
 }
+
 pub unsafe fn dc_truncate_str(mut buf: *mut libc::c_char, mut approx_chars: libc::c_int) {
     if approx_chars > 0
         && strlen(buf)
@@ -375,6 +398,7 @@ pub unsafe fn dc_truncate_str(mut buf: *mut libc::c_char, mut approx_chars: libc
         strcat(p, b"[...]\x00" as *const u8 as *const libc::c_char);
     };
 }
+
 pub unsafe fn dc_truncate_n_unwrap_str(
     mut buf: *mut libc::c_char,
     mut approx_characters: libc::c_int,
@@ -418,6 +442,7 @@ pub unsafe fn dc_truncate_n_unwrap_str(
         dc_remove_cr_chars(buf);
     };
 }
+
 unsafe fn dc_utf8_strnlen(mut s: *const libc::c_char, mut n: size_t) -> size_t {
     if s.is_null() {
         return 0i32 as size_t;
@@ -430,8 +455,10 @@ unsafe fn dc_utf8_strnlen(mut s: *const libc::c_char, mut n: size_t) -> size_t {
         }
         i = i.wrapping_add(1)
     }
-    return j;
+
+    j
 }
+
 /* split string into lines*/
 pub unsafe fn dc_split_into_lines(mut buf_terminated: *const libc::c_char) -> *mut carray {
     let mut lines: *mut carray = carray_new(1024i32 as libc::c_uint);
@@ -459,11 +486,13 @@ pub unsafe fn dc_split_into_lines(mut buf_terminated: *const libc::c_char) -> *m
         strndup(line_start, line_chars) as *mut libc::c_void,
         &mut l_indx,
     );
-    return lines;
+
+    lines
 }
+
 pub unsafe fn dc_free_splitted_lines(mut lines: *mut carray) {
     if !lines.is_null() {
-        let mut i: libc::c_int = 0;
+        let mut i: libc::c_int;
         let mut cnt: libc::c_int = carray_count(lines) as libc::c_int;
         i = 0i32;
         while i < cnt {
@@ -473,6 +502,7 @@ pub unsafe fn dc_free_splitted_lines(mut lines: *mut carray) {
         carray_free(lines);
     };
 }
+
 /* insert a break every n characters, the return must be free()'d */
 pub unsafe fn dc_insert_breaks(
     mut in_0: *const libc::c_char,
@@ -506,8 +536,10 @@ pub unsafe fn dc_insert_breaks(
         }
     }
     *o = 0i32 as libc::c_char;
-    return out;
+
+    out
 }
+
 pub unsafe fn dc_str_from_clist(
     mut list: *const clist,
     mut delimiter: *const libc::c_char,
@@ -540,8 +572,10 @@ pub unsafe fn dc_str_from_clist(
             }
         }
     }
-    return str.buf;
+
+    str.buf
 }
+
 pub unsafe fn dc_str_to_clist(
     mut str: *const libc::c_char,
     mut delimiter: *const libc::c_char,
@@ -570,8 +604,10 @@ pub unsafe fn dc_str_to_clist(
             }
         }
     }
-    return list;
+
+    list
 }
+
 pub unsafe fn dc_str_to_color(mut str: *const libc::c_char) -> libc::c_int {
     let mut str_lower: *mut libc::c_char = dc_strlower(str);
     /* the colors must fulfill some criterions as:
@@ -611,8 +647,10 @@ pub unsafe fn dc_str_to_color(mut str: *const libc::c_char) -> libc::c_int {
             .wrapping_div(::std::mem::size_of::<uint32_t>() as libc::c_ulong),
     ) as libc::c_int;
     free(str_lower as *mut libc::c_void);
-    return colors[color_index as usize] as libc::c_int;
+
+    colors[color_index as usize] as libc::c_int
 }
+
 /* clist tools */
 /* calls free() for each item content */
 pub unsafe fn clist_free_content(mut haystack: *const clist) {
@@ -627,6 +665,7 @@ pub unsafe fn clist_free_content(mut haystack: *const clist) {
         }
     }
 }
+
 pub unsafe fn clist_search_string_nocase(
     mut haystack: *const clist,
     mut needle: *const libc::c_char,
@@ -642,8 +681,10 @@ pub unsafe fn clist_search_string_nocase(
             0 as *mut clistcell_s
         }
     }
-    return 0i32;
+
+    0
 }
+
 /* date/time tools */
 /* the result is UTC or DC_INVALID_TIMESTAMP */
 pub unsafe fn dc_timestamp_from_date(mut date_time: *mut mailimf_date_time) -> time_t {
@@ -660,9 +701,9 @@ pub unsafe fn dc_timestamp_from_date(mut date_time: *mut mailimf_date_time) -> t
         tm_gmtoff: 0,
         tm_zone: 0 as *mut libc::c_char,
     };
-    let mut timeval: time_t = 0i32 as time_t;
-    let mut zone_min: libc::c_int = 0i32;
-    let mut zone_hour: libc::c_int = 0i32;
+    let mut timeval: time_t;
+    let mut zone_min: libc::c_int;
+    let mut zone_hour: libc::c_int;
     memset(
         &mut tmval as *mut tm as *mut libc::c_void,
         0,
@@ -687,26 +728,16 @@ pub unsafe fn dc_timestamp_from_date(mut date_time: *mut mailimf_date_time) -> t
         zone_min = -(-(*date_time).dt_zone % 100i32)
     }
     timeval -= (zone_hour * 3600i32 + zone_min * 60i32) as libc::c_long;
-    return timeval;
+
+    timeval
 }
+
 pub unsafe fn mkgmtime(mut tmp: *mut tm) -> time_t {
-    let mut dir: libc::c_int = 0i32;
-    let mut bits: libc::c_int = 0i32;
-    let mut saved_seconds: libc::c_int = 0i32;
-    let mut t: time_t = 0i32 as time_t;
-    let mut yourtm: tm = tm {
-        tm_sec: 0,
-        tm_min: 0,
-        tm_hour: 0,
-        tm_mday: 0,
-        tm_mon: 0,
-        tm_year: 0,
-        tm_wday: 0,
-        tm_yday: 0,
-        tm_isdst: 0,
-        tm_gmtoff: 0,
-        tm_zone: 0 as *mut libc::c_char,
-    };
+    let mut dir: libc::c_int;
+    let mut bits: libc::c_int;
+    let mut saved_seconds: libc::c_int;
+    let mut t: time_t;
+    let mut yourtm: tm;
     let mut mytm: tm = tm {
         tm_sec: 0,
         tm_min: 0,
@@ -757,13 +788,15 @@ pub unsafe fn mkgmtime(mut tmp: *mut tm) -> time_t {
         }
     }
     t += saved_seconds as libc::c_long;
-    return t;
+
+    t
 }
+
 /* ******************************************************************************
  * date/time tools
  ******************************************************************************/
 unsafe fn tmcomp(mut atmp: *mut tm, mut btmp: *mut tm) -> libc::c_int {
-    let mut result: libc::c_int = 0i32;
+    let mut result: libc::c_int;
     result = (*atmp).tm_year - (*btmp).tm_year;
     if result == 0i32
         && {
@@ -785,8 +818,10 @@ unsafe fn tmcomp(mut atmp: *mut tm, mut btmp: *mut tm) -> libc::c_int {
     {
         result = (*atmp).tm_sec - (*btmp).tm_sec
     }
-    return result;
+
+    result
 }
+
 /* the return value must be free()'d */
 pub unsafe fn dc_timestamp_to_str(mut wanted: time_t) -> *mut libc::c_char {
     let mut wanted_struct: tm = tm {
@@ -817,6 +852,7 @@ pub unsafe fn dc_timestamp_to_str(mut wanted: time_t) -> *mut libc::c_char {
         wanted_struct.tm_sec as libc::c_int,
     );
 }
+
 pub unsafe fn dc_timestamp_to_mailimap_date_time(mut timeval: time_t) -> *mut mailimap_date_time {
     let mut gmt: tm = tm {
         tm_sec: 0,
@@ -844,11 +880,11 @@ pub unsafe fn dc_timestamp_to_mailimap_date_time(mut timeval: time_t) -> *mut ma
         tm_gmtoff: 0,
         tm_zone: 0 as *mut libc::c_char,
     };
-    let mut off: libc::c_int = 0i32;
-    let mut date_time: *mut mailimap_date_time = 0 as *mut mailimap_date_time;
-    let mut sign: libc::c_int = 0i32;
-    let mut hour: libc::c_int = 0i32;
-    let mut min: libc::c_int = 0i32;
+    let mut off: libc::c_int;
+    let mut date_time: *mut mailimap_date_time;
+    let mut sign: libc::c_int;
+    let mut hour: libc::c_int;
+    let mut min: libc::c_int;
     gmtime_r(&mut timeval, &mut gmt);
     localtime_r(&mut timeval, &mut lt);
     off = ((mkgmtime(&mut lt) - mkgmtime(&mut gmt)) / 60i32 as libc::c_long) as libc::c_int;
@@ -871,8 +907,10 @@ pub unsafe fn dc_timestamp_to_mailimap_date_time(mut timeval: time_t) -> *mut ma
         lt.tm_sec,
         off,
     );
-    return date_time;
+
+    date_time
 }
+
 pub unsafe fn dc_gm2local_offset() -> libc::c_long {
     /* returns the offset that must be _added_ to an UTC/GMT-time to create the localtime.
     the function may return nagative values. */
@@ -891,8 +929,10 @@ pub unsafe fn dc_gm2local_offset() -> libc::c_long {
         tm_zone: 0 as *mut libc::c_char,
     };
     localtime_r(&mut gmtime, &mut timeinfo);
-    return timeinfo.tm_gmtoff;
+
+    timeinfo.tm_gmtoff
 }
+
 /* timesmearing */
 pub unsafe fn dc_smeared_time(mut context: &dc_context_t) -> time_t {
     /* function returns a corrected time(NULL) */
@@ -901,6 +941,7 @@ pub unsafe fn dc_smeared_time(mut context: &dc_context_t) -> time_t {
     if ts >= now {
         now = ts + 1;
     }
+
     now
 }
 
@@ -915,7 +956,7 @@ pub unsafe fn dc_create_smeared_timestamp(mut context: &dc_context_t) -> time_t 
             ret = now + 5
         }
     }
-    ts = ret;
+
     ret
 }
 
@@ -930,7 +971,7 @@ pub unsafe fn dc_create_smeared_timestamps(
 
     let mut ts = *context.last_smeared_timestamp.clone().write().unwrap();
     start = if ts + 1 > start { ts + 1 } else { start };
-    ts = start + ((count - 1) as time_t);
+
     start
 }
 
@@ -949,8 +990,10 @@ pub unsafe fn dc_create_id() -> *mut libc::c_char {
 
     let mut rng = thread_rng();
     let mut buf: [uint32_t; 3] = [rng.gen(), rng.gen(), rng.gen()];
-    return encode_66bits_as_base64(buf[0usize], buf[1usize], buf[2usize]);
+
+    encode_66bits_as_base64(buf[0usize], buf[1usize], buf[2usize])
 }
+
 /* ******************************************************************************
  * generate Message-IDs
  ******************************************************************************/
@@ -987,8 +1030,10 @@ unsafe fn encode_66bits_as_base64(
     *ret.offset(10isize) =
         chars[(v2 << 2i32 & 0x3ci32 as libc::c_uint | fill & 0x3i32 as libc::c_uint) as usize];
     *ret.offset(11isize) = 0i32 as libc::c_char;
-    return ret;
+
+    ret
 }
+
 pub unsafe fn dc_create_incoming_rfc724_mid(
     mut message_timestamp: time_t,
     mut contact_id_from: uint32_t,
@@ -1001,7 +1046,6 @@ pub unsafe fn dc_create_incoming_rfc724_mid(
     let mut i: size_t = 0i32 as size_t;
     let mut icnt: size_t = dc_array_get_cnt(contact_ids_to);
     let mut largest_id_to: uint32_t = 0i32 as uint32_t;
-    i = 0i32 as size_t;
     while i < icnt {
         let mut cur_id: uint32_t = dc_array_get_id(contact_ids_to, i);
         if cur_id > largest_id_to {
@@ -1009,13 +1053,15 @@ pub unsafe fn dc_create_incoming_rfc724_mid(
         }
         i = i.wrapping_add(1)
     }
-    return dc_mprintf(
+
+    dc_mprintf(
         b"%lu-%lu-%lu@stub\x00" as *const u8 as *const libc::c_char,
         message_timestamp as libc::c_ulong,
         contact_id_from as libc::c_ulong,
         largest_id_to as libc::c_ulong,
-    );
+    )
 }
+
 pub unsafe fn dc_create_outgoing_rfc724_mid(
     mut grpid: *const libc::c_char,
     mut from_addr: *const libc::c_char,
@@ -1026,7 +1072,7 @@ pub unsafe fn dc_create_outgoing_rfc724_mid(
     - do not add a counter or any private data as as this may give unneeded information to the receiver	*/
     let mut rand1: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut rand2: *mut libc::c_char = dc_create_id();
-    let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut ret: *mut libc::c_char;
     let mut at_hostname: *const libc::c_char = strchr(from_addr, '@' as i32);
     if at_hostname.is_null() {
         at_hostname = b"@nohost\x00" as *const u8 as *const libc::c_char
@@ -1049,14 +1095,16 @@ pub unsafe fn dc_create_outgoing_rfc724_mid(
     }
     free(rand1 as *mut libc::c_void);
     free(rand2 as *mut libc::c_void);
-    return ret;
+
+    ret
 }
+
 pub unsafe fn dc_extract_grpid_from_rfc724_mid(mut mid: *const libc::c_char) -> *mut libc::c_char {
     /* extract our group ID from Message-IDs as `Gr.12345678901.morerandom@domain.de`; "12345678901" is the wanted ID in this example. */
     let mut success: libc::c_int = 0i32;
     let mut grpid: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut p1: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut grpid_len: libc::c_int = 0i32;
+    let mut p1: *mut libc::c_char;
+    let mut grpid_len: libc::c_int;
     if !(mid.is_null()
         || strlen(mid) < 8
         || *mid.offset(0isize) as libc::c_int != 'G' as i32
@@ -1084,6 +1132,7 @@ pub unsafe fn dc_extract_grpid_from_rfc724_mid(mut mid: *const libc::c_char) -> 
         0 as *mut libc::c_char
     };
 }
+
 pub unsafe fn dc_extract_grpid_from_rfc724_mid_list(mut list: *const clist) -> *mut libc::c_char {
     if !list.is_null() {
         let mut cur: *mut clistiter = (*list).first;
@@ -1104,8 +1153,10 @@ pub unsafe fn dc_extract_grpid_from_rfc724_mid_list(mut list: *const clist) -> *
             }
         }
     }
-    return 0 as *mut libc::c_char;
+
+    0 as *mut libc::c_char
 }
+
 /* file tools */
 pub unsafe fn dc_ensure_no_slash(mut pathNfilename: *mut libc::c_char) {
     let mut path_len: libc::c_int = strlen(pathNfilename) as libc::c_int;
@@ -1117,6 +1168,7 @@ pub unsafe fn dc_ensure_no_slash(mut pathNfilename: *mut libc::c_char) {
         }
     };
 }
+
 pub unsafe fn dc_validate_filename(mut filename: *mut libc::c_char) {
     /* function modifies the given buffer and replaces all characters not valid in filenames by a "-" */
     let mut p1: *mut libc::c_char = filename;
@@ -1130,6 +1182,7 @@ pub unsafe fn dc_validate_filename(mut filename: *mut libc::c_char) {
         p1 = p1.offset(1isize)
     }
 }
+
 pub unsafe fn dc_get_filename(mut pathNfilename: *const libc::c_char) -> *mut libc::c_char {
     let mut p: *const libc::c_char = strrchr(pathNfilename, '/' as i32);
     if p.is_null() {
@@ -1142,6 +1195,7 @@ pub unsafe fn dc_get_filename(mut pathNfilename: *const libc::c_char) -> *mut li
         return dc_strdup(pathNfilename);
     };
 }
+
 // the case of the suffix is preserved
 pub unsafe fn dc_split_filename(
     mut pathNfilename: *const libc::c_char,
@@ -1154,7 +1208,7 @@ pub unsafe fn dc_split_filename(
     - if there is no suffix, the returned suffix string is empty, eg. "/path/foobar" is split into "foobar" and ""
     - the case of the returned suffix is preserved; this is to allow reconstruction of (similar) names */
     let mut basename: *mut libc::c_char = dc_get_filename(pathNfilename);
-    let mut suffix: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut suffix: *mut libc::c_char;
     let mut p1: *mut libc::c_char = strrchr(basename, '.' as i32);
     if !p1.is_null() {
         suffix = dc_strdup(p1);
@@ -1173,6 +1227,7 @@ pub unsafe fn dc_split_filename(
         free(suffix as *mut libc::c_void);
     };
 }
+
 // the returned suffix is lower-case
 pub unsafe fn dc_get_filesuffix_lc(mut pathNfilename: *const libc::c_char) -> *mut libc::c_char {
     if !pathNfilename.is_null() {
@@ -1182,8 +1237,10 @@ pub unsafe fn dc_get_filesuffix_lc(mut pathNfilename: *const libc::c_char) -> *m
             return dc_strlower(p);
         }
     }
-    return 0 as *mut libc::c_char;
+
+    0 as *mut libc::c_char
 }
+
 pub unsafe fn dc_get_filemeta(
     mut buf_start: *const libc::c_void,
     mut buf_bytes: size_t,
@@ -1264,8 +1321,10 @@ pub unsafe fn dc_get_filemeta(
             + ((*buf.offset(23isize) as libc::c_int) << 0i32)) as uint32_t;
         return 1i32;
     }
-    return 0i32;
+
+    0
 }
+
 pub unsafe fn dc_get_abs_path(
     mut context: &dc_context_t,
     mut pathNfilename: *const libc::c_char,
@@ -1303,8 +1362,10 @@ pub unsafe fn dc_get_abs_path(
         free(pathNfilename_abs as *mut libc::c_void);
         pathNfilename_abs = 0 as *mut libc::c_char
     }
-    return pathNfilename_abs;
+
+    pathNfilename_abs
 }
+
 pub unsafe fn dc_file_exist(
     mut context: &dc_context_t,
     mut pathNfilename: *const libc::c_char,
@@ -1324,7 +1385,6 @@ pub unsafe fn dc_file_exist(
     };
 
     free(pathNfilename_abs as *mut libc::c_void);
-
     exist as libc::c_int
 }
 
@@ -1545,8 +1605,8 @@ pub unsafe fn dc_get_fine_pathNfilename(
     mut desired_filenameNsuffix__: *const libc::c_char,
 ) -> *mut libc::c_char {
     let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut pathNfolder_wo_slash: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut filenameNsuffix: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut pathNfolder_wo_slash: *mut libc::c_char;
+    let mut filenameNsuffix: *mut libc::c_char;
     let mut basename: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut dotNSuffix: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut now: time_t = time(0 as *mut time_t);
@@ -1556,7 +1616,6 @@ pub unsafe fn dc_get_fine_pathNfilename(
     filenameNsuffix = dc_strdup(desired_filenameNsuffix__);
     dc_validate_filename(filenameNsuffix);
     dc_split_filename(filenameNsuffix, &mut basename, &mut dotNSuffix);
-    i = 0i32;
     while i < 1000i32 {
         /*no deadlocks, please*/
         if 0 != i {
@@ -1593,9 +1652,11 @@ pub unsafe fn dc_get_fine_pathNfilename(
     free(basename as *mut libc::c_void);
     free(dotNSuffix as *mut libc::c_void);
     free(pathNfolder_wo_slash as *mut libc::c_void);
-    return ret;
+
+    ret
 }
 
+// TODO should return bool /rtn
 pub unsafe fn dc_is_blobdir_path(
     mut context: &dc_context_t,
     mut path: *const libc::c_char,
@@ -1605,7 +1666,8 @@ pub unsafe fn dc_is_blobdir_path(
     {
         return 1i32;
     }
-    return 0i32;
+
+    0
 }
 
 pub unsafe fn dc_make_rel_path(mut context: &dc_context_t, mut path: *mut *mut libc::c_char) {
@@ -1621,6 +1683,7 @@ pub unsafe fn dc_make_rel_path(mut context: &dc_context_t, mut path: *mut *mut l
     };
 }
 
+// TODO should return bool /rtn
 pub unsafe fn dc_make_rel_and_copy(
     mut context: &dc_context_t,
     mut path: *mut *mut libc::c_char,
@@ -1655,7 +1718,8 @@ pub unsafe fn dc_make_rel_and_copy(
     }
     free(blobdir_path as *mut libc::c_void);
     free(filename as *mut libc::c_void);
-    return success;
+
+    success
 }
 
 #[cfg(test)]
@@ -1668,8 +1732,7 @@ mod tests {
         unsafe {
             let mut html: *const libc::c_char =
                 b"\r\r\nline1<br>\r\n\r\n\r\rline2\n\r\x00" as *const u8 as *const libc::c_char;
-            let mut out: *mut libc::c_char = 0 as *mut libc::c_char;
-            out = strndup(html, strlen(html) as libc::c_ulong);
+            let mut out: *mut libc::c_char = strndup(html, strlen(html) as libc::c_ulong);
 
             dc_ltrim(out);
 
@@ -1685,8 +1748,7 @@ mod tests {
         unsafe {
             let mut html: *const libc::c_char =
                 b"\r\r\nline1<br>\r\n\r\n\r\rline2\n\r\x00" as *const u8 as *const libc::c_char;
-            let mut out: *mut libc::c_char = 0 as *mut libc::c_char;
-            out = strndup(html, strlen(html) as libc::c_ulong);
+            let mut out: *mut libc::c_char = strndup(html, strlen(html) as libc::c_ulong);
 
             dc_rtrim(out);
 
@@ -1702,8 +1764,7 @@ mod tests {
         unsafe {
             let mut html: *const libc::c_char =
                 b"\r\r\nline1<br>\r\n\r\n\r\rline2\n\r\x00" as *const u8 as *const libc::c_char;
-            let mut out: *mut libc::c_char = 0 as *mut libc::c_char;
-            out = strndup(html, strlen(html) as libc::c_ulong);
+            let mut out: *mut libc::c_char = strndup(html, strlen(html) as libc::c_ulong);
 
             dc_trim(out);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
     non_camel_case_types,
     non_snake_case,
     non_upper_case_globals,
-    unused_assignments,
     unused_mut,
     unused_attributes,
     non_upper_case_globals,

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -57,7 +57,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
         b"<tag attr=\"val\"=\x00" as *const u8 as *const libc::c_char,
     );
 
-    let mut simplify: *mut dc_simplify_t = dc_simplify_new();
+    let simplify: *mut dc_simplify_t = dc_simplify_new();
     let mut html: *const libc::c_char =
         b"\r\r\nline1<br>\r\n\r\n\r\rline2\n\r\x00" as *const u8 as *const libc::c_char;
     let mut plain: *mut libc::c_char =
@@ -125,10 +125,10 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
     } else { };
     free(plain as *mut libc::c_void);
     dc_simplify_unref(simplify);
-    let mut xml: *const libc::c_char =
+    let xml: *const libc::c_char =
         b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<kml xmlns=\"http://www.opengis.net/kml/2.2\">\n<Document addr=\"user@example.org\">\n<Placemark><Timestamp><when>2019-03-06T21:09:57Z</when></Timestamp><Point><coordinates accuracy=\"32.000000\">9.423110,53.790302</coordinates></Point></Placemark>\n<PlaceMARK>\n<Timestamp><WHEN > \n\t2018-12-13T22:11:12Z\t</wHeN></Timestamp><Point><coordinates aCCuracy=\"2.500000\"> 19.423110 \t , \n 63.790302\n </coordinates></Point></Placemark>\n</Document>\n</kml>\x00"
             as *const u8 as *const libc::c_char;
-    let mut kml: *mut dc_kml_t = dc_kml_parse(context, xml, strlen(xml));
+    let kml: *mut dc_kml_t = dc_kml_parse(context, xml, strlen(xml));
     if 0 != !(!(*kml).addr.is_null()
         && strcmp(
             (*kml).addr,
@@ -336,7 +336,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
             );
         } else {
         };
-        let mut abs_path: *mut libc::c_char = dc_mprintf(
+        let abs_path: *mut libc::c_char = dc_mprintf(
             b"%s/%s\x00" as *const u8 as *const libc::c_char,
             context.get_blobdir(),
             b"foobar\x00" as *const u8 as *const libc::c_char,
@@ -526,7 +526,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
             );
         } else {
         };
-        let mut fn0: *mut libc::c_char = dc_get_fine_pathNfilename(
+        let fn0: *mut libc::c_char = dc_get_fine_pathNfilename(
             context,
             b"$BLOBDIR\x00" as *const u8 as *const libc::c_char,
             b"foobar.dadada\x00" as *const u8 as *const libc::c_char,
@@ -562,7 +562,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
             b"content\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
             7i32 as size_t,
         );
-        let mut fn1: *mut libc::c_char = dc_get_fine_pathNfilename(
+        let fn1: *mut libc::c_char = dc_get_fine_pathNfilename(
             context,
             b"$BLOBDIR\x00" as *const u8 as *const libc::c_char,
             b"foobar.dadada\x00" as *const u8 as *const libc::c_char,
@@ -605,7 +605,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
         free(fn0 as *mut libc::c_void);
         free(fn1 as *mut libc::c_void);
     }
-    let mut txt: *const libc::c_char =
+    let txt: *const libc::c_char =
         b"FieldA: ValueA\nFieldB: ValueB\n\x00" as *const u8 as *const libc::c_char;
     let mut mime: *mut mailmime = 0 as *mut mailmime;
     let mut dummy: size_t = 0i32 as size_t;
@@ -632,7 +632,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
         );
     } else {
     };
-    let mut fields: *mut mailimf_fields = mailmime_find_mailimf_fields(mime);
+    let fields: *mut mailimf_fields = mailmime_find_mailimf_fields(mime);
     if 0 != fields.is_null() as libc::c_int as libc::c_long {
         __assert_rtn(
             (*::std::mem::transmute::<&[u8; 17], &[libc::c_char; 17]>(b"stress_functions\x00"))
@@ -722,7 +722,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
         );
     } else {
     };
-    let mut of_b: *mut mailimf_optional_field =
+    let of_b: *mut mailimf_optional_field =
         mailimf_find_optional_field(fields, b"FieldB\x00" as *const u8 as *const libc::c_char);
     if 0 != !(!of_b.is_null() && !(*of_b).fld_value.is_null()) as libc::c_int as libc::c_long {
         __assert_rtn(
@@ -749,8 +749,8 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
     } else {
     };
     mailmime_free(mime);
-    let mut mimeparser: *mut dc_mimeparser_t = dc_mimeparser_new(context.get_blobdir(), context);
-    let mut raw: *const libc::c_char =
+    let mimeparser: *mut dc_mimeparser_t = dc_mimeparser_new(context.get_blobdir(), context);
+    let raw: *const libc::c_char =
         b"Content-Type: multipart/mixed; boundary=\"==break==\";\nSubject: outer-subject\nX-Special-A: special-a\nFoo: Bar\nChat-Version: 0.0\n\n--==break==\nContent-Type: text/plain; protected-headers=\"v1\";\nSubject: inner-subject\nX-Special-B: special-b\nFoo: Xy\nChat-Version: 1.0\n\ntest1\n\n--==break==--\n\n\x00"
             as *const u8 as *const libc::c_char;
     dc_mimeparser_parse(mimeparser, raw, strlen(raw));
@@ -902,7 +902,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
         );
     } else {
     };
-    let mut f: libc::c_double = dc_atof(b"1.23\x00" as *const u8 as *const libc::c_char);
+    let f: libc::c_double = dc_atof(b"1.23\x00" as *const u8 as *const libc::c_char);
     if 0 != !(f > 1.22f64 && f < 1.24f64) as libc::c_int as libc::c_long {
         __assert_rtn(
             (*::std::mem::transmute::<&[u8; 17], &[libc::c_char; 17]>(b"stress_functions\x00"))
@@ -913,7 +913,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
         );
     } else {
     };
-    let mut s: *mut libc::c_char = dc_ftoa(1.23f64);
+    let s: *mut libc::c_char = dc_ftoa(1.23f64);
     if 0 != !(dc_atof(s) > 1.22f64 && dc_atof(s) < 1.24f64) as libc::c_int as libc::c_long {
         __assert_rtn(
             (*::std::mem::transmute::<&[u8; 17], &[libc::c_char; 17]>(b"stress_functions\x00"))
@@ -1080,7 +1080,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
     } else {
     };
     let mut str: *mut libc::c_char = strdup(b"aaa\x00" as *const u8 as *const libc::c_char);
-    let mut replacements: libc::c_int = dc_str_replace(
+    let replacements: libc::c_int = dc_str_replace(
         &mut str,
         b"a\x00" as *const u8 as *const libc::c_char,
         b"ab\x00" as *const u8 as *const libc::c_char,
@@ -2404,7 +2404,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
         );
     } else {
     };
-    let mut arr = dc_array_new(7i32 as size_t);
+    let arr = dc_array_new(7i32 as size_t);
     if 0 != !(dc_array_get_cnt(arr) == 0) as libc::c_int as libc::c_long {
         __assert_rtn(
             (*::std::mem::transmute::<&[u8; 17], &[libc::c_char; 17]>(b"stress_functions\x00"))
@@ -2416,7 +2416,6 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
     } else {
     };
     let mut i: libc::c_int = 0;
-    i = 0i32;
     while i < 1000i32 {
         dc_array_add_id(arr, (i + 1i32 * 2i32) as uint32_t);
         i += 1
@@ -2632,7 +2631,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
     } else {
     };
     dc_array_unref(arr);
-    let mut p1: *mut dc_param_t = dc_param_new();
+    let p1: *mut dc_param_t = dc_param_new();
     dc_param_set_packed(
         p1,
         b"\r\n\r\na=1\nb=2\n\nc = 3 \x00" as *const u8 as *const libc::c_char,
@@ -3171,9 +3170,9 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
     } else {
     };
     free(keys as *mut libc::c_void);
-    let mut ah: *mut dc_aheader_t = dc_aheader_new();
-    let mut rendered: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut ah_ok: libc::c_int = 0;
+    let ah: *mut dc_aheader_t = dc_aheader_new();
+    let rendered: *mut libc::c_char;
+    let mut ah_ok: libc::c_int;
     ah_ok = dc_aheader_set_from_string(
         ah,
         b"addr=a@b.example.org; prefer-encrypt=mutual; keydata=RGVsdGEgQ2hhdA==\x00" as *const u8
@@ -3402,8 +3401,8 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
     };
     dc_aheader_unref(ah);
     free(rendered as *mut libc::c_void);
-    let mut ok: libc::c_int = 0;
-    let mut buf_0: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut ok: libc::c_int;
+    let mut buf_0: *mut libc::c_char;
     let mut headerline: *const libc::c_char = 0 as *const libc::c_char;
     let mut setupcodebegin: *const libc::c_char = 0 as *const libc::c_char;
     let mut preferencrypt: *const libc::c_char = 0 as *const libc::c_char;
@@ -3767,7 +3766,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
     } else {
     };
     free(norm as *mut libc::c_void);
-    let mut buf_1: *mut libc::c_char = 0 as *mut libc::c_char;
+    let mut buf_1: *mut libc::c_char;
     let mut headerline_0: *const libc::c_char = 0 as *const libc::c_char;
     let mut setupcodebegin_0: *const libc::c_char = 0 as *const libc::c_char;
     let mut preferencrypt_0: *const libc::c_char = 0 as *const libc::c_char;
@@ -3906,8 +3905,8 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
     };
     free(buf_1 as *mut libc::c_void);
     if 0 != dc_is_configured(context) {
-        let mut setupcode: *mut libc::c_char = 0 as *mut libc::c_char;
-        let mut setupfile: *mut libc::c_char = 0 as *mut libc::c_char;
+        let setupcode: *mut libc::c_char;
+        let setupfile: *mut libc::c_char;
         setupcode = dc_create_setup_code(context);
         if 0 != setupcode.is_null() as libc::c_int as libc::c_long {
             __assert_rtn(
@@ -3960,7 +3959,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
             );
         } else {
         };
-        let mut buf_2: *mut libc::c_char = dc_strdup(setupfile);
+        let buf_2: *mut libc::c_char = dc_strdup(setupfile);
         let mut headerline_1: *const libc::c_char = 0 as *const libc::c_char;
         let mut setupcodebegin_1: *const libc::c_char = 0 as *const libc::c_char;
         if 0 != (0
@@ -4012,7 +4011,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
         } else {
         };
         free(buf_2 as *mut libc::c_void);
-        let mut payload: *mut libc::c_char = 0 as *mut libc::c_char;
+        let payload: *mut libc::c_char;
         let mut headerline_2: *const libc::c_char = 0 as *const libc::c_char;
         payload = dc_decrypt_setup_file(context, setupcode, setupfile);
         if 0 != payload.is_null() as libc::c_int as libc::c_long {
@@ -4063,7 +4062,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
         free(setupfile as *mut libc::c_void);
         free(setupcode as *mut libc::c_void);
     }
-    let mut bad_key: *mut dc_key_t = dc_key_new();
+    let bad_key: *mut dc_key_t = dc_key_new();
     let mut bad_data: [libc::c_uchar; 4096] = [0; 4096];
     let mut i_0: libc::c_int = 0i32;
     while i_0 < 4096i32 {
@@ -4092,8 +4091,8 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
         j += 1
     }
     dc_key_unref(bad_key);
-    let mut public_key: *mut dc_key_t = dc_key_new();
-    let mut private_key: *mut dc_key_t = dc_key_new();
+    let public_key: *mut dc_key_t = dc_key_new();
+    let private_key: *mut dc_key_t = dc_key_new();
     dc_pgp_create_keypair(
         context,
         b"foo@bar.de\x00" as *const u8 as *const libc::c_char,
@@ -4120,7 +4119,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
         );
     } else {
     };
-    let mut test_key: *mut dc_key_t = dc_key_new();
+    let test_key: *mut dc_key_t = dc_key_new();
     if 0 != (0 == dc_pgp_split_key(context, private_key, test_key)) as libc::c_int as libc::c_long {
         __assert_rtn(
             (*::std::mem::transmute::<&[u8; 17], &[libc::c_char; 17]>(b"stress_functions\x00"))
@@ -4133,8 +4132,8 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
     } else {
     };
     dc_key_unref(test_key);
-    let mut public_key2: *mut dc_key_t = dc_key_new();
-    let mut private_key2: *mut dc_key_t = dc_key_new();
+    let public_key2: *mut dc_key_t = dc_key_new();
+    let private_key2: *mut dc_key_t = dc_key_new();
     dc_pgp_create_keypair(
         context,
         b"two@zwo.de\x00" as *const u8 as *const libc::c_char,
@@ -4151,14 +4150,14 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
         );
     } else {
     };
-    let mut original_text: *const libc::c_char =
+    let original_text: *const libc::c_char =
         b"This is a test\x00" as *const u8 as *const libc::c_char;
     let mut ctext_signed: *mut libc::c_void = 0 as *mut libc::c_void;
     let mut ctext_unsigned: *mut libc::c_void = 0 as *mut libc::c_void;
     let mut ctext_signed_bytes: size_t = 0i32 as size_t;
     let mut ctext_unsigned_bytes: size_t = 0;
     let mut plain_bytes: size_t = 0i32 as size_t;
-    let mut keyring: *mut dc_keyring_t = dc_keyring_new();
+    let keyring: *mut dc_keyring_t = dc_keyring_new();
     dc_keyring_add(keyring, public_key);
     dc_keyring_add(keyring, public_key2);
     let mut ok_0: libc::c_int = dc_pgp_pk_encrypt(
@@ -4263,11 +4262,11 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
     } else {
     };
     dc_keyring_unref(keyring);
-    let mut keyring_0: *mut dc_keyring_t = dc_keyring_new();
+    let keyring_0: *mut dc_keyring_t = dc_keyring_new();
     dc_keyring_add(keyring_0, private_key);
-    let mut public_keyring: *mut dc_keyring_t = dc_keyring_new();
+    let public_keyring: *mut dc_keyring_t = dc_keyring_new();
     dc_keyring_add(public_keyring, public_key);
-    let mut public_keyring2: *mut dc_keyring_t = dc_keyring_new();
+    let public_keyring2: *mut dc_keyring_t = dc_keyring_new();
     dc_keyring_add(public_keyring2, public_key2);
     let mut plain_0: *mut libc::c_void = 0 as *mut libc::c_void;
     let mut valid_signatures: dc_hash_t = dc_hash_t {
@@ -4279,7 +4278,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
         ht: 0 as *mut _ht,
     };
     dc_hash_init(&mut valid_signatures, 3i32, 1i32);
-    let mut ok_1: libc::c_int = 0;
+    let mut ok_1: libc::c_int;
     ok_1 = dc_pgp_pk_decrypt(
         context,
         ctext_signed,
@@ -4519,17 +4518,16 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
     } else {
     };
     free(plain_0);
-    plain_0 = 0 as *mut libc::c_void;
     dc_hash_clear(&mut valid_signatures);
     dc_keyring_unref(keyring_0);
     dc_keyring_unref(public_keyring);
     dc_keyring_unref(public_keyring2);
-    let mut keyring_1: *mut dc_keyring_t = dc_keyring_new();
+    let keyring_1: *mut dc_keyring_t = dc_keyring_new();
     dc_keyring_add(keyring_1, private_key2);
-    let mut public_keyring_0: *mut dc_keyring_t = dc_keyring_new();
+    let public_keyring_0: *mut dc_keyring_t = dc_keyring_new();
     dc_keyring_add(public_keyring_0, public_key);
     let mut plain_1: *mut libc::c_void = 0 as *mut libc::c_void;
-    let mut ok_2: libc::c_int = dc_pgp_pk_decrypt(
+    let ok_2: libc::c_int = dc_pgp_pk_decrypt(
         context,
         ctext_signed,
         ctext_signed_bytes,
@@ -4582,7 +4580,7 @@ unsafe extern "C" fn stress_functions(context: &dc_context_t) {
     dc_key_unref(private_key2);
     dc_key_unref(public_key);
     dc_key_unref(private_key);
-    let mut fingerprint: *mut libc::c_char = dc_normalize_fingerprint(
+    let fingerprint: *mut libc::c_char = dc_normalize_fingerprint(
         b" 1234  567890 \n AbcD abcdef ABCDEF \x00" as *const u8 as *const libc::c_char,
     );
     if 0 != fingerprint.is_null() as libc::c_int as libc::c_long {


### PR DESCRIPTION
There are still warnings left, but I've left them out because they are related to the ongoing work in the `rust-imap` branch. This takes care of all unnecessary mut and also unused assignments.