### PR TITLE
refactor: cast bool functions to libc::c_int instead of if-else

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -684,11 +684,7 @@ pub unsafe extern "C" fn dc_get_msg<'a>(
 
 #[no_mangle]
 pub unsafe extern "C" fn dc_may_be_valid_addr(addr: *mut libc::c_char) -> libc::c_int {
-    if dc_contact::dc_may_be_valid_addr(addr) {
-        1
-    } else {
-        0
-    }
+    dc_contact::dc_may_be_valid_addr(addr) as libc::c_int
 }
 
 #[no_mangle]
@@ -786,11 +782,7 @@ pub unsafe extern "C" fn dc_delete_contact(
     assert!(!context.is_null());
     let context = &*context;
 
-    if dc_contact::dc_delete_contact(context, contact_id) {
-        1
-    } else {
-        0
-    }
+    dc_contact::dc_delete_contact(context, contact_id) as libc::c_int
 }
 
 #[no_mangle]
@@ -1060,12 +1052,9 @@ pub unsafe extern "C" fn dc_array_search_id(
     needle: libc::c_uint,
     ret_index: *mut libc::size_t,
 ) -> libc::c_int {
-    if dc_array::dc_array_search_id(array, needle, ret_index) {
-        1
-    } else {
-        0
-    }
+    dc_array::dc_array_search_id(array, needle, ret_index) as libc::c_int
 }
+
 #[no_mangle]
 pub unsafe extern "C" fn dc_array_get_raw(array: *const dc_array_t) -> *const libc::size_t {
     dc_array::dc_array_get_raw(array)
@@ -1301,11 +1290,7 @@ pub unsafe extern "C" fn dc_msg_get_height(msg: *mut dc_msg::dc_msg_t) -> libc::
 
 #[no_mangle]
 pub unsafe extern "C" fn dc_msg_get_duration(msg: *mut dc_msg::dc_msg_t) -> libc::c_int {
-    if dc_msg::dc_msg_get_duration(msg) {
-        1
-    } else {
-        0
-    }
+    dc_msg::dc_msg_get_duration(msg) as libc::c_int
 }
 
 #[no_mangle]
@@ -1336,11 +1321,7 @@ pub unsafe extern "C" fn dc_msg_has_deviating_timestamp(msg: *mut dc_msg::dc_msg
 
 #[no_mangle]
 pub unsafe extern "C" fn dc_msg_has_location(msg: *mut dc_msg::dc_msg_t) -> libc::c_int {
-    if dc_msg::dc_msg_has_location(msg) {
-        1
-    } else {
-        0
-    }
+    dc_msg::dc_msg_has_location(msg) as libc::c_int
 }
 
 #[no_mangle]


### PR DESCRIPTION
cc @dignifiedquire 