### PR TITLE
chore: remove blobdir member from dc_mimeparser_t struct

### DIFF
--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -53,7 +53,6 @@ pub struct dc_mimeparser_t<'a> {
     pub is_send_by_messenger: libc::c_int,
     pub decrypting_failed: libc::c_int,
     pub e2ee_helper: *mut dc_e2ee_helper_t,
-    pub blobdir: *const libc::c_char,
     pub is_forwarded: libc::c_int,
     pub context: &'a dc_context_t,
     pub reports: *mut carray,
@@ -70,10 +69,7 @@ pub unsafe fn dc_no_compound_msgs() {
 // deprecated: flag to switch generation of compound messages on and off.
 static mut s_generate_compound_msgs: libc::c_int = 1i32;
 
-pub unsafe fn dc_mimeparser_new(
-    blobdir: *const libc::c_char,
-    context: &dc_context_t,
-) -> *mut dc_mimeparser_t {
+pub unsafe fn dc_mimeparser_new(context: &dc_context_t) -> *mut dc_mimeparser_t {
     let mut mimeparser: *mut dc_mimeparser_t;
     mimeparser = calloc(1, ::std::mem::size_of::<dc_mimeparser_t>()) as *mut dc_mimeparser_t;
     if mimeparser.is_null() {
@@ -81,7 +77,6 @@ pub unsafe fn dc_mimeparser_new(
     }
     (*mimeparser).context = context;
     (*mimeparser).parts = carray_new(16i32 as libc::c_uint);
-    (*mimeparser).blobdir = blobdir;
     (*mimeparser).reports = carray_new(16i32 as libc::c_uint);
     (*mimeparser).e2ee_helper =
         calloc(1, ::std::mem::size_of::<dc_e2ee_helper_t>()) as *mut dc_e2ee_helper_t;

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -62,7 +62,7 @@ pub unsafe fn dc_receive_imf(
     let mut sort_timestamp: time_t = -1i32 as time_t;
     let mut sent_timestamp: time_t = -1i32 as time_t;
     let mut rcvd_timestamp: time_t = -1i32 as time_t;
-    let mime_parser: *mut dc_mimeparser_t = dc_mimeparser_new(context.get_blobdir(), context);
+    let mime_parser: *mut dc_mimeparser_t = dc_mimeparser_new(context);
     let mut field: *const mailimf_field;
     let mut mime_in_reply_to: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut mime_references: *mut libc::c_char = 0 as *mut libc::c_char;

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -753,7 +753,7 @@ unsafe fn stress_functions(context: &dc_context_t) {
     } else {
     };
     mailmime_free(mime);
-    let mimeparser: *mut dc_mimeparser_t = dc_mimeparser_new(context.get_blobdir(), context);
+    let mimeparser: *mut dc_mimeparser_t = dc_mimeparser_new(context);
     let raw: *const libc::c_char =
         b"Content-Type: multipart/mixed; boundary=\"==break==\";\nSubject: outer-subject\nX-Special-A: special-a\nFoo: Bar\nChat-Version: 0.0\n\n--==break==\nContent-Type: text/plain; protected-headers=\"v1\";\nSubject: inner-subject\nX-Special-B: special-b\nFoo: Xy\nChat-Version: 1.0\n\ntest1\n\n--==break==--\n\n\x00"
             as *const u8 as *const libc::c_char;


### PR DESCRIPTION
`dc_mimeparser_new()` constructor takes both blobdir and context, but only
uses the blobdir from the context and doesn't care about parser.blobdir,
this can be removed safely since only used internally.