### PR TITLE
[wip] How to generate C API docs for dcc-rs?

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,8 @@ Current commit on deltachat/deltachat-core: `12ef73c8e76185f9b78e844ea673025f56a
 ```sh
 # run example
 $ cargo run --example simple
-# build header file
+# build the C ABI library, libdeltachat_ffi.so.
 $ cargo build -p deltachat_ffi --release
-$ cat deltachat-ffi/deltachat.h
 # run tests
 $ cargo test --all
 ```

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["deltachat", "chat", "openpgp", "email", "encryption"]
 categories = ["cryptography", "std", "email"]
 
 [lib]
-name = "deltachat"
+name = "deltachat_ffi"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]


### PR DESCRIPTION
The primary motivation for this is that rustdoc will otherwise
create docs for a "deltachat" crate both for deltachat as well
as for deltachat-ffi, which is not ideal.

As a side-effect it means it would be possible to install dcc and
dcc-rs next to each other.  But I doubt many people will care much
or for long.  The other effect is that any users, aka the node and
python bindings, need to link with a different lib.  I also think
this isn't the worst idea, it makes it clear which version you're
working with.