### PR TITLE
feat: remove compile date

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -10,7 +10,6 @@ class TestOfflineAccount:
     def test_getinfo(self, acfactory):
         ac1 = acfactory.get_unconfigured_account()
         d = ac1.get_info()
-        assert d["compile_date"]
         assert d["arch"]
         assert d["number_of_chats"] == "0"
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -729,7 +729,6 @@ pub unsafe fn dc_get_info(context: &Context) -> *mut libc::c_char {
         "deltachat_core_version=v{}\n\
          sqlite_version={}\n\
          sqlite_thread_safe={}\n\
-         compile_date=Apr 26 2019, 00:51:50\n\
          arch={}\n\
          number_of_chats={}\n\
          number_of_chat_messages={}\n\


### PR DESCRIPTION
dc_get_info() returned the compile date in core-c (by just adding `__DATE__` and `__TIME__` to a string). by the conversion, this was replaced by a static timestamp, which is of few use.

however, apart from that i did not found an easy way to get the compile time as a usable string (okay, i searched only for 30 seconds or so ;) the compile time as a hardcoded string also has the potential problem to avoid reproducible builds which may be handy in the future.

also, it was of very few use in the past at all (handy only if i forgot to increase the version number ;)

so, i'd suggest to remove it completely.