### PR TITLE
remove unneeded string duplication and fix memory leak

### DIFF
--- a/src/dc_log.rs
+++ b/src/dc_log.rs
@@ -99,7 +99,7 @@ macro_rules! info {
         let formatted_c = $crate::dc_tools::to_cstring(formatted);
         unsafe {
             ($ctx.cb)($ctx, $crate::constants::Event::INFO, $data1 as uintptr_t,
-            $crate::dc_tools::dc_strdup(formatted_c.as_ptr()) as uintptr_t)
+                      formatted_c.as_ptr() as uintptr_t)
         }
     }};
 }
@@ -114,7 +114,7 @@ macro_rules! warn {
         let formatted_c = $crate::dc_tools::to_cstring(formatted);
         unsafe {
             ($ctx.cb)($ctx, $crate::constants::Event::WARNING, $data1 as libc::uintptr_t,
-            $crate::dc_tools::dc_strdup(formatted_c.as_ptr()) as libc::uintptr_t)
+                      formatted_c.as_ptr() as libc::uintptr_t)
         }
     };
 }
@@ -129,7 +129,7 @@ macro_rules! error {
         let formatted_c = $crate::dc_tools::to_cstring(formatted);
         unsafe {
             ($ctx.cb)($ctx, $crate::constants::Event::ERROR, $data1 as uintptr_t,
-            $crate::dc_tools::dc_strdup(formatted_c.as_ptr()) as uintptr_t)
+                      formatted_c.as_ptr() as uintptr_t)
         }
     };
 }
@@ -144,7 +144,7 @@ macro_rules! log_event {
         let formatted_c = $crate::dc_tools::to_cstring(formatted);
         unsafe {
             ($ctx.cb)($ctx, $event, $data1 as uintptr_t,
-            $crate::dc_tools::dc_strdup(formatted_c.as_ptr()) as uintptr_t)
+                      formatted_c.as_ptr() as uintptr_t)
         }
     };
 }


### PR DESCRIPTION
i think the `$crate::dc_tools::dc_strdup()` is not needed for passing strings to the ffi-callback function. the ffi-callback function must treat these strings are being `const` and must not _not_ `free()` them. if the ffi-callbacks need the strings longer (eg. for queing), they must do a copy.

not totally sure, however, `to_ptr()` should do the job here as the return value is probably valid as long as the cstring-object exists - and this is a bit longer as the call to the ffi-callback function.