### PR TITLE
Rename to_str() -> as_str() to match stdlib naming convention

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -172,14 +172,14 @@ unsafe fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int
                 current_block = 1622411330066726685;
             } else {
                 /* import a directory */
-                let dir_name = std::path::Path::new(to_str(real_spec));
+                let dir_name = std::path::Path::new(as_str(real_spec));
                 let dir = std::fs::read_dir(dir_name);
                 if dir.is_err() {
                     error!(
                         context,
                         0,
                         "Import: Cannot open directory \"{}\".",
-                        to_str(real_spec),
+                        as_str(real_spec),
                     );
                     current_block = 8522321847195001863;
                 } else {
@@ -192,7 +192,7 @@ unsafe fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int
                         let name_f = entry.file_name();
                         let name = name_f.to_string_lossy();
                         if name.ends_with(".eml") {
-                            let path_plus_name = format!("{}/{}", to_str(real_spec), name);
+                            let path_plus_name = format!("{}/{}", as_str(real_spec), name);
                             info!(context, 0, "Import: {}", path_plus_name);
                             let path_plus_name_c = to_cstring(path_plus_name);
 
@@ -212,7 +212,7 @@ unsafe fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int
                         0,
                         "Import: {} items read from \"{}\".",
                         read_cnt,
-                        to_str(real_spec)
+                        as_str(real_spec)
                     );
                     if read_cnt > 0 {
                         (context.cb)(context, Event::MSGS_CHANGED, 0 as uintptr_t, 0 as uintptr_t);
@@ -253,9 +253,9 @@ unsafe fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: *mut dc_msg_t
             ""
         },
         if dc_msg_has_location(msg) { "📍" } else { "" },
-        to_str(contact_name),
+        as_str(contact_name),
         contact_id,
-        to_str(msgtext),
+        as_str(msgtext),
         if 0 != dc_msg_is_starred(msg) {
             "★"
         } else {
@@ -276,7 +276,7 @@ unsafe fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: *mut dc_msg_t
             ""
         },
         statestr,
-        to_str(temp2),
+        as_str(temp2),
     );
     free(msgtext as *mut libc::c_void);
     free(temp2 as *mut libc::c_void);
@@ -345,19 +345,19 @@ unsafe fn log_contactlist(context: &Context, contacts: *mut dc_array_t) {
             line = format!(
                 "{}{} <{}>",
                 if !name.is_null() && 0 != *name.offset(0isize) as libc::c_int {
-                    to_str(name)
+                    as_str(name)
                 } else {
                     "<name unset>"
                 },
                 verified_str,
                 if !addr.is_null() && 0 != *addr.offset(0isize) as libc::c_int {
-                    to_str(addr)
+                    as_str(addr)
                 } else {
                     "addr unset"
                 }
             );
             let peerstate =
-                Peerstate::from_addr(context, &context.sql.clone().read().unwrap(), to_str(addr));
+                Peerstate::from_addr(context, &context.sql.clone().read().unwrap(), as_str(addr));
             if peerstate.is_some() && contact_id != 1 as libc::c_uint {
                 line2 = format!(
                     ", prefer-encrypt={}",
@@ -502,7 +502,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             if 0 == S_IS_AUTH {
                 let is_pw =
                     dc_get_config(context, b"mail_pw\x00" as *const u8 as *const libc::c_char);
-                if arg1 == to_str(is_pw) {
+                if arg1 == as_str(is_pw) {
                     S_IS_AUTH = 1;
                 } else {
                     println!("Bad password.");
@@ -527,7 +527,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             if !setup_code.is_null() {
                 println!(
                     "Setup code for the transferred setup message: {}",
-                    to_str(setup_code),
+                    as_str(setup_code),
                 );
                 free(setup_code as *mut libc::c_void);
             } else {
@@ -543,7 +543,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                 println!(
                     "The setup code for setup message Msg#{} starts with: {}",
                     msg_id,
-                    to_str(setupcodebegin),
+                    as_str(setupcodebegin),
                 );
                 free(setupcodebegin as *mut libc::c_void);
             } else {
@@ -597,8 +597,8 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             {
                 println!(
                     "Setup message written to: {}\nSetup code: {}",
-                    to_str(file_name),
-                    to_str(setup_code),
+                    as_str(file_name),
+                    as_str(setup_code),
                 )
             } else {
                 bail!("");
@@ -666,8 +666,8 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                         "{}#{}: {} [{}] [{} fresh]",
                         chat_prefix(chat),
                         dc_chat_get_id(chat) as libc::c_int,
-                        to_str(temp_name),
-                        to_str(temp_subtitle),
+                        as_str(temp_name),
+                        as_str(temp_subtitle),
                         dc_get_fresh_msg_cnt(context, dc_chat_get_id(chat)) as libc::c_int,
                     );
                     free(temp_subtitle as *mut libc::c_void);
@@ -695,7 +695,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                         if !text1.is_null() { ": " } else { "" },
                         to_string(text2),
                         statestr,
-                        to_str(timestr),
+                        as_str(timestr),
                         if 0 != dc_chat_is_sending_locations(chat) {
                             "📍"
                         } else {
@@ -746,8 +746,8 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                 "{}#{}: {} [{}]{}",
                 chat_prefix(sel_chat),
                 dc_chat_get_id(sel_chat),
-                to_str(temp_name),
-                to_str(temp2),
+                as_str(temp_name),
+                as_str(temp2),
                 if 0 != dc_chat_is_sending_locations(sel_chat) {
                     "📍"
                 } else {
@@ -902,7 +902,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                     0,
                     "Loc#{}: {}: lat={} lng={} acc={} Chat#{} Contact#{} Msg#{} {}",
                     dc_array_get_id(loc, j as size_t),
-                    to_str(timestr_0),
+                    as_str(timestr_0),
                     dc_array_get_latitude(loc, j as size_t),
                     dc_array_get_longitude(loc, j as size_t),
                     dc_array_get_accuracy(loc, j as size_t),
@@ -910,7 +910,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                     dc_array_get_contact_id(loc, j as size_t),
                     dc_array_get_msg_id(loc, j as size_t),
                     if !marker.is_null() {
-                        to_str(marker)
+                        as_str(marker)
                     } else {
                         "-"
                     },
@@ -1046,7 +1046,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             ensure!(!arg1.is_empty(), "Argument <msg-id> missing.");
             let id = arg1.parse().unwrap();
             let res = dc_get_msg_info(context, id);
-            println!("{}", to_str(res));
+            println!("{}", as_str(res));
         }
         "listfresh" => {
             let msglist = dc_get_fresh_msgs(context);
@@ -1132,12 +1132,12 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             let contact = dc_get_contact(context, contact_id);
             let name_n_addr = dc_contact_get_name_n_addr(contact);
 
-            let mut res = format!("Contact info for: {}:\n\n", to_str(name_n_addr),);
+            let mut res = format!("Contact info for: {}:\n\n", as_str(name_n_addr),);
             free(name_n_addr as *mut libc::c_void);
             dc_contact_unref(contact);
 
             let encrinfo = dc_get_contact_encrinfo(context, contact_id);
-            res += to_str(encrinfo);
+            res += as_str(encrinfo);
             free(encrinfo as *mut libc::c_void);
 
             let chatlist = dc_get_chatlist(context, 0, 0 as *const libc::c_char, contact_id);

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -521,7 +521,7 @@ unsafe fn handle_cmd(line: &str, ctx: Arc<RwLock<Context>>) -> Result<ExitResult
             } else {
                 let oauth2_url = dc_get_oauth2_url(
                     &ctx.read().unwrap(),
-                    to_str(addr),
+                    as_str(addr),
                     "chat.delta:/com.b44t.messenger",
                 );
                 if oauth2_url.is_none() {

--- a/src/context.rs
+++ b/src/context.rs
@@ -755,8 +755,8 @@ pub unsafe fn dc_get_info(context: &Context) -> *mut libc::c_char {
          public_key_count={}\n\
          fingerprint={}\n\
          level=awesome\n",
-        to_str(DC_VERSION_STR as *const u8 as *const _),
-        to_str(libsqlite3_sys::SQLITE_VERSION as *const u8 as *const libc::c_char),
+        as_str(DC_VERSION_STR as *const u8 as *const _),
+        as_str(libsqlite3_sys::SQLITE_VERSION as *const u8 as *const libc::c_char),
         sqlite3_threadsafe(),
         // arch
         (::std::mem::size_of::<*mut libc::c_void>()).wrapping_mul(8),
@@ -765,31 +765,31 @@ pub unsafe fn dc_get_info(context: &Context) -> *mut libc::c_char {
         deaddrop_msgs,
         contacts,
         if context.has_dbfile() {
-            to_str(context.get_dbfile())
+            as_str(context.get_dbfile())
         } else {
             unset
         },
         dbversion,
         if context.has_blobdir() {
-            to_str(context.get_blobdir())
+            as_str(context.get_blobdir())
         } else {
             unset
         },
         if !displayname.is_null() {
-            to_str(displayname)
+            as_str(displayname)
         } else {
             unset
         },
         is_configured,
-        to_str(l_readable_str),
-        to_str(l2_readable_str),
+        as_str(l_readable_str),
+        as_str(l2_readable_str),
         inbox_watch,
         sentbox_watch,
         mvbox_watch,
         mvbox_move,
         folders_configured,
-        to_str(configured_sentbox_folder),
-        to_str(configured_mvbox_folder),
+        as_str(configured_sentbox_folder),
+        as_str(configured_mvbox_folder),
         mdns_enabled,
         e2ee_enabled,
         prv_key_cnt,

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -360,7 +360,7 @@ pub unsafe fn dc_array_get_string(
     }
     let cnt = (*array).count as usize;
     let slice = std::slice::from_raw_parts((*array).array, cnt);
-    let sep = to_str(sep);
+    let sep = as_str(sep);
 
     let res = slice
         .iter()

--- a/src/dc_configure.rs
+++ b/src/dc_configure.rs
@@ -207,8 +207,8 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                             );
                             let oauth2_addr = dc_get_oauth2_addr(
                                 context,
-                                to_str((*param).addr),
-                                to_str((*param).mail_pw),
+                                as_str((*param).addr),
+                                as_str((*param).mail_pw),
                             );
                             if oauth2_addr.is_some() {
                                 free((*param).addr as *mut libc::c_void);
@@ -1432,7 +1432,7 @@ unsafe fn moz_autoconfigure_text_cb(
                 (*(*moz_ac).out).send_server = val;
                 val = 0 as *mut libc::c_char
             }
-            11 => (*(*moz_ac).out).send_port = to_str(val).parse().unwrap_or_default(),
+            11 => (*(*moz_ac).out).send_port = as_str(val).parse().unwrap_or_default(),
             12 => {
                 free((*(*moz_ac).out).send_user as *mut libc::c_void);
                 (*(*moz_ac).out).send_user = val;
@@ -1526,7 +1526,7 @@ fn read_autoconf_file(context: &Context, url: *const libc::c_char) -> *mut libc:
     info!(context, 0, "Testing {} ...", to_string(url));
 
     match reqwest::Client::new()
-        .get(to_str(url))
+        .get(as_str(url))
         .send()
         .and_then(|mut res| res.text())
     {

--- a/src/dc_contact.rs
+++ b/src/dc_contact.rs
@@ -779,7 +779,7 @@ pub unsafe fn dc_get_contact_encrinfo(
         let peerstate = Peerstate::from_addr(
             context,
             &context.sql.clone().read().unwrap(),
-            to_str((*contact).addr),
+            as_str((*contact).addr),
         );
         dc_loginparam_read(
             context,
@@ -831,7 +831,7 @@ pub unsafe fn dc_get_contact_encrinfo(
                 .map(|k| k.formatted_fingerprint_c())
                 .unwrap_or(std::ptr::null_mut());
             if peerstate.addr.is_some()
-                && to_str((*loginparam).addr) < peerstate.addr.as_ref().unwrap().as_str()
+                && as_str((*loginparam).addr) < peerstate.addr.as_ref().unwrap().as_str()
             {
                 cat_fingerprint(
                     &mut ret,
@@ -1121,7 +1121,7 @@ pub unsafe fn dc_contact_is_verified_ex<'a>(
         let peerstate = Peerstate::from_addr(
             (*contact).context,
             &(*contact).context.sql.clone().read().unwrap(),
-            to_str((*contact).addr),
+            as_str((*contact).addr),
         );
 
         let res = if let Some(ps) = peerstate {

--- a/src/dc_e2ee.rs
+++ b/src/dc_e2ee.rs
@@ -121,7 +121,7 @@ pub unsafe fn dc_e2ee_encrypt(
                             let peerstate = Peerstate::from_addr(
                                 context,
                                 &context.sql.clone().read().unwrap(),
-                                to_str(recipient_addr),
+                                as_str(recipient_addr),
                             );
                             if peerstate.is_some()
                                 && (peerstate.as_ref().unwrap().prefer_encrypt
@@ -613,7 +613,7 @@ pub unsafe fn dc_e2ee_decrypt(
         let autocryptheader = Aheader::from_imffields(from, imffields);
         if message_time > 0 && !from.is_null() {
             peerstate =
-                Peerstate::from_addr(context, &context.sql.clone().read().unwrap(), to_str(from));
+                Peerstate::from_addr(context, &context.sql.clone().read().unwrap(), as_str(from));
 
             if let Some(ref mut peerstate) = peerstate {
                 if let Some(ref header) = autocryptheader {
@@ -648,7 +648,7 @@ pub unsafe fn dc_e2ee_decrypt(
                     peerstate = Peerstate::from_addr(
                         &context,
                         &context.sql.clone().read().unwrap(),
-                        to_str(from),
+                        as_str(from),
                     );
                 }
                 if let Some(ref peerstate) = peerstate {

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -52,7 +52,7 @@ pub unsafe fn dc_imex_has_backup(
     let mut curr_pathNfilename: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut test_sql: Option<dc_sqlite3_t> = None;
 
-    let dir = std::path::Path::new(to_str(dir_name));
+    let dir = std::path::Path::new(as_str(dir_name));
 
     if dir.is_dir() {
         match std::fs::read_dir(dir) {
@@ -1174,7 +1174,7 @@ unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_
                 11487273724841241105 => {}
                 _ => {
                     let mut total_files_cnt = 0;
-                    let dir = std::path::Path::new(to_str(context.get_blobdir()));
+                    let dir = std::path::Path::new(as_str(context.get_blobdir()));
                     let dir_handle = std::fs::read_dir(dir);
                     if dir_handle.is_err() {
                         dc_log_error(
@@ -1378,7 +1378,7 @@ unsafe fn import_self_keys(context: &Context, dir_name: *const libc::c_char) -> 
     // a pointer inside buf2, MUST NOT be free()'d
     let mut buf2_headerline: *const libc::c_char = 0 as *const libc::c_char;
     if !dir_name.is_null() {
-        let dir = std::path::Path::new(to_str(dir_name));
+        let dir = std::path::Path::new(as_str(dir_name));
         let dir_handle = std::fs::read_dir(dir);
         if dir_handle.is_err() {
             dc_log_error(

--- a/src/dc_job.rs
+++ b/src/dc_job.rs
@@ -486,13 +486,13 @@ unsafe fn dc_job_do_DC_JOB_MOVE_MSG(context: &Context, job: &mut dc_job_t) {
                 );
 
                 if !dest_folder.is_null() {
-                    let server_folder = to_str((*msg).server_folder);
+                    let server_folder = as_str((*msg).server_folder);
 
                     match inbox.mv(
                         context,
                         server_folder,
                         (*msg).server_uid,
-                        to_str(dest_folder),
+                        as_str(dest_folder),
                         &mut dest_uid,
                     ) as libc::c_uint
                     {
@@ -593,7 +593,7 @@ unsafe fn dc_job_do_DC_JOB_MARKSEEN_MDN_ON_IMAP(context: &Context, job: &mut dc_
                     0 as *const libc::c_char,
                 );
                 if !dest_folder.is_null() {
-                    let dest_folder = to_str(dest_folder);
+                    let dest_folder = as_str(dest_folder);
                     if 1 == inbox.mv(context, folder, uid, dest_folder, &mut dest_uid)
                         as libc::c_uint
                     {

--- a/src/dc_location.rs
+++ b/src/dc_location.rs
@@ -620,7 +620,7 @@ unsafe fn kml_text_cb(userdata: *mut libc::c_void, text: *const libc::c_char, _l
         if 0 != (*kml).tag & 0x4 && strlen(val) >= 19 {
             // YYYY-MM-DDTHH:MM:SSZ
             // 0   4  7  10 13 16 19
-            let val_r = to_str(val);
+            let val_r = as_str(val);
             match chrono::NaiveDateTime::parse_from_str(val_r, "%Y-%m-%dT%H:%M:%SZ") {
                 Ok(res) => {
                     (*kml).curr.timestamp = res.timestamp();

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -495,7 +495,7 @@ pub fn dc_mimeparser_lookup_field(
 ) -> *mut mailimf_field {
     mimeparser
         .header
-        .get(to_str(field_name))
+        .get(as_str(field_name))
         .map(|v| *v)
         .unwrap_or_else(|| std::ptr::null_mut())
 }
@@ -506,7 +506,7 @@ pub unsafe fn dc_mimeparser_lookup_optional_field(
 ) -> *mut mailimf_optional_field {
     let field = mimeparser
         .header
-        .get(to_str(field_name))
+        .get(as_str(field_name))
         .map(|v| *v)
         .unwrap_or_else(|| std::ptr::null_mut());
     if !field.is_null() && (*field).fld_type == MAILIMF_FIELD_OPTIONAL_FIELD as libc::c_int {
@@ -861,7 +861,7 @@ unsafe fn hash_header(
         }
         if !key.is_null() {
             let key_len: libc::c_int = strlen(key) as libc::c_int;
-            if out.contains_key(to_str(key)) {
+            if out.contains_key(as_str(key)) {
                 if (*field).fld_type != MAILIMF_FIELD_OPTIONAL_FIELD as libc::c_int
                     || key_len > 5i32
                         && strncasecmp(key, b"Chat-\x00" as *const u8 as *const libc::c_char, 5)
@@ -1691,7 +1691,7 @@ pub unsafe fn dc_mimeparser_sender_equals_recipient(mimeparser: &dc_mimeparser_t
                 from_addr_norm = dc_addr_normalize((*mb).mb_addr_spec);
                 let recipients = mailimf_get_recipients(mimeparser.header_root);
                 if recipients.len() == 1 {
-                    if recipients.contains(to_str(from_addr_norm)) {
+                    if recipients.contains(as_str(from_addr_norm)) {
                         sender_equals_recipient = 1i32;
                     }
                 }

--- a/src/dc_param.rs
+++ b/src/dc_param.rs
@@ -164,7 +164,7 @@ pub unsafe fn dc_param_get_int(
     if str.is_null() {
         return def;
     }
-    let ret: int32_t = to_str(str).parse().unwrap_or_default();
+    let ret: int32_t = as_str(str).parse().unwrap_or_default();
     free(str as *mut libc::c_void);
 
     ret

--- a/src/dc_qr.rs
+++ b/src/dc_qr.rs
@@ -240,7 +240,7 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                                     let peerstate = Peerstate::from_fingerprint(
                                         context,
                                         &context.sql.clone().read().unwrap(),
-                                        to_str(fingerprint),
+                                        as_str(fingerprint),
                                     );
                                     if addr.is_null() || invitenumber.is_null() || auth.is_null() {
                                         if let Some(peerstate) = peerstate {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1860,7 +1860,7 @@ unsafe fn check_verified_properties(
             let peerstate = Peerstate::from_addr(
                 context,
                 &context.sql.clone().read().unwrap(),
-                to_str((*contact).addr),
+                as_str((*contact).addr),
             );
 
             if peerstate.is_none() || dc_contact_is_verified_ex(contact, peerstate.as_ref()) != 2 {
@@ -1909,12 +1909,12 @@ unsafe fn check_verified_properties(
                     let mut peerstate = Peerstate::from_addr(
                         context,
                         &context.sql.clone().read().unwrap(),
-                        to_str(to_addr),
+                        as_str(to_addr),
                     );
                     if mimeparser
                         .e2ee_helper
                         .gossipped_addr
-                        .contains(to_str(to_addr))
+                        .contains(as_str(to_addr))
                         && peerstate.is_some()
                     {
                         let peerstate = peerstate.as_mut().unwrap();

--- a/src/dc_securejoin.rs
+++ b/src/dc_securejoin.rs
@@ -372,9 +372,9 @@ unsafe fn fingerprint_equals_sender(
         if let Some(peerstate) = Peerstate::from_addr(
             context,
             &context.sql.clone().read().unwrap(),
-            to_str((*contact).addr),
+            as_str((*contact).addr),
         ) {
-            let fingerprint_normalized = dc_normalize_fingerprint(to_str(fingerprint));
+            let fingerprint_normalized = dc_normalize_fingerprint(as_str(fingerprint));
             if peerstate.public_key_fingerprint.is_some()
                 && &fingerprint_normalized == peerstate.public_key_fingerprint.as_ref().unwrap()
             {
@@ -998,9 +998,9 @@ unsafe fn mark_peer_as_verified(
     if let Some(ref mut peerstate) = Peerstate::from_fingerprint(
         context,
         &context.sql.clone().read().unwrap(),
-        to_str(fingerprint),
+        as_str(fingerprint),
     ) {
-        if peerstate.set_verified(1, to_str(fingerprint), 2) {
+        if peerstate.set_verified(1, as_str(fingerprint), 2) {
             peerstate.prefer_encrypt = EncryptPreference::Mutual;
             peerstate.to_save = Some(ToSave::All);
             peerstate.save_to_db(&context.sql.clone().read().unwrap(), false);
@@ -1047,7 +1047,7 @@ unsafe fn encrypted_and_signed(
     if !mimeparser
         .e2ee_helper
         .signatures
-        .contains(to_str(expected_fingerprint))
+        .contains(as_str(expected_fingerprint))
     {
         dc_log_warning(
             mimeparser.context,

--- a/src/dc_sqlite3.rs
+++ b/src/dc_sqlite3.rs
@@ -863,7 +863,7 @@ pub unsafe fn dc_sqlite3_open(
                                 if let Some(ref mut peerstate) = Peerstate::from_addr(
                                     context,
                                     sql,
-                                    to_str(sqlite3_column_text(stmt, 0) as *const libc::c_char),
+                                    as_str(sqlite3_column_text(stmt, 0) as *const libc::c_char),
                                 ) {
                                     peerstate.recalc_fingerprint();
                                     peerstate.save_to_db(sql, false);
@@ -1239,7 +1239,7 @@ pub fn dc_sqlite3_get_config_int64(
         return def;
     }
 
-    let ret: i64 = to_str(s).parse().unwrap_or_default();
+    let ret: i64 = as_str(s).parse().unwrap_or_default();
     unsafe { free(s as *mut libc::c_void) };
     ret
 }
@@ -1381,7 +1381,7 @@ pub unsafe fn dc_housekeeping(context: &Context) {
         files_in_use.len() as libc::c_int,
     );
     /* go through directory and delete unused files */
-    let p = std::path::Path::new(to_str(context.get_blobdir()));
+    let p = std::path::Path::new(as_str(context.get_blobdir()));
     let dir_handle = std::fs::read_dir(p);
     if dir_handle.is_err() {
         dc_log_warning(
@@ -1493,7 +1493,7 @@ unsafe fn is_file_in_use(
         *name_to_check.offset((name_len - namespc_len) as isize) = 0 as libc::c_char
     }
 
-    let contains = files_in_use.contains(to_str(name_to_check));
+    let contains = files_in_use.contains(as_str(name_to_check));
     free(name_to_check as *mut libc::c_void);
     contains
 }

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -47,7 +47,7 @@ pub unsafe fn dc_strdup_keep_null(s: *const libc::c_char) -> *mut libc::c_char {
 
 pub unsafe fn dc_atoi_null_is_0(s: *const libc::c_char) -> libc::c_int {
     if !s.is_null() {
-        to_str(s).parse().unwrap_or_default()
+        as_str(s).parse().unwrap_or_default()
     } else {
         0
     }
@@ -58,7 +58,7 @@ pub fn dc_atof(s: *const libc::c_char) -> libc::c_double {
         return 0.;
     }
 
-    to_str(s).parse().unwrap_or_default()
+    as_str(s).parse().unwrap_or_default()
 }
 
 pub unsafe fn dc_str_replace(
@@ -1235,7 +1235,7 @@ pub unsafe fn dc_create_folder(
     let mut success = 0;
     let pathNfilename_abs = dc_get_abs_path(context, pathNfilename);
     {
-        let p = std::path::Path::new(to_str(pathNfilename_abs));
+        let p = std::path::Path::new(as_str(pathNfilename_abs));
         if !p.exists() {
             match fs::create_dir_all(p) {
                 Ok(_) => {
@@ -1466,7 +1466,7 @@ pub fn to_string(s: *const libc::c_char) -> String {
     unsafe { std::ffi::CStr::from_ptr(s).to_str().unwrap().to_string() }
 }
 
-pub fn to_str<'a>(s: *const libc::c_char) -> &'a str {
+pub fn as_str<'a>(s: *const libc::c_char) -> &'a str {
     assert!(!s.is_null(), "cannot be used on null pointers");
     unsafe { std::ffi::CStr::from_ptr(s).to_str().unwrap() }
 }

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -7,7 +7,7 @@ use crate::constants::*;
 use crate::context::Context;
 use crate::dc_loginparam::*;
 use crate::dc_sqlite3::*;
-use crate::dc_tools::{to_str, to_string};
+use crate::dc_tools::{as_str, to_string};
 use crate::oauth2::dc_get_oauth2_access_token;
 use crate::types::*;
 
@@ -521,11 +521,11 @@ impl Imap {
         }
 
         {
-            let addr = to_str(lp.addr);
-            let imap_server = to_str(lp.mail_server);
+            let addr = as_str(lp.addr);
+            let imap_server = as_str(lp.mail_server);
             let imap_port = lp.mail_port as u16;
-            let imap_user = to_str(lp.mail_user);
-            let imap_pw = to_str(lp.mail_pw);
+            let imap_user = as_str(lp.mail_user);
+            let imap_pw = as_str(lp.mail_pw);
             let server_flags = lp.server_flags as usize;
 
             let mut config = self.config.write().unwrap();
@@ -695,7 +695,7 @@ impl Imap {
         if val1.is_null() {
             return (0, 0);
         }
-        let entry = to_str(val1);
+        let entry = as_str(val1);
 
         // the entry has the format `imap.mailbox.<folder>=<uidvalidity>:<lastseenuid>`
         let mut parts = entry.split(':');

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -106,13 +106,13 @@ impl Smtp {
 
         let creds = if 0 != lp.server_flags & (DC_LP_AUTH_OAUTH2 as i32) {
             // oauth2
-            let addr = to_str(lp.addr);
-            let send_pw = to_str(lp.send_pw);
+            let addr = as_str(lp.addr);
+            let send_pw = as_str(lp.send_pw);
             let access_token = dc_get_oauth2_access_token(context, addr, send_pw, 0);
             if access_token.is_none() {
                 return 0;
             }
-            let user = to_str(lp.send_user);
+            let user = as_str(lp.send_user);
 
             lettre::smtp::authentication::Credentials::new(user.into(), access_token.unwrap())
         } else {


### PR DESCRIPTION
The function does a cast and does not create a new objects.  The
stdlib convention is to use to_*() for functions which return new
objects and as_*() for functions which keep referring to the same data
but using a different type.  Follow that convention.