### PR TITLE
Refactor the internal sql interface somewhat

### DIFF
--- a/src/dc_chatlist.rs
+++ b/src/dc_chatlist.rs
@@ -145,7 +145,7 @@ unsafe fn dc_chatlist_load_from_db(
             stmt =
                 dc_sqlite3_prepare(
                     (*chatlist).context,
-                    &mut (*chatlist).context.sql.clone().read().unwrap(),
+                    &(*chatlist).context.sql,
                     b"SELECT c.id, m.id FROM chats c  LEFT JOIN msgs m         ON c.id=m.chat_id        AND m.timestamp=( SELECT MAX(timestamp)   FROM msgs  WHERE chat_id=c.id    AND (hidden=0 OR (hidden=1 AND state=19))) WHERE c.id>9   AND c.blocked=0 AND c.id IN(SELECT chat_id FROM chats_contacts WHERE contact_id=?)  GROUP BY c.id  ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;\x00"
                         as *const u8 as *const libc::c_char
                 );
@@ -155,7 +155,7 @@ unsafe fn dc_chatlist_load_from_db(
             stmt =
                 dc_sqlite3_prepare(
                     (*chatlist).context,
-                    &mut (*chatlist).context.sql.clone().read().unwrap(),
+                    &(*chatlist).context.sql,
                     b"SELECT c.id, m.id FROM chats c  LEFT JOIN msgs m         ON c.id=m.chat_id        AND m.timestamp=( SELECT MAX(timestamp)   FROM msgs  WHERE chat_id=c.id    AND (hidden=0 OR (hidden=1 AND state=19))) WHERE c.id>9   AND c.blocked=0 AND c.archived=1  GROUP BY c.id  ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;\x00"
                                        as *const u8 as *const libc::c_char);
             current_block = 3437258052017859086;
@@ -172,7 +172,7 @@ unsafe fn dc_chatlist_load_from_db(
             stmt =
                 dc_sqlite3_prepare(
                     (*chatlist).context,
-                    &mut (*chatlist).context.sql.clone().read().unwrap(),
+                    &(*chatlist).context.sql,
                                    b"SELECT c.id, m.id FROM chats c  LEFT JOIN msgs m         ON c.id=m.chat_id        AND m.timestamp=( SELECT MAX(timestamp)   FROM msgs  WHERE chat_id=c.id    AND (hidden=0 OR (hidden=1 AND state=19))) WHERE c.id>9   AND c.blocked=0 AND c.archived=0  GROUP BY c.id  ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;\x00"
                                        as *const u8 as *const libc::c_char);
             current_block = 3437258052017859086;
@@ -187,7 +187,7 @@ unsafe fn dc_chatlist_load_from_db(
                 stmt =
                     dc_sqlite3_prepare(
                         (*chatlist).context,
-                        &mut (*chatlist).context.sql.clone().read().unwrap(),
+                        &(*chatlist).context.sql,
                         b"SELECT c.id, m.id FROM chats c  LEFT JOIN msgs m         ON c.id=m.chat_id        AND m.timestamp=( SELECT MAX(timestamp)   FROM msgs  WHERE chat_id=c.id    AND (hidden=0 OR (hidden=1 AND state=19))) WHERE c.id>9   AND c.blocked=0 AND c.name LIKE ?  GROUP BY c.id  ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;\x00"
                                            as *const u8 as
                                            *const libc::c_char);
@@ -234,7 +234,7 @@ pub unsafe fn dc_get_archived_cnt(context: &Context) -> libc::c_int {
     let mut ret: libc::c_int = 0i32;
     let stmt: *mut sqlite3_stmt = dc_sqlite3_prepare(
         context,
-        &context.sql.clone().read().unwrap(),
+        &context.sql,
         b"SELECT COUNT(*) FROM chats WHERE blocked=0 AND archived=1;\x00" as *const u8
             as *const libc::c_char,
     );
@@ -251,7 +251,7 @@ unsafe fn get_last_deaddrop_fresh_msg(context: &Context) -> uint32_t {
     stmt =
         dc_sqlite3_prepare(
             context,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"SELECT m.id  FROM msgs m  LEFT JOIN chats c ON c.id=m.chat_id  WHERE m.state=10   AND m.hidden=0    AND c.blocked=2 ORDER BY m.timestamp DESC, m.id DESC;\x00"
                                as *const u8 as *const libc::c_char);
     /* we have an index over the state-column, this should be sufficient as there are typically only few fresh messages */
@@ -346,7 +346,7 @@ pub unsafe fn dc_chatlist_get_summary<'a>(
                         lastcontact = dc_contact_new((*chatlist).context);
                         dc_contact_load_from_db(
                             lastcontact,
-                            &mut (*chatlist).context.sql.clone().read().unwrap(),
+                            &(*chatlist).context.sql,
                             (*lastmsg).from_id,
                         );
                     }

--- a/src/dc_configure.rs
+++ b/src/dc_configure.rs
@@ -82,7 +82,7 @@ pub unsafe fn dc_is_configured(context: &Context) -> libc::c_int {
     return if 0
         != dc_sqlite3_get_config_int(
             context,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"configured\x00" as *const u8 as *const libc::c_char,
             0i32,
         ) {
@@ -127,7 +127,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
 
     if !(0 == dc_alloc_ongoing(context)) {
         ongoing_allocated_here = 1i32;
-        if 0 == dc_sqlite3_is_open(&context.sql.clone().read().unwrap()) {
+        if !context.sql.is_open() {
             dc_log_error(
                 context,
                 0i32,
@@ -173,7 +173,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                 dc_loginparam_read(
                     context,
                     param,
-                    &context.sql.clone().read().unwrap(),
+                    &context.sql,
                     b"\x00" as *const u8 as *const libc::c_char,
                 );
 
@@ -213,7 +213,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                 (*param).addr = strdup(to_cstring(oauth2_addr.unwrap()).as_ptr());
                                 dc_sqlite3_set_config(
                                     context,
-                                    &context.sql.clone().read().unwrap(),
+                                    &context.sql,
                                     b"addr\x00" as *const u8 as *const libc::c_char,
                                     (*param).addr,
                                 );
@@ -1119,7 +1119,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                                             =
                                                                             if 0
                                                                             !=
-                                                                            dc_sqlite3_get_config_int(context, &context.sql.clone().read().unwrap(),
+                                                                            dc_sqlite3_get_config_int(context, &context.sql,
                                                                                                       b"mvbox_watch\x00"
                                                                                                       as
                                                                                                       *const u8
@@ -1129,7 +1129,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                                             ||
                                                                             0
                                                                             !=
-                                                                            dc_sqlite3_get_config_int(context, &context.sql.clone().read().unwrap(),
+                                                                            dc_sqlite3_get_config_int(context, &context.sql,
                                                                                                       b"mvbox_move\x00"
                                                                                                       as
                                                                                                       *const u8
@@ -1170,13 +1170,13 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                                                             as
                                                                                             uintptr_t);
                                                                             dc_loginparam_write(context, param,
-                                                                                                &context.sql.clone().read().unwrap(),
+                                                                                                &context.sql,
                                                                                                 b"configured_\x00"
                                                                                                 as
                                                                                                 *const u8
                                                                                                 as
                                                                                                 *const libc::c_char);
-                                                                            dc_sqlite3_set_config_int(context, &context.sql.clone().read().unwrap(),
+                                                                            dc_sqlite3_set_config_int(context, &context.sql,
                                                                                                       b"configured\x00"
                                                                                                       as
                                                                                                       *const u8
@@ -1725,7 +1725,7 @@ pub unsafe fn dc_connect_to_configured_imap(context: &Context, imap: &Imap) -> l
         ret_connected = 1i32
     } else if dc_sqlite3_get_config_int(
         context,
-        &context.sql.clone().read().unwrap(),
+        &context.sql,
         b"configured\x00" as *const u8 as *const libc::c_char,
         0i32,
     ) == 0i32
@@ -1739,7 +1739,7 @@ pub unsafe fn dc_connect_to_configured_imap(context: &Context, imap: &Imap) -> l
         dc_loginparam_read(
             context,
             param,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"configured_\x00" as *const u8 as *const libc::c_char,
         );
         /*the trailing underscore is correct*/

--- a/src/dc_contact.rs
+++ b/src/dc_contact.rs
@@ -30,7 +30,7 @@ pub struct dc_contact_t<'a> {
 pub unsafe fn dc_marknoticed_contact(context: &Context, contact_id: uint32_t) {
     let stmt: *mut sqlite3_stmt = dc_sqlite3_prepare(
         context,
-        &context.sql.clone().read().unwrap(),
+        &context.sql,
         b"UPDATE msgs SET state=13 WHERE from_id=? AND state=10;\x00" as *const u8
             as *const libc::c_char,
     );
@@ -73,7 +73,7 @@ pub unsafe fn dc_lookup_contact_id_by_addr(
         addr_normalized = dc_addr_normalize(addr);
         addr_self = dc_sqlite3_get_config(
             context,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"configured_addr\x00" as *const u8 as *const libc::c_char,
             b"\x00" as *const u8 as *const libc::c_char,
         );
@@ -82,7 +82,7 @@ pub unsafe fn dc_lookup_contact_id_by_addr(
         } else {
             stmt =
                 dc_sqlite3_prepare(
-                    context,&context.sql.clone().read().unwrap(),
+                    context,&context.sql,
                                    b"SELECT id FROM contacts WHERE addr=?1 COLLATE NOCASE AND id>?2 AND origin>=?3 AND blocked=0;\x00"
                                        as *const u8 as *const libc::c_char);
             sqlite3_bind_text(
@@ -158,12 +158,12 @@ pub unsafe fn dc_block_contact(context: &Context, contact_id: uint32_t, new_bloc
     let contact: *mut dc_contact_t = dc_contact_new(context);
     let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
     if !(contact_id <= 9i32 as libc::c_uint) {
-        if dc_contact_load_from_db(contact, &context.sql.clone().read().unwrap(), contact_id)
+        if dc_contact_load_from_db(contact, &context.sql, contact_id)
             && (*contact).blocked != new_blocking
         {
             stmt = dc_sqlite3_prepare(
                 context,
-                &context.sql.clone().read().unwrap(),
+                &context.sql,
                 b"UPDATE contacts SET blocked=? WHERE id=?;\x00" as *const u8
                     as *const libc::c_char,
             );
@@ -175,7 +175,7 @@ pub unsafe fn dc_block_contact(context: &Context, contact_id: uint32_t, new_bloc
                 sqlite3_finalize(stmt);
                 stmt =
                     dc_sqlite3_prepare(
-                        context,&context.sql.clone().read().unwrap(),
+                        context,&context.sql,
                                        b"UPDATE chats SET blocked=? WHERE type=? AND id IN (SELECT chat_id FROM chats_contacts WHERE contact_id=?);\x00"
                                            as *const u8 as
                                            *const libc::c_char);
@@ -285,7 +285,7 @@ pub unsafe fn dc_contact_empty(mut contact: *mut dc_contact_t) {
 /* contacts with at least this origin value start a new "normal" chat, defaults to off */
 pub unsafe fn dc_contact_load_from_db(
     contact: *mut dc_contact_t,
-    sql: &dc_sqlite3_t,
+    sql: &SQLite,
     contact_id: uint32_t,
 ) -> bool {
     let current_block: u64;
@@ -336,7 +336,7 @@ pub unsafe fn dc_contact_load_from_db(
 pub unsafe fn dc_is_contact_blocked(context: &Context, contact_id: uint32_t) -> bool {
     let mut is_blocked = false;
     let contact: *mut dc_contact_t = dc_contact_new(context);
-    if dc_contact_load_from_db(contact, &context.sql.clone().read().unwrap(), contact_id) {
+    if dc_contact_load_from_db(contact, &context.sql, contact_id) {
         if 0 != (*contact).blocked {
             is_blocked = true
         }
@@ -370,7 +370,7 @@ pub unsafe fn dc_add_or_lookup_contact(
         addr = dc_addr_normalize(addr__);
         addr_self = dc_sqlite3_get_config(
             context,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"configured_addr\x00" as *const u8 as *const libc::c_char,
             b"\x00" as *const u8 as *const libc::c_char,
         );
@@ -391,7 +391,7 @@ pub unsafe fn dc_add_or_lookup_contact(
         } else {
             stmt =
                 dc_sqlite3_prepare(
-                    context,&context.sql.clone().read().unwrap(),
+                    context,&context.sql,
                                    b"SELECT id, name, addr, origin, authname FROM contacts WHERE addr=? COLLATE NOCASE;\x00"
                                        as *const u8 as *const libc::c_char);
             sqlite3_bind_text(stmt, 1i32, addr as *const libc::c_char, -1i32, None);
@@ -429,7 +429,7 @@ pub unsafe fn dc_add_or_lookup_contact(
                 {
                     stmt = dc_sqlite3_prepare(
                         context,
-                        &context.sql.clone().read().unwrap(),
+                        &context.sql,
                         b"UPDATE contacts SET name=?, addr=?, origin=?, authname=? WHERE id=?;\x00"
                             as *const u8 as *const libc::c_char,
                     );
@@ -474,7 +474,7 @@ pub unsafe fn dc_add_or_lookup_contact(
                     if 0 != update_name {
                         stmt =
                             dc_sqlite3_prepare(
-                                context,&context.sql.clone().read().unwrap(),
+                                context,&context.sql,
                                                b"UPDATE chats SET name=? WHERE type=? AND id IN(SELECT chat_id FROM chats_contacts WHERE contact_id=?);\x00"
                                                    as *const u8 as
                                                    *const libc::c_char);
@@ -489,7 +489,7 @@ pub unsafe fn dc_add_or_lookup_contact(
                 sqlite3_finalize(stmt);
                 stmt = dc_sqlite3_prepare(
                     context,
-                    &context.sql.clone().read().unwrap(),
+                    &context.sql,
                     b"INSERT INTO contacts (name, addr, origin) VALUES(?, ?, ?);\x00" as *const u8
                         as *const libc::c_char,
                 );
@@ -509,7 +509,7 @@ pub unsafe fn dc_add_or_lookup_contact(
                 if sqlite3_step(stmt) == 101i32 {
                     row_id = dc_sqlite3_get_rowid(
                         context,
-                        &context.sql.clone().read().unwrap(),
+                        &context.sql,
                         b"contacts\x00" as *const u8 as *const libc::c_char,
                         b"addr\x00" as *const u8 as *const libc::c_char,
                         addr,
@@ -623,7 +623,7 @@ pub unsafe fn dc_get_contacts(
 
     self_addr = dc_sqlite3_get_config(
         context,
-        &context.sql.clone().read().unwrap(),
+        &context.sql,
         b"configured_addr\x00" as *const u8 as *const libc::c_char,
         b"\x00" as *const u8 as *const libc::c_char,
     );
@@ -641,7 +641,7 @@ pub unsafe fn dc_get_contacts(
         } else {
             stmt =
                 dc_sqlite3_prepare(
-                    context,&context.sql.clone().read().unwrap(),
+                    context,&context.sql,
                                        b"SELECT c.id FROM contacts c LEFT JOIN acpeerstates ps ON c.addr=ps.addr  WHERE c.addr!=?1 AND c.id>?2 AND c.origin>=?3 AND c.blocked=0 AND (c.name LIKE ?4 OR c.addr LIKE ?5) AND (1=?6 OR LENGTH(ps.verified_key_fingerprint)!=0)  ORDER BY LOWER(c.name||c.addr),c.id;\x00"
                                            as *const u8 as
                                            *const libc::c_char);
@@ -661,7 +661,7 @@ pub unsafe fn dc_get_contacts(
             );
             self_name = dc_sqlite3_get_config(
                 context,
-                &context.sql.clone().read().unwrap(),
+                &context.sql,
                 b"displayname\x00" as *const u8 as *const libc::c_char,
                 b"\x00" as *const u8 as *const libc::c_char,
             );
@@ -678,7 +678,7 @@ pub unsafe fn dc_get_contacts(
     } else {
         stmt =
             dc_sqlite3_prepare(
-                context,&context.sql.clone().read().unwrap(),
+                context,&context.sql,
                                    b"SELECT id FROM contacts WHERE addr!=?1 AND id>?2 AND origin>=?3 AND blocked=0 ORDER BY LOWER(name||addr),id;\x00"
                                        as *const u8 as *const libc::c_char);
         sqlite3_bind_text(stmt, 1i32, self_addr, -1i32, None);
@@ -714,7 +714,7 @@ pub unsafe fn dc_get_blocked_cnt(context: &Context) -> libc::c_int {
 
     stmt = dc_sqlite3_prepare(
         context,
-        &context.sql.clone().read().unwrap(),
+        &context.sql,
         b"SELECT COUNT(*) FROM contacts WHERE id>? AND blocked!=0\x00" as *const u8
             as *const libc::c_char,
     );
@@ -733,7 +733,7 @@ pub unsafe fn dc_get_blocked_contacts(context: &Context) -> *mut dc_array_t {
 
     stmt = dc_sqlite3_prepare(
         context,
-        &context.sql.clone().read().unwrap(),
+        &context.sql,
         b"SELECT id FROM contacts WHERE id>? AND blocked!=0 ORDER BY LOWER(name||addr),id;\x00"
             as *const u8 as *const libc::c_char,
     );
@@ -759,23 +759,15 @@ pub unsafe fn dc_get_contact_encrinfo(
     let mut fingerprint_other_unverified: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut p: *mut libc::c_char;
 
-    if !(!dc_contact_load_from_db(contact, &context.sql.clone().read().unwrap(), contact_id)) {
-        let peerstate = Peerstate::from_addr(
-            context,
-            &context.sql.clone().read().unwrap(),
-            as_str((*contact).addr),
-        );
+    if !(!dc_contact_load_from_db(contact, &context.sql, contact_id)) {
+        let peerstate = Peerstate::from_addr(context, &context.sql, as_str((*contact).addr));
         dc_loginparam_read(
             context,
             loginparam,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"configured_\x00" as *const u8 as *const libc::c_char,
         );
-        let mut self_key = Key::from_self_public(
-            context,
-            (*loginparam).addr,
-            &context.sql.clone().read().unwrap(),
-        );
+        let mut self_key = Key::from_self_public(context, (*loginparam).addr, &context.sql);
 
         if peerstate.is_some() && peerstate.as_ref().and_then(|p| p.peek_key(0)).is_some() {
             let peerstate = peerstate.as_ref().unwrap();
@@ -791,11 +783,7 @@ pub unsafe fn dc_get_contact_encrinfo(
             free(p as *mut libc::c_void);
             if self_key.is_none() {
                 dc_ensure_secret_key_exists(context);
-                self_key = Key::from_self_public(
-                    context,
-                    (*loginparam).addr,
-                    &context.sql.clone().read().unwrap(),
-                );
+                self_key = Key::from_self_public(context, (*loginparam).addr, &context.sql);
             }
             p = dc_stock_str(context, 30i32);
             ret += &format!(" {}:", as_str(p));
@@ -901,7 +889,7 @@ pub unsafe fn dc_delete_contact(context: &Context, contact_id: uint32_t) -> bool
     if !(contact_id <= 9i32 as libc::c_uint) {
         stmt = dc_sqlite3_prepare(
             context,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"SELECT COUNT(*) FROM chats_contacts WHERE contact_id=?;\x00" as *const u8
                 as *const libc::c_char,
         );
@@ -910,7 +898,7 @@ pub unsafe fn dc_delete_contact(context: &Context, contact_id: uint32_t) -> bool
             sqlite3_finalize(stmt);
             stmt = dc_sqlite3_prepare(
                 context,
-                &context.sql.clone().read().unwrap(),
+                &context.sql,
                 b"SELECT COUNT(*) FROM msgs WHERE from_id=? OR to_id=?;\x00" as *const u8
                     as *const libc::c_char,
             );
@@ -920,7 +908,7 @@ pub unsafe fn dc_delete_contact(context: &Context, contact_id: uint32_t) -> bool
                 sqlite3_finalize(stmt);
                 stmt = dc_sqlite3_prepare(
                     context,
-                    &context.sql.clone().read().unwrap(),
+                    &context.sql,
                     b"DELETE FROM contacts WHERE id=?;\x00" as *const u8 as *const libc::c_char,
                 );
                 sqlite3_bind_int(stmt, 1i32, contact_id as libc::c_int);
@@ -942,7 +930,7 @@ pub unsafe fn dc_delete_contact(context: &Context, contact_id: uint32_t) -> bool
 
 pub unsafe fn dc_get_contact(context: &Context, contact_id: uint32_t) -> *mut dc_contact_t {
     let mut ret: *mut dc_contact_t = dc_contact_new(context);
-    if !dc_contact_load_from_db(ret, &context.sql.clone().read().unwrap(), contact_id) {
+    if !dc_contact_load_from_db(ret, &context.sql, contact_id) {
         dc_contact_unref(ret);
         ret = 0 as *mut dc_contact_t
     }
@@ -1089,7 +1077,7 @@ pub unsafe fn dc_contact_is_verified_ex<'a>(
     } else {
         let peerstate = Peerstate::from_addr(
             (*contact).context,
-            &(*contact).context.sql.clone().read().unwrap(),
+            &(*contact).context.sql,
             as_str((*contact).addr),
         );
 
@@ -1125,7 +1113,7 @@ pub unsafe fn dc_addr_equals_self(context: &Context, addr: *const libc::c_char) 
         normalized_addr = dc_addr_normalize(addr);
         self_addr = dc_sqlite3_get_config(
             context,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"configured_addr\x00" as *const u8 as *const libc::c_char,
             0 as *const libc::c_char,
         );
@@ -1150,7 +1138,7 @@ pub unsafe fn dc_addr_equals_contact(
     let mut addr_are_equal = false;
     if !addr.is_null() {
         let contact: *mut dc_contact_t = dc_contact_new(context);
-        if dc_contact_load_from_db(contact, &context.sql.clone().read().unwrap(), contact_id) {
+        if dc_contact_load_from_db(contact, &context.sql, contact_id) {
             if !(*contact).addr.is_null() {
                 let normalized_addr: *mut libc::c_char = dc_addr_normalize(addr);
                 if strcasecmp((*contact).addr, normalized_addr) == 0i32 {
@@ -1168,10 +1156,10 @@ pub unsafe fn dc_addr_equals_contact(
 pub unsafe fn dc_get_real_contact_cnt(context: &Context) -> size_t {
     let mut ret: size_t = 0i32 as size_t;
     let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
-    if !context.sql.clone().read().unwrap().cobj.is_null() {
+    if context.sql.is_open() {
         stmt = dc_sqlite3_prepare(
             context,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"SELECT COUNT(*) FROM contacts WHERE id>?;\x00" as *const u8 as *const libc::c_char,
         );
         sqlite3_bind_int(stmt, 1i32, 9i32);
@@ -1195,7 +1183,7 @@ pub unsafe fn dc_get_contact_origin(
     }
     let contact: *mut dc_contact_t = dc_contact_new(context);
     *ret_blocked = 0i32;
-    if dc_contact_load_from_db(contact, &context.sql.clone().read().unwrap(), contact_id) {
+    if dc_contact_load_from_db(contact, &context.sql, contact_id) {
         /* we could optimize this by loading only the needed fields */
         if 0 != (*contact).blocked {
             *ret_blocked = 1i32
@@ -1210,10 +1198,10 @@ pub unsafe fn dc_get_contact_origin(
 pub unsafe fn dc_real_contact_exists(context: &Context, contact_id: uint32_t) -> bool {
     let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
     let mut ret = false;
-    if !(context.sql.clone().read().unwrap().cobj.is_null() || contact_id <= 9i32 as libc::c_uint) {
+    if !(!context.sql.is_open() || contact_id <= 9i32 as libc::c_uint) {
         stmt = dc_sqlite3_prepare(
             context,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"SELECT id FROM contacts WHERE id=?;\x00" as *const u8 as *const libc::c_char,
         );
         sqlite3_bind_int(stmt, 1i32, contact_id as libc::c_int);
@@ -1232,7 +1220,7 @@ pub unsafe fn dc_scaleup_contact_origin(
 ) {
     let stmt: *mut sqlite3_stmt = dc_sqlite3_prepare(
         context,
-        &context.sql.clone().read().unwrap(),
+        &context.sql,
         b"UPDATE contacts SET origin=? WHERE id=? AND origin<?;\x00" as *const u8
             as *const libc::c_char,
     );

--- a/src/dc_jobthread.rs
+++ b/src/dc_jobthread.rs
@@ -173,7 +173,7 @@ unsafe fn connect_to_imap(context: &Context, jobthread: &dc_jobthread_t) -> libc
         if !(0 == ret_connected) {
             if dc_sqlite3_get_config_int(
                 context,
-                &context.sql.clone().read().unwrap(),
+                &context.sql,
                 b"folders_configured\x00" as *const u8 as *const libc::c_char,
                 0,
             ) < 3
@@ -182,7 +182,7 @@ unsafe fn connect_to_imap(context: &Context, jobthread: &dc_jobthread_t) -> libc
             }
             mvbox_name = dc_sqlite3_get_config(
                 context,
-                &context.sql.clone().read().unwrap(),
+                &context.sql,
                 jobthread.folder_config_name,
                 0 as *const libc::c_char,
             );

--- a/src/dc_loginparam.rs
+++ b/src/dc_loginparam.rs
@@ -62,7 +62,7 @@ pub unsafe fn dc_loginparam_empty(mut loginparam: *mut dc_loginparam_t) {
 pub unsafe fn dc_loginparam_read(
     context: &Context,
     loginparam: *mut dc_loginparam_t,
-    sql: &dc_sqlite3_t,
+    sql: &SQLite,
     prefix: *const libc::c_char,
 ) {
     let mut key: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -143,7 +143,7 @@ pub unsafe fn dc_loginparam_read(
 pub unsafe fn dc_loginparam_write(
     context: &Context,
     loginparam: *const dc_loginparam_t,
-    sql: &dc_sqlite3_t,
+    sql: &SQLite,
     prefix: *const libc::c_char,
 ) {
     let mut key: *mut libc::c_char = 0 as *mut libc::c_char;

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -140,7 +140,7 @@ pub unsafe fn dc_mimefactory_load_msg(
                 stmt =
                     dc_sqlite3_prepare(
                         context,
-                        &context.sql.clone().read().unwrap(),
+                        &context.sql,
                         b"SELECT c.authname, c.addr  FROM chats_contacts cc  LEFT JOIN contacts c ON cc.contact_id=c.id  WHERE cc.chat_id=? AND cc.contact_id>9;\x00"
                             as *const u8 as
                             *const libc::c_char);
@@ -179,7 +179,7 @@ pub unsafe fn dc_mimefactory_load_msg(
                     );
                     let self_addr: *mut libc::c_char = dc_sqlite3_get_config(
                         context,
-                        &context.sql.clone().read().unwrap(),
+                        &context.sql,
                         b"configured_addr\x00" as *const u8 as *const libc::c_char,
                         b"\x00" as *const u8 as *const libc::c_char,
                     );
@@ -206,7 +206,7 @@ pub unsafe fn dc_mimefactory_load_msg(
                     && command != 7i32
                     && 0 != dc_sqlite3_get_config_int(
                         context,
-                        &context.sql.clone().read().unwrap(),
+                        &context.sql,
                         b"mdns_enabled\x00" as *const u8 as *const libc::c_char,
                         1i32,
                     )
@@ -216,7 +216,7 @@ pub unsafe fn dc_mimefactory_load_msg(
             }
             stmt = dc_sqlite3_prepare(
                 context,
-                &context.sql.clone().read().unwrap(),
+                &context.sql,
                 b"SELECT mime_in_reply_to, mime_references FROM msgs WHERE id=?\x00" as *const u8
                     as *const libc::c_char,
             );
@@ -245,19 +245,19 @@ pub unsafe fn dc_mimefactory_load_msg(
 unsafe fn load_from(mut factory: *mut dc_mimefactory_t) {
     (*factory).from_addr = dc_sqlite3_get_config(
         (*factory).context,
-        &mut (*factory).context.sql.clone().read().unwrap(),
+        &(*factory).context.sql,
         b"configured_addr\x00" as *const u8 as *const libc::c_char,
         0 as *const libc::c_char,
     );
     (*factory).from_displayname = dc_sqlite3_get_config(
         (*factory).context,
-        &mut (*factory).context.sql.clone().read().unwrap(),
+        &(*factory).context.sql,
         b"displayname\x00" as *const u8 as *const libc::c_char,
         0 as *const libc::c_char,
     );
     (*factory).selfstatus = dc_sqlite3_get_config(
         (*factory).context,
-        &mut (*factory).context.sql.clone().read().unwrap(),
+        &(*factory).context.sql,
         b"selfstatus\x00" as *const u8 as *const libc::c_char,
         0 as *const libc::c_char,
     );
@@ -279,7 +279,7 @@ pub unsafe fn dc_mimefactory_load_mdn(
         if !(0
             == dc_sqlite3_get_config_int(
                 (*factory).context,
-                &mut (*factory).context.sql.clone().read().unwrap(),
+                &(*factory).context.sql,
                 b"mdns_enabled\x00" as *const u8 as *const libc::c_char,
                 1i32,
             ))
@@ -289,7 +289,7 @@ pub unsafe fn dc_mimefactory_load_mdn(
             if !(!dc_msg_load_from_db((*factory).msg, (*factory).context, msg_id)
                 || !dc_contact_load_from_db(
                     contact,
-                    &mut (*factory).context.sql.clone().read().unwrap(),
+                    &(*factory).context.sql,
                     (*(*factory).msg).from_id,
                 ))
             {

--- a/src/dc_move.rs
+++ b/src/dc_move.rs
@@ -15,7 +15,7 @@ pub unsafe fn dc_do_heuristics_moves(
     let stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
     if !(dc_sqlite3_get_config_int(
         context,
-        &context.sql.clone().read().unwrap(),
+        &context.sql,
         b"mvbox_move\x00" as *const u8 as *const libc::c_char,
         1i32,
     ) == 0i32)

--- a/src/dc_qr.rs
+++ b/src/dc_qr.rs
@@ -239,7 +239,7 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                                 if !fingerprint.is_null() {
                                     let peerstate = Peerstate::from_fingerprint(
                                         context,
-                                        &context.sql.clone().read().unwrap(),
+                                        &context.sql,
                                         as_str(fingerprint),
                                     );
                                     if addr.is_null() || invitenumber.is_null() || auth.is_null() {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -250,7 +250,7 @@ pub unsafe fn dc_receive_imf(
                             if msgrmsg == 0i32 {
                                 let show_emails: libc::c_int = dc_sqlite3_get_config_int(
                                     context,
-                                    &context.sql.clone().read().unwrap(),
+                                    &context.sql,
                                     b"show_emails\x00" as *const u8 as *const libc::c_char,
                                     0i32,
                                 );
@@ -454,7 +454,7 @@ pub unsafe fn dc_receive_imf(
                             // (the mime-header ends with an empty line)
                             let save_mime_headers: libc::c_int = dc_sqlite3_get_config_int(
                                 context,
-                                &context.sql.clone().read().unwrap(),
+                                &context.sql,
                                 b"save_mime_headers\x00" as *const u8 as *const libc::c_char,
                                 0i32,
                             );
@@ -517,7 +517,7 @@ pub unsafe fn dc_receive_imf(
                             stmt =
                                 dc_sqlite3_prepare(
                                     context,
-                                    &context.sql.clone().read().unwrap(),
+                                    &context.sql,
                                     b"INSERT INTO msgs (rfc724_mid, server_folder, server_uid, chat_id, from_id, to_id, timestamp, timestamp_sent, timestamp_rcvd, type, state, msgrmsg,  txt, txt_raw, param, bytes, hidden, mime_headers,  mime_in_reply_to, mime_references) VALUES (?,?,?,?,?,?, ?,?,?,?,?,?, ?,?,?,?,?,?, ?,?);\x00"
                                                        as *const u8 as
                                                        *const libc::c_char);
@@ -635,7 +635,7 @@ pub unsafe fn dc_receive_imf(
                                         txt_raw = 0 as *mut libc::c_char;
                                         insert_msg_id = dc_sqlite3_get_rowid(
                                             context,
-                                            &context.sql.clone().read().unwrap(),
+                                            &context.sql,
                                             b"msgs\x00" as *const u8 as *const libc::c_char,
                                             b"rfc724_mid\x00" as *const u8 as *const libc::c_char,
                                             rfc724_mid,
@@ -696,7 +696,7 @@ pub unsafe fn dc_receive_imf(
                     if carray_count(mime_parser.reports) > 0i32 as libc::c_uint {
                         let mdns_enabled: libc::c_int = dc_sqlite3_get_config_int(
                             context,
-                            &context.sql.clone().read().unwrap(),
+                            &context.sql,
                             b"mdns_enabled\x00" as *const u8 as *const libc::c_char,
                             1i32,
                         );
@@ -878,7 +878,7 @@ pub unsafe fn dc_receive_imf(
                                         if 0 != mime_parser.is_send_by_messenger
                                             && 0 != dc_sqlite3_get_config_int(
                                                 context,
-                                                &context.sql.clone().read().unwrap(),
+                                                &context.sql,
                                                 b"mvbox_move\x00" as *const u8
                                                     as *const libc::c_char,
                                                 1i32,
@@ -1028,7 +1028,7 @@ unsafe fn calc_timestamps(
     if 0 != is_fresh_msg {
         let stmt: *mut sqlite3_stmt = dc_sqlite3_prepare(
             context,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"SELECT MAX(timestamp) FROM msgs WHERE chat_id=? and from_id!=? AND timestamp>=?\x00"
                 as *const u8 as *const libc::c_char,
         );
@@ -1289,7 +1289,7 @@ unsafe fn create_or_lookup_group(
             group_explicitly_left = dc_is_group_explicitly_left(context, grpid);
             self_addr = dc_sqlite3_get_config(
                 context,
-                &context.sql.clone().read().unwrap(),
+                &context.sql,
                 b"configured_addr\x00" as *const u8 as *const libc::c_char,
                 b"\x00" as *const u8 as *const libc::c_char,
             );
@@ -1367,7 +1367,7 @@ unsafe fn create_or_lookup_group(
                         {
                             stmt = dc_sqlite3_prepare(
                                 context,
-                                &context.sql.clone().read().unwrap(),
+                                &context.sql,
                                 b"UPDATE chats SET name=? WHERE id=?;\x00" as *const u8
                                     as *const libc::c_char,
                             );
@@ -1436,7 +1436,7 @@ unsafe fn create_or_lookup_group(
                             };
                             stmt = dc_sqlite3_prepare(
                                 context,
-                                &context.sql.clone().read().unwrap(),
+                                &context.sql,
                                 b"DELETE FROM chats_contacts WHERE chat_id=?;\x00" as *const u8
                                     as *const libc::c_char,
                             );
@@ -1567,7 +1567,7 @@ unsafe fn create_or_lookup_adhoc_group(
                     sqlite3_mprintf(b"SELECT c.id, c.blocked  FROM chats c  LEFT JOIN msgs m ON m.chat_id=c.id  WHERE c.id IN(%s)  ORDER BY m.timestamp DESC, m.id DESC  LIMIT 1;\x00"
                                         as *const u8 as *const libc::c_char,
                                     chat_ids_str);
-                stmt = dc_sqlite3_prepare(context, &context.sql.clone().read().unwrap(), q3);
+                stmt = dc_sqlite3_prepare(context, &context.sql, q3);
                 if sqlite3_step(stmt) == 100i32 {
                     chat_id = sqlite3_column_int(stmt, 0i32) as uint32_t;
                     chat_id_blocked = sqlite3_column_int(stmt, 1i32);
@@ -1648,7 +1648,7 @@ unsafe fn create_group_record(
     let stmt: *mut sqlite3_stmt;
     stmt = dc_sqlite3_prepare(
         context,
-        &context.sql.clone().read().unwrap(),
+        &context.sql,
         b"INSERT INTO chats (type, name, grpid, blocked) VALUES(?, ?, ?, ?);\x00" as *const u8
             as *const libc::c_char,
     );
@@ -1663,7 +1663,7 @@ unsafe fn create_group_record(
     if !(sqlite3_step(stmt) != 101i32) {
         chat_id = dc_sqlite3_get_rowid(
             context,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"chats\x00" as *const u8 as *const libc::c_char,
             b"grpid\x00" as *const u8 as *const libc::c_char,
             grpid,
@@ -1693,10 +1693,10 @@ unsafe fn create_adhoc_grp_id(context: &Context, member_ids: *mut dc_array_t) ->
             as *const libc::c_char,
         member_ids_str,
     );
-    stmt = dc_sqlite3_prepare(context, &context.sql.clone().read().unwrap(), q3);
+    stmt = dc_sqlite3_prepare(context, &context.sql, q3);
     addr = dc_sqlite3_get_config(
         context,
-        &context.sql.clone().read().unwrap(),
+        &context.sql,
         b"configured_addr\x00" as *const u8 as *const libc::c_char,
         b"no-self\x00" as *const u8 as *const libc::c_char,
     );
@@ -1769,7 +1769,7 @@ unsafe fn search_chat_ids_by_contact_ids(
                     sqlite3_mprintf(b"SELECT DISTINCT cc.chat_id, cc.contact_id  FROM chats_contacts cc  LEFT JOIN chats c ON c.id=cc.chat_id  WHERE cc.chat_id IN(SELECT chat_id FROM chats_contacts WHERE contact_id IN(%s))   AND c.type=120   AND cc.contact_id!=1 ORDER BY cc.chat_id, cc.contact_id;\x00"
                                         as *const u8 as *const libc::c_char,
                                     contact_ids_str);
-            stmt = dc_sqlite3_prepare(context, &context.sql.clone().read().unwrap(), q3);
+            stmt = dc_sqlite3_prepare(context, &context.sql, q3);
             let mut last_chat_id = 0;
             let mut matches = 0;
             let mut mismatches = 0;
@@ -1817,7 +1817,7 @@ unsafe fn check_verified_properties(
     let mut to_ids_str: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut q3: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut stmt: *mut sqlite3_stmt = 0 as *mut sqlite3_stmt;
-    if !dc_contact_load_from_db(contact, &context.sql.clone().read().unwrap(), from_id) {
+    if !dc_contact_load_from_db(contact, &context.sql, from_id) {
         *failure_reason = dc_mprintf(
             b"%s. See \"Info\" for details.\x00" as *const u8 as *const libc::c_char,
             b"Internal Error; cannot load contact.\x00" as *const u8 as *const libc::c_char,
@@ -1835,11 +1835,7 @@ unsafe fn check_verified_properties(
         // this check is skipped for SELF as there is no proper SELF-peerstate
         // and results in group-splits otherwise.
         if from_id != 1i32 as libc::c_uint {
-            let peerstate = Peerstate::from_addr(
-                context,
-                &context.sql.clone().read().unwrap(),
-                as_str((*contact).addr),
-            );
+            let peerstate = Peerstate::from_addr(context, &context.sql, as_str((*contact).addr));
 
             if peerstate.is_none() || dc_contact_is_verified_ex(contact, peerstate.as_ref()) != 2 {
                 *failure_reason = dc_mprintf(
@@ -1874,7 +1870,7 @@ unsafe fn check_verified_properties(
                     sqlite3_mprintf(b"SELECT c.addr, LENGTH(ps.verified_key_fingerprint)  FROM contacts c  LEFT JOIN acpeerstates ps ON c.addr=ps.addr  WHERE c.id IN(%s) \x00"
                                         as *const u8 as *const libc::c_char,
                                     to_ids_str);
-                stmt = dc_sqlite3_prepare(context, &context.sql.clone().read().unwrap(), q3);
+                stmt = dc_sqlite3_prepare(context, &context.sql, q3);
                 loop {
                     if !(sqlite3_step(stmt) == 100i32) {
                         current_block = 2604890879466389055;
@@ -1884,11 +1880,8 @@ unsafe fn check_verified_properties(
                         sqlite3_column_text(stmt, 0i32) as *const libc::c_char;
                     let mut is_verified: libc::c_int = sqlite3_column_int(stmt, 1i32);
 
-                    let mut peerstate = Peerstate::from_addr(
-                        context,
-                        &context.sql.clone().read().unwrap(),
-                        as_str(to_addr),
-                    );
+                    let mut peerstate =
+                        Peerstate::from_addr(context, &context.sql, as_str(to_addr));
                     if mimeparser
                         .e2ee_helper
                         .gossipped_addr
@@ -1912,7 +1905,7 @@ unsafe fn check_verified_properties(
                             let fp = peerstate.gossip_key_fingerprint.clone();
                             if let Some(fp) = fp {
                                 peerstate.set_verified(0, &fp, 2);
-                                peerstate.save_to_db(&context.sql.clone().read().unwrap(), false);
+                                peerstate.save_to_db(&context.sql, false);
                                 is_verified = 1i32;
                             }
                         }
@@ -2039,7 +2032,7 @@ unsafe fn is_known_rfc724_mid(context: &Context, rfc724_mid: *const libc::c_char
     let mut is_known: libc::c_int = 0i32;
     if !rfc724_mid.is_null() {
         let  stmt: *mut sqlite3_stmt =
-            dc_sqlite3_prepare(context, &context.sql.clone().read().unwrap(),
+            dc_sqlite3_prepare(context, &context.sql,
                                b"SELECT m.id FROM msgs m  LEFT JOIN chats c ON m.chat_id=c.id  WHERE m.rfc724_mid=?  AND m.chat_id>9 AND c.blocked=0;\x00"
                                    as *const u8 as *const libc::c_char);
         sqlite3_bind_text(stmt, 1i32, rfc724_mid, -1i32, None);
@@ -2123,7 +2116,7 @@ unsafe fn is_msgrmsg_rfc724_mid(context: &Context, rfc724_mid: *const libc::c_ch
     if !rfc724_mid.is_null() {
         let stmt: *mut sqlite3_stmt = dc_sqlite3_prepare(
             context,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"SELECT id FROM msgs  WHERE rfc724_mid=?  AND msgrmsg!=0  AND chat_id>9;\x00"
                 as *const u8 as *const libc::c_char,
         );
@@ -2241,7 +2234,7 @@ unsafe fn add_or_lookup_contact_by_addr(
     *check_self = 0i32;
     let self_addr: *mut libc::c_char = dc_sqlite3_get_config(
         context,
-        &context.sql.clone().read().unwrap(),
+        &context.sql,
         b"configured_addr\x00" as *const u8 as *const libc::c_char,
         b"\x00" as *const u8 as *const libc::c_char,
     );

--- a/src/dc_token.rs
+++ b/src/dc_token.rs
@@ -19,7 +19,7 @@ pub unsafe fn dc_token_save(
         // foreign_id may be 0
         stmt = dc_sqlite3_prepare(
             context,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"INSERT INTO tokens (namespc, foreign_id, token, timestamp) VALUES (?, ?, ?, ?);\x00"
                 as *const u8 as *const libc::c_char,
         );
@@ -40,7 +40,7 @@ pub unsafe fn dc_token_lookup(
     let stmt: *mut sqlite3_stmt;
     stmt = dc_sqlite3_prepare(
         context,
-        &context.sql.clone().read().unwrap(),
+        &context.sql,
         b"SELECT token FROM tokens WHERE namespc=? AND foreign_id=?;\x00" as *const u8
             as *const libc::c_char,
     );
@@ -63,7 +63,7 @@ pub unsafe fn dc_token_exists(
     if !token.is_null() {
         stmt = dc_sqlite3_prepare(
             context,
-            &context.sql.clone().read().unwrap(),
+            &context.sql,
             b"SELECT id FROM tokens WHERE namespc=? AND token=?;\x00" as *const u8
                 as *const libc::c_char,
         );

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1600,14 +1600,14 @@ impl Imap {
         unsafe {
             dc_sqlite3_set_config_int(
                 context,
-                &context.sql.read().unwrap(),
+                &context.sql,
                 b"folders_configured\x00" as *const u8 as *const libc::c_char,
                 3,
             );
             if let Some(ref mvbox_folder) = mvbox_folder {
                 dc_sqlite3_set_config(
                     context,
-                    &context.sql.read().unwrap(),
+                    &context.sql,
                     b"configured_mvbox_folder\x00" as *const u8 as *const libc::c_char,
                     CString::new(mvbox_folder.clone()).unwrap().as_ptr(),
                 );
@@ -1615,7 +1615,7 @@ impl Imap {
             if let Some(ref sentbox_folder) = sentbox_folder {
                 dc_sqlite3_set_config(
                     context,
-                    &context.sql.read().unwrap(),
+                    &context.sql,
                     b"configured_sentbox_folder\x00" as *const u8 as *const libc::c_char,
                     CString::new(sentbox_folder.name()).unwrap().as_ptr(),
                 );

--- a/src/key.rs
+++ b/src/key.rs
@@ -139,7 +139,7 @@ impl Key {
     pub fn from_self_public(
         context: &Context,
         self_addr: *const libc::c_char,
-        sql: &dc_sqlite3_t,
+        sql: &SQLite,
     ) -> Option<Self> {
         if self_addr.is_null() {
             return None;
@@ -169,7 +169,7 @@ impl Key {
     pub fn from_self_private(
         context: &Context,
         self_addr: *const libc::c_char,
-        sql: &dc_sqlite3_t,
+        sql: &SQLite,
     ) -> Option<Self> {
         if self_addr.is_null() {
             return None;
@@ -332,7 +332,7 @@ pub fn dc_key_save_self_keypair(
     private_key: &Key,
     addr: *const libc::c_char,
     is_default: libc::c_int,
-    sql: &dc_sqlite3_t,
+    sql: &SQLite,
 ) -> bool {
     if addr.is_null() {
         return false;

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -32,7 +32,7 @@ impl<'a> Keyring<'a> {
         &mut self,
         context: &Context,
         self_addr: *const libc::c_char,
-        sql: &dc_sqlite3_t,
+        sql: &SQLite,
     ) -> bool {
         // Can we prevent keyring and self_addr to be null?
         if self_addr.is_null() {

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -281,14 +281,8 @@ impl Oauth2 {
 
 fn get_config(context: &Context, key: &str) -> Option<String> {
     let key_c = CString::new(key).unwrap();
-    let res = unsafe {
-        dc_sqlite3_get_config(
-            context,
-            &context.sql.clone().read().unwrap(),
-            key_c.as_ptr(),
-            std::ptr::null(),
-        )
-    };
+    let res =
+        unsafe { dc_sqlite3_get_config(context, &context.sql, key_c.as_ptr(), std::ptr::null()) };
     if res.is_null() {
         return None;
     }
@@ -299,32 +293,18 @@ fn get_config(context: &Context, key: &str) -> Option<String> {
 fn set_config(context: &Context, key: &str, value: &str) {
     let key_c = CString::new(key).unwrap();
     let value_c = CString::new(value).unwrap();
-    unsafe {
-        dc_sqlite3_set_config(
-            context,
-            &context.sql.clone().read().unwrap(),
-            key_c.as_ptr(),
-            value_c.as_ptr(),
-        )
-    };
+    unsafe { dc_sqlite3_set_config(context, &context.sql, key_c.as_ptr(), value_c.as_ptr()) };
 }
 
 fn set_config_int64(context: &Context, key: &str, value: i64) {
     let key_c = CString::new(key).unwrap();
-    unsafe {
-        dc_sqlite3_set_config_int64(
-            context,
-            &context.sql.clone().read().unwrap(),
-            key_c.as_ptr(),
-            value,
-        )
-    };
+    unsafe { dc_sqlite3_set_config_int64(context, &context.sql, key_c.as_ptr(), value) };
 }
 
 fn is_expired(context: &Context) -> bool {
     let expire_timestamp = dc_sqlite3_get_config_int64(
         context,
-        &context.sql.clone().read().unwrap(),
+        &context.sql,
         b"oauth2_timestamp_expires\x00" as *const u8 as *const libc::c_char,
         0i32 as int64_t,
     );

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -167,7 +167,7 @@ impl<'a> Peerstate<'a> {
         res
     }
 
-    pub fn from_addr(context: &'a Context, sql: &dc_sqlite3_t, addr: &str) -> Option<Self> {
+    pub fn from_addr(context: &'a Context, sql: &SQLite, addr: &str) -> Option<Self> {
         let mut res = None;
 
         let stmt = unsafe {
@@ -187,11 +187,7 @@ impl<'a> Peerstate<'a> {
         res
     }
 
-    pub fn from_fingerprint(
-        context: &'a Context,
-        sql: &dc_sqlite3_t,
-        fingerprint: &str,
-    ) -> Option<Self> {
+    pub fn from_fingerprint(context: &'a Context, sql: &SQLite, fingerprint: &str) -> Option<Self> {
         let mut res = None;
 
         let stmt = unsafe {
@@ -404,7 +400,7 @@ impl<'a> Peerstate<'a> {
         success
     }
 
-    pub fn save_to_db(&self, sql: &dc_sqlite3_t, create: bool) -> bool {
+    pub fn save_to_db(&self, sql: &SQLite, create: bool) -> bool {
         let mut success = false;
 
         if self.addr.is_none() {
@@ -538,7 +534,7 @@ impl<'a> Peerstate<'a> {
         } else if self.to_save == Some(ToSave::Timestamps) {
             let stmt = unsafe {
                 dc_sqlite3_prepare(
-                    self.context,sql,
+                    &self.context,sql,
                     b"UPDATE acpeerstates SET last_seen=?, last_seen_autocrypt=?, gossip_timestamp=? WHERE addr=?;\x00"
                         as *const u8 as *const libc::c_char)
             };
@@ -615,14 +611,10 @@ mod tests {
             degrade_event: None,
         };
 
-        assert!(
-            peerstate.save_to_db(&ctx.ctx.sql.clone().read().unwrap(), true),
-            "failed to save"
-        );
+        assert!(peerstate.save_to_db(&ctx.ctx.sql, true), "failed to save");
 
-        let peerstate_new =
-            Peerstate::from_addr(&ctx.ctx, &ctx.ctx.sql.clone().read().unwrap(), addr.into())
-                .expect("failed to load peerstate from db");
+        let peerstate_new = Peerstate::from_addr(&ctx.ctx, &ctx.ctx.sql, addr.into())
+            .expect("failed to load peerstate from db");
 
         // clear to_save, as that is not persissted
         peerstate.to_save = None;

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -1,7 +1,7 @@
 //! Stress some functions for testing; if used as a lib, this file is obsolete.
 
 use std::collections::HashSet;
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 
 use mmime::mailimf_types::*;
 use tempfile::{tempdir, TempDir};


### PR DESCRIPTION
Experiment with refactoring the internal sql interface a bit.  My
original goal was to modify the schema and thus refactor to a state
where it would be sane to write tests for dc_sqlite_open() (and/or
however it ends up refactored) to assert schame changes before/after.