### PR TITLE
Add as_path() conversion function

### DIFF
--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -51,7 +51,7 @@ pub unsafe fn dc_imex_has_backup(
     let mut curr_pathNfilename: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut test_sql: Option<dc_sqlite3_t> = None;
 
-    let dir = std::path::Path::new(as_str(dir_name));
+    let dir = as_path(dir_name);
 
     if dir.is_dir() {
         match std::fs::read_dir(dir) {

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -1,7 +1,7 @@
 //! Stress some functions for testing; if used as a lib, this file is obsolete.
 
 use std::collections::HashSet;
-use std::ffi::{CString};
+use std::ffi::CString;
 
 use mmime::mailimf_types::*;
 use tempfile::{tempdir, TempDir};

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -1,7 +1,7 @@
 //! Stress some functions for testing; if used as a lib, this file is obsolete.
 
 use std::collections::HashSet;
-use std::ffi::{CStr, CString};
+use std::ffi::{CString};
 
 use mmime::mailimf_types::*;
 use tempfile::{tempdir, TempDir};


### PR DESCRIPTION
This improves things for unix, doesn't actually do much for windows.  Maybe one day a windows expert will come along and improve this.  Alternatively this will be obsolete because we won't be handling raw pointers anymore, though there's always the C API which needs to work.