### PR TITLE
For development statically link dcc-rs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@ include
 .dc-history.txt
 *.db
 *.db-blobs
+
+python/.eggs
+python/.tox
+*.egg-info
+__pycache__
+python/src/deltachat/capi*.so

--- a/ci_scripts/run_all.sh
+++ b/ci_scripts/run_all.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 #
-# Build the Delta Chat C/Rust library
-# typically run in a docker container that contains all library deps
-# but should also work outside if you have the dependencies installed  
-# on your system. 
+# Build the Delta Chat C/Rust library typically run in a docker
+# container that contains all library deps but should also work
+# outside if you have the dependencies installed on your system.
 
 set -e -x
 
-# perform clean build of core and install 
+# Perform clean build of core and install.
 export TOXWORKDIR=.docker-tox
 
 # install core lib
@@ -16,12 +15,11 @@ export PATH=/root/.cargo/bin:$PATH
 cargo build --release -p deltachat_ffi
 # cargo test --all --all-features
 
-# make sure subsequent compiler invocations find header and libraries
-export CFLAGS=-I`pwd`/deltachat-ffi
-export LD_LIBRARY_PATH=`pwd`/target/release
+# Statically link against libdeltachat.a.
+export DCC_RS_DEV=$(pwd)
 
-# configure access to a base python and 
-# to several python interpreters needed by tox below
+# Configure access to a base python and to several python interpreters
+# needed by tox below.
 export PATH=$PATH:/opt/python/cp35-cp35m/bin
 export PYTHONDONTWRITEBYTECODE=1
 pushd /bin
@@ -30,23 +28,23 @@ ln -s /opt/python/cp36-cp36m/bin/python3.6
 ln -s /opt/python/cp37-cp37m/bin/python3.7
 popd
 
-if [ -n "$TESTS" ]; then 
+if [ -n "$TESTS" ]; then
 
-    pushd python 
-    # prepare a clean tox run 
+    pushd python
+    # prepare a clean tox run
     rm -rf tests/__pycache__
     rm -rf src/deltachat/__pycache__
     export PYTHONDONTWRITEBYTECODE=1
 
-    # run tox 
+    # run tox
     tox --workdir "$TOXWORKDIR" -e py27,py35,py36,py37,auditwheels
     popd
 fi
 
 
-if [ -n "$DOCS" ]; then 
+if [ -n "$DOCS" ]; then
     echo -----------------------
     echo generating python docs
     echo -----------------------
-    (cd python && tox --workdir "$TOXWORKDIR" -e doc) 
+    (cd python && tox --workdir "$TOXWORKDIR" -e doc)
 fi

--- a/python/README.rst
+++ b/python/README.rst
@@ -114,6 +114,14 @@ The ``run-integration-tests.sh`` script will automatically use
 .. _`deltachat-core-rust github repository`: https://github.com/deltachat/deltachat-core-rust
 .. _`deltachat-core`: https://github.com/deltachat/deltachat-core-rust
 
+Running test using a debug build
+--------------------------------
+
+If you need to examine e.g. a coredump you may want to run the tests
+using a debug build::
+
+   DCC_RS_TARGET=debug ./run-integration-tests.sh -e py37 -- -x -v -k failing_test
+
 
 Building manylinux1 wheels
 ==========================

--- a/python/README.rst
+++ b/python/README.rst
@@ -50,18 +50,14 @@ to core deltachat library::
     cd deltachat-core-rust
     cargo build -p deltachat_ffi --release
 
-This will result in a ``libdeltachat.so`` and ``deltachat.h`` file
-in the ``deltachat_ffi`` directory. These files are needed for
+This will result in a ``libdeltachat.so`` and ``libdeltachat.a`` files
+in the ``target/release`` directory. These files are needed for
 creating the python bindings for deltachat::
 
     cd python
-    CFLAGS=I`pwd`/../deltachat-ffi pip install -e .
+    DCC_RS_DEV=`pwd`/.. pip install -e .
 
-You then need to set the load-dynamic-library path in your shell::
-
-    export LD_LIBRARY_PATH=`pwd`/../target/release
-
-so that importing the bindings finds the correct library::
+Now test if the bindings find the correct library::
 
     python -c 'import deltachat ; print(deltachat.__version__)'
 
@@ -73,6 +69,14 @@ This should print your deltachat bindings version.
     that'd be much appreciated! please then get
     `in contact with us <https://delta.chat/en/contribute>`_.
 
+Using a system-installed deltachat-core-rust
+--------------------------------------------
+
+When calling ``pip`` without specifying the ``DCC_RS_DEV`` environment
+variable cffi will try to use a ``deltachat.h`` from a system location
+like ``/usr/local/include`` and will try to dynamically link against a
+``libdeltachat.so`` in a similar location (e.g. ``/usr/local/lib``).
+
 
 Code examples
 =============
@@ -83,13 +87,10 @@ You may look at `examples <https://py.delta.chat/examples.html>`_.
 Running tests
 =============
 
-Get a checkout of the `deltachat-core github repository`_ and type::
+Get a checkout of the `deltachat-core-rust github repository`_ and type::
 
-    cd python
-    export CFLAGS=I`pwd`/../deltachat-ffi
-    export LD_LIBRARY_PATH=`pwd`/../target/release
     pip install tox
-    tox
+    ./run-integration-tests.sh
 
 If you want to run functional tests with real
 e-mail test accounts, generate a "liveconfig" file where each
@@ -103,12 +104,14 @@ The "keyword=value" style allows to specify any
 `deltachat account config setting <https://c.delta.chat/classdc__context__t.html#aff3b894f6cfca46cab5248fdffdf083d>`_ so you can also specify smtp or imap servers, ports, ssl modes etc.
 Typically DC's automatic configuration allows to not specify these settings.
 
-You can now run tests with this ``liveconfig`` file::
+The ``run-integration-tests.sh`` script will automatically use
+``python/liveconfig`` if it exists, to manually run tests with this
+``liveconfig`` file use::
 
     tox -- --liveconfig liveconfig
 
 
-.. _`deltachat-core github repository`: https://github.com/deltachat/deltachat-core-rust
+.. _`deltachat-core-rust github repository`: https://github.com/deltachat/deltachat-core-rust
 .. _`deltachat-core`: https://github.com/deltachat/deltachat-core-rust
 
 

--- a/python/src/deltachat/__init__.py
+++ b/python/src/deltachat/__init__.py
@@ -2,7 +2,7 @@ from deltachat import capi, const
 from deltachat.capi import ffi
 from deltachat.account import Account  # noqa
 
-__version__ = "0.10.0dev1"
+__version__ = "0.10.0.dev2"
 
 
 _DC_CALLBACK_MAP = {}

--- a/python/src/deltachat/_build.py
+++ b/python/src/deltachat/_build.py
@@ -8,9 +8,10 @@ import cffi
 
 def ffibuilder():
     projdir = os.environ.get('DCC_RS_DEV')
+    target = os.environ.get('DCC_RS_TARGET', 'release')
     if projdir:
         libs = []
-        objs = [os.path.join(projdir, 'target', 'release', 'libdeltachat.a')]
+        objs = [os.path.join(projdir, 'target', target, 'libdeltachat.a')]
         incs = [os.path.join(projdir, 'deltachat-ffi')]
     else:
         libs = ['deltachat']

--- a/python/src/deltachat/_build.py
+++ b/python/src/deltachat/_build.py
@@ -10,7 +10,7 @@ def ffibuilder():
     projdir = os.environ.get('DCC_RS_DEV')
     target = os.environ.get('DCC_RS_TARGET', 'release')
     if projdir:
-        libs = []
+        libs = ['rt', 'dl', 'm']
         objs = [os.path.join(projdir, 'target', target, 'libdeltachat.a')]
         incs = [os.path.join(projdir, 'deltachat-ffi')]
     else:

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -10,15 +10,17 @@ envlist =
 commands = 
     pytest -rsXx {posargs:tests}
     pip wheel . -w {toxworkdir}/wheelhouse
- 
 passenv = 
     TRAVIS 
-    LD_LIBRARY_PATH 
-    CFLAGS
+    DCC_RS_DEV
 deps = 
     pytest
     pytest-faulthandler
     pdbpp
+    cffi
+    requests
+    attrs
+    six
 
 [testenv:auditwheels]
 skipsdist = True

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -17,10 +17,6 @@ deps =
     pytest
     pytest-faulthandler
     pdbpp
-    cffi
-    requests
-    attrs
-    six
 
 [testenv:auditwheels]
 skipsdist = True

--- a/run-integration-tests.sh
+++ b/run-integration-tests.sh
@@ -10,13 +10,10 @@
 #
 #   ./run-integration-tests.sh -e py35 -- -x
 
-cargo build -p deltachat_ffi --release
+cargo build -p deltachat_ffi
 
-# CFLAGS=-I`pwd`/deltachat-ffi
-# LD_LIBRARY_PATH=`pwd`/target/release
-# export CFLAGS
-# export LD_LIBRARY_PATH
 export DCC_RS_DEV=$(pwd)
+export DCC_RS_TARGET=${DCC_RS_TARGET:-release}
 
 pushd python
 toxargs="$@"

--- a/run-integration-tests.sh
+++ b/run-integration-tests.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Small helper to easily run integration tests locally for development
+# purposes.  Any arguments are passed straight to tox.  E.g. to run
+# only one environment run with:
+#
+#   ./run-integration-tests.sh -e py35
+#
+# To also run with `pytest -x` use:
+#
+#   ./run-integration-tests.sh -e py35 -- -x
+
+cargo build -p deltachat_ffi --release
+
+# CFLAGS=-I`pwd`/deltachat-ffi
+# LD_LIBRARY_PATH=`pwd`/target/release
+# export CFLAGS
+# export LD_LIBRARY_PATH
+export DCC_RS_DEV=$(pwd)
+
+pushd python
+toxargs="$@"
+if [ -e liveconfig ]; then
+    toxargs="--liveconfig liveconfig $@"
+fi
+tox $toxargs
+ret=$?
+popd
+exit $ret

--- a/run-integration-tests.sh
+++ b/run-integration-tests.sh
@@ -10,10 +10,14 @@
 #
 #   ./run-integration-tests.sh -e py35 -- -x
 
-cargo build -p deltachat_ffi
-
 export DCC_RS_DEV=$(pwd)
 export DCC_RS_TARGET=${DCC_RS_TARGET:-release}
+
+if [ $DCC_RS_TARGET = 'release' ]; then
+    cargo build -p deltachat_ffi --release
+else
+    cargo build -p deltachat_ffi
+fi
 
 pushd python
 toxargs="$@"


### PR DESCRIPTION
This links the python bindings statically to libdeltachat.a if the
DCC_RS_DEV environment variable is set to the project's root.  This is
a little simpler then requiring the manual CFLAGS and LD_LIBRARY_PATH
tweaking.

It also adds a script to easily invoke the integration tests locally
without forgetting steps.