### PR TITLE
Make the callback optional again

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -22,7 +22,7 @@ pub type dc_callback_t = types::dc_callback_t;
 
 #[no_mangle]
 pub unsafe extern "C" fn dc_context_new(
-    cb: dc_callback_t,
+    cb: Option<dc_callback_t>,
     userdata: *mut libc::c_void,
     os_name: *const libc::c_char,
 ) -> *mut dc_context_t {

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -83,7 +83,7 @@ pub unsafe fn dc_reset_tables(context: &Context, bits: i32) -> i32 {
         info!(context, 0, "(8) Rest but server config reset.");
     }
 
-    (context.cb)(context, Event::MSGS_CHANGED, 0 as uintptr_t, 0 as uintptr_t);
+    context.call_cb(Event::MSGS_CHANGED, 0 as uintptr_t, 0 as uintptr_t);
 
     1
 }
@@ -215,7 +215,7 @@ unsafe fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int
                         as_str(real_spec)
                     );
                     if read_cnt > 0 {
-                        (context.cb)(context, Event::MSGS_CHANGED, 0 as uintptr_t, 0 as uintptr_t);
+                        context.call_cb(Event::MSGS_CHANGED, 0 as uintptr_t, 0 as uintptr_t);
                     }
                     success = 1
                 }
@@ -1180,7 +1180,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
         "event" => {
             ensure!(!arg1.is_empty(), "Argument <id> missing.");
             let event = Event::from_u32(arg1.parse().unwrap()).unwrap();
-            let r = (context.cb)(context, event, 0 as uintptr_t, 0 as uintptr_t);
+            let r = context.call_cb(event, 0 as uintptr_t, 0 as uintptr_t);
             println!(
                 "Sending event {:?}({}), received value {}.",
                 event, event as usize, r as libc::c_int,

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -386,7 +386,7 @@ impl Helper for DcHelper {}
 
 fn main_0(args: Vec<String>) -> Result<(), failure::Error> {
     let mut context = dc_context_new(
-        receive_event,
+        Some(receive_event),
         0 as *mut libc::c_void,
         b"CLI\x00" as *const u8 as *const libc::c_char,
     );

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -40,7 +40,7 @@ extern "C" fn cb(_ctx: &Context, event: Event, data1: usize, data2: usize) -> us
 
 fn main() {
     unsafe {
-        let ctx = dc_context_new(cb, std::ptr::null_mut(), std::ptr::null_mut());
+        let ctx = dc_context_new(Some(cb), std::ptr::null_mut(), std::ptr::null_mut());
         let running = Arc::new(RwLock::new(true));
         let info = dc_get_info(&ctx);
         let info_s = CStr::from_ptr(info);

--- a/run-integration-tests.sh
+++ b/run-integration-tests.sh
@@ -18,6 +18,9 @@ if [ $DCC_RS_TARGET = 'release' ]; then
 else
     cargo build -p deltachat_ffi
 fi
+if [ $? != 0 ]; then
+    exit $?
+fi
 
 pushd python
 toxargs="$@"

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -52,12 +52,7 @@ pub unsafe fn dc_create_chat_by_msg_id(context: &Context, msg_id: uint32_t) -> u
     dc_msg_unref(msg);
     dc_chat_unref(chat);
     if 0 != send_event {
-        (context.cb)(
-            context,
-            Event::MSGS_CHANGED,
-            0i32 as uintptr_t,
-            0i32 as uintptr_t,
-        );
+        context.call_cb(Event::MSGS_CHANGED, 0i32 as uintptr_t, 0i32 as uintptr_t);
     }
     chat_id
 }
@@ -244,12 +239,7 @@ pub unsafe fn dc_create_chat_by_contact_id(context: &Context, contact_id: uint32
         dc_scaleup_contact_origin(context, contact_id, 0x800i32);
     }
     if 0 != send_event {
-        (context.cb)(
-            context,
-            Event::MSGS_CHANGED,
-            0i32 as uintptr_t,
-            0i32 as uintptr_t,
-        );
+        context.call_cb(Event::MSGS_CHANGED, 0i32 as uintptr_t, 0i32 as uintptr_t);
     }
     chat_id
 }
@@ -405,8 +395,7 @@ pub unsafe fn dc_prepare_msg<'a>(
     }
     (*msg).state = 18i32;
     let msg_id: uint32_t = prepare_msg_common(context, chat_id, msg);
-    (context.cb)(
-        context,
+    context.call_cb(
         Event::MSGS_CHANGED,
         (*msg).chat_id as uintptr_t,
         (*msg).id as uintptr_t,
@@ -1007,15 +996,14 @@ pub unsafe fn dc_send_msg<'a>(
     if 0 == dc_job_send_msg(context, (*msg).id) {
         return 0i32 as uint32_t;
     }
-    (context.cb)(
-        context,
+    context.call_cb(
         Event::MSGS_CHANGED,
         (*msg).chat_id as uintptr_t,
         (*msg).id as uintptr_t,
     );
 
     if 0 != dc_param_exists((*msg).param, DC_PARAM_SET_LATITUDE as libc::c_int) {
-        (context.cb)(context, Event::LOCATION_CHANGED, DC_CONTACT_ID_SELF, 0);
+        context.call_cb(Event::LOCATION_CHANGED, DC_CONTACT_ID_SELF, 0);
     }
 
     if 0 == chat_id {
@@ -1065,12 +1053,7 @@ pub unsafe fn dc_set_draft(context: &Context, chat_id: uint32_t, msg: *mut dc_ms
         return;
     }
     if 0 != set_draft_raw(context, chat_id, msg) {
-        (context.cb)(
-            context,
-            Event::MSGS_CHANGED,
-            chat_id as uintptr_t,
-            0i32 as uintptr_t,
-        );
+        context.call_cb(Event::MSGS_CHANGED, chat_id as uintptr_t, 0i32 as uintptr_t);
     };
 }
 
@@ -1317,12 +1300,7 @@ pub unsafe fn dc_marknoticed_chat(context: &Context, chat_id: uint32_t) {
         );
         sqlite3_bind_int(update, 1i32, chat_id as libc::c_int);
         sqlite3_step(update);
-        (context.cb)(
-            context,
-            Event::MSGS_CHANGED,
-            0i32 as uintptr_t,
-            0i32 as uintptr_t,
-        );
+        context.call_cb(Event::MSGS_CHANGED, 0i32 as uintptr_t, 0i32 as uintptr_t);
     }
 
     sqlite3_finalize(check);
@@ -1345,12 +1323,7 @@ pub unsafe fn dc_marknoticed_all_chats(context: &Context) {
             b"UPDATE msgs    SET state=13 WHERE state=10;\x00" as *const u8 as *const libc::c_char,
         );
         sqlite3_step(update);
-        (context.cb)(
-            context,
-            Event::MSGS_CHANGED,
-            0i32 as uintptr_t,
-            0i32 as uintptr_t,
-        );
+        context.call_cb(Event::MSGS_CHANGED, 0i32 as uintptr_t, 0i32 as uintptr_t);
     }
 
     sqlite3_finalize(check);
@@ -1474,12 +1447,7 @@ pub unsafe fn dc_archive_chat(context: &Context, chat_id: uint32_t, archive: lib
     sqlite3_bind_int(stmt_0, 2i32, chat_id as libc::c_int);
     sqlite3_step(stmt_0);
     sqlite3_finalize(stmt_0);
-    (context.cb)(
-        context,
-        Event::MSGS_CHANGED,
-        0i32 as uintptr_t,
-        0i32 as uintptr_t,
-    );
+    context.call_cb(Event::MSGS_CHANGED, 0i32 as uintptr_t, 0i32 as uintptr_t);
 }
 
 pub unsafe fn dc_delete_chat(context: &Context, chat_id: uint32_t) {
@@ -1523,8 +1491,7 @@ pub unsafe fn dc_delete_chat(context: &Context, chat_id: uint32_t) {
                         {
                             sqlite3_free(q3 as *mut libc::c_void);
                             q3 = 0 as *mut libc::c_char;
-                            (context.cb)(
-                                context,
+                            context.call_cb(
                                 Event::MSGS_CHANGED,
                                 0i32 as uintptr_t,
                                 0i32 as uintptr_t,
@@ -1626,12 +1593,7 @@ pub unsafe fn dc_create_group_chat(
     dc_msg_unref(draft_msg);
     free(grpid as *mut libc::c_void);
     if 0 != chat_id {
-        (context.cb)(
-            context,
-            Event::MSGS_CHANGED,
-            0i32 as uintptr_t,
-            0i32 as uintptr_t,
-        );
+        context.call_cb(Event::MSGS_CHANGED, 0i32 as uintptr_t, 0i32 as uintptr_t);
     }
 
     chat_id
@@ -1766,15 +1728,13 @@ pub unsafe fn dc_add_contact_to_chat_ex(
                                 dc_param_set((*msg).param, 'E' as i32, (*contact).addr);
                                 dc_param_set_int((*msg).param, 'F' as i32, flags);
                                 (*msg).id = dc_send_msg(context, chat_id, msg);
-                                (context.cb)(
-                                    context,
+                                context.call_cb(
                                     Event::MSGS_CHANGED,
                                     chat_id as uintptr_t,
                                     (*msg).id as uintptr_t,
                                 );
                             }
-                            (context.cb)(
-                                context,
+                            context.call_cb(
                                 Event::MSGS_CHANGED,
                                 chat_id as uintptr_t,
                                 0i32 as uintptr_t,
@@ -1907,8 +1867,7 @@ pub unsafe fn dc_remove_contact_from_chat(
                         dc_param_set_int((*msg).param, 'S' as i32, 5i32);
                         dc_param_set((*msg).param, 'E' as i32, (*contact).addr);
                         (*msg).id = dc_send_msg(context, chat_id, msg);
-                        (context.cb)(
-                            context,
+                        context.call_cb(
                             Event::MSGS_CHANGED,
                             chat_id as uintptr_t,
                             (*msg).id as uintptr_t,
@@ -1922,8 +1881,7 @@ pub unsafe fn dc_remove_contact_from_chat(
                     contact_id,
                 );
                 if !(0 == dc_sqlite3_execute(context, &context.sql.clone().read().unwrap(), q3)) {
-                    (context.cb)(
-                        context,
+                    context.call_cb(
                         Event::CHAT_MODIFIED,
                         chat_id as uintptr_t,
                         0i32 as uintptr_t,
@@ -2017,15 +1975,13 @@ pub unsafe fn dc_set_chat_name(
                         dc_param_set_int((*msg).param, 'S' as i32, 2i32);
                         dc_param_set((*msg).param, 'E' as i32, (*chat).name);
                         (*msg).id = dc_send_msg(context, chat_id, msg);
-                        (context.cb)(
-                            context,
+                        context.call_cb(
                             Event::MSGS_CHANGED,
                             chat_id as uintptr_t,
                             (*msg).id as uintptr_t,
                         );
                     }
-                    (context.cb)(
-                        context,
+                    context.call_cb(
                         Event::CHAT_MODIFIED,
                         chat_id as uintptr_t,
                         0i32 as uintptr_t,
@@ -2097,15 +2053,13 @@ pub unsafe fn dc_set_chat_profile_image(
                                     1i32 as uint32_t,
                                 );
                                 (*msg).id = dc_send_msg(context, chat_id, msg);
-                                (context.cb)(
-                                    context,
+                                context.call_cb(
                                     Event::MSGS_CHANGED,
                                     chat_id as uintptr_t,
                                     (*msg).id as uintptr_t,
                                 );
                             }
-                            (context.cb)(
-                                context,
+                            context.call_cb(
                                 Event::CHAT_MODIFIED,
                                 chat_id as uintptr_t,
                                 0i32 as uintptr_t,
@@ -2213,8 +2167,7 @@ pub unsafe fn dc_forward_msgs(
         let mut i = 0u32;
         let icnt = carray_count(created_db_entries);
         while i < icnt {
-            (context.cb)(
-                context,
+            context.call_cb(
                 Event::MSGS_CHANGED,
                 carray_get(created_db_entries, i) as uintptr_t,
                 carray_get(created_db_entries, i.wrapping_add(1)) as uintptr_t,
@@ -2479,8 +2432,7 @@ pub unsafe fn dc_add_device_msg(context: &Context, chat_id: uint32_t, text: *con
                 b"rfc724_mid\x00" as *const u8 as *const libc::c_char,
                 rfc724_mid,
             );
-            (context.cb)(
-                context,
+            context.call_cb(
                 Event::MSGS_CHANGED,
                 chat_id as uintptr_t,
                 msg_id as uintptr_t,

--- a/src/dc_configure.rs
+++ b/src/dc_configure.rs
@@ -158,8 +158,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
             let s = s_a.read().unwrap();
 
             if !s.shall_stop_ongoing {
-                (context.cb)(
-                    context,
+                context.call_cb(
                     Event::CONFIGURE_PROGRESS,
                     (if 0i32 < 1i32 {
                         1i32
@@ -193,8 +192,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                         if s.shall_stop_ongoing {
                             current_block = 2927484062889439186;
                         } else {
-                            (context.cb)(
-                                context,
+                            context.call_cb(
                                 Event::CONFIGURE_PROGRESS,
                                 (if 10i32 < 1i32 {
                                     1i32
@@ -223,8 +221,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                             if s.shall_stop_ongoing {
                                 current_block = 2927484062889439186;
                             } else {
-                                (context.cb)(
-                                    context,
+                                context.call_cb(
                                     Event::CONFIGURE_PROGRESS,
                                     (if 20i32 < 1i32 {
                                         1i32
@@ -260,8 +257,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                     (*param).mail_pw = dc_strdup(0 as *const libc::c_char)
                                 }
                                 if !s.shall_stop_ongoing {
-                                    (context.cb)(
-                                        context,
+                                    context.call_cb(
                                         Event::CONFIGURE_PROGRESS,
                                         (if 200i32 < 1i32 {
                                             1i32
@@ -303,8 +299,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                             if s.shall_stop_ongoing {
                                                 current_block = 2927484062889439186;
                                             } else {
-                                                (context.cb)(
-                                                    context,
+                                                context.call_cb(
                                                     Event::CONFIGURE_PROGRESS,
                                                     (if 300i32 < 1i32 {
                                                         1i32
@@ -341,8 +336,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                     if s.shall_stop_ongoing {
                                                         current_block = 2927484062889439186;
                                                     } else {
-                                                        (context.cb)(
-                                                            context,
+                                                        context.call_cb(
                                                             Event::CONFIGURE_PROGRESS,
                                                             (if 310i32 < 1i32 {
                                                                 1i32
@@ -405,8 +399,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                                         2927484062889439186;
                                                                     break;
                                                                 }
-                                                                (context.cb)(
-                                                                    context,
+                                                                context.call_cb(
                                                                     Event::CONFIGURE_PROGRESS,
                                                                     (if 320i32 + i * 10i32 < 1i32 {
                                                                         1i32
@@ -448,8 +441,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                                         current_block =
                                                                             2927484062889439186;
                                                                     } else {
-                                                                        (context.cb)(
-                                                                            context,
+                                                                        context.call_cb(
                                                                             Event::CONFIGURE_PROGRESS,
                                                                             (if 340i32
                                                                              <
@@ -506,7 +498,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                                                     =
                                                                                     2927484062889439186;
                                                                             } else {
-                                                                                (context.cb)(context,
+                                                                                context.call_cb(
                                                                                                 Event::CONFIGURE_PROGRESS,
                                                                                                 (if 350i32
                                                                                                  <
@@ -565,7 +557,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                                                             =
                                                                                             2927484062889439186;
                                                                                     } else {
-                                                                                        (context.cb)(context,
+                                                                                        context.call_cb(
                                                                                                         Event::CONFIGURE_PROGRESS,
                                                                                                         (if 500i32
                                                                                                          <
@@ -785,8 +777,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                         as *const libc::c_char,
                                                 );
                                             } else if !s.shall_stop_ongoing {
-                                                (context.cb)(
-                                                    context,
+                                                context.call_cb(
                                                     Event::CONFIGURE_PROGRESS,
                                                     (if 600i32 < 1i32 {
                                                         1i32
@@ -834,8 +825,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                         current_block = 2927484062889439186;
                                                         break;
                                                     }
-                                                    (context.cb)(
-                                                        context,
+                                                    context.call_cb(
                                                         Event::CONFIGURE_PROGRESS,
                                                         (if 650i32 + username_variation * 30i32
                                                             < 1i32
@@ -879,8 +869,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                         current_block = 2927484062889439186;
                                                         break;
                                                     }
-                                                    (context.cb)(
-                                                        context,
+                                                    context.call_cb(
                                                         Event::CONFIGURE_PROGRESS,
                                                         (if 660i32 + username_variation * 30i32
                                                             < 1i32
@@ -926,8 +915,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                         current_block = 2927484062889439186;
                                                         break;
                                                     }
-                                                    (context.cb)(
-                                                        context,
+                                                    context.call_cb(
                                                         Event::CONFIGURE_PROGRESS,
                                                         (if 670i32 + username_variation * 30i32
                                                             < 1i32
@@ -964,8 +952,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                     _ => {
                                                         imap_connected_here = 1i32;
                                                         if !s.shall_stop_ongoing {
-                                                            (context.cb)(
-                                                                context,
+                                                            context.call_cb(
                                                                 Event::CONFIGURE_PROGRESS,
                                                                 (if 800i32 < 1i32 {
                                                                     1i32
@@ -992,8 +979,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                                     current_block =
                                                                         2927484062889439186;
                                                                 } else {
-                                                                    (context.cb)(
-                                                                        context,
+                                                                    context.call_cb(
                                                                         Event::CONFIGURE_PROGRESS,
                                                                         (if 850i32 < 1i32 {
                                                                             1i32
@@ -1036,8 +1022,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                                             current_block =
                                                                                 2927484062889439186;
                                                                         } else {
-                                                                            (context.cb)(context,
-                                                                                            Event::CONFIGURE_PROGRESS,
+                                                                            context.call_cb(Event::CONFIGURE_PROGRESS,
                                                                                             (if 860i32
                                                                                              <
                                                                                              1i32
@@ -1111,8 +1096,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                                 _ => {
                                                                     smtp_connected_here = 1i32;
                                                                     if !s.shall_stop_ongoing {
-                                                                        (context.cb)(context,
-                                                                                        Event::CONFIGURE_PROGRESS,
+                                                                        context.call_cb(Event::CONFIGURE_PROGRESS,
                                                                                         (if 900i32
                                                                                          <
                                                                                          1i32
@@ -1166,8 +1150,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                                                 context, flags,
                                                                             );
                                                                         if !s.shall_stop_ongoing {
-                                                                            (context.cb)(context,
-                                                                                            Event::CONFIGURE_PROGRESS,
+                                                                            context.call_cb(Event::CONFIGURE_PROGRESS,
                                                                                             (if 910i32
                                                                                              <
                                                                                              1i32
@@ -1202,8 +1185,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                                                                       1i32);
                                                                             if !s.shall_stop_ongoing
                                                                             {
-                                                                                (context.cb)(context,
-                                                                                                Event::CONFIGURE_PROGRESS,
+                                                                                context.call_cb(Event::CONFIGURE_PROGRESS,
                                                                                                 (if 920i32
                                                                                                  <
                                                                                                  1i32
@@ -1233,8 +1215,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                                                             *const libc::c_char);
                                                                                 if !s.shall_stop_ongoing
                                                                                 {
-                                                                                    (context.cb)(context,
-                                                                                                    Event::CONFIGURE_PROGRESS,
+                                                                                    context.call_cb(Event::CONFIGURE_PROGRESS,
                                                                                                     (if 940i32
                                                                                                      <
                                                                                                      1i32
@@ -1287,8 +1268,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
         dc_free_ongoing(context);
     }
     free(mvbox_folder as *mut libc::c_void);
-    (context.cb)(
-        context,
+    context.call_cb(
         Event::CONFIGURE_PROGRESS,
         (if 0 != success { 1000i32 } else { 0i32 }) as uintptr_t,
         0i32 as uintptr_t,

--- a/src/dc_contact.rs
+++ b/src/dc_contact.rs
@@ -37,12 +37,7 @@ pub unsafe fn dc_marknoticed_contact(context: &Context, contact_id: uint32_t) {
     sqlite3_bind_int(stmt, 1i32, contact_id as libc::c_int);
     sqlite3_step(stmt);
     sqlite3_finalize(stmt);
-    ((*context).cb)(
-        context,
-        Event::MSGS_CHANGED,
-        0i32 as uintptr_t,
-        0i32 as uintptr_t,
-    );
+    context.call_cb(Event::MSGS_CHANGED, 0i32 as uintptr_t, 0i32 as uintptr_t);
 }
 
 /// Returns false if addr is an invalid address, otherwise true.
@@ -140,8 +135,7 @@ pub unsafe fn dc_create_contact(
     if !(addr.is_null() || *addr.offset(0isize) as libc::c_int == 0i32) {
         contact_id = dc_add_or_lookup_contact(context, name, addr, 0x4000000i32, &mut sth_modified);
         blocked = dc_is_contact_blocked(context, contact_id);
-        ((*context).cb)(
-            context,
+        context.call_cb(
             Event::CONTACTS_CHANGED,
             (if sth_modified == 2i32 {
                 contact_id
@@ -203,8 +197,7 @@ pub unsafe fn dc_block_contact(context: &Context, contact_id: uint32_t, new_bloc
             5249903830285462583 => {}
             _ => {
                 if 0 != send_event {
-                    ((*context).cb)(
-                        context,
+                    context.call_cb(
                         Event::CONTACTS_CHANGED,
                         0i32 as uintptr_t,
                         0i32 as uintptr_t,
@@ -566,8 +559,7 @@ pub unsafe fn dc_add_address_book(context: &Context, adr_book: *const libc::c_ch
                 i = (i as libc::c_ulong).wrapping_add(2i32 as libc::c_ulong) as size_t as size_t
             }
             if 0 != modify_cnt {
-                ((*context).cb)(
-                    context,
+                context.call_cb(
                     Event::CONTACTS_CHANGED,
                     0i32 as uintptr_t,
                     0i32 as uintptr_t,
@@ -933,8 +925,7 @@ pub unsafe fn dc_delete_contact(context: &Context, contact_id: uint32_t) -> bool
                 );
                 sqlite3_bind_int(stmt, 1i32, contact_id as libc::c_int);
                 if !(sqlite3_step(stmt) != 101i32) {
-                    ((*context).cb)(
-                        context,
+                    context.call_cb(
                         Event::CONTACTS_CHANGED,
                         0i32 as uintptr_t,
                         0i32 as uintptr_t,

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -678,12 +678,7 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: *mut dc_job_t) 
                 0i32,
                 b"Import/export process started.\x00" as *const u8 as *const libc::c_char,
             );
-            (context.cb)(
-                context,
-                Event::IMEX_PROGRESS,
-                10i32 as uintptr_t,
-                0i32 as uintptr_t,
-            );
+            context.call_cb(Event::IMEX_PROGRESS, 10i32 as uintptr_t, 0i32 as uintptr_t);
             if 0 == dc_sqlite3_is_open(&context.sql.clone().read().unwrap()) {
                 dc_log_error(
                     context,
@@ -901,8 +896,7 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: *mut dc_job_t) 
     if 0 != ongoing_allocated_here {
         dc_free_ongoing(context);
     }
-    (context.cb)(
-        context,
+    context.call_cb(
         Event::IMEX_PROGRESS,
         (if 0 != success { 1000i32 } else { 0i32 }) as uintptr_t,
         0i32 as uintptr_t,
@@ -996,8 +990,7 @@ unsafe fn import_backup(context: &Context, backup_to_import: *const libc::c_char
                     if permille > 990i32 {
                         permille = 990i32
                     }
-                    (context.cb)(
-                        context,
+                    context.call_cb(
                         Event::IMEX_PROGRESS,
                         permille as uintptr_t,
                         0i32 as uintptr_t,
@@ -1213,8 +1206,7 @@ unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_
                                         if permille > 990 {
                                             permille = 990;
                                         }
-                                        (context.cb)(
-                                            context,
+                                        context.call_cb(
                                             Event::IMEX_PROGRESS,
                                             permille as uintptr_t,
                                             0i32 as uintptr_t,
@@ -1294,8 +1286,7 @@ unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_
                                     b"backup_time\x00" as *const u8 as *const libc::c_char,
                                     now as int32_t,
                                 );
-                                (context.cb)(
-                                    context,
+                                context.call_cb(
                                     Event::IMEX_FILE_WRITTEN,
                                     dest_pathNfilename as uintptr_t,
                                     0i32 as uintptr_t,
@@ -1558,8 +1549,7 @@ unsafe fn export_key_to_asc_file(
             file_name,
         );
     } else {
-        (context.cb)(
-            context,
+        context.call_cb(
             Event::IMEX_FILE_WRITTEN,
             file_name as uintptr_t,
             0i32 as uintptr_t,

--- a/src/dc_job.rs
+++ b/src/dc_job.rs
@@ -416,8 +416,7 @@ unsafe fn dc_job_do_DC_JOB_SEND(context: &Context, job: &mut dc_job_t) {
                                     } else {
                                         0i32
                                     };
-                                    (context.cb)(
-                                        context,
+                                    context.call_cb(
                                         Event::MSG_DELIVERED,
                                         chat_id as uintptr_t,
                                         job.foreign_id as uintptr_t,

--- a/src/dc_location.rs
+++ b/src/dc_location.rs
@@ -93,8 +93,7 @@ pub unsafe fn dc_send_locations_to_chat(
             );
             dc_add_device_msg(context, chat_id, stock_str);
         }
-        (context.cb)(
-            context,
+        context.call_cb(
             Event::CHAT_MODIFIED,
             chat_id as uintptr_t,
             0i32 as uintptr_t,
@@ -191,8 +190,7 @@ pub unsafe fn dc_set_location(
             continue_streaming = 1i32
         }
         if 0 != continue_streaming {
-            (context.cb)(
-                context,
+            context.call_cb(
                 Event::LOCATION_CHANGED,
                 1i32 as uintptr_t,
                 0i32 as uintptr_t,
@@ -303,8 +301,7 @@ pub unsafe fn dc_delete_all_locations(context: &Context) {
         b"DELETE FROM locations;\x00" as *const u8 as *const libc::c_char,
     );
     sqlite3_step(stmt);
-    (context.cb)(
-        context,
+    context.call_cb(
         Event::LOCATION_CHANGED,
         0i32 as uintptr_t,
         0i32 as uintptr_t,
@@ -825,8 +822,7 @@ pub unsafe fn dc_job_do_DC_JOB_MAYBE_SEND_LOC_ENDED(context: &Context, job: &mut
                     0i32 as uint32_t,
                 );
                 dc_add_device_msg(context, chat_id, stock_str);
-                (context.cb)(
-                    context,
+                context.call_cb(
                     Event::CHAT_MODIFIED,
                     chat_id as uintptr_t,
                     0i32 as uintptr_t,

--- a/src/dc_log.rs
+++ b/src/dc_log.rs
@@ -44,7 +44,7 @@ unsafe fn log_vprintf(
             event as libc::c_int,
         )
     }
-    ((*context).cb)(context, event, data1 as uintptr_t, msg as uintptr_t);
+    context.call_cb(event, data1 as uintptr_t, msg as uintptr_t);
     free(msg as *mut libc::c_void);
 }
 
@@ -97,10 +97,8 @@ macro_rules! info {
     ($ctx:expr, $data1:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
         let formatted_c = $crate::dc_tools::to_cstring(formatted);
-        unsafe {
-            ($ctx.cb)($ctx, $crate::constants::Event::INFO, $data1 as uintptr_t,
-                      formatted_c.as_ptr() as uintptr_t)
-        }
+        $ctx.call_cb($crate::constants::Event::INFO, $data1 as uintptr_t,
+                     formatted_c.as_ptr() as uintptr_t)
     }};
 }
 
@@ -112,10 +110,8 @@ macro_rules! warn {
     ($ctx:expr, $data1:expr, $msg:expr, $($args:expr),* $(,)?) => {
         let formatted = format!($msg, $($args),*);
         let formatted_c = $crate::dc_tools::to_cstring(formatted);
-        unsafe {
-            ($ctx.cb)($ctx, $crate::constants::Event::WARNING, $data1 as libc::uintptr_t,
-                      formatted_c.as_ptr() as libc::uintptr_t)
-        }
+        $ctx.call_cb($crate::constants::Event::WARNING, $data1 as libc::uintptr_t,
+                     formatted_c.as_ptr() as libc::uintptr_t)
     };
 }
 
@@ -127,10 +123,8 @@ macro_rules! error {
     ($ctx:expr, $data1:expr, $msg:expr, $($args:expr),* $(,)?) => {
         let formatted = format!($msg, $($args),*);
         let formatted_c = $crate::dc_tools::to_cstring(formatted);
-        unsafe {
-            ($ctx.cb)($ctx, $crate::constants::Event::ERROR, $data1 as uintptr_t,
-                      formatted_c.as_ptr() as uintptr_t)
-        }
+        $ctx.call_cb($crate::constants::Event::ERROR, $data1 as uintptr_t,
+                     formatted_c.as_ptr() as uintptr_t)
     };
 }
 
@@ -142,9 +136,7 @@ macro_rules! log_event {
     ($ctx:expr, $event:expr, $data1:expr, $msg:expr, $($args:expr),* $(,)?) => {
         let formatted = format!($msg, $($args),*);
         let formatted_c = $crate::dc_tools::to_cstring(formatted);
-        unsafe {
-            ($ctx.cb)($ctx, $event, $data1 as uintptr_t,
-                      formatted_c.as_ptr() as uintptr_t)
-        }
+        $ctx.call_cb($event, $data1 as uintptr_t,
+                     formatted_c.as_ptr() as uintptr_t)
     };
 }

--- a/src/dc_msg.rs
+++ b/src/dc_msg.rs
@@ -577,12 +577,7 @@ pub unsafe fn dc_delete_msgs(context: &Context, msg_ids: *const uint32_t, msg_cn
     }
 
     if 0 != msg_cnt {
-        ((*context).cb)(
-            context,
-            Event::MSGS_CHANGED,
-            0i32 as uintptr_t,
-            0i32 as uintptr_t,
-        );
+        context.call_cb(Event::MSGS_CHANGED, 0i32 as uintptr_t, 0i32 as uintptr_t);
         dc_job_kill_action(context, 105i32);
         dc_job_add(context, 105i32, 0i32, 0 as *const libc::c_char, 10i32);
     };
@@ -645,12 +640,7 @@ pub unsafe fn dc_markseen_msgs(context: &Context, msg_ids: *const uint32_t, msg_
         }
 
         if 0 != send_event {
-            ((*context).cb)(
-                context,
-                Event::MSGS_CHANGED,
-                0i32 as uintptr_t,
-                0i32 as uintptr_t,
-            );
+            context.call_cb(Event::MSGS_CHANGED, 0i32 as uintptr_t, 0i32 as uintptr_t);
         }
     }
     sqlite3_finalize(stmt);
@@ -1288,8 +1278,7 @@ pub unsafe fn dc_set_msg_failed(context: &Context, msg_id: uint32_t, error: *con
         sqlite3_bind_text(stmt, 2i32, (*(*msg).param).packed, -1i32, None);
         sqlite3_bind_int(stmt, 3i32, msg_id as libc::c_int);
         sqlite3_step(stmt);
-        ((*context).cb)(
-            context,
+        context.call_cb(
             Event::MSG_FAILED,
             (*msg).chat_id as uintptr_t,
             msg_id as uintptr_t,

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -944,8 +944,7 @@ pub unsafe fn dc_receive_imf(
                             dc_contact_unref(contact);
                         }
                         if send_event {
-                            ((*context).cb)(
-                                context,
+                            context.call_cb(
                                 Event::LOCATION_CHANGED,
                                 from_id as uintptr_t,
                                 0i32 as uintptr_t,
@@ -979,8 +978,7 @@ pub unsafe fn dc_receive_imf(
             let mut i_0: size_t = 0;
             let icnt_0: size_t = carray_count(created_db_entries) as size_t;
             while i_0 < icnt_0 {
-                ((*context).cb)(
-                    context,
+                context.call_cb(
                     create_event_to_send,
                     carray_get(created_db_entries, i_0 as libc::c_uint) as uintptr_t,
                     carray_get(created_db_entries, i_0.wrapping_add(1) as libc::c_uint)
@@ -996,8 +994,7 @@ pub unsafe fn dc_receive_imf(
         let icnt_1: size_t = carray_count(rr_event_to_send) as size_t;
         i_1 = 0i32 as size_t;
         while i_1 < icnt_1 {
-            ((*context).cb)(
-                context,
+            context.call_cb(
                 Event::MSG_READ,
                 carray_get(rr_event_to_send, i_1 as libc::c_uint) as uintptr_t,
                 carray_get(rr_event_to_send, i_1.wrapping_add(1) as libc::c_uint) as uintptr_t,
@@ -1378,8 +1375,7 @@ unsafe fn create_or_lookup_group(
                             sqlite3_bind_int(stmt, 2i32, chat_id as libc::c_int);
                             sqlite3_step(stmt);
                             sqlite3_finalize(stmt);
-                            ((*context).cb)(
-                                context,
+                            context.call_cb(
                                 Event::CHAT_MODIFIED,
                                 chat_id as uintptr_t,
                                 0i32 as uintptr_t,
@@ -1481,8 +1477,7 @@ unsafe fn create_or_lookup_group(
                             dc_reset_gossiped_timestamp(context, chat_id);
                         }
                         if 0 != send_EVENT_CHAT_MODIFIED {
-                            ((*context).cb)(
-                                context,
+                            context.call_cb(
                                 Event::CHAT_MODIFIED,
                                 chat_id as uintptr_t,
                                 0i32 as uintptr_t,
@@ -1617,8 +1612,7 @@ unsafe fn create_or_lookup_adhoc_group(
                                 );
                                 i += 1
                             }
-                            ((*context).cb)(
-                                context,
+                            context.call_cb(
                                 Event::CHAT_MODIFIED,
                                 chat_id as uintptr_t,
                                 0i32 as uintptr_t,

--- a/src/dc_securejoin.rs
+++ b/src/dc_securejoin.rs
@@ -222,8 +222,7 @@ pub unsafe fn dc_join_securejoin(context: &Context, qr: *const libc::c_char) -> 
                         b"Taking protocol shortcut.\x00" as *const u8 as *const libc::c_char,
                     );
                     context.bob.clone().write().unwrap().expects = 6;
-                    (context.cb)(
-                        context,
+                    context.call_cb(
                         Event::SECUREJOIN_JOINER_PROGRESS,
                         chat_id_2_contact_id(context, contact_chat_id) as uintptr_t,
                         400i32 as uintptr_t,
@@ -469,8 +468,7 @@ pub unsafe fn dc_handle_securejoin_handshake(
                         0i32,
                         b"Secure-join requested.\x00" as *const u8 as *const libc::c_char,
                     );
-                    (context.cb)(
-                        context,
+                    context.call_cb(
                         Event::SECUREJOIN_INVITER_PROGRESS,
                         contact_id as uintptr_t,
                         300i32 as uintptr_t,
@@ -557,8 +555,7 @@ pub unsafe fn dc_handle_securejoin_handshake(
                             b"Fingerprint verified.\x00" as *const u8 as *const libc::c_char,
                         );
                         own_fingerprint = get_self_fingerprint(context);
-                        (context.cb)(
-                            context,
+                        context.call_cb(
                             Event::SECUREJOIN_JOINER_PROGRESS,
                             contact_id as uintptr_t,
                             400i32 as uintptr_t,
@@ -664,14 +661,12 @@ pub unsafe fn dc_handle_securejoin_handshake(
                             b"Auth verified.\x00" as *const u8 as *const libc::c_char,
                         );
                         secure_connection_established(context, contact_chat_id);
-                        (context.cb)(
-                            context,
+                        context.call_cb(
                             Event::CONTACTS_CHANGED,
                             contact_id as uintptr_t,
                             0i32 as uintptr_t,
                         );
-                        (context.cb)(
-                            context,
+                        context.call_cb(
                             Event::SECUREJOIN_INVITER_PROGRESS,
                             contact_id as uintptr_t,
                             600i32 as uintptr_t,
@@ -713,8 +708,7 @@ pub unsafe fn dc_handle_securejoin_handshake(
                                 0 as *const libc::c_char,
                                 0 as *const libc::c_char,
                             );
-                            (context.cb)(
-                                context,
+                            context.call_cb(
                                 Event::SECUREJOIN_INVITER_PROGRESS,
                                 contact_id as uintptr_t,
                                 1000i32 as uintptr_t,
@@ -807,8 +801,7 @@ pub unsafe fn dc_handle_securejoin_handshake(
                                     current_block = 4378276786830486580;
                                 } else {
                                     dc_scaleup_contact_origin(context, contact_id, 0x2000000i32);
-                                    (context.cb)(
-                                        context,
+                                    context.call_cb(
                                         Event::CONTACTS_CHANGED,
                                         0i32 as uintptr_t,
                                         0i32 as uintptr_t,
@@ -877,14 +870,12 @@ pub unsafe fn dc_handle_securejoin_handshake(
                     );
                     current_block = 4378276786830486580;
                 } else {
-                    (context.cb)(
-                        context,
+                    context.call_cb(
                         Event::SECUREJOIN_INVITER_PROGRESS,
                         contact_id as uintptr_t,
                         800i32 as uintptr_t,
                     );
-                    (context.cb)(
-                        context,
+                    context.call_cb(
                         Event::SECUREJOIN_INVITER_PROGRESS,
                         contact_id as uintptr_t,
                         1000i32 as uintptr_t,
@@ -931,8 +922,7 @@ unsafe fn secure_connection_established(context: &Context, contact_chat_id: uint
         },
     );
     dc_add_device_msg(context, contact_chat_id, msg);
-    (context.cb)(
-        context,
+    context.call_cb(
         Event::CHAT_MODIFIED,
         contact_chat_id as uintptr_t,
         0i32 as uintptr_t,
@@ -1101,8 +1091,7 @@ pub unsafe fn dc_handle_degrade_event(context: &Context, peerstate: &Peerstate) 
             let msg = dc_stock_str_repl_string(context, 37i32, c_addr_ptr);
             dc_add_device_msg(context, contact_chat_id, msg);
             free(msg as *mut libc::c_void);
-            (context.cb)(
-                context,
+            context.call_cb(
                 Event::CHAT_MODIFIED,
                 contact_chat_id as uintptr_t,
                 0i32 as uintptr_t,

--- a/src/dc_stock.rs
+++ b/src/dc_stock.rs
@@ -14,12 +14,8 @@ pub unsafe fn dc_stock_str(context: &Context, id: libc::c_int) -> *mut libc::c_c
 unsafe fn get_string(context: &Context, id: libc::c_int, qty: libc::c_int) -> *mut libc::c_char {
     let mut ret: *mut libc::c_char;
 
-    ret = ((*context).cb)(
-        context,
-        Event::GET_STRING,
-        id as uintptr_t,
-        qty as uintptr_t,
-    ) as *mut libc::c_char;
+    ret =
+        context.call_cb(Event::GET_STRING, id as uintptr_t, qty as uintptr_t) as *mut libc::c_char;
 
     if ret.is_null() {
         ret = default_string(id)

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -646,7 +646,7 @@ mod tests {
     }
 
     unsafe fn create_test_context() -> TestContext {
-        let mut ctx = dc_context_new(cb, std::ptr::null_mut(), std::ptr::null_mut());
+        let mut ctx = dc_context_new(Some(cb), std::ptr::null_mut(), std::ptr::null_mut());
         let dir = tempdir().unwrap();
         let dbfile = CString::new(dir.path().join("db.sqlite").to_str().unwrap()).unwrap();
         assert_eq!(

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -823,7 +823,7 @@ struct TestContext {
 }
 
 unsafe fn create_test_context() -> TestContext {
-    let mut ctx = dc_context_new(cb, std::ptr::null_mut(), std::ptr::null_mut());
+    let mut ctx = dc_context_new(Some(cb), std::ptr::null_mut(), std::ptr::null_mut());
     let dir = tempdir().unwrap();
     let dbfile = CString::new(dir.path().join("db.sqlite").to_str().unwrap()).unwrap();
     assert_eq!(


### PR DESCRIPTION
This fixes the segfault in #143 but doing this here as a separate PR to make reviews easier.  It also simplifies callback calling as bonus.

The gory details by way of commit message:

The C API allows passing a NULL pointer is for the callback function.
However when calling the callback nothing checks for this null pointer
and thus things fail badly.  Even worse since the C API is defined
using an "fn pointer" rather than a "*-ptr" or raw pointer to the
function rust does not realise this can be invalid and therefore the
typechecker does not catch this even though there are no unsafe casts.

Fix this by making the callback an Option in rust, this can be easily
checked when calling.  Also add a Context.call_cb() function which
simplifies calling the callback, hides the weird syntax due to the
function pointer and makes the call a little easier.  Finally it also
means the option checking is only needed in one place.

For the C API this needs to check if this is a NULL pointer or not.
This check can not be pushed to context.rs api since the NULL pointer
check gets optimized out for non extern-c functions since it looks
like a normal rust fn pointer there and the type checker thus assumes
those guarantees of the pointer always being valid, so in release mode
optimized the null check away.  This is the reason the rust API must
use the Option described above.