### PR TITLE
Make the SQLite struct opaque

### DIFF
--- a/src/dc_sqlite3.rs
+++ b/src/dc_sqlite3.rs
@@ -12,9 +12,8 @@ use crate::x::*;
 const DC_OPEN_READONLY: usize = 0x01;
 
 /// A wrapper around the underlying Sqlite3 object.
-#[repr(C)]
 pub struct SQLite {
-    pub cobj: std::sync::RwLock<*mut sqlite3>,
+    cobj: std::sync::RwLock<*mut sqlite3>,
 }
 
 impl SQLite {


### PR DESCRIPTION
This doesn't do much, but it is significant since putting these guarantees in place makes gradually refactoring the API in this module much safer.

In general after having played a bit with #142 I'd like to enable being able to contain changes a little more, e.g with this change, it will be easier to change the sqlite backend without having to modify lots of unrelated code.  Perhaps some signatures of other functions in dc_sqlite need to change too first but each signature change/cleanup could be handled separately and much more safely.

With the API changes already done, notably .is_open(), the
implementation of the sqlite can and should now be private.

This also doesn't need to be #[repr(C)] anymore since the C API does
not need to access the fields in the struct.