### PR TITLE
Make dc_jobthread_t safe

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -158,8 +158,8 @@ pub fn dc_context_new(
         last_smeared_timestamp: Arc::new(RwLock::new(0)),
         cmdline_sel_chat_id: Arc::new(RwLock::new(0)),
         sentbox_thread: Arc::new(RwLock::new(dc_jobthread_init(
-            "SENTBOX\x00",
-            "configured_sentbox_folder\x00",
+            "SENTBOX",
+            "configured_sentbox_folder",
             Imap::new(
                 cb_get_config,
                 cb_set_config,
@@ -169,8 +169,8 @@ pub fn dc_context_new(
         ))),
         mvbox_thread: Arc::new(RwLock::new(unsafe {
             dc_jobthread_init(
-                "MVBOX\x00",
-                "configured_mvbox_folder\x00",
+                "MVBOX",
+                "configured_mvbox_folder",
                 Imap::new(
                     cb_get_config,
                     cb_set_config,

--- a/src/context.rs
+++ b/src/context.rs
@@ -157,10 +157,10 @@ pub fn dc_context_new(
         bob: Arc::new(RwLock::new(Default::default())),
         last_smeared_timestamp: Arc::new(RwLock::new(0)),
         cmdline_sel_chat_id: Arc::new(RwLock::new(0)),
-        sentbox_thread: Arc::new(RwLock::new(unsafe {
+        sentbox_thread: Arc::new(RwLock::new(
             dc_jobthread_init(
-                b"SENTBOX\x00" as *const u8 as *const libc::c_char,
-                b"configured_sentbox_folder\x00" as *const u8 as *const libc::c_char,
+                "SENTBOX\x00",
+                "configured_sentbox_folder\x00",
                 Imap::new(
                     cb_get_config,
                     cb_set_config,
@@ -168,11 +168,11 @@ pub fn dc_context_new(
                     cb_receive_imf,
                 ),
             )
-        })),
+        )),
         mvbox_thread: Arc::new(RwLock::new(unsafe {
             dc_jobthread_init(
-                b"MVBOX\x00" as *const u8 as *const libc::c_char,
-                b"configured_mvbox_folder\x00" as *const u8 as *const libc::c_char,
+                "MVBOX\x00",
+                "configured_mvbox_folder\x00",
                 Imap::new(
                     cb_get_config,
                     cb_set_config,
@@ -283,9 +283,6 @@ pub unsafe fn dc_context_unref(context: &mut Context) {
     if 0 != dc_is_open(context) {
         dc_close(context);
     }
-
-    dc_jobthread_exit(&mut context.sentbox_thread.clone().write().unwrap());
-    dc_jobthread_exit(&mut context.mvbox_thread.clone().write().unwrap());
 
     free(context.os_name as *mut libc::c_void);
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -157,18 +157,16 @@ pub fn dc_context_new(
         bob: Arc::new(RwLock::new(Default::default())),
         last_smeared_timestamp: Arc::new(RwLock::new(0)),
         cmdline_sel_chat_id: Arc::new(RwLock::new(0)),
-        sentbox_thread: Arc::new(RwLock::new(
-            dc_jobthread_init(
-                "SENTBOX\x00",
-                "configured_sentbox_folder\x00",
-                Imap::new(
-                    cb_get_config,
-                    cb_set_config,
-                    cb_precheck_imf,
-                    cb_receive_imf,
-                ),
-            )
-        )),
+        sentbox_thread: Arc::new(RwLock::new(dc_jobthread_init(
+            "SENTBOX\x00",
+            "configured_sentbox_folder\x00",
+            Imap::new(
+                cb_get_config,
+                cb_set_config,
+                cb_precheck_imf,
+                cb_receive_imf,
+            ),
+        ))),
         mvbox_thread: Arc::new(RwLock::new(unsafe {
             dc_jobthread_init(
                 "MVBOX\x00",

--- a/src/dc_jobthread.rs
+++ b/src/dc_jobthread.rs
@@ -38,7 +38,6 @@ pub struct JobState {
     using_handle: i32,
 }
 
-
 pub unsafe fn dc_jobthread_suspend(
     context: &Context,
     jobthread: &dc_jobthread_t,
@@ -178,7 +177,9 @@ unsafe fn connect_to_imap(context: &Context, jobthread: &dc_jobthread_t) -> libc
             mvbox_name = dc_sqlite3_get_config(
                 context,
                 &context.sql,
-                CString::new(&jobthread.folder_config_name[..]).unwrap().as_ptr(),
+                CString::new(&jobthread.folder_config_name[..])
+                    .unwrap()
+                    .as_ptr(),
                 0 as *const libc::c_char,
             );
             if mvbox_name.is_null() {

--- a/src/dc_jobthread.rs
+++ b/src/dc_jobthread.rs
@@ -7,23 +7,24 @@ use crate::dc_sqlite3::*;
 use crate::dc_tools::*;
 use crate::imap::Imap;
 use crate::x::*;
+use std::ffi::CString;
 
 #[repr(C)]
 pub struct dc_jobthread_t {
-    pub name: *mut libc::c_char,
-    pub folder_config_name: *mut libc::c_char,
+    pub name: &'static str,
+    pub folder_config_name: &'static str,
     pub imap: Imap,
     pub state: Arc<(Mutex<JobState>, Condvar)>,
 }
 
-pub unsafe fn dc_jobthread_init(
-    name: *const libc::c_char,
-    folder_config_name: *const libc::c_char,
+pub fn dc_jobthread_init(
+    name: &'static str,
+    folder_config_name: &'static str,
     imap: Imap,
 ) -> dc_jobthread_t {
     dc_jobthread_t {
-        name: dc_strdup(name),
-        folder_config_name: dc_strdup(folder_config_name),
+        name,
+        folder_config_name,
         imap,
         state: Arc::new((Mutex::new(Default::default()), Condvar::new())),
     }
@@ -37,12 +38,6 @@ pub struct JobState {
     using_handle: i32,
 }
 
-pub unsafe fn dc_jobthread_exit(jobthread: &mut dc_jobthread_t) {
-    free(jobthread.name as *mut libc::c_void);
-    jobthread.name = 0 as *mut libc::c_char;
-    free(jobthread.folder_config_name as *mut libc::c_void);
-    jobthread.folder_config_name = 0 as *mut libc::c_char;
-}
 
 pub unsafe fn dc_jobthread_suspend(
     context: &Context,
@@ -54,7 +49,7 @@ pub unsafe fn dc_jobthread_suspend(
             context,
             0i32,
             b"Suspending %s-thread.\x00" as *const u8 as *const libc::c_char,
-            jobthread.name,
+            &jobthread.name,
         );
 
         {
@@ -73,7 +68,7 @@ pub unsafe fn dc_jobthread_suspend(
             context,
             0i32,
             b"Unsuspending %s-thread.\x00" as *const u8 as *const libc::c_char,
-            jobthread.name,
+            &jobthread.name,
         );
 
         let &(ref lock, ref cvar) = &*jobthread.state.clone();
@@ -94,7 +89,7 @@ pub unsafe fn dc_jobthread_interrupt_idle(context: &Context, jobthread: &dc_jobt
         context,
         0,
         b"Interrupting %s-IDLE...\x00" as *const u8 as *const libc::c_char,
-        jobthread.name,
+        &jobthread.name,
     );
 
     jobthread.imap.interrupt_idle();
@@ -131,7 +126,7 @@ pub unsafe fn dc_jobthread_fetch(
                 context,
                 0,
                 b"%s-fetch started...\x00" as *const u8 as *const libc::c_char,
-                jobthread.name,
+                &jobthread.name,
             );
             jobthread.imap.fetch(context);
 
@@ -140,7 +135,7 @@ pub unsafe fn dc_jobthread_fetch(
                     context,
                     0i32,
                     b"%s-fetch aborted, starting over...\x00" as *const u8 as *const libc::c_char,
-                    jobthread.name,
+                    &jobthread.name,
                 );
                 jobthread.imap.fetch(context);
             }
@@ -148,7 +143,7 @@ pub unsafe fn dc_jobthread_fetch(
                 context,
                 0,
                 b"%s-fetch done in %.0f ms.\x00" as *const u8 as *const libc::c_char,
-                jobthread.name,
+                &jobthread.name,
                 clock().wrapping_sub(start) as libc::c_double * 1000.0f64
                     / 1000000i32 as libc::c_double,
             );
@@ -183,7 +178,7 @@ unsafe fn connect_to_imap(context: &Context, jobthread: &dc_jobthread_t) -> libc
             mvbox_name = dc_sqlite3_get_config(
                 context,
                 &context.sql,
-                jobthread.folder_config_name,
+                CString::new(&jobthread.folder_config_name[..]).unwrap().as_ptr(),
                 0 as *const libc::c_char,
             );
             if mvbox_name.is_null() {
@@ -214,7 +209,7 @@ pub unsafe fn dc_jobthread_idle(
                 0,
                 b"%s-IDLE will not be started as it was interrupted while not ideling.\x00"
                     as *const u8 as *const libc::c_char,
-                jobthread.name,
+                &jobthread.name,
             );
             state.jobs_needed = 0;
             return;
@@ -246,14 +241,14 @@ pub unsafe fn dc_jobthread_idle(
         context,
         0i32,
         b"%s-IDLE started...\x00" as *const u8 as *const libc::c_char,
-        jobthread.name,
+        &jobthread.name,
     );
     jobthread.imap.idle(context);
     dc_log_info(
         context,
         0i32,
         b"%s-IDLE ended.\x00" as *const u8 as *const libc::c_char,
-        jobthread.name,
+        &jobthread.name,
     );
 
     jobthread.state.0.lock().unwrap().using_handle = 0;


### PR DESCRIPTION
Remove the unsafe parts. Some functions in this file had to stay unsafe because they get a Context object as a parameter, which contains raw pointers.