### PR TITLE
Write a deltachat.pc file at build time

### DIFF
--- a/deltachat-ffi/build.rs
+++ b/deltachat-ffi/build.rs
@@ -1,0 +1,33 @@
+use std::io::Write;
+use std::path::PathBuf;
+use std::{env, fs};
+
+fn main() {
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let target_path = out_path.join("../../..");
+    let target_triple = env::var("TARGET").unwrap();
+
+    // macOS or iOS, inherited from rpgp
+    let libs_priv = if target_triple.contains("apple") || target_triple.contains("darwin") {
+        // needed for OsRng
+        "-framework Security -framework Foundation"
+    } else {
+        ""
+    };
+
+    let pkg_config = format!(
+        include_str!("deltachat.pc.in"),
+        name = "deltachat",
+        description = env::var("CARGO_PKG_DESCRIPTION").unwrap(),
+        url = env::var("CARGO_PKG_HOMEPAGE").unwrap_or("".to_string()),
+        version = env::var("CARGO_PKG_VERSION").unwrap(),
+        libs_priv = libs_priv,
+        prefix = env::var("PREFIX").unwrap_or("/usr/local".to_string()),
+    );
+
+    fs::create_dir_all(target_path.join("pkgconfig")).unwrap();
+    fs::File::create(target_path.join("pkgconfig").join("deltachat.pc"))
+        .unwrap()
+        .write_all(&pkg_config.as_bytes())
+        .unwrap();
+}

--- a/deltachat-ffi/deltachat.pc.in
+++ b/deltachat-ffi/deltachat.pc.in
@@ -1,0 +1,11 @@
+prefix={prefix}
+libdir=${{prefix}}/lib
+includedir=${{prefix}}/include
+
+Name: {name}
+Description: {description}
+URL: {url}
+Version: {version}
+Cflags: -I${{includedir}}
+Libs: -L${{libdir}} -ldeltachat
+Libs.private: {libs_priv}


### PR DESCRIPTION
This is writes pkg-config/deltachat.pc file in the target directory,
using the PREFIX environment variable at build time.  If this is
undefined at build time /usr/local is used.

No attempt at installing this or any other files is made at this time.

Fixes #170