### PR TITLE
Ignore expensive tests by default

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -33,6 +33,7 @@ else
     export CARGO_SUBCMD="test"
     export OPT="${OPT} "
     export OPT_RELEASE="${OPT_RELEASE} "
+    export OPT_RELEASE_IGNORED="${OPT_RELEASE} -- --ignored"
 fi
 
 # Run all the test configurations:

--- a/src/key.rs
+++ b/src/key.rs
@@ -524,6 +524,7 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
     }
 
     #[test]
+    #[ignore] // is too expensive
     fn test_from_slice_roundtrip() {
         let (public_key, private_key) =
             crate::pgp::dc_pgp_create_keypair(CString::new("hello").unwrap().as_ptr()).unwrap();
@@ -538,6 +539,7 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
     }
 
     #[test]
+    #[ignore] // is too expensive
     fn test_ascii_roundtrip() {
         let (public_key, private_key) =
             crate::pgp::dc_pgp_create_keypair(CString::new("hello").unwrap().as_ptr()).unwrap();

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -643,6 +643,7 @@ unsafe fn stress_functions(context: &Context) {
 }
 
 #[test]
+#[ignore] // is too expensive
 fn test_encryption_decryption() {
     unsafe {
         let mut bad_data: [libc::c_uchar; 4096] = [0; 4096];


### PR DESCRIPTION
This makes interactively running the tests a much more pleasant
experience rather than something one dreads.  These tests will still
be run on the CI.  To run these manually run:

cargo test [TESTNAME] -- --ignored