### PR TITLE
src/top_evil_rs.py: fix shebang to always use Python 3 and make it executable

### DIFF
--- a/src/top_evil_rs.py
+++ b/src/top_evil_rs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 
 import os


### PR DESCRIPTION
PEP-0394 (https://www.python.org/dev/peps/pep-0394/) recommends to use more specific shebangs.
For example, Debian allows /usr/bin/python to be configured to python2 via `update-alternatives python`, but the script does not work with Python 2.