### PR TITLE
Several fixes to the intergration tests

### DIFF
--- a/python/src/deltachat/_build.py
+++ b/python/src/deltachat/_build.py
@@ -30,6 +30,7 @@ def ffibuilder():
         libs = ['deltachat']
         objs = []
         incs = []
+        extra_link_args = []
     builder = cffi.FFI()
     builder.set_source(
         'deltachat.capi',
@@ -69,8 +70,8 @@ def ffibuilder():
     distutils.sysconfig.customize_compiler(cc)
     tmpdir = tempfile.mkdtemp()
     try:
-        src_name = os.path.join(tmpdir, "prep.h")
-        dst_name = os.path.join(tmpdir, "prep2.c")
+        src_name = os.path.join(tmpdir, "include.h")
+        dst_name = os.path.join(tmpdir, "expanded.h")
         with open(src_name, "w") as src_fp:
             src_fp.write('#include <deltachat.h>')
         cc.preprocess(source=src_name,

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -13,6 +13,8 @@ commands =
 passenv = 
     TRAVIS 
     DCC_RS_DEV
+    DCC_RS_TARGET
+    DCC_PY_LIVECONFIG
 deps = 
     pytest
     pytest-faulthandler

--- a/run-integration-tests.sh
+++ b/run-integration-tests.sh
@@ -23,11 +23,10 @@ if [ $? != 0 ]; then
 fi
 
 pushd python
-toxargs="$@"
-if [ -e liveconfig ]; then
-    toxargs="--liveconfig liveconfig $@"
+if [ -e "./liveconfig" ]; then
+    export DCC_PY_LIVECONFIG=liveconfig
 fi
-tox $toxargs
+tox "$@"
 ret=$?
 popd
 exit $ret


### PR DESCRIPTION
- Pass extra_link_args when using an installed libdeltachat
- Allow setting the liveconfig by envvar
- Show lifeconfig path in the pytest summary line
- Pass required envvars through tox
- Fix broken liveconfig passing in run-integration-test.sh
- Allow comments in the liveconfig file