### PR TITLE
Silence warnings from ignored Result values

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -28,7 +28,7 @@ use num_traits::FromPrimitive;
 pub unsafe fn dc_reset_tables(context: &Context, bits: i32) -> i32 {
     info!(context, 0, "Resetting tables ({})...", bits);
     if 0 != bits & 1 {
-        sql::execute(context, &context.sql, "DELETE FROM jobs;", params![]);
+        sql::execute(context, &context.sql, "DELETE FROM jobs;", params![]).unwrap();
         info!(context, 0, "(1) Jobs reset.");
     }
     if 0 != bits & 2 {
@@ -37,11 +37,12 @@ pub unsafe fn dc_reset_tables(context: &Context, bits: i32) -> i32 {
             &context.sql,
             "DELETE FROM acpeerstates;",
             params![],
-        );
+        )
+        .unwrap();
         info!(context, 0, "(2) Peerstates reset.");
     }
     if 0 != bits & 4 {
-        sql::execute(context, &context.sql, "DELETE FROM keypairs;", params![]);
+        sql::execute(context, &context.sql, "DELETE FROM keypairs;", params![]).unwrap();
         info!(context, 0, "(4) Private keypairs reset.");
     }
     if 0 != bits & 8 {
@@ -50,32 +51,37 @@ pub unsafe fn dc_reset_tables(context: &Context, bits: i32) -> i32 {
             &context.sql,
             "DELETE FROM contacts WHERE id>9;",
             params![],
-        );
+        )
+        .unwrap();
         sql::execute(
             context,
             &context.sql,
             "DELETE FROM chats WHERE id>9;",
             params![],
-        );
+        )
+        .unwrap();
         sql::execute(
             context,
             &context.sql,
             "DELETE FROM chats_contacts;",
             params![],
-        );
+        )
+        .unwrap();
         sql::execute(
             context,
             &context.sql,
             "DELETE FROM msgs WHERE id>9;",
             params![],
-        );
+        )
+        .unwrap();
         sql::execute(
             context,
             &context.sql,
             "DELETE FROM config WHERE keyname LIKE 'imap.%' OR keyname LIKE 'configured%';",
             params![],
-        );
-        sql::execute(context, &context.sql, "DELETE FROM leftgrps;", params![]);
+        )
+        .unwrap();
+        sql::execute(context, &context.sql, "DELETE FROM leftgrps;", params![]).unwrap();
         info!(context, 0, "(8) Rest but server config reset.");
     }
 
@@ -129,7 +135,8 @@ unsafe fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int
         real_spec = dc_strdup(spec);
         context
             .sql
-            .set_config(context, "import_spec", Some(as_str(real_spec)));
+            .set_config(context, "import_spec", Some(as_str(real_spec)))
+            .unwrap();
         current_block = 7149356873433890176;
     } else {
         let rs = context.sql.get_config(context, "import_spec");

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -86,8 +86,9 @@ fn main() {
         let args = std::env::args().collect::<Vec<String>>();
         assert_eq!(args.len(), 2, "missing password");
         let pw = args[1].clone();
-        ctx.set_config(config::Config::Addr, Some("d@testrun.org"));
-        ctx.set_config(config::Config::MailPw, Some(&pw));
+        ctx.set_config(config::Config::Addr, Some("d@testrun.org"))
+            .unwrap();
+        ctx.set_config(config::Config::MailPw, Some(&pw)).unwrap();
         dc_configure(&ctx);
 
         thread::sleep(duration);

--- a/src/context.rs
+++ b/src/context.rs
@@ -260,7 +260,7 @@ unsafe fn cb_set_config(context: &Context, key: *const libc::c_char, value: *con
     } else {
         Some(as_str(value))
     };
-    context.sql.set_config(context, as_str(key), v);
+    context.sql.set_config(context, as_str(key), v).ok();
 }
 
 /* *

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -291,7 +291,7 @@ pub unsafe fn dc_create_or_lookup_nchat_by_contact_id(
                 &context.sql,
                 format!("INSERT INTO chats_contacts (chat_id, contact_id) VALUES({}, {})", chat_id, contact_id),
                 params![],
-            );
+            ).ok();
         }
     }
 
@@ -862,13 +862,15 @@ pub unsafe fn dc_is_contact_in_chat(
         .unwrap_or_default() as libc::c_int
 }
 
+// Should return Result
 pub fn dc_unarchive_chat(context: &Context, chat_id: u32) {
     sql::execute(
         context,
         &context.sql,
         "UPDATE chats SET archived=0 WHERE id=?",
         params![chat_id as i32],
-    );
+    )
+    .ok();
 }
 
 pub unsafe fn dc_send_msg<'a>(
@@ -1658,6 +1660,7 @@ pub fn dc_reset_gossiped_timestamp(context: &Context, chat_id: u32) {
     dc_set_gossiped_timestamp(context, chat_id, 0);
 }
 
+// Should return Result
 pub fn dc_set_gossiped_timestamp(context: &Context, chat_id: u32, timestamp: i64) {
     if 0 != chat_id {
         info!(
@@ -1670,7 +1673,8 @@ pub fn dc_set_gossiped_timestamp(context: &Context, chat_id: u32, timestamp: i64
             &context.sql,
             "UPDATE chats SET gossiped_timestamp=? WHERE id=?;",
             params![timestamp, chat_id as i32],
-        );
+        )
+        .ok();
     } else {
         info!(
             context,
@@ -1681,7 +1685,8 @@ pub fn dc_set_gossiped_timestamp(context: &Context, chat_id: u32, timestamp: i64
             &context.sql,
             "UPDATE chats SET gossiped_timestamp=?;",
             params![timestamp],
-        );
+        )
+        .ok();
     }
 }
 
@@ -1764,6 +1769,7 @@ pub unsafe fn dc_remove_contact_from_chat(
     success
 }
 
+// Should return Result
 pub fn dc_set_group_explicitly_left(context: &Context, grpid: *const libc::c_char) {
     if 0 == dc_is_group_explicitly_left(context, grpid) {
         sql::execute(
@@ -1771,7 +1777,8 @@ pub fn dc_set_group_explicitly_left(context: &Context, grpid: *const libc::c_cha
             &context.sql,
             "INSERT INTO leftgrps (grpid) VALUES(?);",
             params![as_str(grpid)],
-        );
+        )
+        .ok();
     }
 }
 

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -152,6 +152,16 @@ pub fn dc_chat_load_from_db(chat: *mut Chat, chat_id: u32) -> bool {
     );
 
     match res {
+        Err(crate::error::Error::Sql(rusqlite::Error::QueryReturnedNoRows)) => false,
+        Err(err) => match err {
+            _ => {
+                error!(
+                    context,
+                    0, "chat: failed to load from db {}: {:?}", chat_id, err
+                );
+                false
+            }
+        },
         Ok(_) => {
             let c = unsafe { &mut *chat };
             match c.id {
@@ -184,16 +194,6 @@ pub fn dc_chat_load_from_db(chat: *mut Chat, chat_id: u32) -> bool {
             }
             true
         }
-        Err(err) => match err {
-            QueryReturnedNoRows => false,
-            _ => {
-                error!(
-                    context,
-                    0, "chat: failed to load from db {}: {:?}", chat_id, err
-                );
-                false
-            }
-        },
     }
 }
 

--- a/src/dc_configure.rs
+++ b/src/dc_configure.rs
@@ -174,7 +174,8 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                 param.addr = oauth2_addr;
                                 context
                                     .sql
-                                    .set_config(context, "addr", Some(param.addr.as_str()));
+                                    .set_config(context, "addr", Some(param.addr.as_str()))
+                                    .ok();
                             }
                             if s.shall_stop_ongoing {
                                 current_block = 2927484062889439186;
@@ -966,7 +967,8 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
                                                                                     context,
                                                                                     "configured",
                                                                                     1,
-                                                                                );
+                                                                                )
+                                                                                .ok();
                                                                             if !s.shall_stop_ongoing
                                                                             {
                                                                                 context.call_cb(

--- a/src/dc_contact.rs
+++ b/src/dc_contact.rs
@@ -421,7 +421,8 @@ pub fn dc_add_or_lookup_contact(
                     },
                     row_id
                 ],
-            );
+            )
+            .ok();
 
             if update_name {
                 sql::execute(
@@ -429,7 +430,7 @@ pub fn dc_add_or_lookup_contact(
                     &context.sql,
                     "UPDATE chats SET name=? WHERE type=? AND id IN(SELECT chat_id FROM chats_contacts WHERE contact_id=?);",
                     params![to_string(name), 100, row_id]
-                );
+                ).ok();
             }
             unsafe { *sth_modified = 1 };
         }

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -872,7 +872,7 @@ unsafe fn import_backup(context: &Context, backup_to_import: *const libc::c_char
                     return Err(format_err!("fail").into());
                 }
                 sql::execute(context, &context.sql, "DROP TABLE backup_blobs;", params![])?;
-                sql::try_execute(context, &context.sql, "VACUUM;");
+                sql::try_execute(context, &context.sql, "VACUUM;").ok();
                 Ok(())
             },
         )
@@ -906,7 +906,7 @@ unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_
 
     sql::housekeeping(context);
 
-    sql::try_execute(context, &context.sql, "VACUUM;");
+    sql::try_execute(context, &context.sql, "VACUUM;").ok();
     context.sql.close(context);
     let mut closed = true;
     info!(

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -877,7 +877,7 @@ unsafe fn import_backup(context: &Context, backup_to_import: *const libc::c_char
     );
 
     res.and_then(|_| {
-        /// only delete backup_blobs if all files were successfully extracted
+        // only delete backup_blobs if all files were successfully extracted
         sql::execute(context, &context.sql, "DROP TABLE backup_blobs;", params![])?;
         sql::try_execute(context, &context.sql, "VACUUM;").ok();
         Ok(())

--- a/src/dc_job.rs
+++ b/src/dc_job.rs
@@ -110,7 +110,7 @@ unsafe fn dc_job_perform(context: &Context, thread: libc::c_int, probe_network: 
         },
     );
     match jobs {
-        Ok(ref res) => {}
+        Ok(ref _res) => {}
         Err(ref err) => {
             info!(context, 0, "query failed: {:?}", err);
         }

--- a/src/dc_job.rs
+++ b/src/dc_job.rs
@@ -814,7 +814,7 @@ pub unsafe fn dc_job_add(
             },
             (timestamp + delay_seconds as i64)
         ]
-    );
+    ).ok();
 
     if thread == 100 {
         dc_interrupt_imap_idle(context);

--- a/src/dc_loginparam.rs
+++ b/src/dc_loginparam.rs
@@ -91,34 +91,39 @@ pub fn dc_loginparam_write(
     let prefix = prefix.as_ref();
 
     let key = format!("{}addr", prefix);
-    sql.set_config(context, key, Some(&loginparam.addr));
+    sql.set_config(context, key, Some(&loginparam.addr)).ok();
 
     let key = format!("{}mail_server", prefix);
-    sql.set_config(context, key, Some(&loginparam.mail_server));
+    sql.set_config(context, key, Some(&loginparam.mail_server))
+        .ok();
 
     let key = format!("{}mail_port", prefix);
-    sql.set_config_int(context, key, loginparam.mail_port);
+    sql.set_config_int(context, key, loginparam.mail_port).ok();
 
     let key = format!("{}mail_user", prefix);
-    sql.set_config(context, key, Some(&loginparam.mail_user));
+    sql.set_config(context, key, Some(&loginparam.mail_user))
+        .ok();
 
     let key = format!("{}mail_pw", prefix);
-    sql.set_config(context, key, Some(&loginparam.mail_pw));
+    sql.set_config(context, key, Some(&loginparam.mail_pw)).ok();
 
     let key = format!("{}send_server", prefix);
-    sql.set_config(context, key, Some(&loginparam.send_server));
+    sql.set_config(context, key, Some(&loginparam.send_server))
+        .ok();
 
     let key = format!("{}send_port", prefix);
-    sql.set_config_int(context, key, loginparam.send_port);
+    sql.set_config_int(context, key, loginparam.send_port).ok();
 
     let key = format!("{}send_user", prefix);
-    sql.set_config(context, key, Some(&loginparam.send_user));
+    sql.set_config(context, key, Some(&loginparam.send_user))
+        .ok();
 
     let key = format!("{}send_pw", prefix);
-    sql.set_config(context, key, Some(&loginparam.send_pw));
+    sql.set_config(context, key, Some(&loginparam.send_pw)).ok();
 
     let key = format!("{}server_flags", prefix);
-    sql.set_config_int(context, key, loginparam.server_flags);
+    sql.set_config_int(context, key, loginparam.server_flags)
+        .ok();
 }
 
 fn unset_empty(s: &String) -> Cow<String> {

--- a/src/dc_msg.rs
+++ b/src/dc_msg.rs
@@ -487,10 +487,7 @@ pub fn dc_msg_load_from_db<'a>(msg: *mut dc_msg_t<'a>, context: &'a Context, id:
         }
     );
 
-    match res {
-        Ok(_) => true,
-        Err(err) => false,
-    }
+    res.is_ok()
 }
 
 pub unsafe fn dc_get_mime_headers(context: &Context, msg_id: uint32_t) -> *mut libc::c_char {

--- a/src/dc_msg.rs
+++ b/src/dc_msg.rs
@@ -1110,13 +1110,15 @@ pub unsafe fn dc_delete_msg_from_db(context: &Context, msg_id: uint32_t) {
             &context.sql,
             "DELETE FROM msgs WHERE id=?;",
             params![(*msg).id as i32],
-        );
+        )
+        .ok();
         sql::execute(
             context,
             &context.sql,
             "DELETE FROM msgs_mdns WHERE msg_id=?;",
             params![(*msg).id as i32],
-        );
+        )
+        .ok();
     }
     dc_msg_unref(msg);
 }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1249,7 +1249,8 @@ unsafe fn create_or_lookup_group(
                                 &context.sql,
                                 "DELETE FROM chats_contacts WHERE chat_id=?;",
                                 params![chat_id as i32],
-                            );
+                            )
+                            .ok();
                             if skip.is_null() || !dc_addr_cmp(&self_addr, as_str(skip)) {
                                 dc_add_to_chat_contacts_table(context, chat_id, 1);
                             }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -515,9 +515,7 @@ pub unsafe fn dc_receive_imf(
                                             (*part).bytes,
                                             hidden,
                                             if 0 != save_mime_headers {
-                                                let body_string = unsafe {
-        std::str::from_utf8(std::slice::from_raw_parts(imf_raw_not_terminated as *const u8, imf_raw_bytes)).unwrap()
-    };
+                                                let body_string = std::str::from_utf8(std::slice::from_raw_parts(imf_raw_not_terminated as *const u8, imf_raw_bytes)).unwrap();
 
                                                 Some(body_string)
                                             } else {

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1597,18 +1597,25 @@ impl Imap {
             }
         }
 
-        context.sql.set_config_int(context, "folders_configured", 3);
+        context
+            .sql
+            .set_config_int(context, "folders_configured", 3)
+            .ok();
         if let Some(ref mvbox_folder) = mvbox_folder {
             context
                 .sql
-                .set_config(context, "configured_mvbox_folder", Some(mvbox_folder));
+                .set_config(context, "configured_mvbox_folder", Some(mvbox_folder))
+                .ok();
         }
         if let Some(ref sentbox_folder) = sentbox_folder {
-            context.sql.set_config(
-                context,
-                "configured_sentbox_folder",
-                Some(sentbox_folder.name()),
-            );
+            context
+                .sql
+                .set_config(
+                    context,
+                    "configured_sentbox_folder",
+                    Some(sentbox_folder.name()),
+                )
+                .ok();
         }
     }
 

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -173,7 +173,9 @@ impl Sql {
     }
 
     /// Set private configuration options.
-    /// Setting `None` deletes the value.
+    ///
+    /// Setting `None` deletes the value.  On failure an error message
+    /// will already have been logged.
     pub fn set_config(
         &self,
         context: &Context,
@@ -439,7 +441,7 @@ fn open(
                 // cannot create the tables - maybe we cannot write?
                 return Err(Error::SqlFailedToOpen);
             } else {
-                sql.set_config_int(context, "dbversion", 0);
+                sql.set_config_int(context, "dbversion", 0)?;
             }
         } else {
             exists_before_update = 1;
@@ -464,7 +466,7 @@ fn open(
                 params![],
             )?;
             dbversion = 1;
-            sql.set_config_int(context, "dbversion", 1);
+            sql.set_config_int(context, "dbversion", 1)?;
         }
         if dbversion < 2 {
             sql.execute(
@@ -472,7 +474,7 @@ fn open(
                 params![],
             )?;
             dbversion = 2;
-            sql.set_config_int(context, "dbversion", 2);
+            sql.set_config_int(context, "dbversion", 2)?;
         }
         if dbversion < 7 {
             sql.execute(
@@ -486,7 +488,7 @@ fn open(
                 params![],
             )?;
             dbversion = 7;
-            sql.set_config_int(context, "dbversion", 7);
+            sql.set_config_int(context, "dbversion", 7)?;
         }
         if dbversion < 10 {
             sql.execute(
@@ -504,7 +506,7 @@ fn open(
                 params![],
             )?;
             dbversion = 10;
-            sql.set_config_int(context, "dbversion", 10);
+            sql.set_config_int(context, "dbversion", 10)?;
         }
         if dbversion < 12 {
             sql.execute(
@@ -516,7 +518,7 @@ fn open(
                 params![],
             )?;
             dbversion = 12;
-            sql.set_config_int(context, "dbversion", 12);
+            sql.set_config_int(context, "dbversion", 12)?;
         }
         if dbversion < 17 {
             sql.execute(
@@ -530,7 +532,7 @@ fn open(
             )?;
             sql.execute("CREATE INDEX msgs_index5 ON msgs (starred);", params![])?;
             dbversion = 17;
-            sql.set_config_int(context, "dbversion", 17);
+            sql.set_config_int(context, "dbversion", 17)?;
         }
         if dbversion < 18 {
             sql.execute(
@@ -539,7 +541,7 @@ fn open(
             )?;
             sql.execute("ALTER TABLE acpeerstates ADD COLUMN gossip_key;", params![])?;
             dbversion = 18;
-            sql.set_config_int(context, "dbversion", 18);
+            sql.set_config_int(context, "dbversion", 18)?;
         }
         if dbversion < 27 {
             sql.execute("DELETE FROM msgs WHERE chat_id=1 OR chat_id=2;", params![])?;
@@ -556,7 +558,7 @@ fn open(
                 params![],
             )?;
             dbversion = 27;
-            sql.set_config_int(context, "dbversion", 27);
+            sql.set_config_int(context, "dbversion", 27)?;
         }
         if dbversion < 34 {
             sql.execute(
@@ -585,7 +587,7 @@ fn open(
             )?;
             recalc_fingerprints = 1;
             dbversion = 34;
-            sql.set_config_int(context, "dbversion", 34);
+            sql.set_config_int(context, "dbversion", 34)?;
         }
         if dbversion < 39 {
             sql.execute(
@@ -615,7 +617,7 @@ fn open(
                 )?;
             }
             dbversion = 39;
-            sql.set_config_int(context, "dbversion", 39);
+            sql.set_config_int(context, "dbversion", 39)?;
         }
         if dbversion < 40 {
             sql.execute(
@@ -623,22 +625,22 @@ fn open(
                 params![],
             )?;
             dbversion = 40;
-            sql.set_config_int(context, "dbversion", 40);
+            sql.set_config_int(context, "dbversion", 40)?;
         }
         if dbversion < 41 {
             update_file_paths = 1;
             dbversion = 41;
-            sql.set_config_int(context, "dbversion", 41);
+            sql.set_config_int(context, "dbversion", 41)?;
         }
         if dbversion < 42 {
             sql.execute("UPDATE msgs SET txt='' WHERE type!=10", params![])?;
             dbversion = 42;
-            sql.set_config_int(context, "dbversion", 42);
+            sql.set_config_int(context, "dbversion", 42)?;
         }
         if dbversion < 44 {
             sql.execute("ALTER TABLE msgs ADD COLUMN mime_headers TEXT;", params![])?;
             dbversion = 44;
-            sql.set_config_int(context, "dbversion", 44);
+            sql.set_config_int(context, "dbversion", 44)?;
         }
         if dbversion < 46 {
             sql.execute(
@@ -650,7 +652,7 @@ fn open(
                 params![],
             )?;
             dbversion = 46;
-            sql.set_config_int(context, "dbversion", 46);
+            sql.set_config_int(context, "dbversion", 46)?;
         }
         if dbversion < 47 {
             info!(context, 0, "[migration] v47");
@@ -659,7 +661,7 @@ fn open(
                 params![],
             )?;
             dbversion = 47;
-            sql.set_config_int(context, "dbversion", 47);
+            sql.set_config_int(context, "dbversion", 47)?;
         }
         if dbversion < 48 {
             info!(context, 0, "[migration] v48");
@@ -673,7 +675,7 @@ fn open(
             assert_eq!(DC_MOVE_STATE_MOVING as libc::c_int, 3);
 
             dbversion = 48;
-            sql.set_config_int(context, "dbversion", 48);
+            sql.set_config_int(context, "dbversion", 48)?;
         }
         if dbversion < 49 {
             info!(context, 0, "[migration] v49");
@@ -682,15 +684,15 @@ fn open(
                 params![],
             )?;
             dbversion = 49;
-            sql.set_config_int(context, "dbversion", 49);
+            sql.set_config_int(context, "dbversion", 49)?;
         }
         if dbversion < 50 {
             info!(context, 0, "[migration] v50");
             if 0 != exists_before_update {
-                sql.set_config_int(context, "show_emails", 2);
+                sql.set_config_int(context, "show_emails", 2)?;
             }
             dbversion = 50;
-            sql.set_config_int(context, "dbversion", 50);
+            sql.set_config_int(context, "dbversion", 50)?;
         }
         if dbversion < 53 {
             info!(context, 0, "[migration] v53");
@@ -723,7 +725,7 @@ fn open(
                 params![],
             )?;
             dbversion = 53;
-            sql.set_config_int(context, "dbversion", 53);
+            sql.set_config_int(context, "dbversion", 53)?;
         }
         if dbversion < 54 {
             info!(context, 0, "[migration] v54");
@@ -733,7 +735,7 @@ fn open(
             )?;
             sql.execute("CREATE INDEX msgs_index6 ON msgs (location_id);", params![])?;
             dbversion = 54;
-            sql.set_config_int(context, "dbversion", 54);
+            sql.set_config_int(context, "dbversion", 54)?;
         }
         if dbversion < 55 {
             sql.execute(
@@ -741,7 +743,7 @@ fn open(
                 params![],
             )?;
 
-            sql.set_config_int(context, "dbversion", 55);
+            sql.set_config_int(context, "dbversion", 55)?;
         }
 
         if 0 != recalc_fingerprints {
@@ -789,7 +791,7 @@ fn open(
                 NO_PARAMS,
             )?;
 
-            sql.set_config(context, "backup_for", None);
+            sql.set_config(context, "backup_for", None)?;
         }
     }
 


### PR DESCRIPTION
For a few of the locations where error handling is done correctly this
does the right thing.  For most other places it gracefully ignores any
issues which is what the original code did as well.  Errors are
already logged by the called functions in those cases.