### PR TITLE
Enable hostname validation for TLS

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -100,10 +100,7 @@ impl Client {
         domain: S,
     ) -> imap::error::Result<Self> {
         let stream = net::TcpStream::connect(addr)?;
-        let tls = native_tls::TlsConnector::builder()
-            .danger_accept_invalid_hostnames(true)
-            .build()
-            .unwrap();
+        let tls = native_tls::TlsConnector::builder().build().unwrap();
 
         let s = stream.try_clone().expect("cloning the stream failed");
         let tls_stream = native_tls::TlsConnector::connect(&tls, domain.as_ref(), s)?;
@@ -126,10 +123,7 @@ impl Client {
     pub fn secure<S: AsRef<str>>(self, domain: S) -> imap::error::Result<Client> {
         match self {
             Client::Insecure(client, stream) => {
-                let tls = native_tls::TlsConnector::builder()
-                    .danger_accept_invalid_hostnames(true)
-                    .build()
-                    .unwrap();
+                let tls = native_tls::TlsConnector::builder().build().unwrap();
 
                 let client_sec = client.secure(domain, &tls)?;
 

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -68,8 +68,6 @@ impl Smtp {
         let port = lp.send_port as u16;
 
         let tls = native_tls::TlsConnector::builder()
-            // FIXME: unfortunately this is needed to make things work on macos + testrun.org
-            .danger_accept_invalid_hostnames(true)
             .min_protocol_version(Some(DEFAULT_TLS_PROTOCOLS[0]))
             .build()
             .unwrap();


### PR DESCRIPTION
The line
.danger_accept_invalid_hostnames(true)
allows any valid certificate to be accepted for any hostname.

It means that anyone controlling at least one domain can get
a free certificate from Let's Encrypt and use it to
intercept (MITM) any connection. This makes TLS encryption useless.

See http://crypto.stanford.edu/~dabo/pubs/abstracts/ssl-client-bugs.html
and https://wiki.openssl.org/index.php/Hostname_validation
for more information.

Also remove related FIXME introduced in 2a4057a7745c4768cb5dddfed313f72e36d07d71