### PR TITLE
[WIP] Add StrExt.strdup() and remove to_string()

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -12,6 +12,7 @@ extern crate human_panic;
 
 use std::str::FromStr;
 
+use deltachat::dc_tools::StrExt;
 use deltachat::*;
 
 // TODO: constants
@@ -109,10 +110,7 @@ pub unsafe extern "C" fn dc_get_config(
     let context = &*context;
 
     match config::Config::from_str(dc_tools::as_str(key)) {
-        Ok(key) => {
-            let value = context.get_config(key).unwrap_or_default();
-            into_cstring(value)
-        }
+        Ok(key) => context.get_config(key).unwrap_or_default().strdup(),
         Err(_) => std::ptr::null_mut(),
     }
 }
@@ -137,7 +135,7 @@ pub unsafe extern "C" fn dc_get_oauth2_url(
     let addr = dc_tools::to_string(addr);
     let redirect = dc_tools::to_string(redirect);
     match oauth2::dc_get_oauth2_url(context, addr, redirect) {
-        Some(res) => libc::strdup(dc_tools::to_cstring(res).as_ptr()),
+        Some(res) => res.strdup(),
         None => std::ptr::null_mut(),
     }
 }
@@ -1545,8 +1543,4 @@ fn as_opt_str<'a>(s: *const libc::c_char) -> Option<&'a str> {
     }
 
     Some(dc_tools::as_str(s))
-}
-
-unsafe fn into_cstring(s: impl AsRef<str>) -> *mut libc::c_char {
-    dc_tools::dc_strdup(dc_tools::to_cstring(s).as_ptr())
 }

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -1,3 +1,4 @@
+use std::ffi::CString;
 use std::str::FromStr;
 
 use deltachat::config;
@@ -139,7 +140,7 @@ unsafe fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int
         } else {
             current_block = 7149356873433890176;
         }
-        real_spec = strdup(to_cstring(rs.unwrap_or_default()).as_ptr());
+        real_spec = rs.unwrap_or_default().strdup();
     }
     match current_block {
         8522321847195001863 => {}
@@ -176,7 +177,7 @@ unsafe fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int
                         if name.ends_with(".eml") {
                             let path_plus_name = format!("{}/{}", as_str(real_spec), name);
                             info!(context, 0, "Import: {}", path_plus_name);
-                            let path_plus_name_c = to_cstring(path_plus_name);
+                            let path_plus_name_c = CString::new(path_plus_name).unwrap();
 
                             if 0 != dc_poke_eml_file(context, path_plus_name_c.as_ptr()) {
                                 read_cnt += 1
@@ -380,14 +381,14 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
     let mut args = line.splitn(3, ' ');
     let arg0 = args.next().unwrap_or_default();
     let arg1 = args.next().unwrap_or_default();
-    let arg1_c = to_cstring(arg1);
+    let arg1_c = CString::new(arg1).unwrap();
     let arg1_c_ptr = if arg1.is_empty() {
         std::ptr::null()
     } else {
         arg1_c.as_ptr()
     };
     let arg2 = args.next().unwrap_or_default();
-    let arg2_c = to_cstring(arg2);
+    let arg2_c = CString::new(arg2).unwrap();
     let arg2_c_ptr = if arg2.is_empty() {
         std::ptr::null()
     } else {
@@ -935,7 +936,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             ensure!(!sel_chat.is_null(), "No chat selected.");
             ensure!(!arg1.is_empty(), "No message text given.");
 
-            let msg = to_cstring(format!("{} {}", arg1, arg2));
+            let msg = CString::new(format!("{} {}", arg1, arg2)).unwrap();
 
             if 0 != dc_send_text_msg(context, dc_chat_get_id(sel_chat), msg.as_ptr()) {
                 println!("Message sent.");

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -14,6 +14,7 @@ extern crate lazy_static;
 extern crate rusqlite;
 
 use std::borrow::Cow::{self, Borrowed, Owned};
+use std::ffi::CString;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -398,11 +399,8 @@ fn main_0(args: Vec<String>) -> Result<(), failure::Error> {
 
     if args.len() == 2 {
         if 0 == unsafe {
-            dc_open(
-                &mut context,
-                to_cstring(&args[1]).as_ptr(),
-                0 as *const libc::c_char,
-            )
+            let tmp = CString::new(args[1].as_str()).unwrap();
+            dc_open(&mut context, tmp.as_ptr(), 0 as *const libc::c_char)
         } {
             println!("Error: Cannot open {}.", args[0],);
         }
@@ -482,7 +480,7 @@ unsafe fn handle_cmd(line: &str, ctx: Arc<RwLock<Context>>) -> Result<ExitResult
     let mut args = line.splitn(2, ' ');
     let arg0 = args.next().unwrap_or_default();
     let arg1 = args.next().unwrap_or_default();
-    let arg1_c = to_cstring(arg1);
+    let arg1_c = CString::new(arg1).unwrap();
     let arg1_c_ptr = if arg1.is_empty() {
         std::ptr::null()
     } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+use std::ffi::CString;
+
 use strum::{EnumProperty, IntoEnumIterator};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumProperty, EnumString};
 
@@ -71,7 +73,8 @@ impl Context {
             Config::Selfavatar => {
                 let rel_path = self.sql.get_config(self, key);
                 rel_path.map(|p| {
-                    let v = unsafe { dc_get_abs_path(self, to_cstring(p).as_ptr()) };
+                    let p_c = CString::new(p).unwrap();
+                    let v = unsafe { dc_get_abs_path(self, p_c.as_ptr()) };
                     let r = to_string(v);
                     unsafe { free(v as *mut _) };
                     r

--- a/src/context.rs
+++ b/src/context.rs
@@ -279,7 +279,7 @@ unsafe fn cb_get_config(
         .sql
         .get_config(context, as_str(key))
         .unwrap_or_else(|| to_string(def));
-    strdup(to_cstring(res).as_ptr())
+    res.strdup()
 }
 
 pub unsafe fn dc_context_unref(context: &mut Context) {
@@ -510,8 +510,7 @@ pub unsafe fn dc_get_info(context: &Context) -> *mut libc::c_char {
         pub_key_cnt.unwrap_or_default(),
         fingerprint_str,
     );
-
-    strdup(to_cstring(res).as_ptr())
+    res.strdup()
 }
 
 pub unsafe fn dc_get_version_str() -> *mut libc::c_char {

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -374,7 +374,7 @@ pub unsafe fn dc_array_get_string(
             }
             res
         });
-    strdup(to_cstring(res).as_ptr())
+    res.strdup()
 }
 
 /// return comma-separated value-string from integer array
@@ -396,7 +396,7 @@ pub unsafe fn dc_arr_to_string(arr: *const uint32_t, cnt: libc::c_int) -> *mut l
             res
         },
     );
-    strdup(to_cstring(res).as_ptr())
+    res.strdup()
 }
 
 #[cfg(test)]

--- a/src/dc_dehtml.rs
+++ b/src/dc_dehtml.rs
@@ -52,8 +52,7 @@ pub unsafe fn dc_dehtml(buf_terminated: *mut libc::c_char) -> *mut libc::c_char 
     dc_saxparser_set_text_handler(&mut saxparser, Some(dehtml_text_cb));
     dc_saxparser_parse(&mut saxparser, buf_terminated);
     free(dehtml.last_href as *mut libc::c_void);
-
-    strdup(to_cstring(dehtml.strbuilder).as_ptr())
+    dehtml.strbuilder.strdup()
 }
 
 unsafe fn dehtml_text_cb(

--- a/src/dc_e2ee.rs
+++ b/src/dc_e2ee.rs
@@ -175,8 +175,7 @@ pub unsafe fn dc_e2ee_encrypt(
                                     let p = peerstates[i as usize]
                                         .render_gossip_header(min_verified as usize);
 
-                                    if p.is_some() {
-                                        let header = to_cstring(p.unwrap());
+                                    if let Some(pp) = p {
                                         mailimf_fields_add(
                                             imffields_encrypted,
                                             mailimf_field_new_custom(
@@ -184,7 +183,7 @@ pub unsafe fn dc_e2ee_encrypt(
                                                     b"Autocrypt-Gossip\x00" as *const u8
                                                         as *const libc::c_char,
                                                 ),
-                                                strdup(header.as_ptr()),
+                                                pp.strdup(),
                                             ),
                                         );
                                     }

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -309,7 +309,7 @@ pub unsafe fn dc_create_setup_code(_context: &Context) -> *mut libc::c_char {
         );
     }
 
-    strdup(to_cstring(ret).as_ptr())
+    ret.strdup()
 }
 
 // TODO should return bool /rtn
@@ -538,8 +538,7 @@ pub unsafe fn dc_normalize_setup_code(
         }
         p1 = p1.offset(1);
     }
-
-    strdup(to_cstring(out).as_ptr())
+    out.strdup()
 }
 
 pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: *mut dc_job_t) {
@@ -896,7 +895,7 @@ unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_
     let res = chrono::NaiveDateTime::from_timestamp(now as i64, 0)
         .format("delta-chat-%Y-%m-%d.bak")
         .to_string();
-    let buffer = to_cstring(res);
+    let buffer = CString::new(res).unwrap();
     let dest_pathNfilename = dc_get_fine_pathNfilename(context, dir, buffer.as_ptr());
     if dest_pathNfilename.is_null() {
         error!(context, 0, "Cannot get backup file name.",);
@@ -1122,8 +1121,7 @@ unsafe fn import_self_keys(context: &Context, dir_name: *const libc::c_char) -> 
                 }
                 let entry = entry.unwrap();
                 free(suffix as *mut libc::c_void);
-                let name_f = entry.file_name();
-                let name_c = to_cstring(name_f.to_string_lossy());
+                let name_c = entry.file_name().to_c_string().unwrap();
                 suffix = dc_get_filesuffix_lc(name_c.as_ptr());
                 if suffix.is_null()
                     || strcmp(suffix, b"asc\x00" as *const u8 as *const libc::c_char) != 0

--- a/src/dc_job.rs
+++ b/src/dc_job.rs
@@ -1,8 +1,7 @@
-use mmime::mmapstring::*;
-
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::time::Duration;
 
+use mmime::mmapstring::*;
 use rand::{thread_rng, Rng};
 
 use crate::constants::Event;
@@ -97,9 +96,9 @@ unsafe fn dc_job_perform(context: &Context, thread: libc::c_int, probe_network: 
                     try_again: 0,
                     pending_error: 0 as *mut libc::c_char,
                 };
-
                 let packed: String = row.get(3)?;
-                dc_param_set_packed(job.param, to_cstring(packed).as_ptr());
+                let packed_c = CString::new(packed)?;
+                dc_param_set_packed(job.param, packed_c.as_ptr());
                 Ok(job)
             },
             |jobs| {

--- a/src/dc_location.rs
+++ b/src/dc_location.rs
@@ -1,3 +1,5 @@
+use std::ffi::CString;
+
 use crate::constants::Event;
 use crate::context::*;
 use crate::dc_array::*;
@@ -213,10 +215,9 @@ pub fn dc_get_locations(
                 (*loc).chat_id = row.get(8)?;
 
                 if 0 != (*loc).msg_id {
-                    let txt: String = row.get(9)?;
-                    let txt_c = to_cstring(txt);
-                    if 0 != is_marker(txt_c.as_ptr()) {
-                        (*loc).marker = strdup(txt_c.as_ptr());
+                    let txt = CString::new(row.get::<_, String>(9)?)?;
+                    if 0 != is_marker(txt.as_ptr()) {
+                        (*loc).marker = strdup(txt.as_ptr());
                     }
                 }
                 Ok(loc)
@@ -330,7 +331,7 @@ pub fn dc_get_location_kml(
     }
 
     if 0 != success {
-        unsafe { strdup(to_cstring(ret).as_ptr()) }
+        unsafe { ret.strdup() }
     } else {
         0 as *mut libc::c_char
     }
@@ -344,7 +345,7 @@ unsafe fn get_kml_timestamp(utc: i64) -> *mut libc::c_char {
     let res = chrono::NaiveDateTime::from_timestamp(utc, 0)
         .format("%Y-%m-%dT%H:%M:%SZ")
         .to_string();
-    strdup(to_cstring(res).as_ptr())
+    res.strdup()
 }
 
 pub unsafe fn dc_get_message_kml(

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -1341,8 +1341,8 @@ unsafe fn dc_mimeparser_add_single_part_if_known(
                         }
                         if !filename_parts.is_empty() {
                             free(desired_filename as *mut libc::c_void);
-                            desired_filename =
-                                dc_decode_ext_header(to_cstring(filename_parts).as_ptr());
+                            let tmp = CString::new(filename_parts).unwrap();
+                            desired_filename = dc_decode_ext_header(tmp.as_ptr());
                         }
                         if desired_filename.is_null() {
                             let param = mailmime_find_ct_parameter(

--- a/src/dc_qr.rs
+++ b/src/dc_qr.rs
@@ -1,3 +1,5 @@
+use std::ffi::CString;
+
 use crate::context::Context;
 use crate::dc_chat::*;
 use crate::dc_contact::*;
@@ -239,12 +241,12 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                                     if addr.is_null() || invitenumber.is_null() || auth.is_null() {
                                         if let Some(peerstate) = peerstate {
                                             (*qr_parsed).state = 210i32;
-                                            let c_addr = peerstate
-                                                .addr
-                                                .as_ref()
-                                                .map(to_cstring)
-                                                .unwrap_or_default();
+                                            let c_addr: CString;
                                             let addr_ptr = if peerstate.addr.is_some() {
+                                                c_addr = CString::new(
+                                                    peerstate.addr.as_ref().unwrap().as_str(),
+                                                )
+                                                .unwrap();
                                                 c_addr.as_ptr()
                                             } else {
                                                 std::ptr::null()

--- a/src/dc_securejoin.rs
+++ b/src/dc_securejoin.rs
@@ -1,3 +1,5 @@
+use std::ffi::CString;
+
 use mmime::mailimf_types::*;
 use percent_encoding::{utf8_percent_encode, DEFAULT_ENCODE_SET};
 
@@ -38,7 +40,7 @@ pub unsafe fn dc_get_securejoin_qr(
     let mut chat = 0 as *mut Chat;
     let mut group_name = 0 as *mut libc::c_char;
     let mut group_name_urlencoded = 0 as *mut libc::c_char;
-    let mut qr = None;
+    let mut qr: Option<String> = None;
 
     dc_ensure_secret_key_exists(context);
     invitenumber = dc_token_lookup(context, DC_TOKEN_INVITENUMBER, group_chat_id);
@@ -62,7 +64,7 @@ pub unsafe fn dc_get_securejoin_qr(
         free(group_name_urlencoded as *mut libc::c_void);
 
         if let Some(qr) = qr {
-            strdup(to_cstring(qr).as_ptr())
+            qr.strdup()
         } else {
             std::ptr::null_mut()
         }
@@ -939,8 +941,9 @@ pub unsafe fn dc_handle_degrade_event(context: &Context, peerstate: &Peerstate) 
                 &mut contact_chat_id,
                 0 as *mut libc::c_int,
             );
-            let c_addr = peerstate.addr.as_ref().map(to_cstring).unwrap_or_default();
+            let c_addr: CString;
             let c_addr_ptr = if peerstate.addr.is_some() {
+                c_addr = CString::new(peerstate.addr.as_ref().unwrap().as_str()).unwrap();
                 c_addr.as_ptr()
             } else {
                 std::ptr::null_mut()

--- a/src/dc_simplify.rs
+++ b/src/dc_simplify.rs
@@ -237,8 +237,7 @@ unsafe fn dc_simplify_simplify_plain_text(
         ret += " [...]";
     }
     dc_free_splitted_lines(lines);
-
-    strdup(to_cstring(ret).as_ptr())
+    ret.strdup()
 }
 
 /**

--- a/src/dc_strencode.rs
+++ b/src/dc_strencode.rs
@@ -711,7 +711,7 @@ unsafe fn print_hex(target: *mut libc::c_char, cur: *const libc::c_char) {
     assert!(!cur.is_null());
 
     let bytes = std::slice::from_raw_parts(cur as *const _, strlen(cur));
-    let raw = to_cstring(format!("={}", &hex::encode_upper(bytes)[..2]));
+    let raw = CString::new(format!("={}", &hex::encode_upper(bytes)[..2])).unwrap();
     libc::memcpy(target as *mut _, raw.as_ptr() as *const _, 4);
 }
 

--- a/src/dc_token.rs
+++ b/src/dc_token.rs
@@ -1,7 +1,6 @@
 use crate::context::Context;
 use crate::dc_tools::*;
 use crate::sql;
-use crate::x::strdup;
 
 // Token namespaces
 pub type dc_tokennamespc_t = usize;
@@ -40,7 +39,7 @@ pub fn dc_token_lookup(
         params![namespc as i32, foreign_id as i32],
         0,
     ) {
-        unsafe { strdup(to_cstring(token).as_ptr()) }
+        unsafe { token.strdup() }
     } else {
         std::ptr::null_mut()
     }

--- a/src/log.rs
+++ b/src/log.rs
@@ -5,7 +5,7 @@ macro_rules! info {
     };
     ($ctx:expr, $data1:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
-        let formatted_c = $crate::dc_tools::to_cstring(formatted);
+        let formatted_c = std::ffi::CString::new(formatted).unwrap();
         $ctx.call_cb($crate::constants::Event::INFO, $data1 as libc::uintptr_t,
                      formatted_c.as_ptr() as libc::uintptr_t)
     }};
@@ -18,7 +18,7 @@ macro_rules! warn {
     };
     ($ctx:expr, $data1:expr, $msg:expr, $($args:expr),* $(,)?) => {
         let formatted = format!($msg, $($args),*);
-        let formatted_c = $crate::dc_tools::to_cstring(formatted);
+        let formatted_c = std::ffi::CString::new(formatted).unwrap();
         $ctx.call_cb($crate::constants::Event::WARNING, $data1 as libc::uintptr_t,
                      formatted_c.as_ptr() as libc::uintptr_t)
     };
@@ -31,7 +31,7 @@ macro_rules! error {
     };
     ($ctx:expr, $data1:expr, $msg:expr, $($args:expr),* $(,)?) => {
         let formatted = format!($msg, $($args),*);
-        let formatted_c = $crate::dc_tools::to_cstring(formatted);
+        let formatted_c = std::ffi::CString::new(formatted).unwrap();
         $ctx.call_cb($crate::constants::Event::ERROR, $data1 as libc::uintptr_t,
                      formatted_c.as_ptr() as libc::uintptr_t)
     };
@@ -44,7 +44,7 @@ macro_rules! log_event {
     };
     ($ctx:expr, $event:expr, $data1:expr, $msg:expr, $($args:expr),* $(,)?) => {
         let formatted = format!($msg, $($args),*);
-        let formatted_c = $crate::dc_tools::to_cstring(formatted);
+        let formatted_c = std::ffi::CString::new(formatted).unwrap();
         $ctx.call_cb($event, $data1 as libc::uintptr_t,
                      formatted_c.as_ptr() as libc::uintptr_t)
     };

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -952,22 +952,30 @@ fn test_stress_tests() {
 fn test_get_contacts() {
     unsafe {
         let context = create_test_context();
-        let contacts = dc_get_contacts(&context.ctx, 0, to_cstring("some2").as_ptr());
+        let contacts = dc_get_contacts(
+            &context.ctx,
+            0,
+            b"some2\x00".as_ptr() as *const libc::c_char,
+        );
         assert_eq!(dc_array_get_cnt(contacts), 0);
         dc_array_unref(contacts);
 
         let id = dc_create_contact(
             &context.ctx,
-            to_cstring("bob").as_ptr(),
-            to_cstring("bob@mail.de").as_ptr(),
+            b"bob\x00".as_ptr() as *const libc::c_char,
+            b"bob@mail.de\x00".as_ptr() as *const libc::c_char,
         );
         assert_ne!(id, 0);
 
-        let contacts = dc_get_contacts(&context.ctx, 0, to_cstring("bob").as_ptr());
+        let contacts = dc_get_contacts(&context.ctx, 0, b"bob\x00".as_ptr() as *const libc::c_char);
         assert_eq!(dc_array_get_cnt(contacts), 1);
         dc_array_unref(contacts);
 
-        let contacts = dc_get_contacts(&context.ctx, 0, to_cstring("alice").as_ptr());
+        let contacts = dc_get_contacts(
+            &context.ctx,
+            0,
+            b"alice\x00".as_ptr() as *const libc::c_char,
+        );
         assert_eq!(dc_array_get_cnt(contacts), 0);
         dc_array_unref(contacts);
     }
@@ -979,8 +987,8 @@ fn test_chat() {
         let context = create_test_context();
         let contact1 = dc_create_contact(
             &context.ctx,
-            to_cstring("bob").as_ptr(),
-            to_cstring("bob@mail.de").as_ptr(),
+            b"bob\x00".as_ptr() as *const libc::c_char,
+            b"bob@mail.de\x00".as_ptr() as *const libc::c_char,
         );
         assert_ne!(contact1, 0);
 


### PR DESCRIPTION
The main part is the adding of the StrExt trait and it's strdup
method.

This mainly removes using a new CString.as_ptr() directly in a
function argument, which is a use-after-free poiniter errror.  It
turns out .strdup() is a lot of these cases.  For the remaining cases
I construct the CString manually as it's easier to see what is
happening and a helper function doesn't do that much.

A few places were Path objects, which can be handled using the
OsStrExt trait's .to_c_string() already in dc_tools, which is custom
made for this and does a much better job and preserving the right
path.

Lastly this removes the incosistent naming of the
to_string()/to_cstring() dc_tools naming.  The remaining to_*()
functions take a *libc::c_char where to_cstring() was the only
exception to this.