### PR TITLE
Use DC_PARAM_* constants everywhere

### DIFF
--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -34,9 +34,9 @@ pub unsafe fn dc_imex(
     param2: *const libc::c_char,
 ) {
     let param: *mut dc_param_t = dc_param_new();
-    dc_param_set_int(param, 'S' as i32, what);
-    dc_param_set(param, 'E' as i32, param1);
-    dc_param_set(param, 'F' as i32, param2);
+    dc_param_set_int(param, DC_PARAM_CMD as i32, what);
+    dc_param_set(param, DC_PARAM_CMD_ARG as i32, param1);
+    dc_param_set(param, DC_PARAM_CMD_ARG2 as i32, param2);
     dc_job_kill_action(context, 910i32);
     dc_job_add(context, 910i32, 0i32, (*param).packed, 0i32);
     dc_param_unref(param);
@@ -143,15 +143,15 @@ pub unsafe fn dc_initiate_key_transfer(context: &Context) -> *mut libc::c_char {
                         if !(chat_id == 0i32 as libc::c_uint) {
                             msg = dc_msg_new_untyped(context);
                             (*msg).type_0 = 60i32;
-                            dc_param_set((*msg).param, 'f' as i32, setup_file_name);
+                            dc_param_set((*msg).param, DC_PARAM_FILE as i32, setup_file_name);
                             dc_param_set(
                                 (*msg).param,
-                                'm' as i32,
+                                DC_PARAM_MIMETYPE as i32,
                                 b"application/autocrypt-setup\x00" as *const u8
                                     as *const libc::c_char,
                             );
-                            dc_param_set_int((*msg).param, 'S' as i32, 6i32);
-                            dc_param_set_int((*msg).param, 'u' as i32, 2i32);
+                            dc_param_set_int((*msg).param, DC_PARAM_CMD as i32, 6);
+                            dc_param_set_int((*msg).param, DC_PARAM_FORCE_PLAINTEXT as i32, 2);
                             if !context
                                 .running_state
                                 .clone()
@@ -551,9 +551,17 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: *mut dc_job_t) 
     let mut param2: *mut libc::c_char = 0 as *mut libc::c_char;
     if !(0 == dc_alloc_ongoing(context)) {
         ongoing_allocated_here = 1i32;
-        what = dc_param_get_int((*job).param, 'S' as i32, 0i32);
-        param1 = dc_param_get((*job).param, 'E' as i32, 0 as *const libc::c_char);
-        param2 = dc_param_get((*job).param, 'F' as i32, 0 as *const libc::c_char);
+        what = dc_param_get_int((*job).param, DC_PARAM_CMD as i32, 0);
+        param1 = dc_param_get(
+            (*job).param,
+            DC_PARAM_CMD_ARG as i32,
+            0 as *const libc::c_char,
+        );
+        param2 = dc_param_get(
+            (*job).param,
+            DC_PARAM_CMD_ARG2 as i32,
+            0 as *const libc::c_char,
+        );
         if param1.is_null() {
             error!(context, 0, "No Import/export dir/file given.",);
         } else {

--- a/src/dc_location.rs
+++ b/src/dc_location.rs
@@ -76,7 +76,7 @@ pub unsafe fn dc_send_locations_to_chat(
                     0 as *const libc::c_char,
                     0,
                 );
-                dc_param_set_int((*msg).param, 'S' as i32, 8i32);
+                dc_param_set_int((*msg).param, DC_PARAM_CMD as i32, 8);
                 dc_send_msg(context, chat_id, msg);
             } else if 0 == seconds && is_sending_locations_before {
                 stock_str = dc_stock_system_msg(
@@ -688,7 +688,7 @@ pub unsafe fn dc_job_do_DC_JOB_MAYBE_SEND_LOCATIONS(context: &Context, _job: *mu
                             // and dc_set_location() is typically called periodically, this is ok)
                             let mut msg = dc_msg_new(context, 10);
                             (*msg).hidden = 1;
-                            dc_param_set_int((*msg).param, 'S' as i32, 9);
+                            dc_param_set_int((*msg).param, DC_PARAM_CMD as i32, 9);
                             dc_send_msg(context, chat_id as u32, msg);
                             dc_msg_unref(msg);
                         }

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -187,11 +187,11 @@ pub unsafe fn dc_mimefactory_load_msg(
                 )
                 .unwrap();
 
-            let command = dc_param_get_int((*(*factory).msg).param, 'S' as i32, 0);
+            let command = dc_param_get_int((*(*factory).msg).param, DC_PARAM_CMD as i32, 0);
             if command == 5 {
                 let email_to_remove_c = dc_param_get(
                     (*(*factory).msg).param,
-                    'E' as i32,
+                    DC_PARAM_CMD_ARG as i32,
                     0 as *const libc::c_char,
                 );
                 let email_to_remove = to_string(email_to_remove_c);
@@ -551,9 +551,11 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                 e2ee_guaranteed = 1;
                 min_verified = 2
             } else {
-                force_plaintext = dc_param_get_int((*(*factory).msg).param, 'u' as i32, 0);
+                force_plaintext =
+                    dc_param_get_int((*(*factory).msg).param, DC_PARAM_FORCE_PLAINTEXT as i32, 0);
                 if force_plaintext == 0 {
-                    e2ee_guaranteed = dc_param_get_int((*(*factory).msg).param, 'c' as i32, 0)
+                    e2ee_guaranteed =
+                        dc_param_get_int((*(*factory).msg).param, DC_PARAM_GUARANTEE_E2EE as i32, 0)
                 }
             }
             if (*chat).gossiped_timestamp == 0
@@ -562,7 +564,7 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                 do_gossip = 1
             }
             /* build header etc. */
-            let command: libc::c_int = dc_param_get_int((*msg).param, 'S' as i32, 0);
+            let command: libc::c_int = dc_param_get_int((*msg).param, DC_PARAM_CMD as i32, 0);
             if (*chat).type_0 == DC_CHAT_TYPE_GROUP as libc::c_int
                 || (*chat).type_0 == DC_CHAT_TYPE_VERIFIED_GROUP as libc::c_int
             {
@@ -581,8 +583,11 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                     ),
                 );
                 if command == 5 {
-                    let email_to_remove: *mut libc::c_char =
-                        dc_param_get((*msg).param, 'E' as i32, 0 as *const libc::c_char);
+                    let email_to_remove: *mut libc::c_char = dc_param_get(
+                        (*msg).param,
+                        DC_PARAM_CMD_ARG as i32,
+                        0 as *const libc::c_char,
+                    );
                     if !email_to_remove.is_null() {
                         mailimf_fields_add(
                             imf_fields,
@@ -597,8 +602,11 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                     }
                 } else if command == 4 {
                     do_gossip = 1;
-                    let email_to_add: *mut libc::c_char =
-                        dc_param_get((*msg).param, 'E' as i32, 0 as *const libc::c_char);
+                    let email_to_add: *mut libc::c_char = dc_param_get(
+                        (*msg).param,
+                        DC_PARAM_CMD_ARG as i32,
+                        0 as *const libc::c_char,
+                    );
                     if !email_to_add.is_null() {
                         mailimf_fields_add(
                             imf_fields,
@@ -610,9 +618,13 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                                 email_to_add,
                             ),
                         );
-                        grpimage = dc_param_get((*chat).param, 'i' as i32, 0 as *const libc::c_char)
+                        grpimage = dc_param_get(
+                            (*chat).param,
+                            DC_PARAM_PROFILE_IMAGE as i32,
+                            0 as *const libc::c_char,
+                        )
                     }
-                    if 0 != dc_param_get_int((*msg).param, 'F' as i32, 0) & 0x1 {
+                    if 0 != dc_param_get_int((*msg).param, DC_PARAM_CMD_ARG2 as i32, 0) & 0x1 {
                         info!(
                             (*msg).context,
                             0,
@@ -636,13 +648,17 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                             ),
                             dc_param_get(
                                 (*msg).param,
-                                'E' as i32,
+                                DC_PARAM_CMD_ARG as i32,
                                 b"\x00" as *const u8 as *const libc::c_char,
                             ),
                         ),
                     );
                 } else if command == 3 {
-                    grpimage = dc_param_get((*msg).param, 'E' as i32, 0 as *const libc::c_char);
+                    grpimage = dc_param_get(
+                        (*msg).param,
+                        DC_PARAM_CMD_ARG as i32,
+                        0 as *const libc::c_char,
+                    );
                     if grpimage.is_null() {
                         mailimf_fields_add(
                             imf_fields,
@@ -676,8 +692,11 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                 placeholdertext = dc_stock_str((*factory).context, 43)
             }
             if command == 7 {
-                let step: *mut libc::c_char =
-                    dc_param_get((*msg).param, 'E' as i32, 0 as *const libc::c_char);
+                let step: *mut libc::c_char = dc_param_get(
+                    (*msg).param,
+                    DC_PARAM_CMD_ARG as i32,
+                    0 as *const libc::c_char,
+                );
                 if !step.is_null() {
                     info!(
                         (*msg).context,
@@ -692,8 +711,11 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                             step,
                         ),
                     );
-                    let param2: *mut libc::c_char =
-                        dc_param_get((*msg).param, 'F' as i32, 0 as *const libc::c_char);
+                    let param2: *mut libc::c_char = dc_param_get(
+                        (*msg).param,
+                        DC_PARAM_CMD_ARG2 as i32,
+                        0 as *const libc::c_char,
+                    );
                     if !param2.is_null() {
                         mailimf_fields_add(
                             imf_fields,
@@ -721,8 +743,11 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                             ),
                         );
                     }
-                    let fingerprint: *mut libc::c_char =
-                        dc_param_get((*msg).param, 'G' as i32, 0 as *const libc::c_char);
+                    let fingerprint: *mut libc::c_char = dc_param_get(
+                        (*msg).param,
+                        DC_PARAM_CMD_ARG3 as i32,
+                        0 as *const libc::c_char,
+                    );
                     if !fingerprint.is_null() {
                         mailimf_fields_add(
                             imf_fields,
@@ -735,8 +760,11 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                             ),
                         );
                     }
-                    let grpid: *mut libc::c_char =
-                        dc_param_get((*msg).param, 'H' as i32, 0 as *const libc::c_char);
+                    let grpid: *mut libc::c_char = dc_param_get(
+                        (*msg).param,
+                        DC_PARAM_CMD_ARG4 as i32,
+                        0 as *const libc::c_char,
+                    );
                     if !grpid.is_null() {
                         mailimf_fields_add(
                             imf_fields,
@@ -753,7 +781,7 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
             if !grpimage.is_null() {
                 let mut meta: *mut dc_msg_t = dc_msg_new_untyped((*factory).context);
                 (*meta).type_0 = DC_MSG_IMAGE as libc::c_int;
-                dc_param_set((*meta).param, 'f' as i32, grpimage);
+                dc_param_set((*meta).param, DC_PARAM_FILE as i32, grpimage);
                 let mut filename_as_sent: *mut libc::c_char = 0 as *mut libc::c_char;
                 meta_part = build_body_file(
                     meta,
@@ -784,7 +812,8 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                         ),
                     );
                 }
-                let duration_ms: libc::c_int = dc_param_get_int((*msg).param, 'd' as i32, 0);
+                let duration_ms: libc::c_int =
+                    dc_param_get_int((*msg).param, DC_PARAM_DURATION as i32, 0);
                 if duration_ms > 0 {
                     mailimf_fields_add(
                         imf_fields,
@@ -798,7 +827,7 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                     );
                 }
             }
-            afwd_email = dc_param_exists((*msg).param, 'a' as i32);
+            afwd_email = dc_param_exists((*msg).param, DC_PARAM_FORWARDED as i32);
             let mut fwdhint: *mut libc::c_char = 0 as *mut libc::c_char;
             if 0 != afwd_email {
                 fwdhint = dc_strdup(
@@ -980,7 +1009,7 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
             mailmime_add_part(message, multipart);
             let p1: *mut libc::c_char;
             let p2: *mut libc::c_char;
-            if 0 != dc_param_get_int((*(*factory).msg).param, 'c' as i32, 0) {
+            if 0 != dc_param_get_int((*(*factory).msg).param, DC_PARAM_GUARANTEE_E2EE as i32, 0) {
                 p1 = dc_stock_str((*factory).context, 24)
             } else {
                 p1 = dc_msg_get_summarytext((*factory).msg, 32)
@@ -1106,7 +1135,7 @@ unsafe fn get_subject(
     } else {
         b"\x00" as *const u8 as *const libc::c_char
     };
-    if dc_param_get_int((*msg).param, 'S' as i32, 0) == 6 {
+    if dc_param_get_int((*msg).param, DC_PARAM_CMD as i32, 0) == 6 {
         ret = dc_stock_str(context, 42)
     } else if (*chat).type_0 == DC_CHAT_TYPE_GROUP as libc::c_int
         || (*chat).type_0 == DC_CHAT_TYPE_VERIFIED_GROUP as libc::c_int
@@ -1167,9 +1196,12 @@ unsafe fn build_body_file(
     let mut mime_sub: *mut mailmime = 0 as *mut mailmime;
     let content: *mut mailmime_content;
     let pathNfilename: *mut libc::c_char =
-        dc_param_get((*msg).param, 'f' as i32, 0 as *const libc::c_char);
-    let mut mimetype: *mut libc::c_char =
-        dc_param_get((*msg).param, 'm' as i32, 0 as *const libc::c_char);
+        dc_param_get((*msg).param, DC_PARAM_FILE as i32, 0 as *const libc::c_char);
+    let mut mimetype: *mut libc::c_char = dc_param_get(
+        (*msg).param,
+        DC_PARAM_MIMETYPE as i32,
+        0 as *const libc::c_char,
+    );
     let suffix: *mut libc::c_char = dc_get_filesuffix_lc(pathNfilename);
     let mut filename_to_send: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut filename_encoded: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -1328,7 +1360,7 @@ unsafe fn build_body_file(
 unsafe fn is_file_size_okay(msg: *const dc_msg_t) -> libc::c_int {
     let mut file_size_okay: libc::c_int = 1;
     let pathNfilename: *mut libc::c_char =
-        dc_param_get((*msg).param, 'f' as i32, 0 as *const libc::c_char);
+        dc_param_get((*msg).param, DC_PARAM_FILE as i32, 0 as *const libc::c_char);
     let bytes: uint64_t = dc_get_filebytes((*msg).context, pathNfilename);
     if bytes > (49 * 1024 * 1024 / 4 * 3) as libc::c_ulonglong {
         file_size_okay = 0;

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -323,7 +323,7 @@ pub unsafe fn dc_mimeparser_parse(
             while i_1 < icnt_0 {
                 let part_2: *mut dc_mimepart_t =
                     carray_get((*mimeparser).parts, i_1 as libc::c_uint) as *mut dc_mimepart_t;
-                dc_param_set_int((*part_2).param, 'a' as i32, 1i32);
+                dc_param_set_int((*part_2).param, DC_PARAM_FORWARDED as i32, 1);
                 i_1 += 1
             }
         }
@@ -348,7 +348,7 @@ pub unsafe fn dc_mimeparser_parse(
                 if !field_0.is_null() {
                     let duration_ms: libc::c_int = dc_atoi_null_is_0((*field_0).fld_value);
                     if duration_ms > 0i32 && duration_ms < 24i32 * 60i32 * 60i32 * 1000i32 {
-                        dc_param_set_int((*part_3).param, 'd' as i32, duration_ms);
+                        dc_param_set_int((*part_3).param, DC_PARAM_DURATION as i32, duration_ms);
                     }
                 }
             }
@@ -385,7 +385,11 @@ pub unsafe fn dc_mimeparser_parse(
                                     let part_4: *mut dc_mimepart_t =
                                         dc_mimeparser_get_last_nonmeta(mimeparser);
                                     if !part_4.is_null() {
-                                        dc_param_set_int((*part_4).param, 'r' as i32, 1i32);
+                                        dc_param_set_int(
+                                            (*part_4).param,
+                                            DC_PARAM_WANTS_MDN as i32,
+                                            1,
+                                        );
                                     }
                                 }
                                 free(from_addr as *mut libc::c_void);
@@ -1486,8 +1490,8 @@ unsafe fn do_add_single_file_part(
             (*part).type_0 = msg_type;
             (*part).int_mimetype = mime_type;
             (*part).bytes = decoded_data_bytes as libc::c_int;
-            dc_param_set((*part).param, 'f' as i32, pathNfilename);
-            dc_param_set((*part).param, 'm' as i32, raw_mime);
+            dc_param_set((*part).param, DC_PARAM_FILE as i32, pathNfilename);
+            dc_param_set((*part).param, DC_PARAM_MIMETYPE as i32, raw_mime);
             if mime_type == 80i32 {
                 let mut w: uint32_t = 0i32 as uint32_t;
                 let mut h: uint32_t = 0i32 as uint32_t;
@@ -1497,8 +1501,8 @@ unsafe fn do_add_single_file_part(
                     &mut w,
                     &mut h,
                 ) {
-                    dc_param_set_int((*part).param, 'w' as i32, w as int32_t);
-                    dc_param_set_int((*part).param, 'h' as i32, h as int32_t);
+                    dc_param_set_int((*part).param, DC_PARAM_WIDTH as i32, w as int32_t);
+                    dc_param_set_int((*part).param, DC_PARAM_HEIGHT as i32, h as int32_t);
                 }
             }
             do_add_single_part(parser, part);
@@ -1511,9 +1515,9 @@ unsafe fn do_add_single_file_part(
 
 unsafe fn do_add_single_part(parser: &dc_mimeparser_t, part: *mut dc_mimepart_t) {
     if 0 != (*parser).e2ee_helper.encrypted && (*parser).e2ee_helper.signatures.len() > 0 {
-        dc_param_set_int((*part).param, 'c' as i32, 1i32);
+        dc_param_set_int((*part).param, DC_PARAM_GUARANTEE_E2EE as i32, 1);
     } else if 0 != (*parser).e2ee_helper.encrypted {
-        dc_param_set_int((*part).param, 'e' as i32, 0x2i32);
+        dc_param_set_int((*part).param, DC_PARAM_ERRONEOUS_E2EE as i32, 0x2);
     }
     carray_add(
         (*parser).parts,

--- a/src/dc_param.rs
+++ b/src/dc_param.rs
@@ -3,58 +3,60 @@ use crate::types::*;
 use crate::x::*;
 
 /// for msgs and jobs
-pub const DC_PARAM_FILE: char = 'f';
+pub const DC_PARAM_FILE: char = 'f'; // string
 /// for msgs
-pub const DC_PARAM_WIDTH: char = 'w';
+pub const DC_PARAM_WIDTH: char = 'w'; // int
 /// for msgs
-pub const DC_PARAM_HEIGHT: char = 'h';
+pub const DC_PARAM_HEIGHT: char = 'h'; // int
 /// for msgs
-pub const DC_PARAM_DURATION: char = 'd';
+pub const DC_PARAM_DURATION: char = 'd'; // int
 /// for msgs
-pub const DC_PARAM_MIMETYPE: char = 'm';
+pub const DC_PARAM_MIMETYPE: char = 'm'; // string
 /// for msgs: incoming: message is encryoted, outgoing: guarantee E2EE or the message is not send
-pub const DC_PARAM_GUARANTEE_E2EE: char = 'c';
+pub const DC_PARAM_GUARANTEE_E2EE: char = 'c'; // int (bool?)
 /// for msgs: decrypted with validation errors or without mutual set, if neither 'c' nor 'e' are preset, the messages is only transport encrypted
-pub const DC_PARAM_ERRONEOUS_E2EE: char = 'e';
+pub const DC_PARAM_ERRONEOUS_E2EE: char = 'e'; // int
 /// for msgs: force unencrypted message, either DC_FP_ADD_AUTOCRYPT_HEADER (1), DC_FP_NO_AUTOCRYPT_HEADER (2) or 0
-pub const DC_PARAM_FORCE_PLAINTEXT: char = 'u';
+pub const DC_PARAM_FORCE_PLAINTEXT: char = 'u'; // int (bool?)
 /// for msgs: an incoming message which requestes a MDN (aka read receipt)
-pub const DC_PARAM_WANTS_MDN: char = 'r';
+pub const DC_PARAM_WANTS_MDN: char = 'r'; // int (bool?)
 /// for msgs
-pub const DC_PARAM_FORWARDED: char = 'a';
+pub const DC_PARAM_FORWARDED: char = 'a'; // int (bool?)
 /// for msgs
-pub const DC_PARAM_CMD: char = 'S';
+pub const DC_PARAM_CMD: char = 'S'; // int
 /// for msgs
-pub const DC_PARAM_CMD_ARG: char = 'E';
+pub const DC_PARAM_CMD_ARG: char = 'E'; // string
 /// for msgs
-pub const DC_PARAM_CMD_ARG2: char = 'F';
+pub const DC_PARAM_CMD_ARG2: char = 'F'; // string
 /// for msgs
-pub const DC_PARAM_CMD_ARG3: char = 'G';
+pub const DC_PARAM_CMD_ARG3: char = 'G'; // string
 /// for msgs
-pub const DC_PARAM_CMD_ARG4: char = 'H';
+pub const DC_PARAM_CMD_ARG4: char = 'H'; // string
 /// for msgs
-pub const DC_PARAM_ERROR: char = 'L';
+pub const DC_PARAM_ERROR: char = 'L'; // string
 /// for msgs in PREPARING: space-separated list of message IDs of forwarded copies
-pub const DC_PARAM_PREP_FORWARDS: char = 'P';
+pub const DC_PARAM_PREP_FORWARDS: char = 'P'; // string
 /// for msgs
-pub const DC_PARAM_SET_LATITUDE: char = 'l';
+pub const DC_PARAM_SET_LATITUDE: char = 'l'; // float
 /// for msgs
-pub const DC_PARAM_SET_LONGITUDE: char = 'n';
+pub const DC_PARAM_SET_LONGITUDE: char = 'n'; // float
 
 /// for jobs
-pub const DC_PARAM_SERVER_FOLDER: char = 'Z';
+pub const DC_PARAM_SERVER_FOLDER: char = 'Z'; // string
 /// for jobs
-pub const DC_PARAM_SERVER_UID: char = 'z';
+pub const DC_PARAM_SERVER_UID: char = 'z'; // int
 /// for jobs
-pub const DC_PARAM_ALSO_MOVE: char = 'M';
+pub const DC_PARAM_ALSO_MOVE: char = 'M'; // int (bool?)
 /// for jobs: space-separated list of message recipients
-pub const DC_PARAM_RECIPIENTS: char = 'R';
+pub const DC_PARAM_RECIPIENTS: char = 'R'; // stringap
 /// for groups
-pub const DC_PARAM_UNPROMOTED: char = 'U';
+pub const DC_PARAM_UNPROMOTED: char = 'U'; // int (bool?)
 /// for groups and contacts
-pub const DC_PARAM_PROFILE_IMAGE: char = 'i';
+pub const DC_PARAM_PROFILE_IMAGE: char = 'i'; // string (bytes?)
 /// for chats
 pub const DC_PARAM_SELFTALK: char = 'K';
+
+// missing: 's', 'x', 'g'
 
 // values for DC_PARAM_FORCE_PLAINTEXT
 pub const DC_FP_ADD_AUTOCRYPT_HEADER: u8 = 1;

--- a/src/dc_qr.rs
+++ b/src/dc_qr.rs
@@ -56,16 +56,23 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                 fragment = fragment.offset(1isize);
                 let param: *mut dc_param_t = dc_param_new();
                 dc_param_set_urlencoded(param, fragment);
-                addr = dc_param_get(param, 'a' as i32, 0 as *const libc::c_char);
+                addr = dc_param_get(param, DC_PARAM_FORWARDED as i32, 0 as *const libc::c_char);
                 if !addr.is_null() {
-                    let mut urlencoded: *mut libc::c_char =
-                        dc_param_get(param, 'n' as i32, 0 as *const libc::c_char);
+                    let mut urlencoded: *mut libc::c_char = dc_param_get(
+                        param,
+                        DC_PARAM_SET_LONGITUDE as i32,
+                        0 as *const libc::c_char,
+                    );
                     if !urlencoded.is_null() {
                         name = dc_urldecode(urlencoded);
                         dc_normalize_name(name);
                         free(urlencoded as *mut libc::c_void);
                     }
-                    invitenumber = dc_param_get(param, 'i' as i32, 0 as *const libc::c_char);
+                    invitenumber = dc_param_get(
+                        param,
+                        DC_PARAM_PROFILE_IMAGE as i32,
+                        0 as *const libc::c_char,
+                    );
                     auth = dc_param_get(param, 's' as i32, 0 as *const libc::c_char);
                     grpid = dc_param_get(param, 'x' as i32, 0 as *const libc::c_char);
                     if !grpid.is_null() {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -741,17 +741,21 @@ pub unsafe fn dc_receive_imf(
                                     let param = dc_param_new();
                                     dc_param_set(
                                         param,
-                                        'Z' as i32,
+                                        DC_PARAM_SERVER_FOLDER as i32,
                                         to_cstring(server_folder.as_ref()).as_ptr(),
                                     );
-                                    dc_param_set_int(param, 'z' as i32, server_uid as i32);
+                                    dc_param_set_int(
+                                        param,
+                                        DC_PARAM_SERVER_UID as i32,
+                                        server_uid as i32,
+                                    );
                                     if 0 != mime_parser.is_send_by_messenger
                                         && 0 != context
                                             .sql
                                             .get_config_int(context, "mvbox_move")
                                             .unwrap_or_else(|| 1)
                                     {
-                                        dc_param_set_int(param, 'M' as i32, 1);
+                                        dc_param_set_int(param, DC_PARAM_ALSO_MOVE as i32, 1);
                                     }
                                     dc_job_add(context, 120, 0, (*param).packed, 0);
                                     dc_param_unref(param);
@@ -1210,7 +1214,7 @@ unsafe fn create_or_lookup_group(
                                     if (*part).type_0 == 20 {
                                         grpimage = dc_param_get(
                                             (*part).param,
-                                            'f' as i32,
+                                            DC_PARAM_FILE as i32,
                                             0 as *const libc::c_char,
                                         );
                                         ok = 1
@@ -1231,7 +1235,11 @@ unsafe fn create_or_lookup_group(
                                     },
                                 );
                                 dc_chat_load_from_db(chat, chat_id);
-                                dc_param_set((*chat).param, 'i' as i32, grpimage);
+                                dc_param_set(
+                                    (*chat).param,
+                                    DC_PARAM_PROFILE_IMAGE as i32,
+                                    grpimage,
+                                );
                                 dc_chat_update_param(chat);
                                 dc_chat_unref(chat);
                                 free(grpimage as *mut libc::c_void);

--- a/src/dc_securejoin.rs
+++ b/src/dc_securejoin.rs
@@ -267,23 +267,23 @@ unsafe fn send_handshake_msg(
         step,
     );
     (*msg).hidden = 1i32;
-    dc_param_set_int((*msg).param, 'S' as i32, 7i32);
-    dc_param_set((*msg).param, 'E' as i32, step);
+    dc_param_set_int((*msg).param, DC_PARAM_CMD as i32, 7);
+    dc_param_set((*msg).param, DC_PARAM_CMD_ARG as i32, step);
     if !param2.is_null() {
-        dc_param_set((*msg).param, 'F' as i32, param2);
+        dc_param_set((*msg).param, DC_PARAM_CMD_ARG2 as i32, param2);
     }
     if !fingerprint.is_null() {
-        dc_param_set((*msg).param, 'G' as i32, fingerprint);
+        dc_param_set((*msg).param, DC_PARAM_CMD_ARG3 as i32, fingerprint);
     }
     if !grpid.is_null() {
-        dc_param_set((*msg).param, 'H' as i32, grpid);
+        dc_param_set((*msg).param, DC_PARAM_CMD_ARG4 as i32, grpid);
     }
     if strcmp(step, b"vg-request\x00" as *const u8 as *const libc::c_char) == 0i32
         || strcmp(step, b"vc-request\x00" as *const u8 as *const libc::c_char) == 0i32
     {
-        dc_param_set_int((*msg).param, 'u' as i32, 1i32);
+        dc_param_set_int((*msg).param, DC_PARAM_FORCE_PLAINTEXT as i32, 1);
     } else {
-        dc_param_set_int((*msg).param, 'c' as i32, 1i32);
+        dc_param_set_int((*msg).param, DC_PARAM_GUARANTEE_E2EE as i32, 1);
     }
     dc_send_msg(context, contact_chat_id, msg);
     dc_msg_unref(msg);

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -131,6 +131,7 @@ impl Sql {
         })
     }
 
+    /// Execute a query which is expected to return one row.
     pub fn query_row<T, P, F>(&self, sql: impl AsRef<str>, params: P, f: F) -> Result<T>
     where
         P: IntoIterator,


### PR DESCRIPTION
Also document each type they store.  This makes existing code a little
more readable and gives some hints towards refactoring this.