### PR TITLE
dc_array_t cleanup

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -521,13 +521,13 @@ pub fn dc_get_fresh_msgs(context: &Context) -> *mut dc_array_t {
             &[10, 9, if 0 != show_deaddrop { 2 } else { 0 }],
             |row| row.get(0),
             |rows| {
-                let ret = dc_array_new(128 as size_t);
+                let mut ret = dc_array_t::new(128);
 
                 for row in rows {
                     let id = row?;
-                    unsafe { dc_array_add_id(ret, id) };
+                    ret.add_id(id);
                 }
-                Ok(ret)
+                Ok(ret.as_ptr())
             },
         )
         .unwrap()
@@ -560,7 +560,7 @@ pub fn dc_search_msgs(
          AND ct.blocked=0 AND (m.txt LIKE ? OR ct.name LIKE ?) ORDER BY m.timestamp DESC,m.id DESC;"
     };
 
-    let ret = dc_array_new(100 as size_t);
+    let mut ret = dc_array_t::new(100);
 
     let success = context
         .sql
@@ -570,7 +570,7 @@ pub fn dc_search_msgs(
             |row| row.get::<_, i32>(0),
             |rows| {
                 for id in rows {
-                    unsafe { dc_array_add_id(ret, id? as u32) };
+                    ret.add_id(id? as u32);
                 }
                 Ok(())
             },
@@ -578,12 +578,9 @@ pub fn dc_search_msgs(
         .is_ok();
 
     if success {
-        return ret;
+        return ret.as_ptr();
     }
 
-    if !ret.is_null() {
-        unsafe { dc_array_unref(ret) };
-    }
     std::ptr::null_mut()
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -521,7 +521,7 @@ pub fn dc_get_fresh_msgs(context: &Context) -> *mut dc_array_t {
             &[10, 9, if 0 != show_deaddrop { 2 } else { 0 }],
             |row| row.get(0),
             |rows| {
-                let ret = unsafe { dc_array_new(128 as size_t) };
+                let ret = dc_array_new(128 as size_t);
 
                 for row in rows {
                     let id = row?;
@@ -560,7 +560,7 @@ pub fn dc_search_msgs(
          AND ct.blocked=0 AND (m.txt LIKE ? OR ct.name LIKE ?) ORDER BY m.timestamp DESC,m.id DESC;"
     };
 
-    let ret = unsafe { dc_array_new(100 as size_t) };
+    let ret = dc_array_new(100 as size_t);
 
     let success = context
         .sql

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -47,6 +47,14 @@ impl dc_array_t {
     pub fn len(&self) -> usize {
         self.array.len()
     }
+
+    pub unsafe fn unref(&mut self) {
+        if self.type_0 == DC_ARRAY_LOCATIONS {
+            for &e in self.array.iter() {
+                Box::from_raw(e as *mut dc_location);
+            }
+        }
+    }
 }
 
 /**
@@ -60,11 +68,6 @@ impl dc_array_t {
 pub unsafe fn dc_array_unref(array: *mut dc_array_t) {
     if array.is_null() {
         return;
-    }
-    if (*array).type_0 == DC_ARRAY_LOCATIONS {
-        for &e in (*array).array.iter() {
-            Box::from_raw(e as *mut dc_location);
-        }
     }
     Box::from_raw(array);
 }

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -55,6 +55,42 @@ impl dc_array_t {
         self.array[index] as *mut libc::c_void
     }
 
+    pub unsafe fn get_location_ptr(&self, index: usize) -> Option<*mut dc_location> {
+        if self.type_0 == DC_ARRAY_LOCATIONS && self.array[index] != 0 {
+            Some(self.array[index] as *mut dc_location)
+        } else {
+            None
+        }
+    }
+
+    pub unsafe fn get_latitude(&self, index: usize) -> libc::c_double {
+        self.get_location_ptr(index).map_or(0.0, |v| (*v).latitude)
+    }
+
+    pub unsafe fn get_longitude(&self, index: size_t) -> libc::c_double {
+        self.get_location_ptr(index).map_or(0.0, |v| (*v).longitude)
+    }
+
+    pub unsafe fn get_accuracy(&self, index: size_t) -> libc::c_double {
+        self.get_location_ptr(index).map_or(0.0, |v| (*v).accuracy)
+    }
+
+    pub unsafe fn get_timestamp(&self, index: size_t) -> i64 {
+        self.get_location_ptr(index).map_or(0, |v| (*v).timestamp)
+    }
+
+    pub unsafe fn get_chat_id(&self, index: size_t) -> uint32_t {
+        self.get_location_ptr(index).map_or(0, |v| (*v).chat_id)
+    }
+
+    pub unsafe fn get_contact_id(&self, index: size_t) -> uint32_t {
+        self.get_location_ptr(index).map_or(0, |v| (*v).contact_id)
+    }
+
+    pub unsafe fn get_msg_id(&self, index: size_t) -> uint32_t {
+        self.get_location_ptr(index).map_or(0, |v| (*v).msg_id)
+    }
+
     pub fn is_empty(&self) -> bool {
         self.array.is_empty()
     }
@@ -146,80 +182,59 @@ pub unsafe fn dc_array_get_ptr(array: *const dc_array_t, index: size_t) -> *mut 
 }
 
 pub unsafe fn dc_array_get_latitude(array: *const dc_array_t, index: size_t) -> libc::c_double {
-    if array.is_null()
-        || index >= (*array).len()
-        || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || (*array).array[index] == 0
-    {
-        return 0i32 as libc::c_double;
+    if array.is_null() || index >= (*array).len() {
+        0.0
+    } else {
+        (*array).get_latitude(index)
     }
-    (*((*array).array[index] as *mut dc_location)).latitude
 }
 
 pub unsafe fn dc_array_get_longitude(array: *const dc_array_t, index: size_t) -> libc::c_double {
-    if array.is_null()
-        || index >= (*array).len()
-        || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || (*array).array[index] == 0
-    {
-        return 0i32 as libc::c_double;
+    if array.is_null() || index >= (*array).len() {
+        0.0
+    } else {
+        (*array).get_longitude(index)
     }
-    (*((*array).array[index] as *mut dc_location)).longitude
 }
 
 pub unsafe fn dc_array_get_accuracy(array: *const dc_array_t, index: size_t) -> libc::c_double {
-    if array.is_null()
-        || index >= (*array).len()
-        || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || (*array).array[index] == 0
-    {
-        return 0i32 as libc::c_double;
+    if array.is_null() || index >= (*array).len() {
+        0.0
+    } else {
+        (*array).get_accuracy(index)
     }
-    (*((*array).array[index] as *mut dc_location)).accuracy
 }
 
 pub unsafe fn dc_array_get_timestamp(array: *const dc_array_t, index: size_t) -> i64 {
-    if array.is_null()
-        || index >= (*array).len()
-        || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || (*array).array[index] == 0
-    {
-        return 0;
+    if array.is_null() || index >= (*array).len() {
+        0
+    } else {
+        (*array).get_timestamp(index)
     }
-    (*((*array).array[index] as *mut dc_location)).timestamp
 }
 
 pub unsafe fn dc_array_get_chat_id(array: *const dc_array_t, index: size_t) -> uint32_t {
-    if array.is_null()
-        || index >= (*array).len()
-        || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || (*array).array[index] == 0
-    {
-        return 0i32 as uint32_t;
+    if array.is_null() || index >= (*array).len() {
+        0
+    } else {
+        (*array).get_chat_id(index)
     }
-    (*((*array).array[index] as *mut dc_location)).chat_id
 }
 
 pub unsafe fn dc_array_get_contact_id(array: *const dc_array_t, index: size_t) -> uint32_t {
-    if array.is_null()
-        || index >= (*array).len()
-        || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || (*array).array[index] == 0
-    {
-        return 0i32 as uint32_t;
+    if array.is_null() || index >= (*array).len() {
+        0
+    } else {
+        (*array).get_contact_id(index)
     }
-    (*((*array).array[index] as *mut dc_location)).contact_id
 }
 
 pub unsafe fn dc_array_get_msg_id(array: *const dc_array_t, index: size_t) -> uint32_t {
-    if array.is_null()
-        || index >= (*array).len()
-        || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || (*array).array[index] == 0
-    {
-        return 0i32 as uint32_t;
+    if array.is_null() || index >= (*array).len() {
+        0
+    } else {
+        (*array).get_msg_id(index)
     }
-    (*((*array).array[index] as *mut dc_location)).msg_id
 }
 
 pub unsafe fn dc_array_get_marker(array: *const dc_array_t, index: size_t) -> *mut libc::c_char {

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -2,13 +2,11 @@ use crate::dc_location::dc_location;
 use crate::dc_tools::*;
 use crate::types::*;
 
-const DC_ARRAY_MAGIC: uint32_t = 0x000a11aa;
 const DC_ARRAY_LOCATIONS: libc::c_int = 1;
 
 /* * the structure behind dc_array_t */
 #[derive(Clone)]
 pub struct dc_array_t {
-    pub magic: uint32_t,
     pub type_0: libc::c_int,
     pub array: Vec<uintptr_t>,
 }
@@ -16,7 +14,6 @@ pub struct dc_array_t {
 impl dc_array_t {
     pub fn new(capacity: usize) -> Self {
         dc_array_t {
-            magic: DC_ARRAY_MAGIC,
             type_0: 0,
             array: Vec::with_capacity(capacity),
         }
@@ -35,19 +32,18 @@ impl dc_array_t {
  * The items of the array are typically IDs.
  * To free an array object, use dc_array_unref().
  */
-pub unsafe fn dc_array_unref(mut array: *mut dc_array_t) {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
+pub unsafe fn dc_array_unref(array: *mut dc_array_t) {
+    if array.is_null() {
         return;
     }
     if (*array).type_0 == DC_ARRAY_LOCATIONS {
         dc_array_free_ptr(array);
     }
-    (*array).magic = 0i32 as uint32_t;
     Box::from_raw(array);
 }
 
 pub unsafe fn dc_array_free_ptr(array: *mut dc_array_t) {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
+    if array.is_null() {
         return;
     }
     for i in 0..(*array).array.len() {
@@ -61,7 +57,7 @@ pub unsafe fn dc_array_free_ptr(array: *mut dc_array_t) {
 }
 
 pub unsafe fn dc_array_add_uint(array: *mut dc_array_t, item: uintptr_t) {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
+    if array.is_null() {
         return;
     }
     (*array).array.push(item);
@@ -76,21 +72,21 @@ pub unsafe fn dc_array_add_ptr(array: *mut dc_array_t, item: *mut libc::c_void) 
 }
 
 pub unsafe fn dc_array_get_cnt(array: *const dc_array_t) -> size_t {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
+    if array.is_null() {
         return 0i32 as size_t;
     }
     (*array).array.len()
 }
 
 pub unsafe fn dc_array_get_uint(array: *const dc_array_t, index: size_t) -> uintptr_t {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || index >= (*array).array.len() {
+    if array.is_null() || index >= (*array).array.len() {
         return 0i32 as uintptr_t;
     }
     (*array).array[index]
 }
 
 pub unsafe fn dc_array_get_id(array: *const dc_array_t, index: size_t) -> uint32_t {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || index >= (*array).array.len() {
+    if array.is_null() || index >= (*array).array.len() {
         return 0i32 as uint32_t;
     }
     if (*array).type_0 == DC_ARRAY_LOCATIONS {
@@ -100,7 +96,7 @@ pub unsafe fn dc_array_get_id(array: *const dc_array_t, index: size_t) -> uint32
 }
 
 pub unsafe fn dc_array_get_ptr(array: *const dc_array_t, index: size_t) -> *mut libc::c_void {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || index >= (*array).array.len() {
+    if array.is_null() || index >= (*array).array.len() {
         return 0 as *mut libc::c_void;
     }
     (*array).array[index] as *mut libc::c_void
@@ -108,7 +104,6 @@ pub unsafe fn dc_array_get_ptr(array: *const dc_array_t, index: size_t) -> *mut 
 
 pub unsafe fn dc_array_get_latitude(array: *const dc_array_t, index: size_t) -> libc::c_double {
     if array.is_null()
-        || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
@@ -120,7 +115,6 @@ pub unsafe fn dc_array_get_latitude(array: *const dc_array_t, index: size_t) -> 
 
 pub unsafe fn dc_array_get_longitude(array: *const dc_array_t, index: size_t) -> libc::c_double {
     if array.is_null()
-        || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
@@ -132,7 +126,6 @@ pub unsafe fn dc_array_get_longitude(array: *const dc_array_t, index: size_t) ->
 
 pub unsafe fn dc_array_get_accuracy(array: *const dc_array_t, index: size_t) -> libc::c_double {
     if array.is_null()
-        || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
@@ -144,7 +137,6 @@ pub unsafe fn dc_array_get_accuracy(array: *const dc_array_t, index: size_t) -> 
 
 pub unsafe fn dc_array_get_timestamp(array: *const dc_array_t, index: size_t) -> i64 {
     if array.is_null()
-        || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
@@ -156,7 +148,6 @@ pub unsafe fn dc_array_get_timestamp(array: *const dc_array_t, index: size_t) ->
 
 pub unsafe fn dc_array_get_chat_id(array: *const dc_array_t, index: size_t) -> uint32_t {
     if array.is_null()
-        || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
@@ -168,7 +159,6 @@ pub unsafe fn dc_array_get_chat_id(array: *const dc_array_t, index: size_t) -> u
 
 pub unsafe fn dc_array_get_contact_id(array: *const dc_array_t, index: size_t) -> uint32_t {
     if array.is_null()
-        || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
@@ -180,7 +170,6 @@ pub unsafe fn dc_array_get_contact_id(array: *const dc_array_t, index: size_t) -
 
 pub unsafe fn dc_array_get_msg_id(array: *const dc_array_t, index: size_t) -> uint32_t {
     if array.is_null()
-        || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
@@ -192,7 +181,6 @@ pub unsafe fn dc_array_get_msg_id(array: *const dc_array_t, index: size_t) -> ui
 
 pub unsafe fn dc_array_get_marker(array: *const dc_array_t, index: size_t) -> *mut libc::c_char {
     if array.is_null()
-        || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
@@ -218,7 +206,6 @@ pub unsafe fn dc_array_get_marker(array: *const dc_array_t, index: size_t) -> *m
  */
 pub unsafe fn dc_array_is_independent(array: *const dc_array_t, index: size_t) -> libc::c_int {
     if array.is_null()
-        || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
@@ -234,7 +221,7 @@ pub unsafe fn dc_array_search_id(
     needle: uint32_t,
     ret_index: *mut size_t,
 ) -> bool {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
+    if array.is_null() {
         return false;
     }
     for i in 0..(*array).array.len() {
@@ -249,7 +236,7 @@ pub unsafe fn dc_array_search_id(
 }
 
 pub unsafe fn dc_array_get_raw(array: *const dc_array_t) -> *const uintptr_t {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
+    if array.is_null() {
         return 0 as *const uintptr_t;
     }
     (*array).array.as_ptr()
@@ -267,7 +254,7 @@ pub unsafe fn dc_array_new_typed(type_0: libc::c_int, initsize: size_t) -> *mut 
 }
 
 pub unsafe fn dc_array_empty(array: *mut dc_array_t) {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
+    if array.is_null() {
         return;
     }
     (*array).array.clear();
@@ -275,7 +262,7 @@ pub unsafe fn dc_array_empty(array: *mut dc_array_t) {
 
 pub unsafe fn dc_array_duplicate(array: *const dc_array_t) -> *mut dc_array_t {
     let mut ret: *mut dc_array_t;
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
+    if array.is_null() {
         return 0 as *mut dc_array_t;
     }
     ret = dc_array_new(1);
@@ -284,7 +271,7 @@ pub unsafe fn dc_array_duplicate(array: *const dc_array_t) -> *mut dc_array_t {
 }
 
 pub unsafe fn dc_array_sort_ids(array: *mut dc_array_t) {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || (*array).array.len() <= 1 {
+    if array.is_null() || (*array).array.len() <= 1 {
         return;
     }
     (*array).array.sort();
@@ -294,7 +281,7 @@ pub unsafe fn dc_array_get_string(
     array: *const dc_array_t,
     sep: *const libc::c_char,
 ) -> *mut libc::c_char {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || sep.is_null() {
+    if array.is_null() || sep.is_null() {
         return dc_strdup(b"\x00" as *const u8 as *const libc::c_char);
     }
     let cnt = (*array).array.len();

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -38,6 +38,10 @@ impl dc_array_t {
     pub fn add_id(&mut self, item: uint32_t) {
         self.add_uint(item as uintptr_t);
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.array.is_empty()
+    }
 }
 
 /**

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -138,14 +138,6 @@ impl dc_array_t {
     }
 }
 
-/**
- * @class dc_array_t
- *
- * An object containing a simple array.
- * This object is used in several places where functions need to return an array.
- * The items of the array are typically IDs.
- * To free an array object, use dc_array_unref().
- */
 pub unsafe fn dc_array_unref(array: *mut dc_array_t) {
     if array.is_null() {
         return;

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -19,6 +19,14 @@ impl dc_array_t {
         }
     }
 
+    /// Constructs a new, empty `dc_array_t` holding locations with specified `capacity`.
+    pub fn new_locations(capacity: usize) -> Self {
+        dc_array_t {
+            type_0: DC_ARRAY_LOCATIONS,
+            array: Vec::with_capacity(capacity),
+        }
+    }
+
     pub fn as_ptr(self) -> *mut Self {
         Box::into_raw(Box::new(self))
     }
@@ -255,10 +263,8 @@ pub fn dc_array_new(initsize: size_t) -> *mut dc_array_t {
     dc_array_t::new(initsize).as_ptr()
 }
 
-pub fn dc_array_new_typed(type_0: libc::c_int, initsize: size_t) -> *mut dc_array_t {
-    let mut array = dc_array_t::new(initsize);
-    array.type_0 = type_0;
-    array.as_ptr()
+pub fn dc_array_new_locations(initsize: size_t) -> *mut dc_array_t {
+    dc_array_t::new_locations(initsize).as_ptr()
 }
 
 pub unsafe fn dc_array_empty(array: *mut dc_array_t) {

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -6,23 +6,19 @@ const DC_ARRAY_MAGIC: uint32_t = 0x000a11aa;
 const DC_ARRAY_LOCATIONS: libc::c_int = 1;
 
 /* * the structure behind dc_array_t */
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct dc_array_t {
     pub magic: uint32_t,
-    pub allocated: size_t,
-    pub count: size_t,
     pub type_0: libc::c_int,
-    pub array: *mut uintptr_t,
+    pub array: Vec<uintptr_t>,
 }
 
 impl dc_array_t {
-    pub fn new() -> Self {
+    pub fn new(capacity: usize) -> Self {
         dc_array_t {
             magic: DC_ARRAY_MAGIC,
-            allocated: 0,
-            count: 0,
             type_0: 0,
-            array: 0 as *mut uintptr_t,
+            array: Vec::with_capacity(capacity),
         }
     }
 
@@ -46,7 +42,6 @@ pub unsafe fn dc_array_unref(mut array: *mut dc_array_t) {
     if (*array).type_0 == DC_ARRAY_LOCATIONS {
         dc_array_free_ptr(array);
     }
-    free((*array).array as *mut libc::c_void);
     (*array).magic = 0i32 as uint32_t;
     Box::from_raw(array);
 }
@@ -55,31 +50,21 @@ pub unsafe fn dc_array_free_ptr(array: *mut dc_array_t) {
     if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
         return;
     }
-    for i in 0..(*array).count {
+    for i in 0..(*array).array.len() {
         if (*array).type_0 == DC_ARRAY_LOCATIONS {
-            Box::from_raw(*(*array).array.offset(i as isize) as *mut dc_location);
+            Box::from_raw((*array).array[i] as *mut dc_location);
         } else {
-            free(*(*array).array.offset(i as isize) as *mut libc::c_void);
+            free((*array).array[i] as *mut libc::c_void);
         }
-        *(*array).array.offset(i as isize) = 0i32 as uintptr_t;
+        (*array).array[i] = 0i32 as uintptr_t;
     }
 }
 
-pub unsafe fn dc_array_add_uint(mut array: *mut dc_array_t, item: uintptr_t) {
+pub unsafe fn dc_array_add_uint(array: *mut dc_array_t, item: uintptr_t) {
     if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
         return;
     }
-    if (*array).count == (*array).allocated {
-        let newsize = (*array).allocated.wrapping_mul(2).wrapping_add(10);
-        (*array).array = realloc(
-            (*array).array as *mut libc::c_void,
-            (newsize).wrapping_mul(::std::mem::size_of::<uintptr_t>()),
-        ) as *mut uintptr_t;
-        assert!(!(*array).array.is_null());
-        (*array).allocated = newsize as size_t
-    }
-    *(*array).array.offset((*array).count as isize) = item;
-    (*array).count = (*array).count.wrapping_add(1);
+    (*array).array.push(item);
 }
 
 pub unsafe fn dc_array_add_id(array: *mut dc_array_t, item: uint32_t) {
@@ -94,127 +79,127 @@ pub unsafe fn dc_array_get_cnt(array: *const dc_array_t) -> size_t {
     if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
         return 0i32 as size_t;
     }
-    (*array).count
+    (*array).array.len()
 }
 
 pub unsafe fn dc_array_get_uint(array: *const dc_array_t, index: size_t) -> uintptr_t {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || index >= (*array).count {
+    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || index >= (*array).array.len() {
         return 0i32 as uintptr_t;
     }
-    *(*array).array.offset(index as isize)
+    (*array).array[index]
 }
 
 pub unsafe fn dc_array_get_id(array: *const dc_array_t, index: size_t) -> uint32_t {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || index >= (*array).count {
+    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || index >= (*array).array.len() {
         return 0i32 as uint32_t;
     }
     if (*array).type_0 == DC_ARRAY_LOCATIONS {
-        return (*(*(*array).array.offset(index as isize) as *mut dc_location)).location_id;
+        return (*((*array).array[index] as *mut dc_location)).location_id;
     }
-    *(*array).array.offset(index as isize) as uint32_t
+    (*array).array[index] as uint32_t
 }
 
 pub unsafe fn dc_array_get_ptr(array: *const dc_array_t, index: size_t) -> *mut libc::c_void {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || index >= (*array).count {
+    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || index >= (*array).array.len() {
         return 0 as *mut libc::c_void;
     }
-    *(*array).array.offset(index as isize) as *mut libc::c_void
+    (*array).array[index] as *mut libc::c_void
 }
 
 pub unsafe fn dc_array_get_latitude(array: *const dc_array_t, index: size_t) -> libc::c_double {
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
-        || index >= (*array).count
+        || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || *(*array).array.offset(index as isize) == 0
+        || (*array).array[index] == 0
     {
         return 0i32 as libc::c_double;
     }
-    (*(*(*array).array.offset(index as isize) as *mut dc_location)).latitude
+    (*((*array).array[index] as *mut dc_location)).latitude
 }
 
 pub unsafe fn dc_array_get_longitude(array: *const dc_array_t, index: size_t) -> libc::c_double {
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
-        || index >= (*array).count
+        || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || *(*array).array.offset(index as isize) == 0
+        || (*array).array[index] == 0
     {
         return 0i32 as libc::c_double;
     }
-    (*(*(*array).array.offset(index as isize) as *mut dc_location)).longitude
+    (*((*array).array[index] as *mut dc_location)).longitude
 }
 
 pub unsafe fn dc_array_get_accuracy(array: *const dc_array_t, index: size_t) -> libc::c_double {
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
-        || index >= (*array).count
+        || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || *(*array).array.offset(index as isize) == 0
+        || (*array).array[index] == 0
     {
         return 0i32 as libc::c_double;
     }
-    (*(*(*array).array.offset(index as isize) as *mut dc_location)).accuracy
+    (*((*array).array[index] as *mut dc_location)).accuracy
 }
 
 pub unsafe fn dc_array_get_timestamp(array: *const dc_array_t, index: size_t) -> i64 {
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
-        || index >= (*array).count
+        || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || *(*array).array.offset(index as isize) == 0
+        || (*array).array[index] == 0
     {
         return 0;
     }
-    (*(*(*array).array.offset(index as isize) as *mut dc_location)).timestamp
+    (*((*array).array[index] as *mut dc_location)).timestamp
 }
 
 pub unsafe fn dc_array_get_chat_id(array: *const dc_array_t, index: size_t) -> uint32_t {
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
-        || index >= (*array).count
+        || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || *(*array).array.offset(index as isize) == 0
+        || (*array).array[index] == 0
     {
         return 0i32 as uint32_t;
     }
-    (*(*(*array).array.offset(index as isize) as *mut dc_location)).chat_id
+    (*((*array).array[index] as *mut dc_location)).chat_id
 }
 
 pub unsafe fn dc_array_get_contact_id(array: *const dc_array_t, index: size_t) -> uint32_t {
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
-        || index >= (*array).count
+        || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || *(*array).array.offset(index as isize) == 0
+        || (*array).array[index] == 0
     {
         return 0i32 as uint32_t;
     }
-    (*(*(*array).array.offset(index as isize) as *mut dc_location)).contact_id
+    (*((*array).array[index] as *mut dc_location)).contact_id
 }
 
 pub unsafe fn dc_array_get_msg_id(array: *const dc_array_t, index: size_t) -> uint32_t {
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
-        || index >= (*array).count
+        || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || *(*array).array.offset(index as isize) == 0
+        || (*array).array[index] == 0
     {
         return 0i32 as uint32_t;
     }
-    (*(*(*array).array.offset(index as isize) as *mut dc_location)).msg_id
+    (*((*array).array[index] as *mut dc_location)).msg_id
 }
 
 pub unsafe fn dc_array_get_marker(array: *const dc_array_t, index: size_t) -> *mut libc::c_char {
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
-        || index >= (*array).count
+        || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || *(*array).array.offset(index as isize) == 0
+        || (*array).array[index] == 0
     {
         return 0 as *mut libc::c_char;
     }
-    if let Some(s) = &(*(*(*array).array.offset(index as isize) as *mut dc_location)).marker {
+    if let Some(s) = &(*((*array).array[index] as *mut dc_location)).marker {
         to_cstring(s)
     } else {
         std::ptr::null_mut()
@@ -234,14 +219,14 @@ pub unsafe fn dc_array_get_marker(array: *const dc_array_t, index: size_t) -> *m
 pub unsafe fn dc_array_is_independent(array: *const dc_array_t, index: size_t) -> libc::c_int {
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
-        || index >= (*array).count
+        || index >= (*array).array.len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
-        || *(*array).array.offset(index as isize) == 0
+        || (*array).array[index] == 0
     {
         return 0;
     }
 
-    (*(*(*array).array.offset(index as isize) as *mut dc_location)).independent as libc::c_int
+    (*((*array).array[index] as *mut dc_location)).independent as libc::c_int
 }
 
 pub unsafe fn dc_array_search_id(
@@ -252,9 +237,8 @@ pub unsafe fn dc_array_search_id(
     if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
         return false;
     }
-    let data: *mut uintptr_t = (*array).array;
-    for i in 0..(*array).count {
-        if *data.offset(i as isize) == needle as size_t {
+    for i in 0..(*array).array.len() {
+        if (*array).array[i] == needle as size_t {
             if !ret_index.is_null() {
                 *ret_index = i
             }
@@ -268,7 +252,7 @@ pub unsafe fn dc_array_get_raw(array: *const dc_array_t) -> *const uintptr_t {
     if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
         return 0 as *const uintptr_t;
     }
-    (*array).array
+    (*array).array.as_ptr()
 }
 
 pub unsafe fn dc_array_new(initsize: size_t) -> *mut dc_array_t {
@@ -276,27 +260,17 @@ pub unsafe fn dc_array_new(initsize: size_t) -> *mut dc_array_t {
 }
 
 pub unsafe fn dc_array_new_typed(type_0: libc::c_int, initsize: size_t) -> *mut dc_array_t {
-    let mut array = dc_array_t::new();
-
-    array.allocated = if initsize < 1 { 1 } else { initsize };
+    let capacity = if initsize < 1 { 1 } else { initsize as usize };
+    let mut array = dc_array_t::new(capacity);
     array.type_0 = type_0;
-    array.array = malloc(
-        array
-            .allocated
-            .wrapping_mul(::std::mem::size_of::<uintptr_t>()),
-    ) as *mut uintptr_t;
-    if array.array.is_null() {
-        exit(48i32);
-    }
-
     array.as_ptr()
 }
 
-pub unsafe fn dc_array_empty(mut array: *mut dc_array_t) {
+pub unsafe fn dc_array_empty(array: *mut dc_array_t) {
     if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
         return;
     }
-    (*array).count = 0i32 as size_t;
+    (*array).array.clear();
 }
 
 pub unsafe fn dc_array_duplicate(array: *const dc_array_t) -> *mut dc_array_t {
@@ -304,40 +278,16 @@ pub unsafe fn dc_array_duplicate(array: *const dc_array_t) -> *mut dc_array_t {
     if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
         return 0 as *mut dc_array_t;
     }
-    ret = dc_array_new((*array).allocated);
-    (*ret).count = (*array).count;
-    memcpy(
-        (*ret).array as *mut libc::c_void,
-        (*array).array as *const libc::c_void,
-        (*array)
-            .count
-            .wrapping_mul(::std::mem::size_of::<uintptr_t>()),
-    );
+    ret = dc_array_new(1);
+    (*ret).array = (*array).array.clone();
     ret
 }
 
 pub unsafe fn dc_array_sort_ids(array: *mut dc_array_t) {
-    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || (*array).count <= 1 {
+    if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || (*array).array.len() <= 1 {
         return;
     }
-    qsort(
-        (*array).array as *mut libc::c_void,
-        (*array).count,
-        ::std::mem::size_of::<uintptr_t>(),
-        Some(cmp_intptr_t),
-    );
-}
-
-unsafe extern "C" fn cmp_intptr_t(p1: *const libc::c_void, p2: *const libc::c_void) -> libc::c_int {
-    let v1: uintptr_t = *(p1 as *mut uintptr_t);
-    let v2: uintptr_t = *(p2 as *mut uintptr_t);
-    return if v1 < v2 {
-        -1i32
-    } else if v1 > v2 {
-        1i32
-    } else {
-        0i32
-    };
+    (*array).array.sort();
 }
 
 pub unsafe fn dc_array_get_string(
@@ -347,14 +297,12 @@ pub unsafe fn dc_array_get_string(
     if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || sep.is_null() {
         return dc_strdup(b"\x00" as *const u8 as *const libc::c_char);
     }
-    let cnt = (*array).count as usize;
-    let slice = std::slice::from_raw_parts((*array).array, cnt);
+    let cnt = (*array).array.len();
     let sep = as_str(sep);
 
-    let res = slice
-        .iter()
-        .enumerate()
-        .fold(String::with_capacity(2 * cnt), |mut res, (i, n)| {
+    let res = (*array).array.iter().enumerate().fold(
+        String::with_capacity(2 * cnt),
+        |mut res, (i, n)| {
             if i == 0 {
                 res += &n.to_string();
             } else {

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -237,16 +237,13 @@ pub unsafe fn dc_array_search_id(
         return false;
     }
     let data: *mut uintptr_t = (*array).array;
-    let mut i: size_t = 0;
-    let cnt: size_t = (*array).count;
-    while i < cnt {
+    for i in 0..(*array).count {
         if *data.offset(i as isize) == needle as size_t {
             if !ret_index.is_null() {
                 *ret_index = i
             }
             return true;
         }
-        i = i.wrapping_add(1)
     }
     false
 }

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -256,8 +256,7 @@ pub fn dc_array_new(initsize: size_t) -> *mut dc_array_t {
 }
 
 pub fn dc_array_new_typed(type_0: libc::c_int, initsize: size_t) -> *mut dc_array_t {
-    let capacity = if initsize < 1 { 1 } else { initsize as usize };
-    let mut array = dc_array_t::new(capacity);
+    let mut array = dc_array_t::new(initsize);
     array.type_0 = type_0;
     array.as_ptr()
 }

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -42,6 +42,11 @@ impl dc_array_t {
     pub fn is_empty(&self) -> bool {
         self.array.is_empty()
     }
+
+    /// Returns the number of elements in the array.
+    pub fn len(&self) -> usize {
+        self.array.len()
+    }
 }
 
 /**
@@ -84,18 +89,18 @@ pub unsafe fn dc_array_get_cnt(array: *const dc_array_t) -> size_t {
     if array.is_null() {
         return 0i32 as size_t;
     }
-    (*array).array.len()
+    (*array).len()
 }
 
 pub unsafe fn dc_array_get_uint(array: *const dc_array_t, index: size_t) -> uintptr_t {
-    if array.is_null() || index >= (*array).array.len() {
+    if array.is_null() || index >= (*array).len() {
         return 0i32 as uintptr_t;
     }
     (*array).array[index]
 }
 
 pub unsafe fn dc_array_get_id(array: *const dc_array_t, index: size_t) -> uint32_t {
-    if array.is_null() || index >= (*array).array.len() {
+    if array.is_null() || index >= (*array).len() {
         return 0i32 as uint32_t;
     }
     if (*array).type_0 == DC_ARRAY_LOCATIONS {
@@ -105,7 +110,7 @@ pub unsafe fn dc_array_get_id(array: *const dc_array_t, index: size_t) -> uint32
 }
 
 pub unsafe fn dc_array_get_ptr(array: *const dc_array_t, index: size_t) -> *mut libc::c_void {
-    if array.is_null() || index >= (*array).array.len() {
+    if array.is_null() || index >= (*array).len() {
         return 0 as *mut libc::c_void;
     }
     (*array).array[index] as *mut libc::c_void
@@ -113,7 +118,7 @@ pub unsafe fn dc_array_get_ptr(array: *const dc_array_t, index: size_t) -> *mut 
 
 pub unsafe fn dc_array_get_latitude(array: *const dc_array_t, index: size_t) -> libc::c_double {
     if array.is_null()
-        || index >= (*array).array.len()
+        || index >= (*array).len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
     {
@@ -124,7 +129,7 @@ pub unsafe fn dc_array_get_latitude(array: *const dc_array_t, index: size_t) -> 
 
 pub unsafe fn dc_array_get_longitude(array: *const dc_array_t, index: size_t) -> libc::c_double {
     if array.is_null()
-        || index >= (*array).array.len()
+        || index >= (*array).len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
     {
@@ -135,7 +140,7 @@ pub unsafe fn dc_array_get_longitude(array: *const dc_array_t, index: size_t) ->
 
 pub unsafe fn dc_array_get_accuracy(array: *const dc_array_t, index: size_t) -> libc::c_double {
     if array.is_null()
-        || index >= (*array).array.len()
+        || index >= (*array).len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
     {
@@ -146,7 +151,7 @@ pub unsafe fn dc_array_get_accuracy(array: *const dc_array_t, index: size_t) -> 
 
 pub unsafe fn dc_array_get_timestamp(array: *const dc_array_t, index: size_t) -> i64 {
     if array.is_null()
-        || index >= (*array).array.len()
+        || index >= (*array).len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
     {
@@ -157,7 +162,7 @@ pub unsafe fn dc_array_get_timestamp(array: *const dc_array_t, index: size_t) ->
 
 pub unsafe fn dc_array_get_chat_id(array: *const dc_array_t, index: size_t) -> uint32_t {
     if array.is_null()
-        || index >= (*array).array.len()
+        || index >= (*array).len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
     {
@@ -168,7 +173,7 @@ pub unsafe fn dc_array_get_chat_id(array: *const dc_array_t, index: size_t) -> u
 
 pub unsafe fn dc_array_get_contact_id(array: *const dc_array_t, index: size_t) -> uint32_t {
     if array.is_null()
-        || index >= (*array).array.len()
+        || index >= (*array).len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
     {
@@ -179,7 +184,7 @@ pub unsafe fn dc_array_get_contact_id(array: *const dc_array_t, index: size_t) -
 
 pub unsafe fn dc_array_get_msg_id(array: *const dc_array_t, index: size_t) -> uint32_t {
     if array.is_null()
-        || index >= (*array).array.len()
+        || index >= (*array).len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
     {
@@ -190,7 +195,7 @@ pub unsafe fn dc_array_get_msg_id(array: *const dc_array_t, index: size_t) -> ui
 
 pub unsafe fn dc_array_get_marker(array: *const dc_array_t, index: size_t) -> *mut libc::c_char {
     if array.is_null()
-        || index >= (*array).array.len()
+        || index >= (*array).len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
     {
@@ -215,7 +220,7 @@ pub unsafe fn dc_array_get_marker(array: *const dc_array_t, index: size_t) -> *m
  */
 pub unsafe fn dc_array_is_independent(array: *const dc_array_t, index: size_t) -> libc::c_int {
     if array.is_null()
-        || index >= (*array).array.len()
+        || index >= (*array).len()
         || (*array).type_0 != DC_ARRAY_LOCATIONS
         || (*array).array[index] == 0
     {
@@ -275,7 +280,7 @@ pub unsafe fn dc_array_duplicate(array: *const dc_array_t) -> *mut dc_array_t {
 }
 
 pub unsafe fn dc_array_sort_ids(array: *mut dc_array_t) {
-    if array.is_null() || (*array).array.len() <= 1 {
+    if array.is_null() || (*array).len() <= 1 {
         return;
     }
     (*array).array.sort();
@@ -288,7 +293,7 @@ pub unsafe fn dc_array_get_string(
     if array.is_null() || sep.is_null() {
         return dc_strdup(b"\x00" as *const u8 as *const libc::c_char);
     }
-    let cnt = (*array).array.len();
+    let cnt = (*array).len();
     let sep = as_str(sep);
 
     let res =

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -233,8 +233,8 @@ pub unsafe fn dc_array_search_id(
     if array.is_null() {
         return false;
     }
-    for i in 0..(*array).array.len() {
-        if (*array).array[i] == needle as size_t {
+    for (i, &u) in (*array).array.iter().enumerate() {
+        if u == needle as size_t {
             if !ret_index.is_null() {
                 *ret_index = i
             }

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -3,6 +3,7 @@ use crate::dc_tools::*;
 use crate::types::*;
 
 const DC_ARRAY_MAGIC: uint32_t = 0x000a11aa;
+const DC_ARRAY_LOCATIONS: libc::c_int = 1;
 
 /* * the structure behind dc_array_t */
 #[derive(Copy, Clone)]
@@ -26,7 +27,7 @@ pub unsafe fn dc_array_unref(mut array: *mut dc_array_t) {
     if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
         return;
     }
-    if (*array).type_0 == 1i32 {
+    if (*array).type_0 == DC_ARRAY_LOCATIONS {
         dc_array_free_ptr(array);
     }
     free((*array).array as *mut libc::c_void);
@@ -40,7 +41,11 @@ pub unsafe fn dc_array_free_ptr(array: *mut dc_array_t) {
     }
     let mut i: size_t = 0i32 as size_t;
     while i < (*array).count {
-        Box::from_raw(*(*array).array.offset(i as isize) as *mut dc_location);
+        if (*array).type_0 == DC_ARRAY_LOCATIONS {
+            Box::from_raw(*(*array).array.offset(i as isize) as *mut dc_location);
+        } else {
+            free(*(*array).array.offset(i as isize) as *mut libc::c_void);
+        }
         *(*array).array.offset(i as isize) = 0i32 as uintptr_t;
         i = i.wrapping_add(1)
     }
@@ -89,7 +94,7 @@ pub unsafe fn dc_array_get_id(array: *const dc_array_t, index: size_t) -> uint32
     if array.is_null() || (*array).magic != DC_ARRAY_MAGIC || index >= (*array).count {
         return 0i32 as uint32_t;
     }
-    if (*array).type_0 == 1i32 {
+    if (*array).type_0 == DC_ARRAY_LOCATIONS {
         return (*(*(*array).array.offset(index as isize) as *mut dc_location)).location_id;
     }
     *(*array).array.offset(index as isize) as uint32_t
@@ -106,7 +111,7 @@ pub unsafe fn dc_array_get_latitude(array: *const dc_array_t, index: size_t) -> 
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).count
-        || (*array).type_0 != 1i32
+        || (*array).type_0 != DC_ARRAY_LOCATIONS
         || *(*array).array.offset(index as isize) == 0
     {
         return 0i32 as libc::c_double;
@@ -118,7 +123,7 @@ pub unsafe fn dc_array_get_longitude(array: *const dc_array_t, index: size_t) ->
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).count
-        || (*array).type_0 != 1i32
+        || (*array).type_0 != DC_ARRAY_LOCATIONS
         || *(*array).array.offset(index as isize) == 0
     {
         return 0i32 as libc::c_double;
@@ -130,7 +135,7 @@ pub unsafe fn dc_array_get_accuracy(array: *const dc_array_t, index: size_t) -> 
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).count
-        || (*array).type_0 != 1i32
+        || (*array).type_0 != DC_ARRAY_LOCATIONS
         || *(*array).array.offset(index as isize) == 0
     {
         return 0i32 as libc::c_double;
@@ -142,7 +147,7 @@ pub unsafe fn dc_array_get_timestamp(array: *const dc_array_t, index: size_t) ->
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).count
-        || (*array).type_0 != 1i32
+        || (*array).type_0 != DC_ARRAY_LOCATIONS
         || *(*array).array.offset(index as isize) == 0
     {
         return 0;
@@ -154,7 +159,7 @@ pub unsafe fn dc_array_get_chat_id(array: *const dc_array_t, index: size_t) -> u
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).count
-        || (*array).type_0 != 1i32
+        || (*array).type_0 != DC_ARRAY_LOCATIONS
         || *(*array).array.offset(index as isize) == 0
     {
         return 0i32 as uint32_t;
@@ -166,7 +171,7 @@ pub unsafe fn dc_array_get_contact_id(array: *const dc_array_t, index: size_t) -
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).count
-        || (*array).type_0 != 1i32
+        || (*array).type_0 != DC_ARRAY_LOCATIONS
         || *(*array).array.offset(index as isize) == 0
     {
         return 0i32 as uint32_t;
@@ -178,7 +183,7 @@ pub unsafe fn dc_array_get_msg_id(array: *const dc_array_t, index: size_t) -> ui
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).count
-        || (*array).type_0 != 1i32
+        || (*array).type_0 != DC_ARRAY_LOCATIONS
         || *(*array).array.offset(index as isize) == 0
     {
         return 0i32 as uint32_t;
@@ -190,7 +195,7 @@ pub unsafe fn dc_array_get_marker(array: *const dc_array_t, index: size_t) -> *m
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).count
-        || (*array).type_0 != 1i32
+        || (*array).type_0 != DC_ARRAY_LOCATIONS
         || *(*array).array.offset(index as isize) == 0
     {
         return 0 as *mut libc::c_char;
@@ -216,7 +221,7 @@ pub unsafe fn dc_array_is_independent(array: *const dc_array_t, index: size_t) -
     if array.is_null()
         || (*array).magic != DC_ARRAY_MAGIC
         || index >= (*array).count
-        || (*array).type_0 != 1i32
+        || (*array).type_0 != DC_ARRAY_LOCATIONS
         || *(*array).array.offset(index as isize) == 0
     {
         return 0;

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -22,6 +22,14 @@ impl dc_array_t {
     pub fn as_ptr(self) -> *mut Self {
         Box::into_raw(Box::new(self))
     }
+
+    pub fn add_uint(&mut self, item: uintptr_t) {
+        self.array.push(item);
+    }
+
+    pub fn add_id(&mut self, item: uint32_t) {
+        self.add_uint(item as uintptr_t);
+    }
 }
 
 /**
@@ -57,14 +65,15 @@ pub unsafe fn dc_array_free_ptr(array: *mut dc_array_t) {
 }
 
 pub unsafe fn dc_array_add_uint(array: *mut dc_array_t, item: uintptr_t) {
-    if array.is_null() {
-        return;
+    if !array.is_null() {
+        (*array).add_uint(item);
     }
-    (*array).array.push(item);
 }
 
 pub unsafe fn dc_array_add_id(array: *mut dc_array_t, item: uint32_t) {
-    dc_array_add_uint(array, item as uintptr_t);
+    if !array.is_null() {
+        (*array).add_id(item);
+    }
 }
 
 pub unsafe fn dc_array_add_ptr(array: *mut dc_array_t, item: *mut libc::c_void) {

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -51,6 +51,10 @@ impl dc_array_t {
         }
     }
 
+    pub fn get_ptr(&self, index: size_t) -> *mut libc::c_void {
+        self.array[index] as *mut libc::c_void
+    }
+
     pub fn is_empty(&self) -> bool {
         self.array.is_empty()
     }
@@ -126,9 +130,10 @@ pub unsafe fn dc_array_get_id(array: *const dc_array_t, index: size_t) -> uint32
 
 pub unsafe fn dc_array_get_ptr(array: *const dc_array_t, index: size_t) -> *mut libc::c_void {
     if array.is_null() || index >= (*array).len() {
-        return 0 as *mut libc::c_void;
+        std::ptr::null_mut()
+    } else {
+        (*array).get_ptr(index)
     }
-    (*array).array[index] as *mut libc::c_void
 }
 
 pub unsafe fn dc_array_get_latitude(array: *const dc_array_t, index: size_t) -> libc::c_double {

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -285,17 +285,18 @@ pub unsafe fn dc_array_get_string(
     let cnt = (*array).array.len();
     let sep = as_str(sep);
 
-    let res = (*array).array.iter().enumerate().fold(
-        String::with_capacity(2 * cnt),
-        |mut res, (i, n)| {
-            if i == 0 {
-                res += &n.to_string();
-            } else {
-                res += sep;
-                res += &n.to_string();
-            }
-            res
-        });
+    let res =
+        (*array)
+            .array
+            .iter()
+            .enumerate()
+            .fold(String::with_capacity(2 * cnt), |res, (i, n)| {
+                if i == 0 {
+                    res + &n.to_string()
+                } else {
+                    res + sep + &n.to_string()
+                }
+            });
     to_cstring(res)
 }
 

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -7,7 +7,6 @@ const DC_ARRAY_MAGIC: uint32_t = 0x000a11aa;
 
 /* * the structure behind dc_array_t */
 #[derive(Copy, Clone)]
-#[repr(C)]
 pub struct dc_array_t {
     pub magic: uint32_t,
     pub allocated: size_t,

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -242,11 +242,11 @@ pub unsafe fn dc_array_get_raw(array: *const dc_array_t) -> *const uintptr_t {
     (*array).array.as_ptr()
 }
 
-pub unsafe fn dc_array_new(initsize: size_t) -> *mut dc_array_t {
+pub fn dc_array_new(initsize: size_t) -> *mut dc_array_t {
     dc_array_new_typed(0, initsize)
 }
 
-pub unsafe fn dc_array_new_typed(type_0: libc::c_int, initsize: size_t) -> *mut dc_array_t {
+pub fn dc_array_new_typed(type_0: libc::c_int, initsize: size_t) -> *mut dc_array_t {
     let capacity = if initsize < 1 { 1 } else { initsize as usize };
     let mut array = dc_array_t::new(capacity);
     array.type_0 = type_0;

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -261,13 +261,11 @@ pub unsafe fn dc_array_empty(array: *mut dc_array_t) {
 }
 
 pub unsafe fn dc_array_duplicate(array: *const dc_array_t) -> *mut dc_array_t {
-    let mut ret: *mut dc_array_t;
     if array.is_null() {
-        return 0 as *mut dc_array_t;
+        std::ptr::null_mut()
+    } else {
+        (*array).clone().as_ptr()
     }
-    ret = dc_array_new(1);
-    (*ret).array = (*array).array.clone();
-    ret
 }
 
 pub unsafe fn dc_array_sort_ids(array: *mut dc_array_t) {

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -252,7 +252,7 @@ pub unsafe fn dc_array_get_raw(array: *const dc_array_t) -> *const uintptr_t {
 }
 
 pub fn dc_array_new(initsize: size_t) -> *mut dc_array_t {
-    dc_array_new_typed(0, initsize)
+    dc_array_t::new(initsize).as_ptr()
 }
 
 pub fn dc_array_new_typed(type_0: libc::c_int, initsize: size_t) -> *mut dc_array_t {

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -39,15 +39,13 @@ pub unsafe fn dc_array_free_ptr(array: *mut dc_array_t) {
     if array.is_null() || (*array).magic != DC_ARRAY_MAGIC {
         return;
     }
-    let mut i: size_t = 0i32 as size_t;
-    while i < (*array).count {
+    for i in 0..(*array).count {
         if (*array).type_0 == DC_ARRAY_LOCATIONS {
             Box::from_raw(*(*array).array.offset(i as isize) as *mut dc_location);
         } else {
             free(*(*array).array.offset(i as isize) as *mut libc::c_void);
         }
         *(*array).array.offset(i as isize) = 0i32 as uintptr_t;
-        i = i.wrapping_add(1)
     }
 }
 

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -39,6 +39,18 @@ impl dc_array_t {
         self.add_uint(item as uintptr_t);
     }
 
+    pub fn get_uint(&self, index: usize) -> uintptr_t {
+        self.array[index]
+    }
+
+    pub unsafe fn get_id(&self, index: usize) -> uint32_t {
+        if self.type_0 == DC_ARRAY_LOCATIONS {
+            (*(self.array[index] as *mut dc_location)).location_id
+        } else {
+            self.array[index] as uint32_t
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
         self.array.is_empty()
     }
@@ -98,19 +110,18 @@ pub unsafe fn dc_array_get_cnt(array: *const dc_array_t) -> size_t {
 
 pub unsafe fn dc_array_get_uint(array: *const dc_array_t, index: size_t) -> uintptr_t {
     if array.is_null() || index >= (*array).len() {
-        return 0i32 as uintptr_t;
+        0
+    } else {
+        (*array).get_uint(index)
     }
-    (*array).array[index]
 }
 
 pub unsafe fn dc_array_get_id(array: *const dc_array_t, index: size_t) -> uint32_t {
     if array.is_null() || index >= (*array).len() {
-        return 0i32 as uint32_t;
+        0
+    } else {
+        (*array).get_id(index)
     }
-    if (*array).type_0 == DC_ARRAY_LOCATIONS {
-        return (*((*array).array[index] as *mut dc_location)).location_id;
-    }
-    (*array).array[index] as uint32_t
 }
 
 pub unsafe fn dc_array_get_ptr(array: *const dc_array_t, index: size_t) -> *mut libc::c_void {

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -90,9 +90,10 @@ pub unsafe fn dc_array_add_ptr(array: *mut dc_array_t, item: *mut libc::c_void) 
 
 pub unsafe fn dc_array_get_cnt(array: *const dc_array_t) -> size_t {
     if array.is_null() {
-        return 0i32 as size_t;
+        0
+    } else {
+        (*array).len()
     }
-    (*array).len()
 }
 
 pub unsafe fn dc_array_get_uint(array: *const dc_array_t, index: size_t) -> uintptr_t {

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -71,6 +71,15 @@ impl dc_array_t {
             }
         }
     }
+
+    pub fn search_id(&self, needle: uintptr_t) -> Option<usize> {
+        for (i, &u) in self.array.iter().enumerate() {
+            if u == needle {
+                return Some(i);
+            }
+        }
+        None
+    }
 }
 
 /**
@@ -258,15 +267,14 @@ pub unsafe fn dc_array_search_id(
     if array.is_null() {
         return false;
     }
-    for (i, &u) in (*array).array.iter().enumerate() {
-        if u == needle as size_t {
-            if !ret_index.is_null() {
-                *ret_index = i
-            }
-            return true;
+    if let Some(i) = (*array).search_id(needle as uintptr_t) {
+        if !ret_index.is_null() {
+            *ret_index = i
         }
+        true
+    } else {
+        false
     }
-    false
 }
 
 pub unsafe fn dc_array_get_raw(array: *const dc_array_t) -> *const uintptr_t {

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -53,23 +53,11 @@ pub unsafe fn dc_array_unref(array: *mut dc_array_t) {
         return;
     }
     if (*array).type_0 == DC_ARRAY_LOCATIONS {
-        dc_array_free_ptr(array);
+        for &e in (*array).array.iter() {
+            Box::from_raw(e as *mut dc_location);
+        }
     }
     Box::from_raw(array);
-}
-
-pub unsafe fn dc_array_free_ptr(array: *mut dc_array_t) {
-    if array.is_null() {
-        return;
-    }
-    for i in 0..(*array).array.len() {
-        if (*array).type_0 == DC_ARRAY_LOCATIONS {
-            Box::from_raw((*array).array[i] as *mut dc_location);
-        } else {
-            free((*array).array[i] as *mut libc::c_void);
-        }
-        (*array).array[i] = 0i32 as uintptr_t;
-    }
 }
 
 pub unsafe fn dc_array_add_uint(array: *mut dc_array_t, item: uintptr_t) {

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -2164,7 +2164,7 @@ pub unsafe fn dc_chat_get_profile_image(chat: *const Chat) -> *mut libc::c_char 
             image_abs = dc_get_abs_path((*chat).context, image_rel)
         } else if (*chat).type_0 == 100i32 {
             contacts = dc_get_chat_contacts((*chat).context, (*chat).id);
-            if !(*contacts).array.is_empty() {
+            if !(*contacts).is_empty() {
                 contact = dc_get_contact((*chat).context, (*contacts).array[0] as uint32_t);
                 image_abs = dc_contact_get_profile_image(contact)
             }
@@ -2185,7 +2185,7 @@ pub unsafe fn dc_chat_get_color(chat: *const Chat) -> uint32_t {
     if !(chat.is_null() || (*chat).magic != 0xc4a7c4a7u32) {
         if (*chat).type_0 == 100i32 {
             contacts = dc_get_chat_contacts((*chat).context, (*chat).id);
-            if !(*contacts).array.is_empty() {
+            if !(*contacts).is_empty() {
                 contact = dc_get_contact((*chat).context, (*contacts).array[0] as uint32_t);
                 color = dc_str_to_color((*contact).addr) as uint32_t
             }

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -1285,7 +1285,7 @@ pub fn dc_get_chat_media(
         ],
         |row| row.get::<_, i32>(0),
         |ids| {
-            let ret = unsafe { dc_array_new(100) };
+            let ret = dc_array_new(100);
             for id in ids {
                 unsafe { dc_array_add_id(ret, id? as u32) };
             }
@@ -1458,7 +1458,7 @@ pub fn dc_get_chat_contacts(context: &Context, chat_id: u32) -> *mut dc_array_t 
             params![chat_id as i32],
             |row| row.get::<_, i32>(0),
             |ids| {
-                let ret = unsafe { dc_array_new(100) };
+                let ret = dc_array_new(100);
 
                 for id in ids {
                     unsafe { dc_array_add_id(ret, id? as u32) };

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -2168,11 +2168,8 @@ pub unsafe fn dc_chat_get_profile_image(chat: *const Chat) -> *mut libc::c_char 
             image_abs = dc_get_abs_path((*chat).context, image_rel)
         } else if (*chat).type_0 == 100i32 {
             contacts = dc_get_chat_contacts((*chat).context, (*chat).id);
-            if (*contacts).count >= 1 {
-                contact = dc_get_contact(
-                    (*chat).context,
-                    *(*contacts).array.offset(0isize) as uint32_t,
-                );
+            if !(*contacts).array.is_empty() {
+                contact = dc_get_contact((*chat).context, (*contacts).array[0] as uint32_t);
                 image_abs = dc_contact_get_profile_image(contact)
             }
         }
@@ -2192,11 +2189,8 @@ pub unsafe fn dc_chat_get_color(chat: *const Chat) -> uint32_t {
     if !(chat.is_null() || (*chat).magic != 0xc4a7c4a7u32) {
         if (*chat).type_0 == 100i32 {
             contacts = dc_get_chat_contacts((*chat).context, (*chat).id);
-            if (*contacts).count >= 1 {
-                contact = dc_get_contact(
-                    (*chat).context,
-                    *(*contacts).array.offset(0isize) as uint32_t,
-                );
+            if !(*contacts).array.is_empty() {
+                contact = dc_get_contact((*chat).context, (*contacts).array[0] as uint32_t);
                 color = dc_str_to_color((*contact).addr) as uint32_t
             }
         } else {

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -2165,7 +2165,7 @@ pub unsafe fn dc_chat_get_profile_image(chat: *const Chat) -> *mut libc::c_char 
         } else if (*chat).type_0 == 100i32 {
             contacts = dc_get_chat_contacts((*chat).context, (*chat).id);
             if !(*contacts).is_empty() {
-                contact = dc_get_contact((*chat).context, (*contacts).array[0] as uint32_t);
+                contact = dc_get_contact((*chat).context, (*contacts).get_id(0));
                 image_abs = dc_contact_get_profile_image(contact)
             }
         }
@@ -2186,7 +2186,7 @@ pub unsafe fn dc_chat_get_color(chat: *const Chat) -> uint32_t {
         if (*chat).type_0 == 100i32 {
             contacts = dc_get_chat_contacts((*chat).context, (*chat).id);
             if !(*contacts).is_empty() {
-                contact = dc_get_contact((*chat).context, (*contacts).array[0] as uint32_t);
+                contact = dc_get_contact((*chat).context, (*contacts).get_id(0));
                 color = dc_str_to_color((*contact).addr) as uint32_t
             }
         } else {

--- a/src/dc_contact.rs
+++ b/src/dc_contact.rs
@@ -537,7 +537,7 @@ pub fn dc_get_contacts(
         .unwrap_or_default();
 
     let mut add_self = false;
-    let ret = dc_array_new(100);
+    let mut ret = dc_array_t::new(100);
 
     if (listflags & DC_GCL_VERIFIED_ONLY) > 0 || !query.is_null() {
         let s3strLikeCmd = format!("%{}%", if !query.is_null() { as_str(query) } else { "" });
@@ -565,7 +565,7 @@ pub fn dc_get_contacts(
                 |row| row.get::<_, i32>(0),
                 |ids| {
                     for id in ids {
-                        unsafe { dc_array_add_id(ret, id? as u32) };
+                        ret.add_id(id? as u32);
                     }
                     Ok(())
                 },
@@ -595,7 +595,7 @@ pub fn dc_get_contacts(
             |row| row.get::<_, i32>(0),
             |ids| {
                 for id in ids {
-                    unsafe { dc_array_add_id(ret, id? as u32) };
+                    ret.add_id(id? as u32);
                 }
                 Ok(())
             }
@@ -603,10 +603,10 @@ pub fn dc_get_contacts(
     }
 
     if 0 != listflags & 0x2 && add_self {
-        unsafe { dc_array_add_id(ret, 1) };
+        ret.add_id(1);
     }
 
-    ret
+    ret.as_ptr()
 }
 
 pub fn dc_get_blocked_cnt(context: &Context) -> libc::c_int {
@@ -629,13 +629,13 @@ pub fn dc_get_blocked_contacts(context: &Context) -> *mut dc_array_t {
             params![9],
             |row| row.get::<_, i32>(0),
             |ids| {
-                let ret = dc_array_new(100);
+                let mut ret = dc_array_t::new(100);
 
                 for id in ids {
-                    unsafe { dc_array_add_id(ret, id? as u32) };
+                    ret.add_id(id? as u32);
                 }
 
-                Ok(ret)
+                Ok(ret.as_ptr())
             },
         )
         .unwrap_or_else(|_| std::ptr::null_mut())

--- a/src/dc_contact.rs
+++ b/src/dc_contact.rs
@@ -537,7 +537,7 @@ pub fn dc_get_contacts(
         .unwrap_or_default();
 
     let mut add_self = false;
-    let ret = unsafe { dc_array_new(100) };
+    let ret = dc_array_new(100);
 
     if (listflags & DC_GCL_VERIFIED_ONLY) > 0 || !query.is_null() {
         let s3strLikeCmd = format!("%{}%", if !query.is_null() { as_str(query) } else { "" });
@@ -629,7 +629,7 @@ pub fn dc_get_blocked_contacts(context: &Context) -> *mut dc_array_t {
             params![9],
             |row| row.get::<_, i32>(0),
             |ids| {
-                let ret = unsafe { dc_array_new(100) };
+                let ret = dc_array_new(100);
 
                 for id in ids {
                     unsafe { dc_array_add_id(ret, id? as u32) };

--- a/src/dc_location.rs
+++ b/src/dc_location.rs
@@ -250,7 +250,7 @@ pub fn dc_get_locations(
                 let mut ret = dc_array_t::new_locations(500);
 
                 for location in locations {
-                    ret.add_ptr(Box::into_raw(Box::new(location?)) as *mut libc::c_void);
+                    ret.add_location(location?);
                 }
                 Ok(ret.as_ptr())
             },
@@ -582,10 +582,7 @@ unsafe fn kml_endtag_cb(userdata: *mut libc::c_void, tag: *const libc::c_char) {
             && 0. != (*kml).curr.longitude
         {
             let location = (*kml).curr.clone();
-            dc_array_add_ptr(
-                (*kml).locations,
-                Box::into_raw(Box::new(location)) as *mut libc::c_void,
-            );
+            (*(*kml).locations).add_location(location);
         }
         (*kml).tag = 0
     };

--- a/src/dc_location.rs
+++ b/src/dc_location.rs
@@ -247,7 +247,7 @@ pub fn dc_get_locations(
                 Ok(loc)
             },
             |locations| {
-                let ret = dc_array_new_typed(1, 500);
+                let ret = dc_array_new_locations(500);
 
                 for location in locations {
                     unsafe {
@@ -501,7 +501,7 @@ pub unsafe fn dc_kml_parse(
     } else {
         content_nullterminated = dc_null_terminate(content, content_bytes as libc::c_int);
         if !content_nullterminated.is_null() {
-            kml.locations = dc_array_new_typed(1, 100 as size_t);
+            kml.locations = dc_array_new_locations(100);
             dc_saxparser_init(
                 &mut saxparser,
                 &mut kml as *mut dc_kml_t as *mut libc::c_void,

--- a/src/dc_location.rs
+++ b/src/dc_location.rs
@@ -247,17 +247,12 @@ pub fn dc_get_locations(
                 Ok(loc)
             },
             |locations| {
-                let ret = dc_array_new_locations(500);
+                let mut ret = dc_array_t::new_locations(500);
 
                 for location in locations {
-                    unsafe {
-                        dc_array_add_ptr(
-                            ret,
-                            Box::into_raw(Box::new(location?)) as *mut libc::c_void,
-                        )
-                    };
+                    ret.add_ptr(Box::into_raw(Box::new(location?)) as *mut libc::c_void);
                 }
-                Ok(ret)
+                Ok(ret.as_ptr())
             },
         )
         .unwrap_or_else(|_| std::ptr::null_mut())

--- a/src/dc_location.rs
+++ b/src/dc_location.rs
@@ -247,7 +247,7 @@ pub fn dc_get_locations(
                 Ok(loc)
             },
             |locations| {
-                let ret = unsafe { dc_array_new_typed(1, 500) };
+                let ret = dc_array_new_typed(1, 500);
 
                 for location in locations {
                     unsafe {


### PR DESCRIPTION
The goal is to replace dc_array_t with a wrapper for Vec, while keeping the same C API.

See #50 