### PR TITLE
Qr remove indent (systematic approach to erase gotos/match/current-block constructs)

### DIFF
--- a/src/dc_qr.rs
+++ b/src/dc_qr.rs
@@ -206,100 +206,93 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                 }
             }
         }
-        
-            if OK_TO_CONTINUE {
-                if !fingerprint.is_null() {
-                    if strlen(fingerprint) != 40 {
-                        (*qr_parsed).state = 400i32;
-                        (*qr_parsed).text1 = dc_strdup(
-                            b"Bad fingerprint length in QR code.\x00" as *const u8
-                                as *const libc::c_char,
-                        );
-                        OK_TO_CONTINUE = false;
-                    }
+
+        if OK_TO_CONTINUE {
+            if !fingerprint.is_null() {
+                if strlen(fingerprint) != 40 {
+                    (*qr_parsed).state = 400i32;
+                    (*qr_parsed).text1 = dc_strdup(
+                        b"Bad fingerprint length in QR code.\x00" as *const u8
+                            as *const libc::c_char,
+                    );
+                    OK_TO_CONTINUE = false;
                 }
             }
-            
-                if OK_TO_CONTINUE {
-                    if !fingerprint.is_null() {
-                        let peerstate =
-                            Peerstate::from_fingerprint(context, &context.sql, as_str(fingerprint));
-                        if addr.is_null() || invitenumber.is_null() || auth.is_null() {
-                            if let Some(peerstate) = peerstate {
-                                (*qr_parsed).state = 210i32;
-                                let addr_ptr = if let Some(ref addr) = peerstate.addr {
-                                    to_cstring(addr)
-                                } else {
-                                    std::ptr::null()
-                                };
-                                (*qr_parsed).id = dc_add_or_lookup_contact(
-                                    context,
-                                    0 as *const libc::c_char,
-                                    addr_ptr,
-                                    0x80i32,
-                                    0 as *mut libc::c_int,
-                                );
-                                free(addr_ptr as *mut _);
-                                dc_create_or_lookup_nchat_by_contact_id(
-                                    context,
-                                    (*qr_parsed).id,
-                                    2i32,
-                                    &mut chat_id,
-                                    0 as *mut libc::c_int,
-                                );
-                                device_msg = dc_mprintf(
-                                    b"%s verified.\x00" as *const u8 as *const libc::c_char,
-                                    peerstate.addr,
-                                )
-                            } else {
-                                (*qr_parsed).text1 = dc_format_fingerprint_c(fingerprint);
-                                (*qr_parsed).state = 230i32
-                            }
+        }
+
+        if OK_TO_CONTINUE {
+            if !fingerprint.is_null() {
+                let peerstate =
+                    Peerstate::from_fingerprint(context, &context.sql, as_str(fingerprint));
+                if addr.is_null() || invitenumber.is_null() || auth.is_null() {
+                    if let Some(peerstate) = peerstate {
+                        (*qr_parsed).state = 210i32;
+                        let addr_ptr = if let Some(ref addr) = peerstate.addr {
+                            to_cstring(addr)
                         } else {
-                            if !grpid.is_null() && !grpname.is_null() {
-                                (*qr_parsed).state = 202i32;
-                                (*qr_parsed).text1 = dc_strdup(grpname);
-                                (*qr_parsed).text2 = dc_strdup(grpid)
-                            } else {
-                                (*qr_parsed).state = 200i32
-                            }
-                            (*qr_parsed).id = dc_add_or_lookup_contact(
-                                context,
-                                name,
-                                addr,
-                                0x80i32,
-                                0 as *mut libc::c_int,
-                            );
-                            (*qr_parsed).fingerprint = dc_strdup(fingerprint);
-                            (*qr_parsed).invitenumber = dc_strdup(invitenumber);
-                            (*qr_parsed).auth = dc_strdup(auth)
-                        }
-                    } else if !addr.is_null() {
-                        (*qr_parsed).state = 320i32;
+                            std::ptr::null()
+                        };
                         (*qr_parsed).id = dc_add_or_lookup_contact(
                             context,
-                            name,
-                            addr,
+                            0 as *const libc::c_char,
+                            addr_ptr,
                             0x80i32,
                             0 as *mut libc::c_int,
+                        );
+                        free(addr_ptr as *mut _);
+                        dc_create_or_lookup_nchat_by_contact_id(
+                            context,
+                            (*qr_parsed).id,
+                            2i32,
+                            &mut chat_id,
+                            0 as *mut libc::c_int,
+                        );
+                        device_msg = dc_mprintf(
+                            b"%s verified.\x00" as *const u8 as *const libc::c_char,
+                            peerstate.addr,
                         )
-                    } else if strstr(qr, b"http://\x00" as *const u8 as *const libc::c_char)
-                        == qr as *mut libc::c_char
-                        || strstr(qr, b"https://\x00" as *const u8 as *const libc::c_char)
-                            == qr as *mut libc::c_char
-                    {
-                        (*qr_parsed).state = 332i32;
-                        (*qr_parsed).text1 = dc_strdup(qr)
                     } else {
-                        (*qr_parsed).state = 330i32;
-                        (*qr_parsed).text1 = dc_strdup(qr)
+                        (*qr_parsed).text1 = dc_format_fingerprint_c(fingerprint);
+                        (*qr_parsed).state = 230i32
                     }
-                    if !device_msg.is_null() {
-                        dc_add_device_msg(context, chat_id, device_msg);
+                } else {
+                    if !grpid.is_null() && !grpname.is_null() {
+                        (*qr_parsed).state = 202i32;
+                        (*qr_parsed).text1 = dc_strdup(grpname);
+                        (*qr_parsed).text2 = dc_strdup(grpid)
+                    } else {
+                        (*qr_parsed).state = 200i32
                     }
+                    (*qr_parsed).id = dc_add_or_lookup_contact(
+                        context,
+                        name,
+                        addr,
+                        0x80i32,
+                        0 as *mut libc::c_int,
+                    );
+                    (*qr_parsed).fingerprint = dc_strdup(fingerprint);
+                    (*qr_parsed).invitenumber = dc_strdup(invitenumber);
+                    (*qr_parsed).auth = dc_strdup(auth)
                 }
-            
-        
+            } else if !addr.is_null() {
+                (*qr_parsed).state = 320i32;
+                (*qr_parsed).id =
+                    dc_add_or_lookup_contact(context, name, addr, 0x80i32, 0 as *mut libc::c_int)
+            } else if strstr(qr, b"http://\x00" as *const u8 as *const libc::c_char)
+                == qr as *mut libc::c_char
+                || strstr(qr, b"https://\x00" as *const u8 as *const libc::c_char)
+                    == qr as *mut libc::c_char
+            {
+                (*qr_parsed).state = 332i32;
+                (*qr_parsed).text1 = dc_strdup(qr)
+            } else {
+                (*qr_parsed).state = 330i32;
+                (*qr_parsed).text1 = dc_strdup(qr)
+            }
+            if !device_msg.is_null() {
+                dc_add_device_msg(context, chat_id, device_msg);
+            }
+        }
     }
     free(addr as *mut libc::c_void);
     free(fingerprint as *mut libc::c_void);

--- a/src/dc_qr.rs
+++ b/src/dc_qr.rs
@@ -188,7 +188,6 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
             }
         }
         if OK_TO_CONTINUE {
-            {
                 /* check the parameters
                 ---------------------- */
                 if !addr.is_null() {
@@ -208,7 +207,6 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                     } 
                 } 
                 if OK_TO_CONTINUE {
-                    {
                         if !fingerprint.is_null() {
                             if strlen(fingerprint) != 40 {
                                 (*qr_parsed).state = 400i32;
@@ -220,7 +218,6 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                             } 
                         } 
                         if OK_TO_CONTINUE {
-                            {
                                 if !fingerprint.is_null() {
                                     let peerstate = Peerstate::from_fingerprint(
                                         context,
@@ -306,11 +303,11 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                                 if !device_msg.is_null() {
                                     dc_add_device_msg(context, chat_id, device_msg);
                                 }
-                            }
+                            
                         }
-                    }
+                    
                 }
-            }
+            
         }
     }
     free(addr as *mut libc::c_void);

--- a/src/dc_qr.rs
+++ b/src/dc_qr.rs
@@ -21,7 +21,7 @@ use crate::x::*;
 // text1=URL
 // text1=error string
 pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc_lot_t {
-    let mut current_block: u64;
+    let mut OK_TO_CONTINUE = true;
     let mut payload: *mut libc::c_char = 0 as *mut libc::c_char;
     // must be normalized, if set
     let mut addr: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -86,7 +86,6 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                 dc_param_unref(param);
             }
             fingerprint = dc_normalize_fingerprint_c(payload);
-            current_block = 5023038348526654800;
         } else if strncasecmp(
             qr,
             b"mailto:\x00" as *const u8 as *const libc::c_char,
@@ -101,7 +100,6 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                 *query = 0i32 as libc::c_char
             }
             addr = dc_strdup(payload);
-            current_block = 5023038348526654800;
         } else if strncasecmp(
             qr,
             b"SMTP:\x00" as *const u8 as *const libc::c_char,
@@ -116,7 +114,6 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                 *colon = 0i32 as libc::c_char
             }
             addr = dc_strdup(payload);
-            current_block = 5023038348526654800;
         } else if strncasecmp(
             qr,
             b"MATMSG:\x00" as *const u8 as *const libc::c_char,
@@ -132,12 +129,11 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                 if !semicolon.is_null() {
                     *semicolon = 0i32 as libc::c_char
                 }
-                current_block = 5023038348526654800;
             } else {
                 (*qr_parsed).state = 400i32;
                 (*qr_parsed).text1 =
                     dc_strdup(b"Bad e-mail address.\x00" as *const u8 as *const libc::c_char);
-                current_block = 16562876845594826114;
+                OK_TO_CONTINUE = false;
             }
         } else {
             if strncasecmp(
@@ -190,11 +186,9 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                 }
                 dc_free_splitted_lines(lines);
             }
-            current_block = 5023038348526654800;
         }
-        match current_block {
-            16562876845594826114 => {}
-            _ => {
+        if OK_TO_CONTINUE {
+            {
                 /* check the parameters
                 ---------------------- */
                 if !addr.is_null() {
@@ -210,16 +204,11 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                         (*qr_parsed).text1 = dc_strdup(
                             b"Bad e-mail address.\x00" as *const u8 as *const libc::c_char,
                         );
-                        current_block = 16562876845594826114;
-                    } else {
-                        current_block = 14116432890150942211;
-                    }
-                } else {
-                    current_block = 14116432890150942211;
-                }
-                match current_block {
-                    16562876845594826114 => {}
-                    _ => {
+                        OK_TO_CONTINUE = false;
+                    } 
+                } 
+                if OK_TO_CONTINUE {
+                    {
                         if !fingerprint.is_null() {
                             if strlen(fingerprint) != 40 {
                                 (*qr_parsed).state = 400i32;
@@ -227,16 +216,11 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                                     b"Bad fingerprint length in QR code.\x00" as *const u8
                                         as *const libc::c_char,
                                 );
-                                current_block = 16562876845594826114;
-                            } else {
-                                current_block = 5409161009579131794;
-                            }
-                        } else {
-                            current_block = 5409161009579131794;
-                        }
-                        match current_block {
-                            16562876845594826114 => {}
-                            _ => {
+                                OK_TO_CONTINUE = false;
+                            } 
+                        } 
+                        if OK_TO_CONTINUE {
+                            {
                                 if !fingerprint.is_null() {
                                     let peerstate = Peerstate::from_fingerprint(
                                         context,

--- a/src/dc_qr.rs
+++ b/src/dc_qr.rs
@@ -205,6 +205,8 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                     OK_TO_CONTINUE = false;
                 }
             }
+        }
+        {
             if OK_TO_CONTINUE {
                 if !fingerprint.is_null() {
                     if strlen(fingerprint) != 40 {
@@ -216,6 +218,8 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                         OK_TO_CONTINUE = false;
                     }
                 }
+            }
+            {
                 if OK_TO_CONTINUE {
                     if !fingerprint.is_null() {
                         let peerstate =

--- a/src/dc_qr.rs
+++ b/src/dc_qr.rs
@@ -206,7 +206,7 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                 }
             }
         }
-        {
+        
             if OK_TO_CONTINUE {
                 if !fingerprint.is_null() {
                     if strlen(fingerprint) != 40 {
@@ -219,7 +219,7 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                     }
                 }
             }
-            {
+            
                 if OK_TO_CONTINUE {
                     if !fingerprint.is_null() {
                         let peerstate =
@@ -298,8 +298,8 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                         dc_add_device_msg(context, chat_id, device_msg);
                     }
                 }
-            }
-        }
+            
+        
     }
     free(addr as *mut libc::c_void);
     free(fingerprint as *mut libc::c_void);

--- a/src/dc_qr.rs
+++ b/src/dc_qr.rs
@@ -188,126 +188,113 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
             }
         }
         if OK_TO_CONTINUE {
-                /* check the parameters
-                ---------------------- */
-                if !addr.is_null() {
-                    /* urldecoding is needed at least for OPENPGP4FPR but should not hurt in the other cases */
-                    let mut temp: *mut libc::c_char = dc_urldecode(addr);
-                    free(addr as *mut libc::c_void);
-                    addr = temp;
-                    temp = dc_addr_normalize(addr);
-                    free(addr as *mut libc::c_void);
-                    addr = temp;
-                    if !dc_may_be_valid_addr(addr) {
+            /* check the parameters
+            ---------------------- */
+            if !addr.is_null() {
+                /* urldecoding is needed at least for OPENPGP4FPR but should not hurt in the other cases */
+                let mut temp: *mut libc::c_char = dc_urldecode(addr);
+                free(addr as *mut libc::c_void);
+                addr = temp;
+                temp = dc_addr_normalize(addr);
+                free(addr as *mut libc::c_void);
+                addr = temp;
+                if !dc_may_be_valid_addr(addr) {
+                    (*qr_parsed).state = 400i32;
+                    (*qr_parsed).text1 =
+                        dc_strdup(b"Bad e-mail address.\x00" as *const u8 as *const libc::c_char);
+                    OK_TO_CONTINUE = false;
+                }
+            }
+            if OK_TO_CONTINUE {
+                if !fingerprint.is_null() {
+                    if strlen(fingerprint) != 40 {
                         (*qr_parsed).state = 400i32;
                         (*qr_parsed).text1 = dc_strdup(
-                            b"Bad e-mail address.\x00" as *const u8 as *const libc::c_char,
+                            b"Bad fingerprint length in QR code.\x00" as *const u8
+                                as *const libc::c_char,
                         );
                         OK_TO_CONTINUE = false;
-                    } 
-                } 
-                if OK_TO_CONTINUE {
-                        if !fingerprint.is_null() {
-                            if strlen(fingerprint) != 40 {
-                                (*qr_parsed).state = 400i32;
-                                (*qr_parsed).text1 = dc_strdup(
-                                    b"Bad fingerprint length in QR code.\x00" as *const u8
-                                        as *const libc::c_char,
-                                );
-                                OK_TO_CONTINUE = false;
-                            } 
-                        } 
-                        if OK_TO_CONTINUE {
-                                if !fingerprint.is_null() {
-                                    let peerstate = Peerstate::from_fingerprint(
-                                        context,
-                                        &context.sql,
-                                        as_str(fingerprint),
-                                    );
-                                    if addr.is_null() || invitenumber.is_null() || auth.is_null() {
-                                        if let Some(peerstate) = peerstate {
-                                            (*qr_parsed).state = 210i32;
-                                            let addr_ptr = if let Some(ref addr) = peerstate.addr {
-                                                to_cstring(addr)
-                                            } else {
-                                                std::ptr::null()
-                                            };
-                                            (*qr_parsed).id = dc_add_or_lookup_contact(
-                                                context,
-                                                0 as *const libc::c_char,
-                                                addr_ptr,
-                                                0x80i32,
-                                                0 as *mut libc::c_int,
-                                            );
-                                            free(addr_ptr as *mut _);
-                                            dc_create_or_lookup_nchat_by_contact_id(
-                                                context,
-                                                (*qr_parsed).id,
-                                                2i32,
-                                                &mut chat_id,
-                                                0 as *mut libc::c_int,
-                                            );
-                                            device_msg = dc_mprintf(
-                                                b"%s verified.\x00" as *const u8
-                                                    as *const libc::c_char,
-                                                peerstate.addr,
-                                            )
-                                        } else {
-                                            (*qr_parsed).text1 =
-                                                dc_format_fingerprint_c(fingerprint);
-                                            (*qr_parsed).state = 230i32
-                                        }
-                                    } else {
-                                        if !grpid.is_null() && !grpname.is_null() {
-                                            (*qr_parsed).state = 202i32;
-                                            (*qr_parsed).text1 = dc_strdup(grpname);
-                                            (*qr_parsed).text2 = dc_strdup(grpid)
-                                        } else {
-                                            (*qr_parsed).state = 200i32
-                                        }
-                                        (*qr_parsed).id = dc_add_or_lookup_contact(
-                                            context,
-                                            name,
-                                            addr,
-                                            0x80i32,
-                                            0 as *mut libc::c_int,
-                                        );
-                                        (*qr_parsed).fingerprint = dc_strdup(fingerprint);
-                                        (*qr_parsed).invitenumber = dc_strdup(invitenumber);
-                                        (*qr_parsed).auth = dc_strdup(auth)
-                                    }
-                                } else if !addr.is_null() {
-                                    (*qr_parsed).state = 320i32;
-                                    (*qr_parsed).id = dc_add_or_lookup_contact(
-                                        context,
-                                        name,
-                                        addr,
-                                        0x80i32,
-                                        0 as *mut libc::c_int,
-                                    )
-                                } else if strstr(
-                                    qr,
-                                    b"http://\x00" as *const u8 as *const libc::c_char,
-                                ) == qr as *mut libc::c_char
-                                    || strstr(
-                                        qr,
-                                        b"https://\x00" as *const u8 as *const libc::c_char,
-                                    ) == qr as *mut libc::c_char
-                                {
-                                    (*qr_parsed).state = 332i32;
-                                    (*qr_parsed).text1 = dc_strdup(qr)
-                                } else {
-                                    (*qr_parsed).state = 330i32;
-                                    (*qr_parsed).text1 = dc_strdup(qr)
-                                }
-                                if !device_msg.is_null() {
-                                    dc_add_device_msg(context, chat_id, device_msg);
-                                }
-                            
-                        }
-                    
+                    }
                 }
-            
+                if OK_TO_CONTINUE {
+                    if !fingerprint.is_null() {
+                        let peerstate =
+                            Peerstate::from_fingerprint(context, &context.sql, as_str(fingerprint));
+                        if addr.is_null() || invitenumber.is_null() || auth.is_null() {
+                            if let Some(peerstate) = peerstate {
+                                (*qr_parsed).state = 210i32;
+                                let addr_ptr = if let Some(ref addr) = peerstate.addr {
+                                    to_cstring(addr)
+                                } else {
+                                    std::ptr::null()
+                                };
+                                (*qr_parsed).id = dc_add_or_lookup_contact(
+                                    context,
+                                    0 as *const libc::c_char,
+                                    addr_ptr,
+                                    0x80i32,
+                                    0 as *mut libc::c_int,
+                                );
+                                free(addr_ptr as *mut _);
+                                dc_create_or_lookup_nchat_by_contact_id(
+                                    context,
+                                    (*qr_parsed).id,
+                                    2i32,
+                                    &mut chat_id,
+                                    0 as *mut libc::c_int,
+                                );
+                                device_msg = dc_mprintf(
+                                    b"%s verified.\x00" as *const u8 as *const libc::c_char,
+                                    peerstate.addr,
+                                )
+                            } else {
+                                (*qr_parsed).text1 = dc_format_fingerprint_c(fingerprint);
+                                (*qr_parsed).state = 230i32
+                            }
+                        } else {
+                            if !grpid.is_null() && !grpname.is_null() {
+                                (*qr_parsed).state = 202i32;
+                                (*qr_parsed).text1 = dc_strdup(grpname);
+                                (*qr_parsed).text2 = dc_strdup(grpid)
+                            } else {
+                                (*qr_parsed).state = 200i32
+                            }
+                            (*qr_parsed).id = dc_add_or_lookup_contact(
+                                context,
+                                name,
+                                addr,
+                                0x80i32,
+                                0 as *mut libc::c_int,
+                            );
+                            (*qr_parsed).fingerprint = dc_strdup(fingerprint);
+                            (*qr_parsed).invitenumber = dc_strdup(invitenumber);
+                            (*qr_parsed).auth = dc_strdup(auth)
+                        }
+                    } else if !addr.is_null() {
+                        (*qr_parsed).state = 320i32;
+                        (*qr_parsed).id = dc_add_or_lookup_contact(
+                            context,
+                            name,
+                            addr,
+                            0x80i32,
+                            0 as *mut libc::c_int,
+                        )
+                    } else if strstr(qr, b"http://\x00" as *const u8 as *const libc::c_char)
+                        == qr as *mut libc::c_char
+                        || strstr(qr, b"https://\x00" as *const u8 as *const libc::c_char)
+                            == qr as *mut libc::c_char
+                    {
+                        (*qr_parsed).state = 332i32;
+                        (*qr_parsed).text1 = dc_strdup(qr)
+                    } else {
+                        (*qr_parsed).state = 330i32;
+                        (*qr_parsed).text1 = dc_strdup(qr)
+                    }
+                    if !device_msg.is_null() {
+                        dc_add_device_msg(context, chat_id, device_msg);
+                    }
+                }
+            }
         }
     }
     free(addr as *mut libc::c_void);


### PR DESCRIPTION
This is an attempt to systamateically make several functions more readable that were converted by C2Rust -- which lead to deep indentation bevcause of the way C2Rust translates "goto cleanup" constructs. 

Idea is the review the changes commit-by-commit, and to use "cargo fmt" to do the actual deindentation.  These "automated" cargo-fmt commits need no review because we trust the rust fmt ;) 

