### PR TITLE
Remove gotos from mimefactory, systematical approach, implements cleanup routine as closure

### DIFF
--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -899,14 +899,8 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                         mailmime_smart_add_part(message, file_part);
                         parts += 1
                     }
-                    current_block = 13000670339742628194;
                 }
-            } else {
-                current_block = 13000670339742628194;
             }
-            match current_block {
-                11328123142868406523 => {}
-                _ => {
                     if parts == 0 {
                         set_error(
                             factory,
@@ -985,8 +979,6 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                             }
                         }
                     }
-                }
-            }
         } else if (*factory).loaded as libc::c_uint
             == DC_MF_MDN_LOADED as libc::c_int as libc::c_uint
         {
@@ -1031,7 +1023,6 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
             mailmime_set_body_text(mach_mime_part, message_text2, strlen(message_text2));
             mailmime_add_part(multipart, mach_mime_part);
             force_plaintext = 2;
-            current_block = 9952640327414195044;
         } else {
             set_error(
                 factory,
@@ -1039,9 +1030,6 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
             );
             return cleanup(e2ee_helper);
         }
-        match current_block {
-            11328123142868406523 => {}
-            _ => {
                 if (*factory).loaded as libc::c_uint
                     == DC_MF_MDN_LOADED as libc::c_int as libc::c_uint
                 {
@@ -1103,8 +1091,6 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                 (*factory).out = mmap_string_new(b"\x00" as *const u8 as *const libc::c_char);
                 mailmime_write_mem((*factory).out, &mut col, message);
                 success = 1
-            }
-        }
     }
     if !message.is_null() {
         mailmime_free(message);

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -355,7 +355,6 @@ pub unsafe fn dc_mimefactory_load_mdn(
 // TODO should return bool /rtn
 pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc::c_int {
     let subject: *mut mailimf_subject;
-    let mut current_block: u64;
     let imf_fields: *mut mailimf_fields;
     let mut message: *mut mailmime = 0 as *mut mailmime;
     let mut message_text: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -892,7 +891,7 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                     );
                     set_error(factory, error);
                     free(error as *mut libc::c_void);
-                    current_block = 11328123142868406523;
+                    return cleanup(e2ee_helper); 
                 } else {
                     let file_part: *mut mailmime =
                         build_body_file(msg, 0 as *const libc::c_char, 0 as *mut *mut libc::c_char);
@@ -913,7 +912,7 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                             factory,
                             b"Empty message.\x00" as *const u8 as *const libc::c_char,
                         );
-                        current_block = 11328123142868406523;
+                        return cleanup(e2ee_helper);
                     } else {
                         if !meta_part.is_null() {
                             mailmime_smart_add_part(message, meta_part);
@@ -985,7 +984,6 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                                 }
                             }
                         }
-                        current_block = 9952640327414195044;
                     }
                 }
             }
@@ -1039,7 +1037,7 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                 factory,
                 b"No message loaded.\x00" as *const u8 as *const libc::c_char,
             );
-            current_block = 11328123142868406523;
+            return cleanup(e2ee_helper);
         }
         match current_block {
             11328123142868406523 => {}

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -891,7 +891,7 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                     );
                     set_error(factory, error);
                     free(error as *mut libc::c_void);
-                    return cleanup(e2ee_helper); 
+                    return cleanup(e2ee_helper);
                 } else {
                     let file_part: *mut mailmime =
                         build_body_file(msg, 0 as *const libc::c_char, 0 as *mut *mut libc::c_char);
@@ -901,84 +901,71 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                     }
                 }
             }
-                    if parts == 0 {
-                        set_error(
-                            factory,
-                            b"Empty message.\x00" as *const u8 as *const libc::c_char,
+            if parts == 0 {
+                set_error(
+                    factory,
+                    b"Empty message.\x00" as *const u8 as *const libc::c_char,
+                );
+                return cleanup(e2ee_helper);
+            } else {
+                if !meta_part.is_null() {
+                    mailmime_smart_add_part(message, meta_part);
+                }
+                if 0 != dc_param_exists((*msg).param, DC_PARAM_SET_LATITUDE as libc::c_int) {
+                    let latitude =
+                        dc_param_get_float((*msg).param, DC_PARAM_SET_LATITUDE as libc::c_int, 0.0);
+                    let longitude = dc_param_get_float(
+                        (*msg).param,
+                        DC_PARAM_SET_LONGITUDE as libc::c_int,
+                        0.0,
+                    );
+                    let kml_file = dc_get_message_kml((*msg).timestamp_sort, latitude, longitude);
+                    if !kml_file.is_null() {
+                        let content_type = mailmime_content_new_with_str(
+                            b"application/vnd.google-earth.kml+xml\x00" as *const u8
+                                as *const libc::c_char,
                         );
-                        return cleanup(e2ee_helper);
-                    } else {
-                        if !meta_part.is_null() {
-                            mailmime_smart_add_part(message, meta_part);
-                        }
-                        if 0 != dc_param_exists((*msg).param, DC_PARAM_SET_LATITUDE as libc::c_int)
+                        let mime_fields = mailmime_fields_new_filename(
+                            MAILMIME_DISPOSITION_TYPE_ATTACHMENT as libc::c_int,
+                            dc_strdup(b"message.kml\x00" as *const u8 as *const libc::c_char),
+                            MAILMIME_MECHANISM_8BIT as libc::c_int,
+                        );
+                        let kml_mime_part = mailmime_new_empty(content_type, mime_fields);
+                        mailmime_set_body_text(kml_mime_part, kml_file, strlen(kml_file));
+
+                        mailmime_smart_add_part(message, kml_mime_part);
+                    }
+                }
+
+                if dc_is_sending_locations_to_chat((*msg).context, (*msg).chat_id) {
+                    let mut last_added_location_id: uint32_t = 0 as uint32_t;
+                    let kml_file: *mut libc::c_char = dc_get_location_kml(
+                        (*msg).context,
+                        (*msg).chat_id,
+                        &mut last_added_location_id,
+                    );
+                    if !kml_file.is_null() {
+                        let content_type: *mut mailmime_content = mailmime_content_new_with_str(
+                            b"application/vnd.google-earth.kml+xml\x00" as *const u8
+                                as *const libc::c_char,
+                        );
+                        let mime_fields: *mut mailmime_fields = mailmime_fields_new_filename(
+                            MAILMIME_DISPOSITION_TYPE_ATTACHMENT as libc::c_int,
+                            dc_strdup(b"location.kml\x00" as *const u8 as *const libc::c_char),
+                            MAILMIME_MECHANISM_8BIT as libc::c_int,
+                        );
+                        let kml_mime_part: *mut mailmime =
+                            mailmime_new_empty(content_type, mime_fields);
+                        mailmime_set_body_text(kml_mime_part, kml_file, strlen(kml_file));
+                        mailmime_smart_add_part(message, kml_mime_part);
+                        if 0 == dc_param_exists((*msg).param, DC_PARAM_SET_LATITUDE as libc::c_int)
                         {
-                            let latitude = dc_param_get_float(
-                                (*msg).param,
-                                DC_PARAM_SET_LATITUDE as libc::c_int,
-                                0.0,
-                            );
-                            let longitude = dc_param_get_float(
-                                (*msg).param,
-                                DC_PARAM_SET_LONGITUDE as libc::c_int,
-                                0.0,
-                            );
-                            let kml_file =
-                                dc_get_message_kml((*msg).timestamp_sort, latitude, longitude);
-                            if !kml_file.is_null() {
-                                let content_type = mailmime_content_new_with_str(
-                                    b"application/vnd.google-earth.kml+xml\x00" as *const u8
-                                        as *const libc::c_char,
-                                );
-                                let mime_fields = mailmime_fields_new_filename(
-                                    MAILMIME_DISPOSITION_TYPE_ATTACHMENT as libc::c_int,
-                                    dc_strdup(
-                                        b"message.kml\x00" as *const u8 as *const libc::c_char,
-                                    ),
-                                    MAILMIME_MECHANISM_8BIT as libc::c_int,
-                                );
-                                let kml_mime_part = mailmime_new_empty(content_type, mime_fields);
-                                mailmime_set_body_text(kml_mime_part, kml_file, strlen(kml_file));
-
-                                mailmime_smart_add_part(message, kml_mime_part);
-                            }
-                        }
-
-                        if dc_is_sending_locations_to_chat((*msg).context, (*msg).chat_id) {
-                            let mut last_added_location_id: uint32_t = 0 as uint32_t;
-                            let kml_file: *mut libc::c_char = dc_get_location_kml(
-                                (*msg).context,
-                                (*msg).chat_id,
-                                &mut last_added_location_id,
-                            );
-                            if !kml_file.is_null() {
-                                let content_type: *mut mailmime_content =
-                                    mailmime_content_new_with_str(
-                                        b"application/vnd.google-earth.kml+xml\x00" as *const u8
-                                            as *const libc::c_char,
-                                    );
-                                let mime_fields: *mut mailmime_fields =
-                                    mailmime_fields_new_filename(
-                                        MAILMIME_DISPOSITION_TYPE_ATTACHMENT as libc::c_int,
-                                        dc_strdup(
-                                            b"location.kml\x00" as *const u8 as *const libc::c_char,
-                                        ),
-                                        MAILMIME_MECHANISM_8BIT as libc::c_int,
-                                    );
-                                let kml_mime_part: *mut mailmime =
-                                    mailmime_new_empty(content_type, mime_fields);
-                                mailmime_set_body_text(kml_mime_part, kml_file, strlen(kml_file));
-                                mailmime_smart_add_part(message, kml_mime_part);
-                                if 0 == dc_param_exists(
-                                    (*msg).param,
-                                    DC_PARAM_SET_LATITUDE as libc::c_int,
-                                ) {
-                                    // otherwise, the independent location is already filed
-                                    (*factory).out_last_added_location_id = last_added_location_id;
-                                }
-                            }
+                            // otherwise, the independent location is already filed
+                            (*factory).out_last_added_location_id = last_added_location_id;
                         }
                     }
+                }
+            }
         } else if (*factory).loaded as libc::c_uint
             == DC_MF_MDN_LOADED as libc::c_int as libc::c_uint
         {
@@ -1030,67 +1017,64 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
             );
             return cleanup(e2ee_helper);
         }
-                if (*factory).loaded as libc::c_uint
-                    == DC_MF_MDN_LOADED as libc::c_int as libc::c_uint
-                {
-                    let e: *mut libc::c_char = dc_stock_str((*factory).context, 31);
-                    subject_str =
-                        dc_mprintf(b"Chat: %s\x00" as *const u8 as *const libc::c_char, e);
-                    free(e as *mut libc::c_void);
-                } else {
-                    subject_str = get_subject((*factory).chat, (*factory).msg, afwd_email)
-                }
-                subject = mailimf_subject_new(dc_encode_header_words(subject_str));
-                mailimf_fields_add(
-                    imf_fields,
-                    mailimf_field_new(
-                        MAILIMF_FIELD_SUBJECT as libc::c_int,
-                        0 as *mut mailimf_return,
-                        0 as *mut mailimf_orig_date,
-                        0 as *mut mailimf_from,
-                        0 as *mut mailimf_sender,
-                        0 as *mut mailimf_to,
-                        0 as *mut mailimf_cc,
-                        0 as *mut mailimf_bcc,
-                        0 as *mut mailimf_message_id,
-                        0 as *mut mailimf_orig_date,
-                        0 as *mut mailimf_from,
-                        0 as *mut mailimf_sender,
-                        0 as *mut mailimf_reply_to,
-                        0 as *mut mailimf_to,
-                        0 as *mut mailimf_cc,
-                        0 as *mut mailimf_bcc,
-                        0 as *mut mailimf_message_id,
-                        0 as *mut mailimf_in_reply_to,
-                        0 as *mut mailimf_references,
-                        subject,
-                        0 as *mut mailimf_comments,
-                        0 as *mut mailimf_keywords,
-                        0 as *mut mailimf_optional_field,
-                    ),
-                );
-                if force_plaintext != 2 {
-                    dc_e2ee_encrypt(
-                        (*factory).context,
-                        (*factory).recipients_addr,
-                        force_plaintext,
-                        e2ee_guaranteed,
-                        min_verified,
-                        do_gossip,
-                        message,
-                        &mut e2ee_helper,
-                    );
-                }
-                
-                if 0 != e2ee_helper.encryption_successfull {
-                    (*factory).out_encrypted = 1;
-                    if 0 != do_gossip {
-                        (*factory).out_gossiped = 1
-                    }
-                }
-                (*factory).out = mmap_string_new(b"\x00" as *const u8 as *const libc::c_char);
-                mailmime_write_mem((*factory).out, &mut col, message);
-                success = 1
+        if (*factory).loaded as libc::c_uint == DC_MF_MDN_LOADED as libc::c_int as libc::c_uint {
+            let e: *mut libc::c_char = dc_stock_str((*factory).context, 31);
+            subject_str = dc_mprintf(b"Chat: %s\x00" as *const u8 as *const libc::c_char, e);
+            free(e as *mut libc::c_void);
+        } else {
+            subject_str = get_subject((*factory).chat, (*factory).msg, afwd_email)
+        }
+        subject = mailimf_subject_new(dc_encode_header_words(subject_str));
+        mailimf_fields_add(
+            imf_fields,
+            mailimf_field_new(
+                MAILIMF_FIELD_SUBJECT as libc::c_int,
+                0 as *mut mailimf_return,
+                0 as *mut mailimf_orig_date,
+                0 as *mut mailimf_from,
+                0 as *mut mailimf_sender,
+                0 as *mut mailimf_to,
+                0 as *mut mailimf_cc,
+                0 as *mut mailimf_bcc,
+                0 as *mut mailimf_message_id,
+                0 as *mut mailimf_orig_date,
+                0 as *mut mailimf_from,
+                0 as *mut mailimf_sender,
+                0 as *mut mailimf_reply_to,
+                0 as *mut mailimf_to,
+                0 as *mut mailimf_cc,
+                0 as *mut mailimf_bcc,
+                0 as *mut mailimf_message_id,
+                0 as *mut mailimf_in_reply_to,
+                0 as *mut mailimf_references,
+                subject,
+                0 as *mut mailimf_comments,
+                0 as *mut mailimf_keywords,
+                0 as *mut mailimf_optional_field,
+            ),
+        );
+        if force_plaintext != 2 {
+            dc_e2ee_encrypt(
+                (*factory).context,
+                (*factory).recipients_addr,
+                force_plaintext,
+                e2ee_guaranteed,
+                min_verified,
+                do_gossip,
+                message,
+                &mut e2ee_helper,
+            );
+        }
+
+        if 0 != e2ee_helper.encryption_successfull {
+            (*factory).out_encrypted = 1;
+            if 0 != do_gossip {
+                (*factory).out_gossiped = 1
+            }
+        }
+        (*factory).out = mmap_string_new(b"\x00" as *const u8 as *const libc::c_char);
+        mailmime_write_mem((*factory).out, &mut col, message);
+        success = 1
     }
     if !message.is_null() {
         mailmime_free(message);


### PR DESCRIPTION
What makes me wonder is that after this changes, i get compiler warnings:
```
warning: value assigned to `force_plaintext` is never read
   --> src/dc_mimefactory.rs:370:13
    |
370 |     let mut force_plaintext: libc::c_int = 0;
    |             ^^^^^^^^^^^^^^^
    |
    = note: #[warn(unused_assignments)] on by default
    = help: maybe it is overwritten before being read?

warning: value assigned to `success` is never read
    --> src/dc_mimefactory.rs:1077:9
     |
1077 |         success = 1
     |         ^^^^^^^
     |
     = help: maybe it is overwritten before being read?

```