### PR TITLE
add test, fix and high level python api for dc_delete_contact

### DIFF
--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -166,6 +166,17 @@ class Account(object):
         assert contact_id > const.DC_CHAT_ID_LAST_SPECIAL
         return Contact(self._dc_context, contact_id)
 
+    def delete_contact(self, contact):
+        """ delete a Contact.
+
+        :param contact: contact object obtained
+        :returns: True if deletion succeeded (contact was deleted)
+        """
+        contact_id = contact.id
+        assert contact._dc_context == self._dc_context
+        assert contact_id > const.DC_CHAT_ID_LAST_SPECIAL
+        return bool(lib.dc_delete_contact(self._dc_context, contact_id))
+
     def get_contacts(self, query=None, with_self=False, only_verified=False):
         """ get a (filtered) list of contacts.
 

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -66,7 +66,7 @@ class TestOfflineAccount:
         assert not contact1.is_blocked()
         assert not contact1.is_verified()
 
-    def test_get_contacts(self, acfactory):
+    def test_get_contacts_and_delete(self, acfactory):
         ac1 = acfactory.get_configured_offline_account()
         contact1 = ac1.create_contact(email="some1@hello.com", name="some1")
         contacts = ac1.get_contacts()
@@ -78,6 +78,16 @@ class TestOfflineAccount:
         assert not ac1.get_contacts(only_verified=True)
         contacts = ac1.get_contacts(with_self=True)
         assert len(contacts) == 2
+
+        assert ac1.delete_contact(contact1)
+        assert contact1 not in ac1.get_contacts()
+
+    def test_get_contacts_and_delete_fails(self, acfactory):
+        ac1 = acfactory.get_configured_offline_account()
+        contact1 = ac1.create_contact(email="some1@example.com", name="some1")
+        chat = ac1.create_chat_by_contact(contact1)
+        chat.send_text("one messae")
+        assert not ac1.delete_contact(contact1)
 
     def test_chat(self, acfactory):
         ac1 = acfactory.get_configured_offline_account()

--- a/src/dc_contact.rs
+++ b/src/dc_contact.rs
@@ -796,7 +796,7 @@ pub fn dc_delete_contact(context: &Context, contact_id: u32) -> bool {
         0
     };
 
-    if count_msgs > 0 {
+    if count_msgs == 0 {
         if sql::execute(
             context,
             &context.sql,
@@ -808,9 +808,14 @@ pub fn dc_delete_contact(context: &Context, contact_id: u32) -> bool {
             context.call_cb(Event::CONTACTS_CHANGED, 0, 0);
             true
         } else {
+            error!(context, 0, "delete_contact {} failed", contact_id);
             false
         }
     } else {
+        info!(
+            context,
+            0, "could not delete contact {}, there are {} messages with it", contact_id, count_msgs
+        );
         false
     }
 }


### PR DESCRIPTION
the rust-logic was inverted -- you can not delete a contact that still has messages with it.