### PR TITLE
Improve punctuation of message, printed by "repl" program

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -340,7 +340,7 @@ fn open(
             info!(
                 context,
                 0,
-                "First time init: creating tables in \"{:?}\".",
+                "First time init: creating tables in {:?}.",
                 dbfile.as_ref(),
             );
             sql.execute(
@@ -816,7 +816,7 @@ fn open(
         }
     }
 
-    info!(context, 0, "Opened \"{:?}\".", dbfile.as_ref(),);
+    info!(context, 0, "Opened {:?}.", dbfile.as_ref(),);
 
     Ok(())
 }


### PR DESCRIPTION
This patch changes output of following command (from README.md)

	$ cargo run --example repl -- /tmp/main.db

from

	First time init: creating tables in ""/tmp/main.db""
	[...]
	Opened ""/tmp/main.db"".

to

	First time init: creating tables in "/tmp/main.db"
	[...]
	Opened "/tmp/main.db".

Note lack of double quotation mark, which was confusing and could have been
interpreted as part of file name.