### PR TITLE
carefully replace msg state and type numbers with constants

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -222,10 +222,10 @@ unsafe fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: *mut dc_msg_t
     let contact_name: *mut libc::c_char = dc_contact_get_name(contact);
     let contact_id: libc::c_int = dc_contact_get_id(contact) as libc::c_int;
     let statestr = match dc_msg_get_state(msg) {
-        20 => " o",
-        26 => " √",
-        28 => " √√",
-        24 => " !!",
+        DC_STATE_OUT_PENDING => " o",
+        DC_STATE_OUT_DELIVERED => " √",
+        DC_STATE_OUT_MDN_RCVD => " √√",
+        DC_STATE_OUT_FAILED => " !!",
         _ => "",
     };
     let temp2: *mut libc::c_char = dc_timestamp_to_str(dc_msg_get_timestamp(msg));
@@ -252,9 +252,9 @@ unsafe fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: *mut dc_msg_t
         },
         if dc_msg_get_from_id(msg) == 1 as libc::c_uint {
             ""
-        } else if dc_msg_get_state(msg) == 16 {
+        } else if dc_msg_get_state(msg) == DC_STATE_IN_SEEN {
             "[SEEN]"
-        } else if dc_msg_get_state(msg) == 13 {
+        } else if dc_msg_get_state(msg) == DC_STATE_IN_NOTICED {
             "[NOTICED]"
         } else {
             "[FRESH]"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -68,17 +68,17 @@ pub const DC_MSG_ID_MARKER1: usize = 1;
 pub const DC_MSG_ID_DAYMARKER: usize = 9;
 pub const DC_MSG_ID_LAST_SPECIAL: usize = 9;
 
-pub const DC_STATE_UNDEFINED: usize = 0;
-pub const DC_STATE_IN_FRESH: usize = 10;
-pub const DC_STATE_IN_NOTICED: usize = 13;
-pub const DC_STATE_IN_SEEN: usize = 16;
-pub const DC_STATE_OUT_PREPARING: usize = 18;
-pub const DC_STATE_OUT_DRAFT: usize = 19;
-pub const DC_STATE_OUT_PENDING: usize = 20;
-pub const DC_STATE_OUT_FAILED: usize = 24;
+pub const DC_STATE_UNDEFINED: i32 = 0;
+pub const DC_STATE_IN_FRESH: i32 = 10;
+pub const DC_STATE_IN_NOTICED: i32 = 13;
+pub const DC_STATE_IN_SEEN: i32 = 16;
+pub const DC_STATE_OUT_PREPARING: i32 = 18;
+pub const DC_STATE_OUT_DRAFT: i32 = 19;
+pub const DC_STATE_OUT_PENDING: i32 = 20;
+pub const DC_STATE_OUT_FAILED: i32 = 24;
 /// to check if a mail was sent, use dc_msg_is_sent()
-pub const DC_STATE_OUT_DELIVERED: usize = 26;
-pub const DC_STATE_OUT_MDN_RCVD: usize = 28;
+pub const DC_STATE_OUT_DELIVERED: i32 = 26;
+pub const DC_STATE_OUT_MDN_RCVD: i32 = 28;
 
 /// approx. max. length returned by dc_msg_get_text()
 pub const DC_MAX_GET_TEXT_LEN: usize = 30000;
@@ -98,29 +98,29 @@ pub const DC_CREATE_MVBOX: usize = 1;
 /// Text message.
 /// The text of the message is set using dc_msg_set_text()
 /// and retrieved with dc_msg_get_text().
-pub const DC_MSG_TEXT: usize = 10;
+pub const DC_MSG_TEXT: i32 = 10;
 
 /// Image message.
 /// If the image is an animated GIF, the type DC_MSG_GIF should be used.
 /// File, width and height are set via dc_msg_set_file(), dc_msg_set_dimension
 /// and retrieved via dc_msg_set_file(), dc_msg_set_dimension().
-pub const DC_MSG_IMAGE: usize = 20;
+pub const DC_MSG_IMAGE: i32 = 20;
 
 /// Animated GIF message.
 /// File, width and height are set via dc_msg_set_file(), dc_msg_set_dimension()
 /// and retrieved via dc_msg_get_file(), dc_msg_get_width(), dc_msg_get_height().
-pub const DC_MSG_GIF: usize = 21;
+pub const DC_MSG_GIF: i32 = 21;
 
 /// Message containing an Audio file.
 /// File and duration are set via dc_msg_set_file(), dc_msg_set_duration()
 /// and retrieved via dc_msg_get_file(), dc_msg_get_duration().
-pub const DC_MSG_AUDIO: usize = 40;
+pub const DC_MSG_AUDIO: i32 = 40;
 
 /// A voice message that was directly recorded by the user.
 /// For all other audio messages, the type #DC_MSG_AUDIO should be used.
 /// File and duration are set via dc_msg_set_file(), dc_msg_set_duration()
 /// and retrieved via dc_msg_get_file(), dc_msg_get_duration()
-pub const DC_MSG_VOICE: usize = 41;
+pub const DC_MSG_VOICE: i32 = 41;
 
 /// Video messages.
 /// File, width, height and durarion
@@ -128,12 +128,12 @@ pub const DC_MSG_VOICE: usize = 41;
 /// and retrieved via
 /// dc_msg_get_file(), dc_msg_get_width(),
 /// dc_msg_get_height(), dc_msg_get_duration().
-pub const DC_MSG_VIDEO: usize = 50;
+pub const DC_MSG_VIDEO: i32 = 50;
 
 /// Message containing any file, eg. a PDF.
 /// The file is set via dc_msg_set_file()
 /// and retrieved via dc_msg_get_file().
-pub const DC_MSG_FILE: usize = 60;
+pub const DC_MSG_FILE: i32 = 60;
 
 // Flags for configuring IMAP and SMTP servers.
 // These flags are optional

--- a/src/dc_contact.rs
+++ b/src/dc_contact.rs
@@ -1,6 +1,6 @@
 use crate::aheader::EncryptPreference;
 use crate::config;
-use crate::constants::Event;
+use crate::constants::*;
 use crate::context::Context;
 use crate::dc_array::*;
 use crate::dc_e2ee::*;
@@ -32,8 +32,8 @@ pub fn dc_marknoticed_contact(context: &Context, contact_id: u32) {
     if sql::execute(
         context,
         &context.sql,
-        "UPDATE msgs SET state=13 WHERE from_id=? AND state=10;",
-        params![contact_id as i32],
+        "UPDATE msgs SET state=? WHERE from_id=? AND state=?;",
+        params![DC_STATE_IN_NOTICED, contact_id as i32, DC_STATE_IN_FRESH],
     )
     .is_ok()
     {

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -142,7 +142,7 @@ pub unsafe fn dc_initiate_key_transfer(context: &Context) -> *mut libc::c_char {
                         chat_id = dc_create_chat_by_contact_id(context, 1i32 as uint32_t);
                         if !(chat_id == 0i32 as libc::c_uint) {
                             msg = dc_msg_new_untyped(context);
-                            (*msg).type_0 = 60i32;
+                            (*msg).type_0 = DC_MSG_FILE;
                             dc_param_set((*msg).param, DC_PARAM_FILE as i32, setup_file_name);
                             dc_param_set(
                                 (*msg).param,

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -787,11 +787,11 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                 }
                 dc_msg_unref(meta);
             }
-            if (*msg).type_0 == DC_MSG_VOICE as libc::c_int
-                || (*msg).type_0 == DC_MSG_AUDIO as libc::c_int
-                || (*msg).type_0 == DC_MSG_VIDEO as libc::c_int
+            if (*msg).type_0 == DC_MSG_VOICE
+                || (*msg).type_0 == DC_MSG_AUDIO
+                || (*msg).type_0 == DC_MSG_VIDEO
             {
-                if (*msg).type_0 == DC_MSG_VOICE as libc::c_int {
+                if (*msg).type_0 == DC_MSG_VOICE {
                     mailimf_fields_add(
                         imf_fields,
                         mailimf_field_new_custom(
@@ -867,13 +867,7 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
             free(fwdhint as *mut libc::c_void);
             free(placeholdertext as *mut libc::c_void);
             /* add attachment part */
-            if (*msg).type_0 == DC_MSG_IMAGE as libc::c_int
-                || (*msg).type_0 == DC_MSG_GIF as libc::c_int
-                || (*msg).type_0 == DC_MSG_AUDIO as libc::c_int
-                || (*msg).type_0 == DC_MSG_VOICE as libc::c_int
-                || (*msg).type_0 == DC_MSG_VIDEO as libc::c_int
-                || (*msg).type_0 == DC_MSG_FILE as libc::c_int
-            {
+            if msgtype_has_file((*msg).type_0) {
                 if 0 == is_file_size_okay(msg) {
                     let error: *mut libc::c_char = dc_mprintf(
                         b"Message exceeds the recommended %i MB.\x00" as *const u8
@@ -1194,7 +1188,7 @@ unsafe fn build_body_file(
     let mut filename_to_send: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut filename_encoded: *mut libc::c_char = 0 as *mut libc::c_char;
     if !pathNfilename.is_null() {
-        if (*msg).type_0 == DC_MSG_VOICE as libc::c_int {
+        if (*msg).type_0 == DC_MSG_VOICE {
             let ts = chrono::Utc.timestamp((*msg).timestamp_sort as i64, 0);
 
             let suffix = if !suffix.is_null() {
@@ -1206,11 +1200,9 @@ unsafe fn build_body_file(
                 .format(&format!("voice-message_%Y-%m-%d_%H-%M-%S.{}", suffix))
                 .to_string();
             filename_to_send = to_cstring(res);
-        } else if (*msg).type_0 == DC_MSG_AUDIO as libc::c_int {
+        } else if (*msg).type_0 == DC_MSG_AUDIO {
             filename_to_send = dc_get_filename(pathNfilename)
-        } else if (*msg).type_0 == DC_MSG_IMAGE as libc::c_int
-            || (*msg).type_0 == DC_MSG_GIF as libc::c_int
-        {
+        } else if (*msg).type_0 == DC_MSG_IMAGE || (*msg).type_0 == DC_MSG_GIF {
             if base_name.is_null() {
                 base_name = b"image\x00" as *const u8 as *const libc::c_char
             }
@@ -1223,7 +1215,7 @@ unsafe fn build_body_file(
                     b"dat\x00" as *const u8 as *const libc::c_char
                 },
             )
-        } else if (*msg).type_0 == DC_MSG_VIDEO as libc::c_int {
+        } else if (*msg).type_0 == DC_MSG_VIDEO {
             filename_to_send = dc_mprintf(
                 b"video.%s\x00" as *const u8 as *const libc::c_char,
                 if !suffix.is_null() {

--- a/src/dc_msg.rs
+++ b/src/dc_msg.rs
@@ -127,14 +127,14 @@ pub unsafe fn dc_get_msg_info(context: &Context, msg_id: u32) -> *mut libc::c_ch
 
     ret += "State: ";
     match (*msg).state {
-        10 => ret += "Fresh",
-        13 => ret += "Noticed",
-        16 => ret += "Seen",
-        26 => ret += "Delivered",
-        24 => ret += "Failed",
-        28 => ret += "Read",
-        20 => ret += "Pending",
-        18 => ret += "Preparing",
+        DC_STATE_IN_FRESH => ret += "Fresh",
+        DC_STATE_IN_NOTICED => ret += "Noticed",
+        DC_STATE_IN_SEEN => ret += "Seen",
+        DC_STATE_OUT_DELIVERED => ret += "Delivered",
+        DC_STATE_OUT_FAILED => ret += "Failed",
+        DC_STATE_OUT_MDN_RCVD => ret += "Read",
+        DC_STATE_OUT_PENDING => ret += "Pending",
+        DC_STATE_OUT_PREPARING => ret += "Preparing",
         _ => ret += &format!("{}", (*msg).state),
     }
 
@@ -172,15 +172,15 @@ pub unsafe fn dc_get_msg_info(context: &Context, msg_id: u32) -> *mut libc::c_ch
     }
     free(p as *mut libc::c_void);
 
-    if (*msg).type_0 != 10 {
+    if (*msg).type_0 != DC_MSG_TEXT {
         ret += "Type: ";
         match (*msg).type_0 {
-            40 => ret += "Audio",
-            60 => ret += "File",
-            21 => ret += "GIF",
-            20 => ret += "Image",
-            50 => ret += "Video",
-            41 => ret += "Voice",
+            DC_MSG_AUDIO => ret += "Audio",
+            DC_MSG_FILE => ret += "File",
+            DC_MSG_GIF => ret += "GIF",
+            DC_MSG_IMAGE => ret += "Image",
+            DC_MSG_VIDEO => ret += "Video",
+            DC_MSG_VOICE => ret += "Voice",
             _ => ret += &format!("{}", (*msg).type_0),
         }
         ret += "\n";
@@ -237,7 +237,7 @@ pub unsafe fn dc_msg_new<'a>(context: &'a Context, viewtype: libc::c_int) -> *mu
     (*msg).context = context;
     (*msg).magic = 0x11561156i32 as uint32_t;
     (*msg).type_0 = viewtype;
-    (*msg).state = 0i32;
+    (*msg).state = 0;
     (*msg).param = dc_param_new();
 
     msg
@@ -304,7 +304,7 @@ pub unsafe fn dc_msg_guess_msgtype_from_suffix(
     mut ret_mime: *mut *mut libc::c_char,
 ) {
     let mut suffix: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut dummy_msgtype: libc::c_int = 0i32;
+    let mut dummy_msgtype: libc::c_int = 0;
     let mut dummy_buf: *mut libc::c_char = 0 as *mut libc::c_char;
     if !pathNfilename.is_null() {
         if ret_msgtype.is_null() {
@@ -313,37 +313,37 @@ pub unsafe fn dc_msg_guess_msgtype_from_suffix(
         if ret_mime.is_null() {
             ret_mime = &mut dummy_buf
         }
-        *ret_msgtype = 0i32;
+        *ret_msgtype = 0;
         *ret_mime = 0 as *mut libc::c_char;
         suffix = dc_get_filesuffix_lc(pathNfilename);
         if !suffix.is_null() {
             if strcmp(suffix, b"mp3\x00" as *const u8 as *const libc::c_char) == 0i32 {
-                *ret_msgtype = DC_MSG_AUDIO as libc::c_int;
+                *ret_msgtype = DC_MSG_AUDIO;
                 *ret_mime = dc_strdup(b"audio/mpeg\x00" as *const u8 as *const libc::c_char)
             } else if strcmp(suffix, b"aac\x00" as *const u8 as *const libc::c_char) == 0i32 {
-                *ret_msgtype = DC_MSG_AUDIO as libc::c_int;
+                *ret_msgtype = DC_MSG_AUDIO;
                 *ret_mime = dc_strdup(b"audio/aac\x00" as *const u8 as *const libc::c_char)
             } else if strcmp(suffix, b"mp4\x00" as *const u8 as *const libc::c_char) == 0i32 {
-                *ret_msgtype = DC_MSG_VIDEO as libc::c_int;
+                *ret_msgtype = DC_MSG_VIDEO;
                 *ret_mime = dc_strdup(b"video/mp4\x00" as *const u8 as *const libc::c_char)
             } else if strcmp(suffix, b"jpg\x00" as *const u8 as *const libc::c_char) == 0i32
                 || strcmp(suffix, b"jpeg\x00" as *const u8 as *const libc::c_char) == 0i32
             {
-                *ret_msgtype = DC_MSG_IMAGE as libc::c_int;
+                *ret_msgtype = DC_MSG_IMAGE;
                 *ret_mime = dc_strdup(b"image/jpeg\x00" as *const u8 as *const libc::c_char)
             } else if strcmp(suffix, b"png\x00" as *const u8 as *const libc::c_char) == 0i32 {
-                *ret_msgtype = DC_MSG_IMAGE as libc::c_int;
+                *ret_msgtype = DC_MSG_IMAGE;
                 *ret_mime = dc_strdup(b"image/png\x00" as *const u8 as *const libc::c_char)
             } else if strcmp(suffix, b"webp\x00" as *const u8 as *const libc::c_char) == 0i32 {
-                *ret_msgtype = DC_MSG_IMAGE as libc::c_int;
+                *ret_msgtype = DC_MSG_IMAGE;
                 *ret_mime = dc_strdup(b"image/webp\x00" as *const u8 as *const libc::c_char)
             } else if strcmp(suffix, b"gif\x00" as *const u8 as *const libc::c_char) == 0i32 {
-                *ret_msgtype = DC_MSG_GIF as libc::c_int;
+                *ret_msgtype = DC_MSG_GIF;
                 *ret_mime = dc_strdup(b"image/gif\x00" as *const u8 as *const libc::c_char)
             } else if strcmp(suffix, b"vcf\x00" as *const u8 as *const libc::c_char) == 0i32
                 || strcmp(suffix, b"vcard\x00" as *const u8 as *const libc::c_char) == 0i32
             {
-                *ret_msgtype = DC_MSG_FILE as libc::c_int;
+                *ret_msgtype = DC_MSG_FILE;
                 *ret_mime = dc_strdup(b"text/vcard\x00" as *const u8 as *const libc::c_char)
             }
         }
@@ -571,14 +571,14 @@ pub fn dc_markseen_msgs(context: &Context, msg_ids: *const u32, msg_cnt: usize) 
     for (id, curr_state, curr_blocked) in msgs.into_iter() {
         if curr_blocked == 0 {
             if curr_state == 10 || curr_state == 13 {
-                dc_update_msg_state(context, id, 16);
+                dc_update_msg_state(context, id, DC_STATE_IN_SEEN);
                 info!(context, 0, "Seen message #{}.", id);
 
                 unsafe { dc_job_add(context, 130, id as i32, 0 as *const libc::c_char, 0) };
                 send_event = true;
             }
-        } else if curr_state == 10 {
-            dc_update_msg_state(context, id, 13);
+        } else if curr_state == DC_STATE_IN_FRESH {
+            dc_update_msg_state(context, id, DC_STATE_IN_NOTICED);
             send_event = true;
         }
     }
@@ -917,9 +917,13 @@ pub unsafe fn dc_msg_has_deviating_timestamp(msg: *const dc_msg_t) -> libc::c_in
 // TODO should return bool /rtn
 pub unsafe fn dc_msg_is_sent(msg: *const dc_msg_t) -> libc::c_int {
     if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
-        return 0i32;
+        return 0;
     }
-    return if (*msg).state >= 26i32 { 1i32 } else { 0i32 };
+    if (*msg).state >= DC_STATE_OUT_DELIVERED {
+        1
+    } else {
+        0
+    }
 }
 
 // TODO should return bool /rtn
@@ -961,16 +965,14 @@ pub unsafe fn dc_msg_is_info(msg: *const dc_msg_t) -> libc::c_int {
 // TODO should return bool /rtn
 pub unsafe fn dc_msg_is_increation(msg: *const dc_msg_t) -> libc::c_int {
     if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
-        return 0i32;
+        return 0;
     }
 
-    (((*msg).type_0 == DC_MSG_IMAGE as libc::c_int
-        || (*msg).type_0 == DC_MSG_GIF as libc::c_int
-        || (*msg).type_0 == DC_MSG_AUDIO as libc::c_int
-        || (*msg).type_0 == DC_MSG_VOICE as libc::c_int
-        || (*msg).type_0 == DC_MSG_VIDEO as libc::c_int
-        || (*msg).type_0 == DC_MSG_FILE as libc::c_int)
-        && (*msg).state == 18i32) as libc::c_int
+    if msgtype_has_file((*msg).type_0) && (*msg).state == DC_STATE_OUT_PREPARING {
+        1
+    } else {
+        0
+    }
 }
 
 pub unsafe fn dc_msg_is_setupmessage(msg: *const dc_msg_t) -> bool {
@@ -1046,7 +1048,6 @@ pub unsafe fn dc_msg_set_text(mut msg: *mut dc_msg_t, text: *const libc::c_char)
     (*msg).text = dc_strdup(text);
 }
 
-// TODO should return bool /rtn
 pub unsafe fn dc_msg_set_file(
     msg: *mut dc_msg_t,
     file: *const libc::c_char,
@@ -1177,12 +1178,18 @@ pub fn dc_update_msg_move_state(
     .is_ok()
 }
 
+fn msgstate_can_fail(state: i32) -> bool {
+    return DC_STATE_OUT_PREPARING == state
+        || DC_STATE_OUT_PENDING == state
+        || DC_STATE_OUT_DELIVERED == state;
+}
+
 pub unsafe fn dc_set_msg_failed(context: &Context, msg_id: uint32_t, error: *const libc::c_char) {
     let mut msg = dc_msg_new_untyped(context);
 
     if dc_msg_load_from_db(msg, context, msg_id) {
-        if 18 == (*msg).state || 20 == (*msg).state || 26 == (*msg).state {
-            (*msg).state = 24
+        if msgstate_can_fail((*msg).state) {
+            (*msg).state = DC_STATE_OUT_FAILED;
         }
         if !error.is_null() {
             dc_param_set((*msg).param, DC_PARAM_ERROR as i32, error);
@@ -1247,8 +1254,10 @@ pub unsafe fn dc_mdn_from_ext(
         *ret_msg_id = msg_id as u32;
         *ret_chat_id = chat_id as u32;
 
-        if !(msg_state != 18 && msg_state != 20 && msg_state != 26) {
-            /* eg. already marked as MDNS_RCVD. however, it is importent, that the message ID is set above as this will allow the caller eg. to move the message away */
+        /* if already marked as MDNS_RCVD msgstate_can_fail() returns false.
+        however, it is important, that ret_msg_id is set above as this
+        will allow the caller eg. to move the message away */
+        if msgstate_can_fail(msg_state) {
             let mdn_already_in_table = context
                 .sql
                 .exists(
@@ -1266,7 +1275,7 @@ pub unsafe fn dc_mdn_from_ext(
 
             // Normal chat? that's quite easy.
             if chat_type == 100 {
-                dc_update_msg_state(context, *ret_msg_id, 28);
+                dc_update_msg_state(context, *ret_msg_id, DC_STATE_OUT_MDN_RCVD);
                 read_by_all = 1;
             } else {
                 /* send event about new state */
@@ -1293,11 +1302,10 @@ pub unsafe fn dc_mdn_from_ext(
                  */
                 // for rounding, SELF is already included!
                 let soll_cnt = (dc_get_chat_contact_cnt(context, *ret_chat_id) + 1) / 2;
-                if !(ist_cnt < soll_cnt) {
-                    /* wait for more receipts */
-                    dc_update_msg_state(context, *ret_msg_id, 28);
+                if ist_cnt >= soll_cnt {
+                    dc_update_msg_state(context, *ret_msg_id, DC_STATE_OUT_MDN_RCVD);
                     read_by_all = 1;
-                }
+                } /* else wait for more receipts */
             }
         }
     }

--- a/src/dc_securejoin.rs
+++ b/src/dc_securejoin.rs
@@ -2,7 +2,7 @@ use mmime::mailimf_types::*;
 use percent_encoding::{utf8_percent_encode, DEFAULT_ENCODE_SET};
 
 use crate::aheader::EncryptPreference;
-use crate::constants::Event;
+use crate::constants::*;
 use crate::context::Context;
 use crate::dc_array::*;
 use crate::dc_chat::*;
@@ -261,7 +261,7 @@ unsafe fn send_handshake_msg(
     grpid: *const libc::c_char,
 ) {
     let mut msg: *mut dc_msg_t = dc_msg_new_untyped(context);
-    (*msg).type_0 = 10i32;
+    (*msg).type_0 = DC_MSG_TEXT;
     (*msg).text = dc_mprintf(
         b"Secure-Join: %s\x00" as *const u8 as *const libc::c_char,
         step,


### PR DESCRIPTION
this replaces hopefully all uses of msg state numbers and types with their respective constants. 
also declare the constants as i32 to avoid casts.  (i guess macros were defined as usize by c2rust or so) 