### PR TITLE
dc_location: store marker as Option<String> instead of C string

### DIFF
--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -42,13 +42,7 @@ pub unsafe fn dc_array_free_ptr(array: *mut dc_array_t) {
     }
     let mut i: size_t = 0i32 as size_t;
     while i < (*array).count {
-        if (*array).type_0 == 1i32 {
-            free(
-                (*(*(*array).array.offset(i as isize) as *mut _dc_location)).marker
-                    as *mut libc::c_void,
-            );
-        }
-        free(*(*array).array.offset(i as isize) as *mut libc::c_void);
+        Box::from_raw(*(*array).array.offset(i as isize) as *mut _dc_location);
         *(*array).array.offset(i as isize) = 0i32 as uintptr_t;
         i = i.wrapping_add(1)
     }
@@ -203,7 +197,11 @@ pub unsafe fn dc_array_get_marker(array: *const dc_array_t, index: size_t) -> *m
     {
         return 0 as *mut libc::c_char;
     }
-    dc_strdup_keep_null((*(*(*array).array.offset(index as isize) as *mut _dc_location)).marker)
+    if let Some(s) = &(*(*(*array).array.offset(index as isize) as *mut _dc_location)).marker {
+        to_cstring(s)
+    } else {
+        0 as *mut libc::c_char
+    }
 }
 
 /**

--- a/src/dc_location.rs
+++ b/src/dc_location.rs
@@ -13,7 +13,7 @@ use crate::types::*;
 use crate::x::*;
 
 // location handling
-#[derive(Copy, Clone)]
+#[derive(Clone, Default)]
 #[repr(C)]
 pub struct _dc_location {
     pub location_id: uint32_t,
@@ -24,11 +24,17 @@ pub struct _dc_location {
     pub contact_id: uint32_t,
     pub msg_id: uint32_t,
     pub chat_id: uint32_t,
-    pub marker: *mut libc::c_char,
+    pub marker: Option<String>,
     pub independent: uint32_t,
 }
 
-#[derive(Copy, Clone)]
+impl _dc_location {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+#[derive(Clone)]
 #[repr(C)]
 pub struct dc_kml_t {
     pub addr: *mut libc::c_char,
@@ -198,28 +204,26 @@ pub fn dc_get_locations(
                 timestamp_from,
                 timestamp_to,
             ],
-            |row| unsafe {
-                let mut loc: *mut _dc_location =
-                    calloc(1, ::std::mem::size_of::<_dc_location>()) as *mut _dc_location;
-                assert!(!loc.is_null(), "allocation failed");
+            |row| {
+                let mut loc = _dc_location::new();
 
-                (*loc).location_id = row.get(0)?;
-                (*loc).latitude = row.get(1)?;
-                (*loc).longitude = row.get(2)?;
-                (*loc).accuracy = row.get(3)?;
-                (*loc).timestamp = row.get(4)?;
-                (*loc).independent = row.get(5)?;
-                (*loc).msg_id = row.get(6)?;
-                (*loc).contact_id = row.get(7)?;
-                (*loc).chat_id = row.get(8)?;
+                loc.location_id = row.get(0)?;
+                loc.latitude = row.get(1)?;
+                loc.longitude = row.get(2)?;
+                loc.accuracy = row.get(3)?;
+                loc.timestamp = row.get(4)?;
+                loc.independent = row.get(5)?;
+                loc.msg_id = row.get(6)?;
+                loc.contact_id = row.get(7)?;
+                loc.chat_id = row.get(8)?;
 
-                if 0 != (*loc).msg_id {
+                if 0 != loc.msg_id {
                     let txt: String = row.get(9)?;
                     if is_marker(&txt) {
-                        (*loc).marker = to_cstring(txt);
+                        loc.marker = Some(txt);
                     }
                 }
-                Ok(loc)
+                Ok(Box::into_raw(Box::new(loc)))
             },
             |locations| {
                 let ret = unsafe { dc_array_new_typed(1, 500) };
@@ -553,10 +557,13 @@ unsafe fn kml_endtag_cb(userdata: *mut libc::c_void, tag: *const libc::c_char) {
             && 0. != (*kml).curr.latitude
             && 0. != (*kml).curr.longitude
         {
-            let location: *mut _dc_location =
-                calloc(1, ::std::mem::size_of::<_dc_location>()) as *mut _dc_location;
-            *location = (*kml).curr;
-            dc_array_add_ptr((*kml).locations, location as *mut libc::c_void);
+            // TODO: we have to clone and deallocate marker manually,
+            // because it is impossible to move behind a raw pointer.
+            // The long-term solution is to stop using raw pointers in this module.
+            let location = (*kml).curr.clone();
+            (*kml).curr.marker = None;
+            let location_ptr = Box::into_raw(Box::new(location));
+            dc_array_add_ptr((*kml).locations, location_ptr as *mut libc::c_void);
         }
         (*kml).tag = 0
     };


### PR DESCRIPTION
Note that we still allocate dc_kml_t, which contains _dc_location, with calloc.
It is, however, safe, because of #[repr(C)], so Option is set to None after allocation.