### PR TITLE
rework python high level mechanics, re-group tests 

### DIFF
--- a/python/doc/api.rst
+++ b/python/doc/api.rst
@@ -11,8 +11,6 @@ high level API reference
 - :class:`deltachat.chatting.Contact`
 - :class:`deltachat.chatting.Chat`
 - :class:`deltachat.message.Message`
-- :class:`deltachat.message.MessageType`
-- :class:`deltachat.message.MessageState`
 
 Account
 -------

--- a/python/doc/conf.py
+++ b/python/doc/conf.py
@@ -288,10 +288,6 @@ intersphinx_mapping = {'http://docs.python.org/': None}
 autodoc_member_order = "bysource"
 # always document __init__ functions
 def skip(app, what, name, obj, skip, options):
-    import attr
-    if name == "__init__":
-        if not hasattr(obj.im_class, "__attrs_attrs__"):
-            return False
     return skip
 
 def setup(app):

--- a/python/setup.py
+++ b/python/setup.py
@@ -17,7 +17,7 @@ def main():
         description='Python bindings for the Delta Chat Core library using CFFI against the Rust-implemented libdeltachat',
         long_description=long_description,
         author='holger krekel, Floris Bruynooghe, Bjoern Petersen and contributors',
-        install_requires=['cffi>=1.0.0', 'attrs', 'six'],
+        install_requires=['cffi>=1.0.0', 'six'],
         packages=setuptools.find_packages('src'),
         package_dir={'': 'src'},
         cffi_modules=['src/deltachat/_build.py:ffibuilder'],

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -69,6 +69,10 @@ class Account(object):
             d[key.lower()] = value
         return d
 
+    def get_blob_dir(self):
+        """ return blob directory for this account. """
+        return from_dc_charpointer(lib.dc_get_blobdir(self._dc_context))
+
     def set_config(self, name, value):
         """ set configuration values.
 
@@ -142,15 +146,6 @@ class Account(object):
         self.check_is_configured()
         return Contact(self._dc_context, const.DC_CONTACT_ID_SELF)
 
-    def create_message(self, view_type):
-        """ create a new non persistent message.
-
-        :param view_type: a string specifying "text", "video",
-                          "image", "audio" or "file".
-        :returns: :class:`deltachat.message.Message` instance.
-        """
-        return Message.new(self._dc_context, view_type)
-
     def create_contact(self, email, name=None):
         """ create a (new) Contact. If there already is a Contact
         with that e-mail address, it is unblocked and its name is
@@ -212,7 +207,7 @@ class Account(object):
             assert isinstance(contact, int)
             contact_id = contact
         chat_id = lib.dc_create_chat_by_contact_id(self._dc_context, contact_id)
-        return Chat(self._dc_context, chat_id)
+        return Chat(self, chat_id)
 
     def create_chat_by_message(self, message):
         """ create or get an existing chat object for the
@@ -229,7 +224,7 @@ class Account(object):
             assert isinstance(message, int)
             msg_id = message
         chat_id = lib.dc_create_chat_by_msg_id(self._dc_context, msg_id)
-        return Chat(self._dc_context, chat_id)
+        return Chat(self, chat_id)
 
     def create_group_chat(self, name, verified=False):
         """ create a new group chat object.
@@ -241,7 +236,7 @@ class Account(object):
         """
         bytes_name = name.encode("utf8")
         chat_id = lib.dc_create_group_chat(self._dc_context, verified, bytes_name)
-        return Chat(self._dc_context, chat_id)
+        return Chat(self, chat_id)
 
     def get_chats(self):
         """ return list of chats.
@@ -257,15 +252,15 @@ class Account(object):
         chatlist = []
         for i in range(0, lib.dc_chatlist_get_cnt(dc_chatlist)):
             chat_id = lib.dc_chatlist_get_chat_id(dc_chatlist, i)
-            chatlist.append(Chat(self._dc_context, chat_id))
+            chatlist.append(Chat(self, chat_id))
         return chatlist
 
     def get_deaddrop_chat(self):
-        return Chat(self._dc_context, const.DC_CHAT_ID_DEADDROP)
+        return Chat(self, const.DC_CHAT_ID_DEADDROP)
 
     def get_message_by_id(self, msg_id):
         """ return Message instance. """
-        return Message.from_db(self._dc_context, msg_id)
+        return Message.from_db(self, msg_id)
 
     def mark_seen_messages(self, messages):
         """ mark the given set of messages as seen.

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -69,10 +69,6 @@ class Account(object):
             d[key.lower()] = value
         return d
 
-    def get_blob_dir(self):
-        """ return blob directory for this account. """
-        return from_dc_charpointer(lib.dc_get_blobdir(self._dc_context))
-
     def set_config(self, name, value):
         """ set configuration values.
 

--- a/python/src/deltachat/chatting.py
+++ b/python/src/deltachat/chatting.py
@@ -191,7 +191,7 @@ class Chat(object):
 
         :param path: path to the file.
         :param mime_type: the mime-type of this file, defaults to auto-detection.
-        :param view_type: passed to :meth:`MessageType.new`.
+        :param view_type: "text", "image", "gif", "audio", "video", "file"
         :raises ValueError: if message can not be prepared/chat does not exist.
         :returns: the resulting :class:`Message` instance
         """

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -158,7 +158,7 @@ class TestOfflineChat:
         assert msg == ac1.get_message_by_id(msg.id)
 
     def test_prepare_file(self, ac1, chat1):
-        blobdir = ac1.get_blob_dir()
+        blobdir = ac1.get_blobdir()
         p = os.path.join(blobdir, "somedata.txt")
         with open(p, "w") as f:
             f.write("some data")
@@ -180,13 +180,13 @@ class TestOfflineChat:
     def test_message_send_text(self, chat1):
         msg = chat1.send_text("msg1")
         assert msg
-        assert msg.view_type.is_text()
-        assert msg.view_type.name == "text"
-        assert not msg.view_type.is_audio()
-        assert not msg.view_type.is_video()
-        assert not msg.view_type.is_gif()
-        assert not msg.view_type.is_file()
-        assert not msg.view_type.is_image()
+        assert msg.is_text()
+        assert not msg.is_audio()
+        assert not msg.is_video()
+        assert not msg.is_gif()
+        assert not msg.is_file()
+        assert not msg.is_image()
+
         assert not msg.is_in_fresh()
         assert not msg.is_in_noticed()
         assert not msg.is_in_seen()
@@ -206,7 +206,7 @@ class TestOfflineChat:
         fn = data.get_path("d.png")
         lp.sec("sending image")
         msg = chat1.send_image(fn)
-        assert msg.view_type.name == "image"
+        assert msg.is_image()
         assert msg
         assert msg.id > 0
         assert os.path.exists(msg.filename)
@@ -223,8 +223,7 @@ class TestOfflineChat:
         msg = chat1.send_file(fn, typein)
         assert msg
         assert msg.id > 0
-        assert msg.view_type.name == "file"
-        assert msg.view_type.is_file()
+        assert msg.is_file()
         assert os.path.exists(msg.filename)
         assert msg.filename.endswith(msg.basename)
         assert msg.filemime == typeout
@@ -470,7 +469,7 @@ class TestOnlineAccount:
         ev = ac2._evlogger.get_matching("DC_EVENT_MSGS_CHANGED")
         assert ev[2] == msg_out.id
         msg_in = ac2.get_message_by_id(msg_out.id)
-        assert msg_in.view_type.is_image()
+        assert msg_in.is_image()
         assert os.path.exists(msg_in.filename)
         assert os.stat(msg_in.filename).st_size == os.stat(path).st_size
 

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -147,11 +147,11 @@ class TestOfflineChat:
             chat1.send_text("msg1")
 
     def test_prepare_message_and_send(self, ac1, chat1):
-        msg = chat1.prepare_message(Message.new(chat1.account, "text"))
+        msg = chat1.prepare_message(Message.new_empty(chat1.account, "text"))
         msg.set_text("hello world")
         assert msg.text == "hello world"
         assert msg.id > 0
-        msg = chat1.send_prepared(msg)
+        chat1.send_prepared(msg)
         assert "Sent" in msg.get_message_info()
         str(msg)
         repr(msg)
@@ -165,11 +165,10 @@ class TestOfflineChat:
         message = chat1.prepare_message_file(p)
         assert message.id > 0
         message.set_text("hello world")
-        assert message.get_state().is_out_preparing()
+        assert message.is_out_preparing()
         assert message.text == "hello world"
-        msg = chat1.send_prepared(message)
-        s = msg.get_message_info()
-        assert "Sent" in s
+        chat1.send_prepared(message)
+        assert "Sent" in message.get_message_info()
 
     def test_message_eq_contains(self, chat1):
         msg = chat1.send_text("msg1")
@@ -188,14 +187,13 @@ class TestOfflineChat:
         assert not msg.view_type.is_gif()
         assert not msg.view_type.is_file()
         assert not msg.view_type.is_image()
-        msg_state = msg.get_state()
-        assert not msg_state.is_in_fresh()
-        assert not msg_state.is_in_noticed()
-        assert not msg_state.is_in_seen()
-        assert msg_state.is_out_pending()
-        assert not msg_state.is_out_failed()
-        assert not msg_state.is_out_delivered()
-        assert not msg_state.is_out_mdn_received()
+        assert not msg.is_in_fresh()
+        assert not msg.is_in_noticed()
+        assert not msg.is_in_seen()
+        assert msg.is_out_pending()
+        assert not msg.is_out_failed()
+        assert not msg.is_out_delivered()
+        assert not msg.is_out_mdn_received()
 
     def test_create_chat_by_message_id(self, ac1, chat1):
         msg = chat1.send_text("msg1")
@@ -299,7 +297,7 @@ class TestOfflineChat:
             ac1.initiate_key_transfer()
 
     def test_set_get_draft(self, chat1):
-        msg = Message.new(chat1.account, "text")
+        msg = Message.new_empty(chat1.account, "text")
         msg1 = chat1.prepare_message(msg)
         msg1.set_text("hello")
         chat1.set_draft(msg1)
@@ -397,7 +395,7 @@ class TestOnlineAccount:
         evt_name, data1, data2 = ev
         assert data1 == chat.id
         assert data2 == msg_out.id
-        assert msg_out.get_state().is_out_delivered()
+        assert msg_out.is_out_delivered()
 
         lp.sec("wait for ac2 to receive message")
         ev = ac2._evlogger.get_matching("DC_EVENT_MSGS_CHANGED")
@@ -426,7 +424,7 @@ class TestOnlineAccount:
         lp.step("1")
         ac1._evlogger.get_matching("DC_EVENT_MSG_READ")
         lp.step("2")
-        assert msg_out.get_state().is_out_mdn_received()
+        assert msg_out.is_out_mdn_received()
 
     def test_saved_mime_on_received_message(self, acfactory, lp):
         lp.sec("starting accounts, waiting for configuration")
@@ -466,7 +464,7 @@ class TestOnlineAccount:
         evt_name, data1, data2 = ev
         assert data1 == chat.id
         assert data2 == msg_out.id
-        assert msg_out.get_state().is_out_delivered()
+        assert msg_out.is_out_delivered()
 
         lp.sec("wait for ac2 to receive message")
         ev = ac2._evlogger.get_matching("DC_EVENT_MSGS_CHANGED")

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -8,7 +8,7 @@ envlist =
 
 [testenv]
 commands = 
-    pytest -rsXx {posargs:tests}
+    pytest -v -rsXx {posargs:tests}
     python tests/package_wheels.py {toxworkdir}/wheelhouse
 passenv = 
     TRAVIS 


### PR DESCRIPTION
- properly support prepare-msg API and implement get_message_info()
- make API safer wrt to prepare-msg usage 
- remove usage of "attr.s" across the code
- simpler, safer API usage: merge MessageType, MessageState functionality all into the Message class
- add chat.set_draft|get_draft API
- make msg.set_file() copy a file into blobdir if it isn't already
- regroup tests
- simplify caching of dc_msg
