### PR TITLE
remove current_block/goto reminiscenes in dc_chat.rs

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -59,10 +59,10 @@ pub const DC_CHAT_ID_ALLDONE_HINT: usize = 7;
 /// larger chat IDs are "real" chats, their messages are "real" messages.
 pub const DC_CHAT_ID_LAST_SPECIAL: usize = 9;
 
-pub const DC_CHAT_TYPE_UNDEFINED: usize = 0;
-pub const DC_CHAT_TYPE_SINGLE: usize = 100;
-pub const DC_CHAT_TYPE_GROUP: usize = 120;
-pub const DC_CHAT_TYPE_VERIFIED_GROUP: usize = 130;
+pub const DC_CHAT_TYPE_UNDEFINED: i32 = 0;
+pub const DC_CHAT_TYPE_SINGLE: i32 = 100;
+pub const DC_CHAT_TYPE_GROUP: i32 = 120;
+pub const DC_CHAT_TYPE_VERIFIED_GROUP: i32 = 130;
 
 pub const DC_MSG_ID_MARKER1: usize = 1;
 pub const DC_MSG_ID_DAYMARKER: usize = 9;

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -1375,15 +1375,9 @@ pub unsafe fn dc_get_fine_pathNfilename(
     ret
 }
 
-// TODO should return bool /rtn
-pub unsafe fn dc_is_blobdir_path(context: &Context, path: *const libc::c_char) -> libc::c_int {
-    if strncmp(path, context.get_blobdir(), strlen(context.get_blobdir())) == 0i32
-        || strncmp(path, b"$BLOBDIR\x00" as *const u8 as *const libc::c_char, 8) == 0i32
-    {
-        return 1i32;
-    }
-
-    0
+pub unsafe fn dc_is_blobdir_path(context: &Context, path: *const libc::c_char) -> bool {
+    return strncmp(path, context.get_blobdir(), strlen(context.get_blobdir())) == 0
+        || strncmp(path, b"$BLOBDIR\x00" as *const u8 as *const libc::c_char, 8) == 0;
 }
 
 pub unsafe fn dc_make_rel_path(context: &Context, path: *mut *mut libc::c_char) {
@@ -1399,15 +1393,14 @@ pub unsafe fn dc_make_rel_path(context: &Context, path: *mut *mut libc::c_char) 
     };
 }
 
-// TODO should return bool /rtn
-pub unsafe fn dc_make_rel_and_copy(context: &Context, path: *mut *mut libc::c_char) -> libc::c_int {
-    let mut success: libc::c_int = 0i32;
+pub unsafe fn dc_make_rel_and_copy(context: &Context, path: *mut *mut libc::c_char) -> bool {
+    let mut success = false;
     let mut filename: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut blobdir_path: *mut libc::c_char = 0 as *mut libc::c_char;
     if !(path.is_null() || (*path).is_null()) {
-        if 0 != dc_is_blobdir_path(context, *path) {
+        if dc_is_blobdir_path(context, *path) {
             dc_make_rel_path(context, path);
-            success = 1i32
+            success = true;
         } else {
             filename = dc_get_filename(*path);
             if !(filename.is_null()
@@ -1425,7 +1418,7 @@ pub unsafe fn dc_make_rel_and_copy(context: &Context, path: *mut *mut libc::c_ch
                 *path = blobdir_path;
                 blobdir_path = 0 as *mut libc::c_char;
                 dc_make_rel_path(context, path);
-                success = 1i32
+                success = true;
             }
         }
     }

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -123,21 +123,15 @@ unsafe fn stress_functions(context: &Context) {
             context.get_blobdir(),
             b"foobar\x00" as *const u8 as *const libc::c_char,
         );
-        assert_ne!(0, dc_is_blobdir_path(context, abs_path));
-        assert_ne!(
-            0,
-            dc_is_blobdir_path(
-                context,
-                b"$BLOBDIR/fofo\x00" as *const u8 as *const libc::c_char,
-            )
-        );
-        assert_eq!(
-            0,
-            dc_is_blobdir_path(
-                context,
-                b"/BLOBDIR/fofo\x00" as *const u8 as *const libc::c_char,
-            )
-        );
+        assert!(dc_is_blobdir_path(context, abs_path));
+        assert!(dc_is_blobdir_path(
+            context,
+            b"$BLOBDIR/fofo\x00" as *const u8 as *const libc::c_char,
+        ));
+        assert!(!dc_is_blobdir_path(
+            context,
+            b"/BLOBDIR/fofo\x00" as *const u8 as *const libc::c_char,
+        ));
         assert_ne!(0, dc_file_exist(context, abs_path));
         free(abs_path as *mut libc::c_void);
         assert_ne!(


### PR DESCRIPTION
This is a two-commit PR where you only [need to review the first commit](https://github.com/deltachat/deltachat-core-rust/commit/8628d3d54031beff3d3ad08cdd6aeffd2c33c124).  The second commit is purely a "cargo fmt" which performs a lot of deindentation and does not need reviewing given that "cargo fmt" does not introduce errors.  So if you are fine with the first commit, please merge this PR. 

The PR also uses some DC_CHAT_TYPE_* constants but using them more consistently everywhere is for a different PR. 

FWIW I went with the "OK_TO_CONTINUE" pattern to replace the "current_block" and "match current_block ..." constructs.  This only changes few lines compared to trying to do go for a "cleanup" closure. 