### PR TITLE
(jikstra, hpk) fix markseen logic to work like C

### DIFF
--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -7,9 +7,9 @@ import re
 import time
 from array import array
 try:
-    from queue import Queue
+    from queue import Queue, Empty
 except ImportError:
-    from Queue import Queue
+    from Queue import Queue, Empty
 
 import deltachat
 from . import const
@@ -438,6 +438,17 @@ class EventLogger:
         if check_error and ev[0] == "DC_EVENT_ERROR":
             raise ValueError("{}({!r},{!r})".format(*ev))
         return ev
+
+    def ensure_event_not_queued(self, event_name_regex):
+        __tracebackhide__ = True
+        rex = re.compile("(?:{}).*".format(event_name_regex))
+        while 1:
+            try:
+                ev = self._event_queue.get(False)
+            except Empty:
+                break
+            else:
+                assert not rex.match(ev[0]), "event found {}".format(ev)
 
     def get_matching(self, event_name_regex, check_error=True):
         self._log("-- waiting for event with regex: {} --".format(event_name_regex))

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -64,3 +64,14 @@ def test_sig():
     assert sig(const.DC_EVENT_SMTP_CONNECTED) == 2
     assert sig(const.DC_EVENT_IMAP_CONNECTED) == 2
     assert sig(const.DC_EVENT_SMTP_MESSAGE_SENT) == 2
+
+
+def test_markseen_invalid_message_ids(acfactory):
+    ac1 = acfactory.get_configured_offline_account()
+    contact1 = ac1.create_contact(email="some1@example.com", name="some1")
+    chat = ac1.create_chat_by_contact(contact1)
+    chat.send_text("one messae")
+    ac1._evlogger.get_matching("DC_EVENT_MSGS_CHANGED")
+    msg_ids = [9]
+    lib.dc_markseen_msgs(ac1._dc_context, msg_ids, len(msg_ids))
+    ac1._evlogger.ensure_event_not_queued("DC_EVENT_WARNING|DC_EVENT_ERROR")


### PR DESCRIPTION
ignore if we get no rows for a message (eg desktop calls itwith msg_id=9 which is a special id -- and C just ignored it