### PR TITLE
repl: do not treat empty string as command

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -1192,6 +1192,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                 bail!("Command failed.");
             }
         }
+        "" => (),
         _ => bail!("Unknown command: \"{}\" type ? for help.", arg0),
     }
 


### PR DESCRIPTION
Previously, just pressing "<Enter>" at prompt resulted in following error
message:

	Error: Unknown command: "" type ? for help.

This message is harmless, but useless.  Also, such behaviour is different from
many (if not all) interactive environments: python, bash, dash, ...

With this change empty input string is silently ignored.