### PR TITLE
Avoid per-project compiler warnings override (ref: #55)

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,3 +1,4 @@
+#![allow(non_camel_case_types)]
 //! Constants
 
 pub const DC_VERSION_STR: &'static [u8; 14] = b"1.0.0-alpha.3\x00";

--- a/src/context.rs
+++ b/src/context.rs
@@ -533,6 +533,7 @@ pub fn dc_get_fresh_msgs(context: &Context) -> *mut dc_array_t {
         .unwrap()
 }
 
+#[allow(non_snake_case)]
 pub fn dc_search_msgs(
     context: &Context,
     chat_id: uint32_t,

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -380,6 +380,7 @@ pub fn msgtype_has_file(msgtype: i32) -> bool {
     }
 }
 
+#[allow(non_snake_case)]
 unsafe fn prepare_msg_common<'a>(
     context: &'a Context,
     chat_id: uint32_t,
@@ -468,6 +469,7 @@ unsafe fn prepare_msg_common<'a>(
     (*msg).id
 }
 
+#[allow(non_snake_case)]
 unsafe fn prepare_msg_raw(
     context: &Context,
     chat: *mut Chat,
@@ -997,6 +999,7 @@ pub unsafe fn dc_set_draft(context: &Context, chat_id: uint32_t, msg: *mut dc_ms
 }
 
 // TODO should return bool /rtn
+#[allow(non_snake_case)]
 unsafe fn set_draft_raw(context: &Context, chat_id: uint32_t, msg: *mut dc_msg_t) -> libc::c_int {
     let mut OK_TO_CONTINUE = true;
     // similar to as dc_set_draft() but does not emit an event
@@ -1554,6 +1557,7 @@ pub unsafe fn dc_add_contact_to_chat(
 }
 
 // TODO should return bool /rtn
+#[allow(non_snake_case)]
 pub unsafe fn dc_add_contact_to_chat_ex(
     context: &Context,
     chat_id: u32,
@@ -1880,6 +1884,7 @@ pub unsafe fn dc_set_chat_name(
 }
 
 // TODO should return bool /rtn
+#[allow(non_snake_case)]
 pub unsafe fn dc_set_chat_profile_image(
     context: &Context,
     chat_id: uint32_t,

--- a/src/dc_configure.rs
+++ b/src/dc_configure.rs
@@ -99,6 +99,7 @@ pub fn dc_stop_ongoing_process(context: &Context) {
 }
 
 // the other dc_job_do_DC_JOB_*() functions are declared static in the c-file
+#[allow(non_snake_case)]
 pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_job_t) {
     let flags: libc::c_int;
     let mut current_block: u64;

--- a/src/dc_contact.rs
+++ b/src/dc_contact.rs
@@ -454,6 +454,7 @@ pub fn dc_add_or_lookup_contact(
     row_id
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_add_address_book(context: &Context, adr_book: *const libc::c_char) -> libc::c_int {
     let mut lines: *mut carray = 0 as *mut carray;
     let mut i: size_t;
@@ -526,6 +527,7 @@ pub unsafe fn dc_normalize_name(full_name: *mut libc::c_char) {
     };
 }
 
+#[allow(non_snake_case)]
 pub fn dc_get_contacts(
     context: &Context,
     listflags: u32,

--- a/src/dc_e2ee.rs
+++ b/src/dc_e2ee.rs
@@ -34,6 +34,7 @@ use crate::x::*;
 // to get the netto sizes, we subtract 1 mb header-overhead and the base64-overhead.
 // some defaults
 #[derive(Clone)]
+#[allow(non_camel_case_types)]
 pub struct dc_e2ee_helper_t {
     pub encryption_successfull: libc::c_int,
     pub cdata_to_free: *mut libc::c_void,

--- a/src/dc_e2ee.rs
+++ b/src/dc_e2ee.rs
@@ -318,11 +318,11 @@ pub unsafe fn dc_e2ee_encrypt(
                                             as *mut libc::c_char,
                                     ) as *mut libc::c_void,
                                 );
-                                static mut version_content: [libc::c_char; 13] =
+                                static mut VERSION_CONTENT: [libc::c_char; 13] =
                                     [86, 101, 114, 115, 105, 111, 110, 58, 32, 49, 13, 10, 0];
                                 let version_mime: *mut mailmime = new_data_part(
-                                    version_content.as_mut_ptr() as *mut libc::c_void,
-                                    strlen(version_content.as_mut_ptr()),
+                                    VERSION_CONTENT.as_mut_ptr() as *mut libc::c_void,
+                                    strlen(VERSION_CONTENT.as_mut_ptr()),
                                     b"application/pgp-encrypted\x00" as *const u8
                                         as *const libc::c_char
                                         as *mut libc::c_char,
@@ -491,7 +491,7 @@ unsafe fn load_or_generate_self_public_key(
     _random_data_mime: *mut mailmime,
 ) -> Option<Key> {
     /* avoid double creation (we unlock the database during creation) */
-    static mut s_in_key_creation: libc::c_int = 0;
+    static mut S_IN_KEY_CREATION: libc::c_int = 0;
 
     let mut key = Key::from_self_public(context, &self_addr, &context.sql);
     if key.is_some() {
@@ -499,11 +499,11 @@ unsafe fn load_or_generate_self_public_key(
     }
 
     /* create the keypair - this may take a moment, however, as this is in a thread, this is no big deal */
-    if 0 != s_in_key_creation {
+    if 0 != S_IN_KEY_CREATION {
         return None;
     }
     let key_creation_here = 1;
-    s_in_key_creation = 1;
+    S_IN_KEY_CREATION = 1;
 
     let start = clock();
     info!(
@@ -537,7 +537,7 @@ unsafe fn load_or_generate_self_public_key(
     }
 
     if 0 != key_creation_here {
-        s_in_key_creation = 0;
+        S_IN_KEY_CREATION = 0;
     }
 
     key

--- a/src/dc_e2ee.rs
+++ b/src/dc_e2ee.rs
@@ -54,6 +54,7 @@ impl Default for dc_e2ee_helper_t {
     }
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_e2ee_encrypt(
     context: &Context,
     recipients_addr: *const clist,

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -536,6 +536,7 @@ pub unsafe fn dc_normalize_setup_code(
     to_cstring(out)
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: *mut dc_job_t) {
     let mut current_block: u64;
     let mut success: libc::c_int = 0i32;
@@ -767,6 +768,7 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: *mut dc_job_t) 
  ******************************************************************************/
 
 // TODO should return bool /rtn
+#[allow(non_snake_case)]
 unsafe fn import_backup(context: &Context, backup_to_import: *const libc::c_char) -> libc::c_int {
     info!(
         context,
@@ -885,6 +887,7 @@ unsafe fn import_backup(context: &Context, backup_to_import: *const libc::c_char
 /* the FILE_PROGRESS macro calls the callback with the permille of files processed.
 The macro avoids weird values of 0% or 100% while still working. */
 // TODO should return bool /rtn
+#[allow(non_snake_case)]
 unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_int {
     let mut current_block: u64;
     let mut success: libc::c_int = 0;

--- a/src/dc_job.rs
+++ b/src/dc_job.rs
@@ -240,6 +240,7 @@ fn dc_job_delete(context: &Context, job: &dc_job_t) -> bool {
 /* ******************************************************************************
  * Tools
  ******************************************************************************/
+#[allow(non_snake_case)]
 unsafe fn get_backoff_time_offset(c_tries: libc::c_int) -> i64 {
     // results in ~3 weeks for the last backoff timespan
     let mut N = 2_i32.pow((c_tries - 1) as u32);
@@ -279,6 +280,8 @@ unsafe fn dc_suspend_smtp_thread(context: &Context, suspend: libc::c_int) {
         }
     }
 }
+
+#[allow(non_snake_case)]
 unsafe fn dc_job_do_DC_JOB_SEND(context: &Context, job: &mut dc_job_t) {
     let mut current_block: u64;
     let mut filename: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -409,6 +412,7 @@ pub unsafe fn dc_job_try_again_later(
     job.pending_error = dc_strdup_keep_null(pending_error);
 }
 
+#[allow(non_snake_case)]
 unsafe fn dc_job_do_DC_JOB_MOVE_MSG(context: &Context, job: &mut dc_job_t) {
     let mut current_block: u64;
     let msg = dc_msg_new_untyped(context);
@@ -505,6 +509,7 @@ fn connect_to_inbox(context: &Context, inbox: &Imap) -> libc::c_int {
     ret_connected
 }
 
+#[allow(non_snake_case)]
 unsafe fn dc_job_do_DC_JOB_MARKSEEN_MDN_ON_IMAP(context: &Context, job: &mut dc_job_t) {
     let current_block: u64;
     let folder: *mut libc::c_char = dc_param_get(
@@ -557,6 +562,7 @@ unsafe fn dc_job_do_DC_JOB_MARKSEEN_MDN_ON_IMAP(context: &Context, job: &mut dc_
     free(folder as *mut libc::c_void);
 }
 
+#[allow(non_snake_case)]
 unsafe fn dc_job_do_DC_JOB_MARKSEEN_MSG_ON_IMAP(context: &Context, job: &mut dc_job_t) {
     let mut current_block: u64;
     let msg: *mut dc_msg_t = dc_msg_new_untyped(context);
@@ -741,6 +747,7 @@ unsafe fn dc_send_mdn(context: &Context, msg_id: uint32_t) {
  * @param mimefactory An instance of dc_mimefactory_t with a loaded and rendered message or MDN
  * @return 1=success, 0=error
  */
+#[allow(non_snake_case)]
 unsafe fn dc_add_smtp_job(
     context: &Context,
     action: libc::c_int,
@@ -863,6 +870,7 @@ pub unsafe fn dc_interrupt_imap_idle(context: &Context) {
     context.inbox.read().unwrap().interrupt_idle();
 }
 
+#[allow(non_snake_case)]
 unsafe fn dc_job_do_DC_JOB_DELETE_MSG_ON_IMAP(context: &Context, job: &mut dc_job_t) {
     let mut current_block: u64;
     let mut delete_from_server: libc::c_int = 1i32;
@@ -1141,6 +1149,7 @@ pub fn dc_job_action_exists(context: &Context, action: libc::c_int) -> bool {
 }
 
 /* special case for DC_JOB_SEND_MSG_TO_SMTP */
+#[allow(non_snake_case)]
 pub unsafe fn dc_job_send_msg(context: &Context, msg_id: uint32_t) -> libc::c_int {
     let mut success = 0;
     let mut mimefactory = dc_mimefactory_t {

--- a/src/dc_location.rs
+++ b/src/dc_location.rs
@@ -138,6 +138,7 @@ pub unsafe fn dc_send_locations_to_chat(
 /*******************************************************************************
  * job to send locations out to all chats that want them
  ******************************************************************************/
+#[allow(non_snake_case)]
 unsafe fn schedule_MAYBE_SEND_LOCATIONS(context: &Context, flags: libc::c_int) {
     if 0 != flags & 0x1 || !dc_job_action_exists(context, 5005) {
         dc_job_add(context, 5005, 0, 0 as *const libc::c_char, 60);
@@ -641,6 +642,7 @@ pub unsafe fn dc_kml_unref(kml: *mut dc_kml_t) {
     free((*kml).addr as *mut libc::c_void);
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_job_do_DC_JOB_MAYBE_SEND_LOCATIONS(context: &Context, _job: *mut dc_job_t) {
     let now = time();
     let mut continue_streaming: libc::c_int = 1;
@@ -721,6 +723,7 @@ pub unsafe fn dc_job_do_DC_JOB_MAYBE_SEND_LOCATIONS(context: &Context, _job: *mu
     }
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_job_do_DC_JOB_MAYBE_SEND_LOC_ENDED(context: &Context, job: &mut dc_job_t) {
     // this function is called when location-streaming _might_ have ended for a chat.
     // the function checks, if location-streaming is really ended;

--- a/src/dc_location.rs
+++ b/src/dc_location.rs
@@ -16,6 +16,7 @@ use crate::x::*;
 
 // location handling
 #[derive(Clone, Default)]
+#[allow(non_camel_case_types)]
 pub struct dc_location {
     pub location_id: uint32_t,
     pub latitude: libc::c_double,
@@ -47,6 +48,7 @@ impl dc_location {
 }
 
 #[derive(Clone)]
+#[allow(non_camel_case_types)]
 pub struct dc_kml_t {
     pub addr: *mut libc::c_char,
     pub locations: *mut dc_array_t,

--- a/src/dc_loginparam.rs
+++ b/src/dc_loginparam.rs
@@ -4,6 +4,7 @@ use crate::context::Context;
 use crate::sql::Sql;
 
 #[derive(Default, Debug)]
+#[allow(non_camel_case_types)]
 pub struct dc_loginparam_t {
     pub addr: String,
     pub mail_server: String,

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -1182,6 +1182,7 @@ unsafe fn build_body_text(text: *mut libc::c_char) -> *mut mailmime {
     message_part
 }
 
+#[allow(non_snake_case)]
 unsafe fn build_body_file(
     msg: *const dc_msg_t,
     mut base_name: *const libc::c_char,
@@ -1350,7 +1351,7 @@ unsafe fn build_body_file(
 /*******************************************************************************
  * Render
  ******************************************************************************/
-
+#[allow(non_snake_case)]
 unsafe fn is_file_size_okay(msg: *const dc_msg_t) -> libc::c_int {
     let mut file_size_okay: libc::c_int = 1;
     let pathNfilename: *mut libc::c_char =

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -26,6 +26,7 @@ use crate::x::*;
 
 #[derive(Copy, Clone)]
 #[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct dc_mimefactory_t<'a> {
     pub from_addr: *mut libc::c_char,
     pub from_displayname: *mut libc::c_char,
@@ -49,6 +50,7 @@ pub struct dc_mimefactory_t<'a> {
     pub context: &'a Context,
 }
 
+#[allow(non_camel_case_types)]
 pub type dc_mimefactory_loaded_t = libc::c_uint;
 pub const DC_MF_MDN_LOADED: dc_mimefactory_loaded_t = 2;
 pub const DC_MF_MSG_LOADED: dc_mimefactory_loaded_t = 1;

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -1448,6 +1448,7 @@ unsafe fn dc_mimeparser_add_single_part_if_known(
     };
 }
 
+#[allow(non_snake_case)]
 unsafe fn do_add_single_file_part(
     parser: &dc_mimeparser_t,
     msg_type: libc::c_int,
@@ -1755,6 +1756,7 @@ pub unsafe fn mailimf_get_recipients(imffields: *mut mailimf_fields) -> HashSet<
 /* ******************************************************************************
  * low-level-tools for getting a list of all recipients
  ******************************************************************************/
+#[allow(non_snake_case)]
 unsafe fn mailimf_get_recipients__add_addr(
     recipients: &mut HashSet<String>,
     mb: *mut mailimf_mailbox,

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -62,11 +62,11 @@ pub struct dc_mimeparser_t<'a> {
 
 // deprecated
 pub unsafe fn dc_no_compound_msgs() {
-    s_generate_compound_msgs = 0i32;
+    S_GENERATE_COMPOUND_MSGS = 0i32;
 }
 
 // deprecated: flag to switch generation of compound messages on and off.
-static mut s_generate_compound_msgs: libc::c_int = 1i32;
+static mut S_GENERATE_COMPOUND_MSGS: libc::c_int = 1i32;
 
 pub unsafe fn dc_mimeparser_new(context: &Context) -> dc_mimeparser_t {
     dc_mimeparser_t {
@@ -249,7 +249,7 @@ pub unsafe fn dc_mimeparser_parse(
             }
         }
         if 0 != (*mimeparser).is_send_by_messenger
-            && 0 != s_generate_compound_msgs
+            && 0 != S_GENERATE_COMPOUND_MSGS
             && carray_count((*mimeparser).parts) == 2i32 as libc::c_uint
         {
             let mut textpart_0: *mut dc_mimepart_t =

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -42,6 +42,7 @@ pub struct dc_mimepart_t {
  * @class dc_mimeparser_t
  */
 #[derive(Clone)]
+#[allow(non_camel_case_types)]
 pub struct dc_mimeparser_t<'a> {
     pub parts: *mut carray,
     pub mimeroot: *mut mailmime,

--- a/src/dc_msg.rs
+++ b/src/dc_msg.rs
@@ -300,6 +300,7 @@ pub unsafe fn dc_msg_get_filemime(msg: *const dc_msg_t) -> *mut libc::c_char {
     };
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_msg_guess_msgtype_from_suffix(
     pathNfilename: *const libc::c_char,
     mut ret_msgtype: *mut libc::c_int,
@@ -708,6 +709,7 @@ pub unsafe fn dc_msg_get_text(msg: *const dc_msg_t) -> *mut libc::c_char {
     to_cstring(res)
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_msg_get_filename(msg: *const dc_msg_t) -> *mut libc::c_char {
     let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut pathNfilename: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -831,6 +833,7 @@ pub unsafe fn dc_msg_get_summarytext(
 }
 
 /* the returned value must be free()'d */
+#[allow(non_snake_case)]
 pub unsafe fn dc_msg_get_summarytext_by_raw(
     type_0: libc::c_int,
     text: *const libc::c_char,

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -917,6 +917,7 @@ which tries to create or find out the chat_id by:
 
 So when the function returns, the caller has the group id matching the current
 state of the group. */
+#[allow(non_snake_case)]
 unsafe fn create_or_lookup_group(
     context: &Context,
     mime_parser: &mut dc_mimeparser_t,
@@ -1540,6 +1541,7 @@ fn hex_hash(s: impl AsRef<str>) -> *const libc::c_char {
     unsafe { to_cstring(result_hex) as *const _ }
 }
 
+#[allow(non_snake_case)]
 unsafe fn search_chat_ids_by_contact_ids(
     context: &Context,
     unsorted_contact_ids: *const dc_array_t,

--- a/src/dc_saxparser.rs
+++ b/src/dc_saxparser.rs
@@ -12,10 +12,13 @@ pub struct dc_saxparser_t {
 }
 
 /* len is only informational, text is already null-terminated */
+#[allow(non_camel_case_types)]
 pub type dc_saxparser_text_cb_t =
     Option<unsafe fn(_: *mut libc::c_void, _: *const libc::c_char, _: libc::c_int) -> ()>;
+#[allow(non_camel_case_types)]
 pub type dc_saxparser_endtag_cb_t =
     Option<unsafe fn(_: *mut libc::c_void, _: *const libc::c_char) -> ()>;
+#[allow(non_camel_case_types)]
 pub type dc_saxparser_starttag_cb_t = Option<
     unsafe fn(_: *mut libc::c_void, _: *const libc::c_char, _: *mut *mut libc::c_char) -> (),
 >;

--- a/src/dc_saxparser.rs
+++ b/src/dc_saxparser.rs
@@ -492,19 +492,19 @@ unsafe fn xml_decode(mut s: *mut libc::c_char, type_0: libc::c_char) -> *mut lib
             && (type_0 as libc::c_int == '&' as i32 || type_0 as libc::c_int == ' ' as i32)
         {
             b = 0;
-            while !s_ent[b as usize].is_null()
+            while !S_ENT[b as usize].is_null()
                 && 0 != strncmp(
                     s.offset(1isize),
-                    s_ent[b as usize],
-                    strlen(s_ent[b as usize]),
+                    S_ENT[b as usize],
+                    strlen(S_ENT[b as usize]),
                 )
             {
                 b += 2;
             }
             let fresh5 = b;
             b = b + 1;
-            if !s_ent[fresh5 as usize].is_null() {
-                c = strlen(s_ent[b as usize]) as isize;
+            if !S_ENT[fresh5 as usize].is_null() {
+                c = strlen(S_ENT[b as usize]) as isize;
                 e = strchr(s, ';' as i32);
                 if c - 1 > e.wrapping_offset_from(s) as isize {
                     d = s.wrapping_offset_from(r) as isize;
@@ -532,7 +532,7 @@ unsafe fn xml_decode(mut s: *mut libc::c_char, type_0: libc::c_char) -> *mut lib
                     e.offset(1isize) as *const libc::c_void,
                     strlen(e),
                 );
-                strncpy(s, s_ent[b as usize], c as usize);
+                strncpy(s, S_ENT[b as usize], c as usize);
             } else {
                 s = s.offset(1isize)
             }
@@ -566,7 +566,7 @@ NB: SAX = Simple API for XML */
 /* ******************************************************************************
  * Decoding text
  ******************************************************************************/
-static mut s_ent: [*const libc::c_char; 508] = [
+static mut S_ENT: [*const libc::c_char; 508] = [
     b"lt;\x00" as *const u8 as *const libc::c_char,
     b"<\x00" as *const u8 as *const libc::c_char,
     b"gt;\x00" as *const u8 as *const libc::c_char,

--- a/src/dc_simplify.rs
+++ b/src/dc_simplify.rs
@@ -61,6 +61,7 @@ impl dc_simplify_t {
     /**
      * Simplify Plain Text
      */
+    #[allow(non_snake_case)]
     unsafe fn simplify_plain_text(
         &mut self,
         buf_terminated: *const libc::c_char,

--- a/src/dc_strencode.rs
+++ b/src/dc_strencode.rs
@@ -64,11 +64,11 @@ pub unsafe fn dc_urlencode(to_encode: *const libc::c_char) -> *mut libc::c_char 
  * URL encoding and decoding, RFC 3986
  ******************************************************************************/
 unsafe fn int_2_uppercase_hex(code: libc::c_char) -> libc::c_char {
-    static mut hex: [libc::c_char; 17] = [
+    static mut HEX: [libc::c_char; 17] = [
         48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 65, 66, 67, 68, 69, 70, 0,
     ];
 
-    hex[(code as libc::c_int & 15i32) as usize]
+    HEX[(code as libc::c_int & 15i32) as usize]
 }
 
 pub unsafe fn dc_urldecode(to_decode: *const libc::c_char) -> *mut libc::c_char {
@@ -378,7 +378,7 @@ pub unsafe fn dc_encode_modified_utf7(
                 if 0 != bitstogo {
                     let fresh8 = dst;
                     dst = dst.offset(1);
-                    *fresh8 = base64chars
+                    *fresh8 = BASE64CHARS
                         [(bitbuf << (6i32 as libc::c_uint).wrapping_sub(bitstogo) & 0x3f) as usize]
                 }
                 let fresh9 = dst;
@@ -449,7 +449,7 @@ pub unsafe fn dc_encode_modified_utf7(
                     bitstogo = bitstogo.wrapping_sub(6i32 as libc::c_uint);
                     let fresh14 = dst;
                     dst = dst.offset(1);
-                    *fresh14 = base64chars[(if 0 != bitstogo {
+                    *fresh14 = BASE64CHARS[(if 0 != bitstogo {
                         bitbuf >> bitstogo
                     } else {
                         bitbuf
@@ -465,7 +465,7 @@ pub unsafe fn dc_encode_modified_utf7(
         if 0 != bitstogo {
             let fresh15 = dst;
             dst = dst.offset(1);
-            *fresh15 = base64chars
+            *fresh15 = BASE64CHARS
                 [(bitbuf << (6i32 as libc::c_uint).wrapping_sub(bitstogo) & 0x3f) as usize]
         }
         let fresh16 = dst;
@@ -482,7 +482,7 @@ pub unsafe fn dc_encode_modified_utf7(
  ******************************************************************************/
 
 // UTF7 modified base64 alphabet
-static mut base64chars: [libc::c_char; 65] = [
+static mut BASE64CHARS: [libc::c_char; 65] = [
     65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88,
     89, 90, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114,
     115, 116, 117, 118, 119, 120, 121, 122, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 43, 44, 0,
@@ -517,7 +517,7 @@ pub unsafe fn dc_decode_modified_utf7(
     );
     i = 0i32 as libc::c_uint;
     while (i as libc::c_ulong) < ::std::mem::size_of::<[libc::c_char; 65]>() as libc::c_ulong {
-        base64[base64chars[i as usize] as libc::c_uint as usize] = i as libc::c_uchar;
+        base64[BASE64CHARS[i as usize] as libc::c_uint as usize] = i as libc::c_uchar;
         i = i.wrapping_add(1)
     }
     while *src as libc::c_int != '\u{0}' as i32 {

--- a/src/dc_token.rs
+++ b/src/dc_token.rs
@@ -3,6 +3,7 @@ use crate::dc_tools::*;
 use crate::sql;
 
 // Token namespaces
+#[allow(non_camel_case_types)]
 pub type dc_tokennamespc_t = usize;
 pub const DC_TOKEN_AUTH: dc_tokennamespc_t = 110;
 pub const DC_TOKEN_INVITENUMBER: dc_tokennamespc_t = 100;

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -359,6 +359,7 @@ pub fn dc_truncate_str(buf: &str, approx_chars: usize) -> Cow<str> {
     }
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_truncate_n_unwrap_str(
     buf: *mut libc::c_char,
     approx_characters: libc::c_int,
@@ -902,6 +903,7 @@ pub unsafe fn dc_extract_grpid_from_rfc724_mid_list(list: *const clist) -> *mut 
 }
 
 /* file tools */
+#[allow(non_snake_case)]
 pub unsafe fn dc_ensure_no_slash(pathNfilename: *mut libc::c_char) {
     let path_len = strlen(pathNfilename);
     if path_len > 0 {
@@ -934,6 +936,7 @@ pub unsafe fn dc_validate_filename(filename: *mut libc::c_char) {
     }
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_get_filename(pathNfilename: *const libc::c_char) -> *mut libc::c_char {
     let mut p: *const libc::c_char = strrchr(pathNfilename, '/' as i32);
     if p.is_null() {
@@ -948,6 +951,7 @@ pub unsafe fn dc_get_filename(pathNfilename: *const libc::c_char) -> *mut libc::
 }
 
 // the case of the suffix is preserved
+#[allow(non_snake_case)]
 pub unsafe fn dc_split_filename(
     pathNfilename: *const libc::c_char,
     ret_basename: *mut *mut libc::c_char,
@@ -980,6 +984,7 @@ pub unsafe fn dc_split_filename(
 }
 
 // the returned suffix is lower-case
+#[allow(non_snake_case)]
 pub unsafe fn dc_get_filesuffix_lc(pathNfilename: *const libc::c_char) -> *mut libc::c_char {
     if !pathNfilename.is_null() {
         let mut p: *const libc::c_char = strrchr(pathNfilename, '.' as i32);
@@ -1075,6 +1080,7 @@ pub unsafe fn dc_get_filemeta(
     0
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_get_abs_path(
     context: &Context,
     pathNfilename: *const libc::c_char,
@@ -1104,6 +1110,7 @@ pub unsafe fn dc_get_abs_path(
     pathNfilename_abs
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_file_exist(context: &Context, pathNfilename: *const libc::c_char) -> libc::c_int {
     let pathNfilename_abs = dc_get_abs_path(context, pathNfilename);
     if pathNfilename_abs.is_null() {
@@ -1119,6 +1126,7 @@ pub unsafe fn dc_file_exist(context: &Context, pathNfilename: *const libc::c_cha
     exist as libc::c_int
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_get_filebytes(context: &Context, pathNfilename: *const libc::c_char) -> uint64_t {
     let pathNfilename_abs = dc_get_abs_path(context, pathNfilename);
     if pathNfilename_abs.is_null() {
@@ -1139,6 +1147,7 @@ pub unsafe fn dc_get_filebytes(context: &Context, pathNfilename: *const libc::c_
     filebytes as uint64_t
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_delete_file(context: &Context, pathNfilename: *const libc::c_char) -> libc::c_int {
     let mut success: libc::c_int = 0i32;
     let pathNfilename_abs = dc_get_abs_path(context, pathNfilename);
@@ -1170,6 +1179,7 @@ pub unsafe fn dc_delete_file(context: &Context, pathNfilename: *const libc::c_ch
     success
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_copy_file(
     context: &Context,
     src: *const libc::c_char,
@@ -1201,6 +1211,7 @@ pub unsafe fn dc_copy_file(
     success
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_create_folder(
     context: &Context,
     pathNfilename: *const libc::c_char,
@@ -1232,6 +1243,7 @@ pub unsafe fn dc_create_folder(
     success
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_write_file(
     context: &Context,
     pathNfilename: *const libc::c_char,
@@ -1243,6 +1255,7 @@ pub unsafe fn dc_write_file(
     dc_write_file_safe(context, as_str(pathNfilename), bytes) as libc::c_int
 }
 
+#[allow(non_snake_case)]
 pub fn dc_write_file_safe(context: &Context, pathNfilename: impl AsRef<str>, buf: &[u8]) -> bool {
     let pathNfilename_abs = unsafe {
         let n = to_cstring(pathNfilename.as_ref());
@@ -1273,6 +1286,7 @@ pub fn dc_write_file_safe(context: &Context, pathNfilename: impl AsRef<str>, buf
     success
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_read_file(
     context: &Context,
     pathNfilename: *const libc::c_char,
@@ -1292,6 +1306,7 @@ pub unsafe fn dc_read_file(
     }
 }
 
+#[allow(non_snake_case)]
 pub fn dc_read_file_safe(context: &Context, pathNfilename: impl AsRef<str>) -> Option<Vec<u8>> {
     let pathNfilename_abs = unsafe {
         let n = to_cstring(pathNfilename.as_ref());
@@ -1323,6 +1338,7 @@ pub fn dc_read_file_safe(context: &Context, pathNfilename: impl AsRef<str>) -> O
     res
 }
 
+#[allow(non_snake_case)]
 pub unsafe fn dc_get_fine_pathNfilename(
     context: &Context,
     pathNfolder: *const libc::c_char,

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -568,7 +568,7 @@ pub unsafe fn dc_str_to_color(str: *const libc::c_char) -> libc::c_int {
     - being noticeable on a typical map
     - harmonize together while being different enough
     (therefore, we cannot just use random rgb colors :) */
-    static mut colors: [uint32_t; 16] = [
+    static mut COLORS: [uint32_t; 16] = [
         0xe56555i32 as uint32_t,
         0xf28c48i32 as uint32_t,
         0x8e85eei32 as uint32_t,
@@ -600,7 +600,7 @@ pub unsafe fn dc_str_to_color(str: *const libc::c_char) -> libc::c_int {
     ) as libc::c_int;
     free(str_lower as *mut libc::c_void);
 
-    colors[color_index as usize] as libc::c_int
+    COLORS[color_index as usize] as libc::c_int
 }
 
 /* clist tools */
@@ -754,25 +754,25 @@ unsafe fn encode_66bits_as_base64(v1: uint32_t, v2: uint32_t, fill: uint32_t) ->
     let ret: *mut libc::c_char = malloc(12) as *mut libc::c_char;
     assert!(!ret.is_null());
 
-    static mut chars: [libc::c_char; 65] = [
+    static mut CHARS: [libc::c_char; 65] = [
         65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87,
         88, 89, 90, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112,
         113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57,
         45, 95, 0,
     ];
-    *ret.offset(0isize) = chars[(v1 >> 26i32 & 0x3fi32 as libc::c_uint) as usize];
-    *ret.offset(1isize) = chars[(v1 >> 20i32 & 0x3fi32 as libc::c_uint) as usize];
-    *ret.offset(2isize) = chars[(v1 >> 14i32 & 0x3fi32 as libc::c_uint) as usize];
-    *ret.offset(3isize) = chars[(v1 >> 8i32 & 0x3fi32 as libc::c_uint) as usize];
-    *ret.offset(4isize) = chars[(v1 >> 2i32 & 0x3fi32 as libc::c_uint) as usize];
-    *ret.offset(5isize) = chars
+    *ret.offset(0isize) = CHARS[(v1 >> 26i32 & 0x3fi32 as libc::c_uint) as usize];
+    *ret.offset(1isize) = CHARS[(v1 >> 20i32 & 0x3fi32 as libc::c_uint) as usize];
+    *ret.offset(2isize) = CHARS[(v1 >> 14i32 & 0x3fi32 as libc::c_uint) as usize];
+    *ret.offset(3isize) = CHARS[(v1 >> 8i32 & 0x3fi32 as libc::c_uint) as usize];
+    *ret.offset(4isize) = CHARS[(v1 >> 2i32 & 0x3fi32 as libc::c_uint) as usize];
+    *ret.offset(5isize) = CHARS
         [(v1 << 4i32 & 0x30i32 as libc::c_uint | v2 >> 28i32 & 0xfi32 as libc::c_uint) as usize];
-    *ret.offset(6isize) = chars[(v2 >> 22i32 & 0x3fi32 as libc::c_uint) as usize];
-    *ret.offset(7isize) = chars[(v2 >> 16i32 & 0x3fi32 as libc::c_uint) as usize];
-    *ret.offset(8isize) = chars[(v2 >> 10i32 & 0x3fi32 as libc::c_uint) as usize];
-    *ret.offset(9isize) = chars[(v2 >> 4i32 & 0x3fi32 as libc::c_uint) as usize];
+    *ret.offset(6isize) = CHARS[(v2 >> 22i32 & 0x3fi32 as libc::c_uint) as usize];
+    *ret.offset(7isize) = CHARS[(v2 >> 16i32 & 0x3fi32 as libc::c_uint) as usize];
+    *ret.offset(8isize) = CHARS[(v2 >> 10i32 & 0x3fi32 as libc::c_uint) as usize];
+    *ret.offset(9isize) = CHARS[(v2 >> 4i32 & 0x3fi32 as libc::c_uint) as usize];
     *ret.offset(10isize) =
-        chars[(v2 << 2i32 & 0x3ci32 as libc::c_uint | fill & 0x3i32 as libc::c_uint) as usize];
+        CHARS[(v2 << 2i32 & 0x3ci32 as libc::c_uint | fill & 0x3i32 as libc::c_uint) as usize];
     *ret.offset(11isize) = 0i32 as libc::c_char;
 
     ret

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 #![allow(
     non_camel_case_types,
-    non_snake_case,
     non_camel_case_types,
-    non_snake_case
 )]
 #![feature(c_variadic, ptr_wrapping_offset_from)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 #![allow(
     non_camel_case_types,
     non_snake_case,
-    non_upper_case_globals,
-    non_upper_case_globals,
     non_camel_case_types,
     non_snake_case
 )]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,3 @@
-#![allow(
-    non_camel_case_types,
-    non_camel_case_types,
-)]
 #![feature(c_variadic, ptr_wrapping_offset_from)]
 
 #[macro_use]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,4 @@
+#![allow(non_camel_case_types)]
 use crate::constants::Event;
 use crate::context::Context;
 


### PR DESCRIPTION
In face of ambiguity, refuse temptation to guess.

Since I was not sure how correctly convert 'iCnt', 'pathNfilename',
to snake_case, I just added override instead.

Changes:

  86c0653 (Dmitry Bogatov, 4 minutes ago)
     Override `non_camel_case_types` warning on per-declaration basis

  f9c7a30 (Dmitry Bogatov, 40 minutes ago)
     Override `non_shake_case' warning on per-function basis

     This change removes global override of `non_shake_case' warning and
     replaces it with per-function overrrides. This way, compiler will complain
     about style guide violation in new code.

     It should be noted, that `rustc' is not smart enough to emit warning when 
     override is no longer needed, it must be checked manually.

  3117208 (Dmitry Bogatov, 3 hours ago)
     Fix 'non_upper_case_globals' compiler warnings