### PR TITLE
dc_decrypt_setup_file: extend lifetime of CString

### DIFF
--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -490,7 +490,8 @@ pub unsafe fn dc_decrypt_setup_file(
             if let Some(plain) =
                 dc_pgp_symm_decrypt(passphrase, binary as *const libc::c_void, binary_bytes)
             {
-                payload = strdup(CString::new(plain).unwrap().as_ptr());
+                let payload_c = CString::new(plain).unwrap();
+                payload = strdup(payload_c.as_ptr());
             }
         }
     }


### PR DESCRIPTION
payload_c binding makes sure the memory is not freed until strdup exits.

See as_ptr documentation:
https://doc.rust-lang.org/std/ffi/struct.CString.html#method.as_ptr