### PR TITLE
Rename dc_array_t::as_ptr() into dc_array_t::into_raw()

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -527,7 +527,7 @@ pub fn dc_get_fresh_msgs(context: &Context) -> *mut dc_array_t {
                     let id = row?;
                     ret.add_id(id);
                 }
-                Ok(ret.as_ptr())
+                Ok(ret.into_raw())
             },
         )
         .unwrap()
@@ -578,7 +578,7 @@ pub fn dc_search_msgs(
         .is_ok();
 
     if success {
-        return ret.as_ptr();
+        return ret.into_raw();
     }
 
     std::ptr::null_mut()

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -19,7 +19,7 @@ impl dc_array_t {
         dc_array_t::Locations(Vec::with_capacity(capacity))
     }
 
-    pub fn as_ptr(self) -> *mut Self {
+    pub fn into_raw(self) -> *mut Self {
         Box::into_raw(Box::new(self))
     }
 
@@ -317,11 +317,11 @@ pub unsafe fn dc_array_get_raw(array: *const dc_array_t) -> *const uintptr_t {
 }
 
 pub fn dc_array_new(initsize: size_t) -> *mut dc_array_t {
-    dc_array_t::new(initsize).as_ptr()
+    dc_array_t::new(initsize).into_raw()
 }
 
 pub fn dc_array_new_locations(initsize: size_t) -> *mut dc_array_t {
-    dc_array_t::new_locations(initsize).as_ptr()
+    dc_array_t::new_locations(initsize).into_raw()
 }
 
 pub unsafe fn dc_array_empty(array: *mut dc_array_t) {
@@ -335,7 +335,7 @@ pub unsafe fn dc_array_duplicate(array: *const dc_array_t) -> *mut dc_array_t {
     if array.is_null() {
         std::ptr::null_mut()
     } else {
-        (*array).clone().as_ptr()
+        (*array).clone().into_raw()
     }
 }
 

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -1168,7 +1168,7 @@ pub fn dc_get_chat_msgs(
     };
 
     if success.is_ok() {
-        ret.as_ptr()
+        ret.into_raw()
     } else {
         0 as *mut dc_array_t
     }
@@ -1285,7 +1285,7 @@ pub fn dc_get_chat_media(
             for id in ids {
                 ret.add_id(id? as u32);
             }
-            Ok(ret.as_ptr())
+            Ok(ret.into_raw())
         }
     ).unwrap_or_else(|_| std::ptr::null_mut())
 }
@@ -1460,7 +1460,7 @@ pub fn dc_get_chat_contacts(context: &Context, chat_id: u32) -> *mut dc_array_t 
                     ret.add_id(id? as u32);
                 }
 
-                Ok(ret.as_ptr())
+                Ok(ret.into_raw())
             },
         )
         .unwrap_or_else(|_| std::ptr::null_mut())

--- a/src/dc_contact.rs
+++ b/src/dc_contact.rs
@@ -606,7 +606,7 @@ pub fn dc_get_contacts(
         ret.add_id(1);
     }
 
-    ret.as_ptr()
+    ret.into_raw()
 }
 
 pub fn dc_get_blocked_cnt(context: &Context) -> libc::c_int {
@@ -635,7 +635,7 @@ pub fn dc_get_blocked_contacts(context: &Context) -> *mut dc_array_t {
                     ret.add_id(id? as u32);
                 }
 
-                Ok(ret.as_ptr())
+                Ok(ret.into_raw())
             },
         )
         .unwrap_or_else(|_| std::ptr::null_mut())

--- a/src/dc_location.rs
+++ b/src/dc_location.rs
@@ -252,7 +252,7 @@ pub fn dc_get_locations(
                 for location in locations {
                     ret.add_location(location?);
                 }
-                Ok(ret.as_ptr())
+                Ok(ret.into_raw())
             },
         )
         .unwrap_or_else(|_| std::ptr::null_mut())


### PR DESCRIPTION
By convention as_* functions do not consume self by taking the reference.