### PR TITLE
Actually fix all compiler warnings

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -4,6 +4,7 @@ set -ex
 
 export RUST_TEST_THREADS=1
 export RUST_BACKTRACE=1
+export RUSTFLAGS='--deny warnings'
 export OPT="--target=$TARGET"
 export OPT_RELEASE="--release ${OPT}"
 export OPT_FFI_RELEASE="--manifest-path=deltachat-ffi/Cargo.toml --release"

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -155,7 +155,7 @@ impl<'a> Chatlist<'a> {
             let query = query.trim().to_string();
             ensure!(!query.is_empty(), "missing query");
 
-            let strLikeCmd = format!("%{}%", query);
+            let str_like_cmd = format!("%{}%", query);
             context.sql.query_map(
                 "SELECT c.id, m.id FROM chats c  LEFT JOIN msgs m         \
                  ON c.id=m.chat_id        \
@@ -164,7 +164,7 @@ impl<'a> Chatlist<'a> {
                  AND (hidden=0 OR (hidden=1 AND state=19))) WHERE c.id>9   \
                  AND c.blocked=0 AND c.name LIKE ?  \
                  GROUP BY c.id  ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;",
-                params![strLikeCmd],
+                params![str_like_cmd],
                 process_row,
                 process_rows,
             )?

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -4,6 +4,7 @@ use crate::types::*;
 
 /* * the structure behind dc_array_t */
 #[derive(Clone)]
+#[allow(non_camel_case_types)]
 pub enum dc_array_t {
     Locations(Vec<dc_location>),
     Uint(Vec<uintptr_t>),

--- a/src/x.rs
+++ b/src/x.rs
@@ -1,5 +1,3 @@
-use crate::types::*;
-
 pub use libc::{
     calloc, exit, free, malloc, memcmp, memcpy, memmove, memset, realloc, strcat, strchr, strcmp,
     strcpy, strcspn, strlen, strncmp, strncpy, strrchr, strspn, strstr, strtol, system,


### PR DESCRIPTION
Previous pull-request on this left two warnings behind, this should fix
them and make such oversights impossible by treating warnings as errors
-- CI should catch them.