### PR TITLE
Remove to_cstring() naming convention ambiguity

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -15,6 +15,7 @@ use num_traits::{FromPrimitive, ToPrimitive};
 use std::ptr;
 use std::str::FromStr;
 
+use deltachat::dc_tools::StrExt;
 use deltachat::*;
 
 // TODO: constants
@@ -126,10 +127,7 @@ pub unsafe extern "C" fn dc_get_config(
     let context = &*context;
 
     match config::Config::from_str(dc_tools::as_str(key)) {
-        Ok(key) => {
-            let value = context.get_config(key).unwrap_or_default();
-            dc_tools::to_cstring(value)
-        }
+        Ok(key) => context.get_config(key).unwrap_or_default().strdup(),
         Err(_) => std::ptr::null_mut(),
     }
 }
@@ -154,7 +152,7 @@ pub unsafe extern "C" fn dc_get_oauth2_url(
     let addr = dc_tools::to_string(addr);
     let redirect = dc_tools::to_string(redirect);
     match oauth2::dc_get_oauth2_url(context, addr, redirect) {
-        Some(res) => dc_tools::to_cstring(res),
+        Some(res) => res.strdup(),
         None => std::ptr::null_mut(),
     }
 }

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -481,7 +481,7 @@ unsafe fn handle_cmd(line: &str, ctx: Arc<RwLock<Context>>) -> Result<ExitResult
     let arg1_c = if arg1.is_empty() {
         std::ptr::null()
     } else {
-        to_cstring(arg1)
+        arg1.strdup()
     };
 
     match arg0 {

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -256,7 +256,7 @@ impl<'a> Chatlist<'a> {
 
         let mut ret = dc_lot_new();
         if index >= self.ids.len() {
-            (*ret).text2 = to_cstring("ErrBadChatlistIndex");
+            (*ret).text2 = "ErrBadChatlistIndex".strdup();
             return ret;
         }
 
@@ -267,7 +267,7 @@ impl<'a> Chatlist<'a> {
             chat = dc_chat_new(self.context);
             let chat_to_delete = chat;
             if !dc_chat_load_from_db(chat, self.ids[index].0) {
-                (*ret).text2 = to_cstring("ErrCannotReadChat");
+                (*ret).text2 = "ErrCannotReadChat".strdup();
                 dc_chat_unref(chat_to_delete);
 
                 return ret;
@@ -293,7 +293,7 @@ impl<'a> Chatlist<'a> {
         if (*chat).id == DC_CHAT_ID_ARCHIVED_LINK as u32 {
             (*ret).text2 = dc_strdup(0 as *const libc::c_char)
         } else if lastmsg.is_null() || (*lastmsg).from_id == DC_CONTACT_ID_SELF as u32 {
-            (*ret).text2 = to_cstring(self.context.stock_str(StockMessage::NoMessages));
+            (*ret).text2 = self.context.stock_str(StockMessage::NoMessages).strdup();
         } else {
             dc_lot_fill(ret, lastmsg, chat, lastcontact, self.context);
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+use std::ffi::CString;
+
 use strum::{EnumProperty, IntoEnumIterator};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumProperty, EnumString};
 
@@ -72,10 +74,8 @@ impl Context {
                 let rel_path = self.sql.get_config(self, key);
                 rel_path.map(|p| {
                     let v = unsafe {
-                        let n = to_cstring(p);
-                        let res = dc_get_abs_path(self, n);
-                        free(n as *mut libc::c_void);
-                        res
+                        let n = CString::yolo(p);
+                        dc_get_abs_path(self, n.as_ptr())
                     };
                     let r = to_string(v);
                     unsafe { free(v as *mut _) };

--- a/src/context.rs
+++ b/src/context.rs
@@ -483,7 +483,7 @@ pub unsafe fn dc_get_info(context: &Context) -> *mut libc::c_char {
         fingerprint_str,
     );
 
-    to_cstring(res)
+    res.strdup()
 }
 
 pub unsafe fn dc_get_version_str() -> *mut libc::c_char {

--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -271,7 +271,7 @@ pub unsafe fn dc_array_get_marker(array: *const dc_array_t, index: size_t) -> *m
 
     if let dc_array_t::Locations(v) = &*array {
         if let Some(s) = &v[index].marker {
-            to_cstring(s)
+            s.strdup()
         } else {
             std::ptr::null_mut()
         }
@@ -375,7 +375,7 @@ pub unsafe fn dc_array_get_string(
                     res + sep + &n.to_string()
                 }
             });
-        to_cstring(res)
+        res.strdup()
     } else {
         panic!("Attempt to get string from array of other type");
     }

--- a/src/dc_configure.rs
+++ b/src/dc_configure.rs
@@ -1102,14 +1102,14 @@ unsafe fn moz_autoconfigure(
         tag_config: 0,
     };
 
-    let url_c = to_cstring(url);
+    let url_c = url.strdup();
     let xml_raw = read_autoconf_file(context, url_c);
     free(url_c as *mut libc::c_void);
     if xml_raw.is_null() {
         return None;
     }
 
-    moz_ac.in_emaillocalpart = to_cstring(&param_in.addr);
+    moz_ac.in_emaillocalpart = param_in.addr.strdup();
     let p = strchr(moz_ac.in_emaillocalpart, '@' as i32);
 
     if p.is_null() {
@@ -1166,7 +1166,7 @@ unsafe fn moz_autoconfigure_text_cb(
     let mut moz_ac: *mut moz_autoconfigure_t = userdata as *mut moz_autoconfigure_t;
     let mut val: *mut libc::c_char = dc_strdup(text);
     dc_trim(val);
-    let addr = to_cstring(&(*moz_ac).in_0.addr);
+    let addr = (*moz_ac).in_0.addr.strdup();
     dc_str_replace(
         &mut val,
         b"%EMAILADDRESS%\x00" as *const u8 as *const libc::c_char,
@@ -1306,7 +1306,7 @@ fn read_autoconf_file(context: &Context, url: *const libc::c_char) -> *mut libc:
         .send()
         .and_then(|mut res| res.text())
     {
-        Ok(res) => unsafe { to_cstring(res) },
+        Ok(res) => unsafe { res.strdup() },
         Err(_err) => {
             info!(context, 0, "Can\'t read file.",);
 
@@ -1322,7 +1322,7 @@ unsafe fn outlk_autodiscover(
 ) -> Option<dc_loginparam_t> {
     let current_block: u64;
     let mut xml_raw: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut url = to_cstring(url__);
+    let mut url = url__.strdup();
     let mut outlk_ad = outlk_autodiscover_t {
         in_0: param_in,
         out: dc_loginparam_new(),

--- a/src/dc_dehtml.rs
+++ b/src/dc_dehtml.rs
@@ -53,7 +53,7 @@ pub unsafe fn dc_dehtml(buf_terminated: *mut libc::c_char) -> *mut libc::c_char 
     dc_saxparser_parse(&mut saxparser, buf_terminated);
     free(dehtml.last_href as *mut libc::c_void);
 
-    to_cstring(dehtml.strbuilder)
+    dehtml.strbuilder.strdup()
 }
 
 unsafe fn dehtml_text_cb(

--- a/src/dc_e2ee.rs
+++ b/src/dc_e2ee.rs
@@ -177,16 +177,12 @@ pub unsafe fn dc_e2ee_encrypt(
                                     let p = peerstates[i as usize]
                                         .render_gossip_header(min_verified as usize);
 
-                                    if p.is_some() {
-                                        let header = to_cstring(p.unwrap());
+                                    if let Some(header) = p {
                                         mailimf_fields_add(
                                             imffields_encrypted,
                                             mailimf_field_new_custom(
-                                                strdup(
-                                                    b"Autocrypt-Gossip\x00" as *const u8
-                                                        as *const libc::c_char,
-                                                ),
-                                                header,
+                                                "Autocrypt-Gossip".strdup(),
+                                                header.strdup(),
                                             ),
                                         );
                                     }
@@ -296,7 +292,7 @@ pub unsafe fn dc_e2ee_encrypt(
                                 sign_key.as_ref(),
                             ) {
                                 let ctext_bytes = ctext_v.len();
-                                let ctext = to_cstring(ctext_v);
+                                let ctext = ctext_v.strdup();
                                 (*helper).cdata_to_free = ctext as *mut _;
 
                                 /* create MIME-structure that will contain the encrypted text */
@@ -354,13 +350,11 @@ pub unsafe fn dc_e2ee_encrypt(
                         14181132614457621749 => {}
                         _ => {
                             let aheader = Aheader::new(addr, public_key, prefer_encrypt);
-                            let rendered = to_cstring(aheader.to_string());
-
                             mailimf_fields_add(
                                 imffields_unprotected,
                                 mailimf_field_new_custom(
-                                    strdup(b"Autocrypt\x00" as *const u8 as *const libc::c_char),
-                                    rendered,
+                                    "Autocrypt".strdup(),
+                                    aheader.to_string().strdup(),
                                 ),
                             );
                         }

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -515,7 +515,7 @@ pub unsafe fn dc_normalize_setup_code(
         p1 = p1.offset(1);
     }
 
-    to_cstring(out)
+    out.strdup()
 }
 
 #[allow(non_snake_case)]
@@ -524,16 +524,14 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: *mut dc_job_t) 
     let mut success: libc::c_int = 0;
     let mut ongoing_allocated_here: libc::c_int = 0;
     let what: libc::c_int;
-    let mut param1 = 0 as *mut libc::c_char;
-    let mut param2 = 0 as *mut libc::c_char;
 
     if !(0 == dc_alloc_ongoing(context)) {
         ongoing_allocated_here = 1;
         what = (*job).param.get_int(Param::Cmd).unwrap_or_default();
-        param1 = to_cstring((*job).param.get(Param::Arg).unwrap_or_default());
-        param2 = to_cstring((*job).param.get(Param::Arg2).unwrap_or_default());
+        let param1 = CString::yolo((*job).param.get(Param::Arg).unwrap_or_default());
+        let _param2 = CString::yolo((*job).param.get(Param::Arg2).unwrap_or_default());
 
-        if strlen(param1) == 0 {
+        if strlen(param1.as_ptr()) == 0 {
             error!(context, 0, "No Import/export dir/file given.",);
         } else {
             info!(context, 0, "Import/export process started.",);
@@ -551,7 +549,7 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: *mut dc_job_t) 
                         );
                         current_block = 3568988166330621280;
                     } else {
-                        dc_create_folder(context, param1);
+                        dc_create_folder(context, param1.as_ptr());
                         current_block = 4495394744059808450;
                     }
                 } else {
@@ -564,28 +562,28 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: *mut dc_job_t) 
                             current_block = 10991094515395304355;
                             match current_block {
                                 2973387206439775448 => {
-                                    if 0 == import_backup(context, param1) {
+                                    if 0 == import_backup(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
                                     }
                                 }
                                 11250025114629486028 => {
-                                    if 0 == import_self_keys(context, param1) {
+                                    if 0 == import_self_keys(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
                                     }
                                 }
                                 12669919903773909120 => {
-                                    if 0 == export_backup(context, param1) {
+                                    if 0 == export_backup(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
                                     }
                                 }
                                 _ => {
-                                    if 0 == export_self_keys(context, param1) {
+                                    if 0 == export_self_keys(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
@@ -604,28 +602,28 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: *mut dc_job_t) 
                             current_block = 11250025114629486028;
                             match current_block {
                                 2973387206439775448 => {
-                                    if 0 == import_backup(context, param1) {
+                                    if 0 == import_backup(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
                                     }
                                 }
                                 11250025114629486028 => {
-                                    if 0 == import_self_keys(context, param1) {
+                                    if 0 == import_self_keys(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
                                     }
                                 }
                                 12669919903773909120 => {
-                                    if 0 == export_backup(context, param1) {
+                                    if 0 == export_backup(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
                                     }
                                 }
                                 _ => {
-                                    if 0 == export_self_keys(context, param1) {
+                                    if 0 == export_self_keys(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
@@ -644,28 +642,28 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: *mut dc_job_t) 
                             current_block = 12669919903773909120;
                             match current_block {
                                 2973387206439775448 => {
-                                    if 0 == import_backup(context, param1) {
+                                    if 0 == import_backup(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
                                     }
                                 }
                                 11250025114629486028 => {
-                                    if 0 == import_self_keys(context, param1) {
+                                    if 0 == import_self_keys(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
                                     }
                                 }
                                 12669919903773909120 => {
-                                    if 0 == export_backup(context, param1) {
+                                    if 0 == export_backup(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
                                     }
                                 }
                                 _ => {
-                                    if 0 == export_self_keys(context, param1) {
+                                    if 0 == export_self_keys(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
@@ -684,28 +682,28 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: *mut dc_job_t) 
                             current_block = 2973387206439775448;
                             match current_block {
                                 2973387206439775448 => {
-                                    if 0 == import_backup(context, param1) {
+                                    if 0 == import_backup(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
                                     }
                                 }
                                 11250025114629486028 => {
-                                    if 0 == import_self_keys(context, param1) {
+                                    if 0 == import_self_keys(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
                                     }
                                 }
                                 12669919903773909120 => {
-                                    if 0 == export_backup(context, param1) {
+                                    if 0 == export_backup(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
                                     }
                                 }
                                 _ => {
-                                    if 0 == export_self_keys(context, param1) {
+                                    if 0 == export_self_keys(context, param1.as_ptr()) {
                                         current_block = 3568988166330621280;
                                     } else {
                                         current_block = 1118134448028020070;
@@ -727,8 +725,6 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: *mut dc_job_t) 
         }
     }
 
-    free(param1 as *mut libc::c_void);
-    free(param2 as *mut libc::c_void);
     if 0 != ongoing_allocated_here {
         dc_free_ongoing(context);
     }
@@ -875,9 +871,8 @@ unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_
     let res = chrono::NaiveDateTime::from_timestamp(now as i64, 0)
         .format("delta-chat-%Y-%m-%d.bak")
         .to_string();
-    let buffer = to_cstring(res);
-    let dest_pathNfilename = dc_get_fine_pathNfilename(context, dir, buffer);
-    free(buffer as *mut _);
+    let buffer = CString::yolo(res);
+    let dest_pathNfilename = dc_get_fine_pathNfilename(context, dir, buffer.as_ptr());
     if dest_pathNfilename.is_null() {
         error!(context, 0, "Cannot get backup file name.",);
 
@@ -1076,7 +1071,6 @@ unsafe fn import_self_keys(context: &Context, dir_name: *const libc::c_char) -> 
     let mut imported_cnt: libc::c_int = 0;
     let mut suffix: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut path_plus_name: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut name_c: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut set_default: libc::c_int;
     let mut buf: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut buf_bytes: size_t = 0 as size_t;
@@ -1104,9 +1098,8 @@ unsafe fn import_self_keys(context: &Context, dir_name: *const libc::c_char) -> 
                 let entry = entry.unwrap();
                 free(suffix as *mut libc::c_void);
                 let name_f = entry.file_name();
-                free(name_c as *mut libc::c_void);
-                name_c = to_cstring(name_f.to_string_lossy());
-                suffix = dc_get_filesuffix_lc(name_c);
+                let name_c = name_f.to_c_string().unwrap();
+                suffix = dc_get_filesuffix_lc(name_c.as_ptr());
                 if suffix.is_null()
                     || strcmp(suffix, b"asc\x00" as *const u8 as *const libc::c_char) != 0
                 {
@@ -1116,7 +1109,7 @@ unsafe fn import_self_keys(context: &Context, dir_name: *const libc::c_char) -> 
                 path_plus_name = dc_mprintf(
                     b"%s/%s\x00" as *const u8 as *const libc::c_char,
                     dir_name,
-                    name_c,
+                    name_c.as_ptr(),
                 );
                 info!(context, 0, "Checking: {}", as_str(path_plus_name));
                 free(buf as *mut libc::c_void);
@@ -1154,7 +1147,12 @@ unsafe fn import_self_keys(context: &Context, dir_name: *const libc::c_char) -> 
                     }
                 }
                 set_default = 1;
-                if !strstr(name_c, b"legacy\x00" as *const u8 as *const libc::c_char).is_null() {
+                if !strstr(
+                    name_c.as_ptr(),
+                    b"legacy\x00" as *const u8 as *const libc::c_char,
+                )
+                .is_null()
+                {
                     info!(
                         context,
                         0,
@@ -1179,7 +1177,6 @@ unsafe fn import_self_keys(context: &Context, dir_name: *const libc::c_char) -> 
         }
     }
 
-    free(name_c as *mut libc::c_void);
     free(suffix as *mut libc::c_void);
     free(path_plus_name as *mut libc::c_void);
     free(buf as *mut libc::c_void);

--- a/src/dc_job.rs
+++ b/src/dc_job.rs
@@ -314,7 +314,7 @@ unsafe fn dc_job_do_DC_JOB_SEND(context: &Context, job: &mut dc_job_t) {
     }
     match current_block {
         13109137661213826276 => {
-            filename = to_cstring(job.param.get(Param::File).unwrap_or_default());
+            filename = job.param.get(Param::File).unwrap_or_default().strdup();
             if strlen(filename) == 0 {
                 warn!(context, 0, "Missing file name for job {}", job.job_id,);
             } else if !(0 == dc_read_file(context, filename, &mut buf, &mut buf_bytes)) {
@@ -1177,12 +1177,11 @@ pub unsafe fn dc_job_send_msg(context: &Context, msg_id: uint32_t) -> libc::c_in
     } else {
         // no redo, no IMAP. moreover, as the data does not exist, there is no need in calling dc_set_msg_failed()
         if msgtype_has_file((*mimefactory.msg).type_0) {
-            let pathNfilename = to_cstring(
-                (*mimefactory.msg)
-                    .param
-                    .get(Param::File)
-                    .unwrap_or_default(),
-            );
+            let pathNfilename = (*mimefactory.msg)
+                .param
+                .get(Param::File)
+                .unwrap_or_default()
+                .strdup();
             if strlen(pathNfilename) > 0 {
                 if ((*mimefactory.msg).type_0 == Viewtype::Image
                     || (*mimefactory.msg).type_0 == Viewtype::Gif)

--- a/src/dc_location.rs
+++ b/src/dc_location.rs
@@ -100,12 +100,9 @@ pub unsafe fn dc_send_locations_to_chat(
         {
             if 0 != seconds && !is_sending_locations_before {
                 msg = dc_msg_new(context, Viewtype::Text);
-                (*msg).text = to_cstring(context.stock_system_msg(
-                    StockMessage::MsgLocationEnabled,
-                    "",
-                    "",
-                    0,
-                ));
+                (*msg).text = context
+                    .stock_system_msg(StockMessage::MsgLocationEnabled, "", "", 0)
+                    .strdup();
                 (*msg).param.set_int(Param::Cmd, 8);
                 dc_send_msg(context, chat_id, msg);
             } else if 0 == seconds && is_sending_locations_before {
@@ -351,7 +348,7 @@ pub fn dc_get_location_kml(
     }
 
     if 0 != success {
-        unsafe { to_cstring(ret) }
+        unsafe { ret.strdup() }
     } else {
         std::ptr::null_mut()
     }
@@ -365,7 +362,7 @@ unsafe fn get_kml_timestamp(utc: i64) -> *mut libc::c_char {
     let res = chrono::NaiveDateTime::from_timestamp(utc, 0)
         .format("%Y-%m-%dT%H:%M:%SZ")
         .to_string();
-    to_cstring(res)
+    res.strdup()
 }
 
 pub unsafe fn dc_get_message_kml(

--- a/src/dc_lot.rs
+++ b/src/dc_lot.rs
@@ -134,14 +134,14 @@ pub unsafe fn dc_lot_fill(
         return;
     }
     if (*msg).state == 19i32 {
-        (*lot).text1 = to_cstring(context.stock_str(StockMessage::Draft));
+        (*lot).text1 = context.stock_str(StockMessage::Draft).strdup();
         (*lot).text1_meaning = 1i32
     } else if (*msg).from_id == 1i32 as libc::c_uint {
         if 0 != dc_msg_is_info(msg) || 0 != dc_chat_is_self_talk(chat) {
             (*lot).text1 = 0 as *mut libc::c_char;
             (*lot).text1_meaning = 0i32
         } else {
-            (*lot).text1 = to_cstring(context.stock_str(StockMessage::SelfMsg));
+            (*lot).text1 = context.stock_str(StockMessage::SelfMsg).strdup();
             (*lot).text1_meaning = 3i32
         }
     } else if chat.is_null() {

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -1312,9 +1312,8 @@ unsafe fn dc_mimeparser_add_single_part_if_known(
                         }
                         if !filename_parts.is_empty() {
                             free(desired_filename as *mut libc::c_void);
-                            let parts_c = to_cstring(filename_parts);
-                            desired_filename = dc_decode_ext_header(parts_c);
-                            free(parts_c as *mut _);
+                            let parts_c = CString::yolo(filename_parts);
+                            desired_filename = dc_decode_ext_header(parts_c.as_ptr());
                         }
                         if desired_filename.is_null() {
                             let param = mailmime_find_ct_parameter(

--- a/src/dc_qr.rs
+++ b/src/dc_qr.rs
@@ -59,34 +59,34 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                 let param: Params = as_str(fragment).parse().expect("invalid params");
                 addr = param
                     .get(Param::Forwarded)
-                    .map(|s| to_cstring(s))
+                    .map(|s| s.strdup())
                     .unwrap_or_else(|| std::ptr::null_mut());
                 if !addr.is_null() {
                     if let Some(ref name_enc) = param.get(Param::SetLongitude) {
                         let name_r = percent_decode_str(name_enc)
                             .decode_utf8()
                             .expect("invalid name");
-                        name = to_cstring(name_r);
+                        name = name_r.strdup();
                         dc_normalize_name(name);
                     }
                     invitenumber = param
                         .get(Param::ProfileImage)
-                        .map(|s| to_cstring(s))
+                        .map(|s| s.strdup())
                         .unwrap_or_else(|| std::ptr::null_mut());
                     auth = param
                         .get(Param::Auth)
-                        .map(|s| to_cstring(s))
+                        .map(|s| s.strdup())
                         .unwrap_or_else(|| std::ptr::null_mut());
                     grpid = param
                         .get(Param::GroupId)
-                        .map(|s| to_cstring(s))
+                        .map(|s| s.strdup())
                         .unwrap_or_else(|| std::ptr::null_mut());
                     if !grpid.is_null() {
                         if let Some(grpname_enc) = param.get(Param::GroupName) {
                             let grpname_r = percent_decode_str(grpname_enc)
                                 .decode_utf8()
                                 .expect("invalid groupname");
-                            grpname = to_cstring(grpname_r);
+                            grpname = grpname_r.strdup();
                         }
                     }
                 }
@@ -253,7 +253,7 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                                         if let Some(peerstate) = peerstate {
                                             (*qr_parsed).state = 210i32;
                                             let addr_ptr = if let Some(ref addr) = peerstate.addr {
-                                                to_cstring(addr)
+                                                addr.strdup()
                                             } else {
                                                 std::ptr::null()
                                             };

--- a/src/dc_securejoin.rs
+++ b/src/dc_securejoin.rs
@@ -40,7 +40,7 @@ pub unsafe fn dc_get_securejoin_qr(
     let mut chat = 0 as *mut Chat;
     let mut group_name = 0 as *mut libc::c_char;
     let mut group_name_urlencoded = 0 as *mut libc::c_char;
-    let mut qr = None;
+    let mut qr: Option<String> = None;
 
     dc_ensure_secret_key_exists(context);
     invitenumber = dc_token_lookup(context, DC_TOKEN_INVITENUMBER, group_chat_id);
@@ -64,7 +64,7 @@ pub unsafe fn dc_get_securejoin_qr(
         free(group_name_urlencoded as *mut libc::c_void);
 
         if let Some(qr) = qr {
-            to_cstring(qr)
+            qr.strdup()
         } else {
             std::ptr::null_mut()
         }

--- a/src/dc_simplify.rs
+++ b/src/dc_simplify.rs
@@ -229,7 +229,7 @@ impl dc_simplify_t {
         }
         dc_free_splitted_lines(lines);
 
-        to_cstring(ret)
+        ret.strdup()
     }
 }
 

--- a/src/dc_strencode.rs
+++ b/src/dc_strencode.rs
@@ -1,4 +1,4 @@
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 
 use charset::Charset;
 use mmime::mailmime_decode::*;
@@ -710,9 +710,8 @@ unsafe fn print_hex(target: *mut libc::c_char, cur: *const libc::c_char) {
     assert!(!cur.is_null());
 
     let bytes = std::slice::from_raw_parts(cur as *const _, strlen(cur));
-    let raw = to_cstring(format!("={}", &hex::encode_upper(bytes)[..2]));
-    libc::memcpy(target as *mut _, raw as *const _, 4);
-    free(raw as *mut libc::c_void);
+    let raw = CString::yolo(format!("={}", &hex::encode_upper(bytes)[..2]));
+    libc::memcpy(target as *mut _, raw.as_ptr() as *const _, 4);
 }
 
 #[cfg(test)]

--- a/src/dc_token.rs
+++ b/src/dc_token.rs
@@ -42,7 +42,7 @@ pub fn dc_token_lookup(
             params![namespc as i32, foreign_id as i32],
             0,
         )
-        .map(|s| unsafe { to_cstring(s) })
+        .map(|s| unsafe { s.strdup() })
         .unwrap_or_else(|| std::ptr::null_mut())
 }
 

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1,3 +1,4 @@
+use std::ffi::CString;
 use std::net;
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 use std::time::{Duration, SystemTime};
@@ -5,10 +6,9 @@ use std::time::{Duration, SystemTime};
 use crate::constants::*;
 use crate::context::Context;
 use crate::dc_loginparam::*;
-use crate::dc_tools::to_cstring;
+use crate::dc_tools::CStringExt;
 use crate::oauth2::dc_get_oauth2_access_token;
 use crate::types::*;
-use crate::x::free;
 
 pub const DC_IMAP_SEEN: usize = 0x0001;
 pub const DC_REGENERATE: usize = 0x01;
@@ -843,10 +843,8 @@ impl Imap {
                     .expect("missing message id");
 
                 if 0 == unsafe {
-                    let message_id_c = to_cstring(message_id);
-                    let res = (self.precheck_imf)(context, message_id_c, folder.as_ref(), cur_uid);
-                    free(message_id_c as *mut _);
-                    res
+                    let message_id_c = CString::yolo(message_id);
+                    (self.precheck_imf)(context, message_id_c.as_ptr(), folder.as_ref(), cur_uid)
                 } {
                     // check passed, go fetch the rest
                     if self.fetch_single_msg(context, &folder, cur_uid) == 0 {

--- a/src/log.rs
+++ b/src/log.rs
@@ -7,10 +7,9 @@ macro_rules! info {
         #[allow(unused_unsafe)]
         unsafe {
             let formatted = format!($msg, $($args),*);
-            let formatted_c =  $crate::dc_tools::to_cstring(formatted);
+            let formatted_c =  std::ffi::CString::new(formatted).unwrap();
             $ctx.call_cb($crate::constants::Event::INFO, $data1 as libc::uintptr_t,
-                     formatted_c as libc::uintptr_t);
-            libc::free(formatted_c as *mut libc::c_void);
+                     formatted_c.as_ptr() as libc::uintptr_t);
     }};
 }
 
@@ -23,10 +22,9 @@ macro_rules! warn {
         #[allow(unused_unsafe)]
         unsafe {
             let formatted = format!($msg, $($args),*);
-            let formatted_c = $crate::dc_tools::to_cstring(formatted);
+            let formatted_c = std::ffi::CString::new(formatted).unwrap();
             $ctx.call_cb($crate::constants::Event::WARNING, $data1 as libc::uintptr_t,
-                         formatted_c as libc::uintptr_t);
-            libc::free(formatted_c as *mut libc::c_void) ;
+                         formatted_c.as_ptr() as libc::uintptr_t);
         }};
 }
 
@@ -39,10 +37,9 @@ macro_rules! error {
         #[allow(unused_unsafe)]
         unsafe {
         let formatted = format!($msg, $($args),*);
-        let formatted_c = $crate::dc_tools::to_cstring(formatted);
+        let formatted_c = std::ffi::CString::new(formatted).unwrap();
         $ctx.call_cb($crate::constants::Event::ERROR, $data1 as libc::uintptr_t,
-                     formatted_c as libc::uintptr_t);
-        libc::free(formatted_c as *mut libc::c_void);
+                     formatted_c.as_ptr() as libc::uintptr_t);
     }};
 }
 
@@ -55,9 +52,8 @@ macro_rules! log_event {
         #[allow(unused_unsafe)]
         unsafe {
             let formatted = format!($msg, $($args),*);
-            let formatted_c = $crate::dc_tools::to_cstring(formatted);
+            let formatted_c = std::ffi::CString::new(formatted).unwrap();
             $ctx.call_cb($event, $data1 as libc::uintptr_t,
-                         formatted_c as libc::uintptr_t);
-            libc::free(formatted_c as *mut libc::c_void);
+                         formatted_c.as_ptr() as libc::uintptr_t);
     }};
 }

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -462,13 +462,11 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
 
-    use tempfile::{tempdir, TempDir};
-
-    use crate::context::*;
+    use tempfile::TempDir;
 
     #[test]
     fn test_peerstate_save_to_db() {
-        let ctx = unsafe { create_test_context() };
+        let ctx = crate::test_utils::dummy_context();
         let addr = "hello@mail.com";
 
         let pub_key = crate::key::Key::from_base64("xsBNBFztUVkBCADYaQl/UOUpRPd32nLRzx8eU0eI+jQEnG+g5anjYA+3oct1rROGl5SygjMULDKdaUy27O3o9Srsti0YjA7uxZnavIqhSopJhFidqY1M1wA9JZa/duucZdNwUGbjGIRsS/4Cjr5+3svscK24hVYub1dvDWXpwUTnj3K6xOEnJdoM+MhCqtSD5+zcJhFc9vyZm9ZTGWUxAhKh0iJTcCD8V6CQ3XZ2z9GruwzZT/FTFovWrz7m3TUI2OdSSHh0eZLRGEoxMCT/vzflAFGAr8ijCaRsEIfqP6FW8uQWnFTqkjxEUCZG6XkeFHB84aj5jqYG/1KCLjL5vEKwfl1tz/WnPhY7ABEBAAHNEDxoZWxsb0BtYWlsLmNvbT7CwIkEEAEIADMCGQEFAlztUVoCGwMECwkIBwYVCAkKCwIDFgIBFiEEgMjHGVbvLXe6ioRROg8oKCvye7gACgkQOg8oKCvye7ijAwf+PTsuawUax9cNPn1bN90H+g9qyHZJMEwKXtUnNaXJxPW3iB7ThhpCiCzsZwP7+l7ArS8tmLeNDw2bENtcf1XCv4wovP2fdXOP3QOUUFX/GdakcTwv7DzC7CO0grB1HtaPhGw/6UX2o2cx2i9xiUf4Givq2MfCbgAW5zloH6WXGPb6yLQYJXxqDIphr4+uZDb+bMAyWHN/DUkAjHrV8nnVki7PMHqzzZpwglalxMX8RGeiGZE39ALJKL/Og87DMFah87/yoxQWGoS7Wqv0XDcCPKoTCPrpk8pOe2KEsq/lz215nefHd4aRpfUX5YCYa8HPvvfPQbGF73uvyQw5w7qjis7ATQRc7VFZAQgAt8ONdnX6KEEQ5Jw6ilJ+LBtY44SP5t0I3eK+goKepgIiKhjGDa+Mntyi4jdhH+HO6kvK5SHMh2sPp4rRO/WKHJwWFySyM1OdyiywhyH0J9R5rBY4vPHsJjf6vSKJdWLWT+ho1fNet2IIC+jVCYli91MAMbRvk6EKVj1nCc+67giOahXEkHt6xxkeCGlOvbw8hxGj1A8+AC1BLms/OR3oc4JMi9O3kq6uG0z9tlUEerac9HVwcjoO1XLe+hJhoT5H+TbnGjPuhuURP3pFiIKHpbRYgUfdSAY0dTObO7t4I5y/drPOrCTnWrBUg2wXAECUhpRKow9/ai2YemLv9KqhhwARAQABwsB2BBgBCAAgBQJc7VFaAhsMFiEEgMjHGVbvLXe6ioRROg8oKCvye7gACgkQOg8oKCvye7jmyggAhs4QzCzIbT2OsAReBxkxtm0AI+g1HZ1KFKof5NDHfgv9C/Qu1I8mKEjlZzA4qFyPmLqntgwJ0RuFy6gLbljZBNCFO7vB478AhYtnWjuKZmA40HUPwcB1hEJ31c42akzfUbioY1TLLepngdsJg7Cm8O+rhI9+1WRA66haJDgFs793SVUDyJh8f9NX50l5zR87/bsV30CFSw0q4OSSy9VI/z+2g5khn1LnuuOrCfFnYIPYtJED1BfkXkosxGlgbzy79VvGmI9d23x4atDK7oBPCzIj+lP8sytJ0u3HOguXi9OgDitKy+Pt1r8gH8frdktMJr5Ts6DW+tIn2vR23KR8aA==", KeyType::Public).unwrap();
@@ -505,27 +503,5 @@ mod tests {
     struct TestContext {
         ctx: Context,
         dir: TempDir,
-    }
-
-    unsafe extern "C" fn cb(
-        _context: &Context,
-        _event: Event,
-        _data1: libc::uintptr_t,
-        _data2: libc::uintptr_t,
-    ) -> libc::uintptr_t {
-        0
-    }
-
-    unsafe fn create_test_context() -> TestContext {
-        let mut ctx = dc_context_new(Some(cb), std::ptr::null_mut(), None);
-        let dir = tempdir().unwrap();
-        let dbfile = dir.path().join("db.sqlite");
-        assert!(
-            dc_open(&mut ctx, dbfile.to_str().unwrap(), None),
-            "Failed to open {}",
-            dbfile.to_str().unwrap()
-        );
-
-        TestContext { ctx: ctx, dir: dir }
     }
 }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -10,7 +10,6 @@ use crate::dc_tools::*;
 use crate::error::{Error, Result};
 use crate::param::*;
 use crate::peerstate::*;
-use crate::x::*;
 
 const DC_OPEN_READONLY: usize = 0x01;
 
@@ -1049,9 +1048,8 @@ pub fn housekeeping(context: &Context) {
                     entry.file_name()
                 );
                 unsafe {
-                    let path = to_cstring(entry.path().to_str().unwrap());
-                    dc_delete_file(context, path);
-                    free(path as *mut _);
+                    let path = entry.path().to_c_string().unwrap();
+                    dc_delete_file(context, path.as_ptr());
                 }
             }
         }


### PR DESCRIPTION
Replaces #204 and has same rationale

Add a trait for str.strdup() to replace to_cstring() which avoid the
signature ambiguity with .to_string().

Also instruduce CString::yolo() as a shortcut to
CString::new().unwrap() and use it whenever the variable does can be
deallocated by going out of scope.  This is less error prone.

Use some Path.to_c_string() functions where possible.