### PR TITLE
Fix "In-Reply-To acting weird"

### DIFF
--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -781,9 +781,9 @@ unsafe fn get_parent_mime_headers(
             .sql
             .query_row(
                 "SELECT rfc724_mid, mime_in_reply_to, mime_references \
-                 FROM msgs WHERE timestamp=(SELECT max(timestamp) \
+                 FROM msgs WHERE chat_id=? AND timestamp=(SELECT max(timestamp) \
                  FROM msgs WHERE chat_id=? AND from_id!=?);",
-                params![(*chat).id as i32, 1],
+                params![(*chat).id as i32, (*chat).id as i32, 1],
                 |row| {
                     *parent_rfc724_mid = row.get::<_, String>(0)?.strdup();
                     *parent_in_reply_to = row.get::<_, String>(1)?.strdup();
@@ -799,9 +799,9 @@ unsafe fn get_parent_mime_headers(
                 .sql
                 .query_row(
                     "SELECT rfc724_mid, mime_in_reply_to, mime_references \
-                     FROM msgs WHERE timestamp=(SELECT min(timestamp) \
+                     FROM msgs WHERE chat_id=? AND timestamp=(SELECT min(timestamp) \
                      FROM msgs WHERE chat_id=? AND from_id==?);",
-                    params![(*chat).id as i32, 1],
+                    params![(*chat).id as i32, (*chat).id as i32, 1],
                     |row| {
                         *parent_rfc724_mid = row.get::<_, String>(0)?.strdup();
                         *parent_in_reply_to = row.get::<_, String>(1)?.strdup();

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -782,9 +782,9 @@ unsafe fn get_parent_mime_headers(
             .sql
             .query_row(
                 "SELECT rfc724_mid, mime_in_reply_to, mime_references \
-                 FROM msgs WHERE chat_id=? AND timestamp=(SELECT max(timestamp) \
-                 FROM msgs WHERE chat_id=? AND from_id!=?);",
-                params![(*chat).id as i32, (*chat).id as i32, DC_CONTACT_ID_SELF as i32],
+                 FROM msgs WHERE chat_id=?1 AND timestamp=(SELECT max(timestamp) \
+                 FROM msgs WHERE chat_id=?1 AND from_id!=?2);",
+                params![(*chat).id as i32, DC_CONTACT_ID_SELF as i32],
                 |row| {
                     *parent_rfc724_mid = row.get::<_, String>(0)?.strdup();
                     *parent_in_reply_to = row.get::<_, String>(1)?.strdup();
@@ -800,9 +800,9 @@ unsafe fn get_parent_mime_headers(
                 .sql
                 .query_row(
                     "SELECT rfc724_mid, mime_in_reply_to, mime_references \
-                     FROM msgs WHERE chat_id=? AND timestamp=(SELECT min(timestamp) \
-                     FROM msgs WHERE chat_id=? AND from_id==?);",
-                    params![(*chat).id as i32, (*chat).id as i32, DC_CONTACT_ID_SELF as i32],
+                     FROM msgs WHERE chat_id=?1 AND timestamp=(SELECT min(timestamp) \
+                     FROM msgs WHERE chat_id=?1 AND from_id==?2);",
+                    params![(*chat).id as i32, DC_CONTACT_ID_SELF as i32],
                     |row| {
                         *parent_rfc724_mid = row.get::<_, String>(0)?.strdup();
                         *parent_in_reply_to = row.get::<_, String>(1)?.strdup();

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -784,7 +784,7 @@ unsafe fn get_parent_mime_headers(
                 "SELECT rfc724_mid, mime_in_reply_to, mime_references \
                  FROM msgs WHERE chat_id=? AND timestamp=(SELECT max(timestamp) \
                  FROM msgs WHERE chat_id=? AND from_id!=?);",
-                params![(*chat).id as i32, (*chat).id as i32, DC_CONTACT_ID_SELF],
+                params![(*chat).id as i32, (*chat).id as i32, DC_CONTACT_ID_SELF as i32],
                 |row| {
                     *parent_rfc724_mid = row.get::<_, String>(0)?.strdup();
                     *parent_in_reply_to = row.get::<_, String>(1)?.strdup();
@@ -802,7 +802,7 @@ unsafe fn get_parent_mime_headers(
                     "SELECT rfc724_mid, mime_in_reply_to, mime_references \
                      FROM msgs WHERE chat_id=? AND timestamp=(SELECT min(timestamp) \
                      FROM msgs WHERE chat_id=? AND from_id==?);",
-                    params![(*chat).id as i32, (*chat).id as i32, DC_CONTACT_ID_SELF],
+                    params![(*chat).id as i32, (*chat).id as i32, DC_CONTACT_ID_SELF as i32],
                     |row| {
                         *parent_rfc724_mid = row.get::<_, String>(0)?.strdup();
                         *parent_in_reply_to = row.get::<_, String>(1)?.strdup();

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -784,7 +784,7 @@ unsafe fn get_parent_mime_headers(
                 "SELECT rfc724_mid, mime_in_reply_to, mime_references \
                  FROM msgs WHERE chat_id=? AND timestamp=(SELECT max(timestamp) \
                  FROM msgs WHERE chat_id=? AND from_id!=?);",
-                params![(*chat).id as i32, (*chat).id as i32, 1],
+                params![(*chat).id as i32, (*chat).id as i32, DC_CONTACT_ID_SELF],
                 |row| {
                     *parent_rfc724_mid = row.get::<_, String>(0)?.strdup();
                     *parent_in_reply_to = row.get::<_, String>(1)?.strdup();
@@ -802,7 +802,7 @@ unsafe fn get_parent_mime_headers(
                     "SELECT rfc724_mid, mime_in_reply_to, mime_references \
                      FROM msgs WHERE chat_id=? AND timestamp=(SELECT min(timestamp) \
                      FROM msgs WHERE chat_id=? AND from_id==?);",
-                    params![(*chat).id as i32, (*chat).id as i32, 1],
+                    params![(*chat).id as i32, (*chat).id as i32, DC_CONTACT_ID_SELF],
                     |row| {
                         *parent_rfc724_mid = row.get::<_, String>(0)?.strdup();
                         *parent_in_reply_to = row.get::<_, String>(1)?.strdup();

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -776,6 +776,7 @@ unsafe fn get_parent_mime_headers(
         || parent_in_reply_to.is_null()
         || parent_references.is_null())
     {
+        // prefer a last message that isn't from us
         success = (*chat)
             .context
             .sql


### PR DESCRIPTION
The sql statement didn't expect more than one message to have the same timestamps, so it sometimes gave back wrong results.
![2019-08-04_08-58](https://user-images.githubusercontent.com/18725968/62420638-0531a500-b696-11e9-8325-179648c63e44.png)
See the first entry having a wrong chat id.

_We should also fix this in the C core...._