### PR TITLE
python: assert that underlying dc_msg_t* for Message is not NULL

### DIFF
--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -20,6 +20,7 @@ class Message(object):
         self._dc_context = account._dc_context
         assert isinstance(self._dc_context, ffi.CData)
         assert isinstance(dc_msg, ffi.CData)
+        assert dc_msg != ffi.NULL
         self._dc_msg = dc_msg
         self.id = lib.dc_msg_get_id(dc_msg)
         assert self.id is not None and self.id >= 0, repr(self.id)


### PR DESCRIPTION
Somewhy several tests on master fails locally for me, and root of problem was
that Message was created with NULL underlying dc_msg, so errors manifest
themself several function calls later.

This assert makes sure that error is caught as early as possible.