### PR TITLE
Make dc_may_be_valid_addr() safe

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -732,7 +732,11 @@ pub unsafe extern "C" fn dc_get_msg<'a>(
 
 #[no_mangle]
 pub unsafe extern "C" fn dc_may_be_valid_addr(addr: *mut libc::c_char) -> libc::c_int {
-    dc_contact::dc_may_be_valid_addr(addr) as libc::c_int
+    if addr.is_null() {
+        return 0;
+    }
+
+    dc_contact::dc_may_be_valid_addr(&dc_tools::to_string(addr)) as libc::c_int
 }
 
 #[no_mangle]

--- a/src/dc_contact.rs
+++ b/src/dc_contact.rs
@@ -45,23 +45,14 @@ pub fn dc_marknoticed_contact(context: &Context, contact_id: u32) {
 
 /// Returns false if addr is an invalid address, otherwise true.
 pub unsafe fn dc_may_be_valid_addr(addr: *const libc::c_char) -> bool {
-    if addr.is_null() {
-        return false;
-    }
-    let at: *const libc::c_char = strchr(addr, '@' as i32);
-    if at.is_null() || at.wrapping_offset_from(addr) < 1 {
-        return false;
-    }
-    let dot: *const libc::c_char = strchr(at, '.' as i32);
-    if dot.is_null()
-        || dot.wrapping_offset_from(at) < 2
-        || *dot.offset(1isize) as libc::c_int == 0i32
-        || *dot.offset(2isize) as libc::c_int == 0i32
-    {
-        return false;
-    }
+    let s = to_string(addr);
 
-    true
+    // Regexp: /.+@.+\..{2,}/
+    if let (Some(at), Some(dot)) = (s.find('@'), s.rfind('.')) {
+        at > 0 && dot > 2 && dot + 2 < s.len()
+    } else {
+        false
+    }
 }
 
 pub unsafe fn dc_lookup_contact_id_by_addr(

--- a/src/dc_contact.rs
+++ b/src/dc_contact.rs
@@ -44,9 +44,7 @@ pub fn dc_marknoticed_contact(context: &Context, contact_id: u32) {
 }
 
 /// Returns false if addr is an invalid address, otherwise true.
-pub unsafe fn dc_may_be_valid_addr(addr: *const libc::c_char) -> bool {
-    let s = to_string(addr);
-
+pub fn dc_may_be_valid_addr(s: &str) -> bool {
     // Regexp: /.+@.+\..{2,}/
     if let (Some(at), Some(dot)) = (s.find('@'), s.rfind('.')) {
         at > 0 && dot > 2 && dot + 2 < s.len()
@@ -337,7 +335,7 @@ pub fn dc_add_or_lookup_contact(
         return 1;
     }
 
-    if !unsafe { dc_may_be_valid_addr(addr_c) } {
+    if !dc_may_be_valid_addr(&addr) {
         warn!(
             context,
             0,
@@ -1077,52 +1075,16 @@ mod tests {
 
     #[test]
     fn test_dc_may_be_valid_addr() {
-        unsafe {
-            assert_eq!(dc_may_be_valid_addr(0 as *const libc::c_char), false);
-            assert_eq!(
-                dc_may_be_valid_addr(b"\x00" as *const u8 as *const libc::c_char),
-                false
-            );
-            assert_eq!(
-                dc_may_be_valid_addr(b"user@domain.tld\x00" as *const u8 as *const libc::c_char),
-                true
-            );
-            assert_eq!(
-                dc_may_be_valid_addr(b"uuu\x00" as *const u8 as *const libc::c_char),
-                false
-            );
-            assert_eq!(
-                dc_may_be_valid_addr(b"dd.tt\x00" as *const u8 as *const libc::c_char),
-                false
-            );
-            assert_eq!(
-                dc_may_be_valid_addr(b"tt.dd@uu\x00" as *const u8 as *const libc::c_char),
-                false
-            );
-            assert_eq!(
-                dc_may_be_valid_addr(b"u@d\x00" as *const u8 as *const libc::c_char),
-                false
-            );
-            assert_eq!(
-                dc_may_be_valid_addr(b"u@d.\x00" as *const u8 as *const libc::c_char),
-                false
-            );
-            assert_eq!(
-                dc_may_be_valid_addr(b"u@d.t\x00" as *const u8 as *const libc::c_char),
-                false
-            );
-            assert_eq!(
-                dc_may_be_valid_addr(b"u@d.tt\x00" as *const u8 as *const libc::c_char),
-                true
-            );
-            assert_eq!(
-                dc_may_be_valid_addr(b"u@.tt\x00" as *const u8 as *const libc::c_char),
-                false
-            );
-            assert_eq!(
-                dc_may_be_valid_addr(b"@d.tt\x00" as *const u8 as *const libc::c_char),
-                false
-            );
-        }
+        assert_eq!(dc_may_be_valid_addr(""), false);
+        assert_eq!(dc_may_be_valid_addr("user@domain.tld"), true);
+        assert_eq!(dc_may_be_valid_addr("uuu"), false);
+        assert_eq!(dc_may_be_valid_addr("dd.tt"), false);
+        assert_eq!(dc_may_be_valid_addr("tt.dd@uu"), false);
+        assert_eq!(dc_may_be_valid_addr("u@d"), false);
+        assert_eq!(dc_may_be_valid_addr("u@d."), false);
+        assert_eq!(dc_may_be_valid_addr("u@d.t"), false);
+        assert_eq!(dc_may_be_valid_addr("u@d.tt"), true);
+        assert_eq!(dc_may_be_valid_addr("u@.tt"), false);
+        assert_eq!(dc_may_be_valid_addr("@d.tt"), false);
     }
 }

--- a/src/dc_qr.rs
+++ b/src/dc_qr.rs
@@ -207,7 +207,7 @@ pub unsafe fn dc_check_qr(context: &Context, qr: *const libc::c_char) -> *mut dc
                     temp = dc_addr_normalize(addr);
                     free(addr as *mut libc::c_void);
                     addr = temp;
-                    if !dc_may_be_valid_addr(addr) {
+                    if !dc_may_be_valid_addr(&to_string(addr)) {
                         (*qr_parsed).state = 400i32;
                         (*qr_parsed).text1 = dc_strdup(
                             b"Bad e-mail address.\x00" as *const u8 as *const libc::c_char,


### PR DESCRIPTION
Changes:

d3ff3ab (Dmitry Bogatov, 14 minutes ago)
   Change `dc_may_be_valid_addr()` accept &str, not const char *

8fc74ff (Dmitry Bogatov, 31 minutes ago)
   Reimplement `dc_may_be_valid_addr' without raw pointers