### PR TITLE
fix own messages displayed as noMsgs in summary

### DIFF
--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -291,7 +291,7 @@ impl<'a> Chatlist<'a> {
 
         if (*chat).id == DC_CHAT_ID_ARCHIVED_LINK as u32 {
             (*ret).text2 = dc_strdup(0 as *const libc::c_char)
-        } else if lastmsg.is_null() || (*lastmsg).from_id == DC_CONTACT_ID_SELF as u32 {
+        } else if lastmsg.is_null() || (*lastmsg).from_id == DC_CONTACT_ID_UNDEFINED as u32 {
             (*ret).text2 = self.context.stock_str(StockMessage::NoMessages).strdup();
         } else {
             dc_lot_fill(ret, lastmsg, chat, lastcontact.as_ref(), self.context);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -89,6 +89,7 @@ pub const DC_MAX_GET_TEXT_LEN: usize = 30000;
 /// approx. max. length returned by dc_get_msg_info()
 pub const DC_MAX_GET_INFO_LEN: usize = 100000;
 
+pub const DC_CONTACT_ID_UNDEFINED: usize = 0;
 pub const DC_CONTACT_ID_SELF: usize = 1;
 pub const DC_CONTACT_ID_DEVICE: usize = 2;
 pub const DC_CONTACT_ID_LAST_SPECIAL: usize = 9;


### PR DESCRIPTION
`fromid == 0`
was translated to
`(*lastmsg).from_id == DC_CONTACT_ID_SELF as u32`
in a previous refactoring https://github.com/deltachat/deltachat-core-rust/pull/238 (https://github.com/deltachat/deltachat-core-rust/pull/238/files#diff-be6aa465b7fdd075d577ca0278ac0dffL377 to https://github.com/deltachat/deltachat-core-rust/pull/238/files#diff-6c7f44e9e741553e1e92cb62ff03b7ddR295)
but `DC_CONTACT_ID_SELF` is 1
(also the code makes no sense with `DC_CONTACT_ID_SELF` because that would mean: treat my own messages as they wouldn't exist in the chatlist summary)