### PR TITLE
Fix broken string allocations in message handling

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -421,7 +421,9 @@ class TestOnlineAccount:
         lp.sec("mark message as seen on ac2, wait for changes on ac1")
         ac2.mark_seen_messages([msg_in])
         lp.step("1")
-        ac1._evlogger.get_matching("DC_EVENT_MSG_READ")
+        ev = ac1._evlogger.get_matching("DC_EVENT_MSG_READ")
+        assert ev[1] >= const.DC_CHAT_ID_LAST_SPECIAL
+        assert ev[2] >= const.DC_MSG_ID_LAST_SPECIAL
         lp.step("2")
         assert msg_out.is_out_mdn_received()
 

--- a/src/dc_e2ee.rs
+++ b/src/dc_e2ee.rs
@@ -293,7 +293,7 @@ pub unsafe fn dc_e2ee_encrypt(
                             ) {
                                 let ctext_bytes = ctext_v.len();
                                 let ctext = ctext_v.strdup();
-                                (*helper).cdata_to_free = ctext as *mut _;
+                                helper.cdata_to_free = ctext as *mut _;
 
                                 /* create MIME-structure that will contain the encrypted text */
                                 let mut encrypted_part: *mut mailmime = new_data_part(
@@ -339,7 +339,7 @@ pub unsafe fn dc_e2ee_encrypt(
                                 (*in_out_message).mm_data.mm_message.mm_msg_mime = encrypted_part;
                                 (*encrypted_part).mm_parent = in_out_message;
                                 mailmime_free(message_to_encrypt);
-                                (*helper).encryption_successfull = 1i32;
+                                helper.encryption_successfull = 1i32;
                             }
                         }
                     }
@@ -926,6 +926,7 @@ unsafe fn decrypt_part(
                         *ret_decrypted_mime = decrypted_mime;
                         sth_decrypted = 1i32
                     }
+                    std::mem::forget(plain);
                 }
             }
         }
@@ -1054,4 +1055,70 @@ pub unsafe fn dc_ensure_secret_key_exists(context: &Context) -> libc::c_int {
     }
 
     success
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mailmime_parse() {
+        let plain = b"Chat-Disposition-Notification-To: holger@deltachat.de
+Chat-Group-ID: CovhGgau8M-
+Chat-Group-Name: Delta Chat Dev
+Subject: =?utf-8?Q?Chat=3A?= Delta Chat =?utf-8?Q?Dev=3A?= sidenote for
+ =?utf-8?Q?all=3A?= rust core master ...
+Content-Type: text/plain; charset=\"utf-8\"; protected-headers=\"v1\"
+Content-Transfer-Encoding: quoted-printable
+
+sidenote for all: rust core master is broken currently ... so dont recomm=
+end to try to run with desktop or ios unless you are ready to hunt bugs
+
+-- =20
+Sent with my Delta Chat Messenger: https://delta.chat";
+        let plain_bytes = plain.len();
+        let plain_buf = plain.as_ptr() as *const libc::c_char;
+
+        let mut index = 0;
+        let mut decrypted_mime = std::ptr::null_mut();
+
+        let res = unsafe {
+            mailmime_parse(
+                plain_buf as *const _,
+                plain_bytes,
+                &mut index,
+                &mut decrypted_mime,
+            )
+        };
+        unsafe {
+            let msg1 = (*decrypted_mime).mm_data.mm_message.mm_msg_mime;
+            let mut decoded_data = 0 as *const libc::c_char;
+            let mut decoded_data_bytes = 0;
+            let mut transfer_decoding_buffer: *mut libc::c_char = 0 as *mut libc::c_char;
+
+            assert_eq!(
+                mailmime_transfer_decode(
+                    msg1,
+                    &mut decoded_data,
+                    &mut decoded_data_bytes,
+                    &mut transfer_decoding_buffer,
+                ),
+                1
+            );
+            println!(
+                "{:?}",
+                String::from_utf8_lossy(std::slice::from_raw_parts(
+                    decoded_data as *const u8,
+                    decoded_data_bytes as usize,
+                ))
+            );
+
+            free(decoded_data as *mut _);
+        }
+
+        assert_eq!(res, 0);
+        assert!(!decrypted_mime.is_null());
+
+        unsafe { free(decrypted_mime as *mut _) };
+    }
 }

--- a/src/dc_job.rs
+++ b/src/dc_job.rs
@@ -786,7 +786,7 @@ unsafe fn dc_add_smtp_job(
             b"\x1e\x00" as *const u8 as *const libc::c_char,
         );
         param.set(Param::File, as_str(pathNfilename));
-        param.set(Param::File, as_str(recipients));
+        param.set(Param::Recipients, as_str(recipients));
         dc_job_add(
             context,
             action,

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -723,8 +723,7 @@ pub unsafe fn dc_receive_imf(
                                                                 &mut msg_id,
                                                             ) {
                                                                 rr_event_to_send
-                                                                    .push((chat_id_0, 0));
-                                                                rr_event_to_send.push((msg_id, 0));
+                                                                    .push((chat_id_0, msg_id));
                                                             }
                                                             mdn_consumed = (msg_id
                                                                 != 0 as libc::c_uint)

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1723,7 +1723,7 @@ unsafe fn check_verified_properties(
 
 unsafe fn set_better_msg<T: AsRef<str>>(mime_parser: &mut dc_mimeparser_t, better_msg: T) {
     let msg = better_msg.as_ref();
-    if !(msg.len() > 0) && !mime_parser.parts.is_empty() {
+    if msg.len() > 0 && !mime_parser.parts.is_empty() {
         let part = &mut mime_parser.parts[0];
         if (*part).type_0 == 10 {
             free(part.msg as *mut libc::c_void);

--- a/src/dc_simplify.rs
+++ b/src/dc_simplify.rs
@@ -29,6 +29,10 @@ impl dc_simplify_t {
         is_html: libc::c_int,
         is_msgrmsg: libc::c_int,
     ) -> *mut libc::c_char {
+        if in_bytes <= 0 {
+            return "".strdup();
+        }
+
         /* create a copy of the given buffer */
         let mut out: *mut libc::c_char;
         let mut temp: *mut libc::c_char;


### PR DESCRIPTION
Desktop with current master is heavily broken. This is a attempt of fixing it "sufficiently" and a bit of a random mix of fixing commits.  

This PR also contains three fixes that, together with friedel's changes let python liveconfig tests pass again and also probably fixes #223.  The #233 remains an open issue and is not fixed yet.  