### PR TITLE
fix encryption-not-available #233

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -120,6 +120,8 @@ def acfactory(pytestconfig, tmpdir, request):
                 pytest.skip("specify a --liveconfig file to run tests with real accounts")
             self.live_count += 1
             configdict = self.configlist.pop(0)
+            if "e2ee_enabled" not in configdict:
+                configdict["e2ee_enabled"] = "1"
             tmpdb = tmpdir.join("livedb%d" % self.live_count)
             ac = Account(tmpdb.strpath, logid="ac{}".format(self.live_count))
             ac._evlogger.init_time = self.init_time

--- a/src/dc_e2ee.rs
+++ b/src/dc_e2ee.rs
@@ -76,11 +76,6 @@ pub unsafe fn dc_e2ee_encrypt(
     let mut peerstates: Vec<Peerstate> = Vec::new();
     *helper = Default::default();
 
-    info!(
-        context,
-        0, "dc_e2ee_encrypt guaruanteed={}", e2ee_guaranteed
-    );
-
     if !(recipients_addr.is_null()
         || in_out_message.is_null()
         || !(*in_out_message).mm_parent.is_null()
@@ -111,10 +106,6 @@ pub unsafe fn dc_e2ee_encrypt(
                     iter1 = (*recipients_addr).first;
                     while !iter1.is_null() {
                         let recipient_addr = to_string((*iter1).data as *const libc::c_char);
-                        info!(
-                            context,
-                            0, "dc_e2ee_encrypt recipient_addr {}", recipient_addr
-                        );
                         if recipient_addr != addr {
                             let peerstate =
                                 Peerstate::from_addr(context, &context.sql, &recipient_addr);
@@ -594,7 +585,6 @@ pub unsafe fn dc_e2ee_decrypt(
                 }
             } else if let Some(ref header) = autocryptheader {
                 let p = Peerstate::from_header(context, header, message_time);
-                info!(context, 0, "setting peerstate from header for {:?}", p.addr);
                 assert!(p.save_to_db(&context.sql, true));
                 peerstate = Some(p);
             }

--- a/src/dc_e2ee.rs
+++ b/src/dc_e2ee.rs
@@ -812,7 +812,7 @@ unsafe fn decrypt_recursive(
 }
 
 unsafe fn decrypt_part(
-    _context: &Context,
+    context: &Context,
     mime: *mut mailmime,
     private_keyring: &Keyring,
     public_keyring_for_validate: &Keyring,

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -1041,6 +1041,11 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                     &mut e2ee_helper,
                 );
             }
+            info!(
+                (*factory).context,
+                0, "encryption successful {}", e2ee_helper.encryption_successfull
+            );
+
             if 0 != e2ee_helper.encryption_successfull {
                 (*factory).out_encrypted = 1;
                 if 0 != do_gossip {

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -1041,11 +1041,6 @@ pub unsafe fn dc_mimefactory_render(mut factory: *mut dc_mimefactory_t) -> libc:
                     &mut e2ee_helper,
                 );
             }
-            info!(
-                (*factory).context,
-                0, "encryption successful {}", e2ee_helper.encryption_successfull
-            );
-
             if 0 != e2ee_helper.encryption_successfull {
                 (*factory).out_encrypted = 1;
                 if 0 != do_gossip {

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -166,7 +166,6 @@ impl<'a> Peerstate<'a> {
 
     pub fn from_addr(context: &'a Context, _sql: &Sql, addr: &str) -> Option<Self> {
         let query = "SELECT addr, last_seen, last_seen_autocrypt, prefer_encrypted, public_key, gossip_timestamp, gossip_key, public_key_fingerprint, gossip_key_fingerprint, verified_key, verified_key_fingerprint FROM acpeerstates  WHERE addr=? COLLATE NOCASE;";
-        info!(context, 0, "peerstate.from_addr {}", addr);
         Self::from_stmt(context, query, &[addr])
     }
 
@@ -188,7 +187,6 @@ impl<'a> Peerstate<'a> {
         P: IntoIterator,
         P::Item: rusqlite::ToSql,
     {
-        info!(context, 0, "from_stmt query {:?}", query);
         context
             .sql
             .query_row(query, params, |row| {
@@ -200,7 +198,6 @@ impl<'a> Peerstate<'a> {
                 let mut res = Self::new(context);
 
                 res.addr = Some(row.get(0)?);
-                info!(context, 0, "from_stmt res.addr {:?} starting", res.addr);
                 res.last_seen = row.get(1)?;
                 res.last_seen_autocrypt = row.get(2)?;
                 res.prefer_encrypt = EncryptPreference::from_i32(row.get(3)?).unwrap_or_default();
@@ -429,10 +426,6 @@ impl<'a> Peerstate<'a> {
         }
 
         if self.to_save == Some(ToSave::All) || create {
-            info!(
-                self.context,
-                0, "update acpeerstates with peerstate {:?}", self
-            );
             success = sql::execute(
                 self.context,
                 sql,

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -166,7 +166,7 @@ impl<'a> Peerstate<'a> {
 
     pub fn from_addr(context: &'a Context, _sql: &Sql, addr: &str) -> Option<Self> {
         let query = "SELECT addr, last_seen, last_seen_autocrypt, prefer_encrypted, public_key, gossip_timestamp, gossip_key, public_key_fingerprint, gossip_key_fingerprint, verified_key, verified_key_fingerprint FROM acpeerstates  WHERE addr=? COLLATE NOCASE;";
-
+        info!(context, 0, "peerstate.from_addr {}", addr);
         Self::from_stmt(context, query, &[addr])
     }
 
@@ -188,21 +188,38 @@ impl<'a> Peerstate<'a> {
         P: IntoIterator,
         P::Item: rusqlite::ToSql,
     {
+        info!(context, 0, "from_stmt query {:?}", query);
         context
             .sql
             .query_row(query, params, |row| {
+                /* all the above queries start with this: SELECT
+                addr, last_seen, last_seen_autocrypt, prefer_encrypted,
+                public_key, gossip_timestamp, gossip_key, public_key_fingerprint,
+                gossip_key_fingerprint, verified_key, verified_key_fingerprint
+                */
                 let mut res = Self::new(context);
 
                 res.addr = Some(row.get(0)?);
+                info!(context, 0, "from_stmt res.addr {:?} starting", res.addr);
                 res.last_seen = row.get(1)?;
                 res.last_seen_autocrypt = row.get(2)?;
                 res.prefer_encrypt = EncryptPreference::from_i32(row.get(3)?).unwrap_or_default();
                 res.gossip_timestamp = row.get(5)?;
                 let pkf: String = row.get(7)?;
                 res.public_key_fingerprint = if pkf.is_empty() { None } else { Some(pkf) };
-                let gkf: String = row.get(8)?;
+
+                let t: Result<String, rusqlite::Error> = row.get(8);
+                let gkf: String = match t {
+                    Err(_) => String::from(""),
+                    Ok(res) => res,
+                };
                 res.gossip_key_fingerprint = if gkf.is_empty() { None } else { Some(gkf) };
-                let vkf: String = row.get(10)?;
+
+                let t: Result<String, rusqlite::Error> = row.get(10);
+                let vkf: String = match t {
+                    Err(_) => String::from(""),
+                    Ok(res) => res,
+                };
                 res.verified_key_fingerprint = if vkf.is_empty() { None } else { Some(vkf) };
 
                 res.public_key = row
@@ -217,7 +234,7 @@ impl<'a> Peerstate<'a> {
                     .get(9)
                     .ok()
                     .and_then(|blob: Vec<u8>| Key::from_slice(&blob, KeyType::Public));
-                res.verified_key = if vk == res.gossip_key {
+                res.verified_key = if vk == res.gossip_key && res.gossip_key.is_some() {
                     VerifiedKey::Gossip
                 } else if vk == res.public_key {
                     VerifiedKey::Public
@@ -400,6 +417,10 @@ impl<'a> Peerstate<'a> {
         }
 
         if self.to_save == Some(ToSave::All) || create {
+            info!(
+                self.context,
+                0, "update acpeerstates with peerstate {:?}", self
+            );
             success = sql::execute(
                 self.context,
                 sql,
@@ -422,6 +443,7 @@ impl<'a> Peerstate<'a> {
                     &self.addr,
                 ],
             ).is_ok();
+            assert_eq!(success, true);
         } else if self.to_save == Some(ToSave::Timestamps) {
             success = sql::execute(
                 self.context,
@@ -484,6 +506,40 @@ mod tests {
             gossip_key_fingerprint: Some(pub_key.fingerprint()),
             verified_key: VerifiedKey::Gossip,
             verified_key_fingerprint: Some(pub_key.fingerprint()),
+            to_save: Some(ToSave::All),
+            degrade_event: None,
+        };
+
+        assert!(peerstate.save_to_db(&ctx.ctx.sql, true), "failed to save");
+
+        let peerstate_new = Peerstate::from_addr(&ctx.ctx, &ctx.ctx.sql, addr.into())
+            .expect("failed to load peerstate from db");
+
+        // clear to_save, as that is not persissted
+        peerstate.to_save = None;
+        assert_eq!(peerstate, peerstate_new);
+    }
+
+    #[test]
+    fn test_peerstate_with_empty_gossip_key_save_to_db() {
+        let ctx = crate::test_utils::dummy_context();
+        let addr = "hello@mail.com";
+
+        let pub_key = crate::key::Key::from_base64("xsBNBFztUVkBCADYaQl/UOUpRPd32nLRzx8eU0eI+jQEnG+g5anjYA+3oct1rROGl5SygjMULDKdaUy27O3o9Srsti0YjA7uxZnavIqhSopJhFidqY1M1wA9JZa/duucZdNwUGbjGIRsS/4Cjr5+3svscK24hVYub1dvDWXpwUTnj3K6xOEnJdoM+MhCqtSD5+zcJhFc9vyZm9ZTGWUxAhKh0iJTcCD8V6CQ3XZ2z9GruwzZT/FTFovWrz7m3TUI2OdSSHh0eZLRGEoxMCT/vzflAFGAr8ijCaRsEIfqP6FW8uQWnFTqkjxEUCZG6XkeFHB84aj5jqYG/1KCLjL5vEKwfl1tz/WnPhY7ABEBAAHNEDxoZWxsb0BtYWlsLmNvbT7CwIkEEAEIADMCGQEFAlztUVoCGwMECwkIBwYVCAkKCwIDFgIBFiEEgMjHGVbvLXe6ioRROg8oKCvye7gACgkQOg8oKCvye7ijAwf+PTsuawUax9cNPn1bN90H+g9qyHZJMEwKXtUnNaXJxPW3iB7ThhpCiCzsZwP7+l7ArS8tmLeNDw2bENtcf1XCv4wovP2fdXOP3QOUUFX/GdakcTwv7DzC7CO0grB1HtaPhGw/6UX2o2cx2i9xiUf4Givq2MfCbgAW5zloH6WXGPb6yLQYJXxqDIphr4+uZDb+bMAyWHN/DUkAjHrV8nnVki7PMHqzzZpwglalxMX8RGeiGZE39ALJKL/Og87DMFah87/yoxQWGoS7Wqv0XDcCPKoTCPrpk8pOe2KEsq/lz215nefHd4aRpfUX5YCYa8HPvvfPQbGF73uvyQw5w7qjis7ATQRc7VFZAQgAt8ONdnX6KEEQ5Jw6ilJ+LBtY44SP5t0I3eK+goKepgIiKhjGDa+Mntyi4jdhH+HO6kvK5SHMh2sPp4rRO/WKHJwWFySyM1OdyiywhyH0J9R5rBY4vPHsJjf6vSKJdWLWT+ho1fNet2IIC+jVCYli91MAMbRvk6EKVj1nCc+67giOahXEkHt6xxkeCGlOvbw8hxGj1A8+AC1BLms/OR3oc4JMi9O3kq6uG0z9tlUEerac9HVwcjoO1XLe+hJhoT5H+TbnGjPuhuURP3pFiIKHpbRYgUfdSAY0dTObO7t4I5y/drPOrCTnWrBUg2wXAECUhpRKow9/ai2YemLv9KqhhwARAQABwsB2BBgBCAAgBQJc7VFaAhsMFiEEgMjHGVbvLXe6ioRROg8oKCvye7gACgkQOg8oKCvye7jmyggAhs4QzCzIbT2OsAReBxkxtm0AI+g1HZ1KFKof5NDHfgv9C/Qu1I8mKEjlZzA4qFyPmLqntgwJ0RuFy6gLbljZBNCFO7vB478AhYtnWjuKZmA40HUPwcB1hEJ31c42akzfUbioY1TLLepngdsJg7Cm8O+rhI9+1WRA66haJDgFs793SVUDyJh8f9NX50l5zR87/bsV30CFSw0q4OSSy9VI/z+2g5khn1LnuuOrCfFnYIPYtJED1BfkXkosxGlgbzy79VvGmI9d23x4atDK7oBPCzIj+lP8sytJ0u3HOguXi9OgDitKy+Pt1r8gH8frdktMJr5Ts6DW+tIn2vR23KR8aA==", KeyType::Public).unwrap();
+
+        let mut peerstate = Peerstate {
+            context: &ctx.ctx,
+            addr: Some(addr.into()),
+            last_seen: 10,
+            last_seen_autocrypt: 11,
+            prefer_encrypt: EncryptPreference::Mutual,
+            public_key: Some(pub_key.clone()),
+            public_key_fingerprint: Some(pub_key.fingerprint()),
+            gossip_key: None,
+            gossip_timestamp: 12,
+            gossip_key_fingerprint: None,
+            verified_key: VerifiedKey::None,
+            verified_key_fingerprint: None,
             to_save: Some(ToSave::All),
             degrade_event: None,
         };


### PR DESCRIPTION
this adds a rust and python test and fixes #233 -- and is on top of #306 but still against master. 

please feel free to add commits to cleanup the sql-error-handling code -- i am sure there are more elegant ways than what i came up with quickly. 