### PR TITLE
Remove dc_context_unref from Rust API

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -44,11 +44,14 @@ pub unsafe extern "C" fn dc_context_new(
     Box::into_raw(Box::new(ctx))
 }
 
+/// Release the context structure.
+///
+/// This function releases the memory of the `dc_context_t` structure.
 #[no_mangle]
 pub unsafe extern "C" fn dc_context_unref(context: *mut dc_context_t) {
     assert!(!context.is_null());
     let context = &mut *context;
-    context::dc_context_unref(context);
+    context::dc_close(context);
     Box::from_raw(context);
 }
 

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -456,12 +456,6 @@ fn main_0(args: Vec<String>) -> Result<(), failure::Error> {
     println!("history saved");
     {
         stop_threads(&ctx.read().unwrap());
-
-        unsafe {
-            let mut ctx = ctx.write().unwrap();
-            dc_close(&mut ctx);
-            dc_context_unref(&mut ctx);
-        }
     }
 
     Ok(())


### PR DESCRIPTION
My goal is to make Context more Rusty by removing dc_open() and dc_close() but without changing the C API.  In a next step I plan to make some kind of wrapper struct which the ffi dc_context_new() would return which contains an Option<Context> and thus the dc_open()/dc_close() API can create and destroy the Context that way.

This removes the dc_context_unref function from the Rust API which was
just an alias for dc_close.  It still exists on the C API where it
makes sure to free the memory.

It also implements Drop for the context which just calls dc_close to
make sure all the memory is freed.  Since you can call dc_close as
many times as you like this ensures that at the Rust level you can't
Drop the struct without releasing the memory.

Finally since memory is now freed by dropping the struct this removes
the #[repr(C)] for the struct.  This struct is fully opaque to the C
API.