### PR TITLE
Replace DC_MOVE_* constants with enum

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,10 +6,29 @@ use rusqlite::types::*;
 
 pub const DC_VERSION_STR: &'static [u8; 14] = b"1.0.0-alpha.3\x00";
 
-pub const DC_MOVE_STATE_MOVING: u32 = 3;
-pub const DC_MOVE_STATE_STAY: u32 = 2;
-pub const DC_MOVE_STATE_PENDING: u32 = 1;
-pub const DC_MOVE_STATE_UNDEFINED: u32 = 0;
+#[repr(u8)]
+#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+pub enum MoveState {
+    Undefined = 0,
+    Pending = 1,
+    Stay = 2,
+    Moving = 3,
+}
+
+impl ToSql for MoveState {
+    fn to_sql(&self) -> sql::Result<ToSqlOutput> {
+        let num = *self as i64;
+
+        Ok(ToSqlOutput::Owned(Value::Integer(num)))
+    }
+}
+
+impl FromSql for MoveState {
+    fn column_result(col: ValueRef) -> FromSqlResult<Self> {
+        let inner = FromSql::column_result(col)?;
+        FromPrimitive::from_i64(inner).ok_or(FromSqlError::InvalidType)
+    }
+}
 
 pub const DC_GCL_ARCHIVED_ONLY: usize = 0x01;
 pub const DC_GCL_NO_SPECIALS: usize = 0x02;

--- a/src/context.rs
+++ b/src/context.rs
@@ -229,7 +229,7 @@ unsafe fn cb_precheck_imf(
                 "[move] detected moved message {}",
                 as_str(rfc724_mid),
             );
-            dc_update_msg_move_state(context, rfc724_mid, DC_MOVE_STATE_STAY);
+            dc_update_msg_move_state(context, rfc724_mid, MoveState::Stay);
         }
         if as_str(old_server_folder) != server_folder || old_server_uid != server_uid {
             dc_update_server_uid(context, rfc724_mid, server_folder, server_uid);

--- a/src/dc_move.rs
+++ b/src/dc_move.rs
@@ -27,13 +27,13 @@ pub unsafe fn dc_do_heuristics_moves(context: &Context, folder: &str, msg_id: u3
     }
 
     if dc_is_mvbox(context, folder) {
-        dc_update_msg_move_state(context, (*msg).rfc724_mid, DC_MOVE_STATE_STAY);
+        dc_update_msg_move_state(context, (*msg).rfc724_mid, MoveState::Stay);
     }
 
     // 1 = dc message, 2 = reply to dc message
     if 0 != (*msg).is_dc_message {
         dc_job_add(context, 200, (*msg).id as libc::c_int, Params::new(), 0);
-        dc_update_msg_move_state(context, (*msg).rfc724_mid, DC_MOVE_STATE_MOVING);
+        dc_update_msg_move_state(context, (*msg).rfc724_mid, MoveState::Moving);
     }
 
     dc_msg_unref(msg);

--- a/src/dc_msg.rs
+++ b/src/dc_msg.rs
@@ -25,7 +25,7 @@ pub struct dc_msg_t<'a> {
     pub from_id: uint32_t,
     pub to_id: uint32_t,
     pub chat_id: uint32_t,
-    pub move_state: dc_move_state_t,
+    pub move_state: MoveState,
     pub type_0: Viewtype,
     pub state: libc::c_int,
     pub hidden: libc::c_int,
@@ -229,7 +229,7 @@ pub unsafe fn dc_msg_new<'a>(context: &'a Context, viewtype: Viewtype) -> *mut d
         from_id: 0,
         to_id: 0,
         chat_id: 0,
-        move_state: 0,
+        move_state: MoveState::Undefined,
         type_0: viewtype,
         state: 0,
         hidden: 0,
@@ -1187,7 +1187,7 @@ pub unsafe fn dc_msg_exists(context: &Context, msg_id: uint32_t) -> libc::c_int 
 pub fn dc_update_msg_move_state(
     context: &Context,
     rfc724_mid: *const libc::c_char,
-    state: dc_move_state_t,
+    state: MoveState,
 ) -> bool {
     // we update the move_state for all messages belonging to a given Message-ID
     // so that the state stay intact when parts are deleted

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -4,7 +4,6 @@ use std::sync::{Arc, RwLock};
 use rusqlite::{Connection, OpenFlags, Statement, NO_PARAMS};
 use thread_local_object::ThreadLocal;
 
-use crate::constants::*;
 use crate::context::Context;
 use crate::dc_tools::*;
 use crate::error::{Error, Result};
@@ -689,10 +688,6 @@ fn open(
                 "ALTER TABLE msgs ADD COLUMN move_state INTEGER DEFAULT 1;",
                 params![],
             )?;
-            assert_eq!(DC_MOVE_STATE_UNDEFINED as libc::c_int, 0);
-            assert_eq!(DC_MOVE_STATE_PENDING as libc::c_int, 1);
-            assert_eq!(DC_MOVE_STATE_STAY as libc::c_int, 2);
-            assert_eq!(DC_MOVE_STATE_MOVING as libc::c_int, 3);
 
             dbversion = 48;
             sql.set_config_int(context, "dbversion", 48)?;

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,8 +16,6 @@ pub use rusqlite::ffi::*;
 pub type dc_callback_t =
     unsafe extern "C" fn(_: &Context, _: Event, _: uintptr_t, _: uintptr_t) -> uintptr_t;
 
-pub type dc_move_state_t = u32;
-
 pub type dc_receive_imf_t = unsafe fn(
     _: &Context,
     _: *const libc::c_char,


### PR DESCRIPTION
By the way, I noticed that `MoveState = Pending` is not used anywhere. It is okay?