### PR TITLE
streamline python test runs, make DCC_PY_LIVECONFIG support  https-account creation

### DIFF
--- a/ci_scripts/ci_run.sh
+++ b/ci_scripts/ci_run.sh
@@ -16,7 +16,7 @@ export BRANCH=${CIRCLE_BRANCH:-test7}
 #fi
 
 # run everything else inside docker (TESTS, DOCS, WHEELS) 
-docker run -e BRANCH -e TESTS -e DOCS \
+docker run -e DCC_PY_LIVECONFIG -e BRANCH -e TESTS -e DOCS \
            --rm -it -v $(pwd):/mnt -w /mnt \
            deltachat/coredeps ci_scripts/run_all.sh
 

--- a/ci_scripts/docker-coredeps/deps/build_rust.sh
+++ b/ci_scripts/docker-coredeps/deps/build_rust.sh
@@ -3,9 +3,9 @@
 set -e -x 
 
 # Install Rust 
-curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2019-04-19 -y
+curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly-2019-07-10 -y
 export PATH=/root/.cargo/bin:$PATH
 rustc --version
 
 # remove some 300-400 MB that we don't need for automated builds
-rm -rf /root/.rustup/toolchains/nightly-2019-04-19-x86_64-unknown-linux-gnu/share/
+rm -rf /root/.rustup/toolchains/nightly-2019-07-10-x86_64-unknown-linux-gnu/share/

--- a/ci_scripts/run_all.sh
+++ b/ci_scripts/run_all.sh
@@ -37,6 +37,10 @@ if [ -n "$TESTS" ]; then
     export PYTHONDONTWRITEBYTECODE=1
 
     # run tox
+    # XXX we don't run liveconfig tests because they hang sometimes
+    # see https://github.com/deltachat/deltachat-core-rust/issues/331
+    unset DCC_PY_LIVECONFIG
+
     tox --workdir "$TOXWORKDIR" -e lint,py27,py35,py36,py37,auditwheels
     popd
 fi

--- a/python/README.rst
+++ b/python/README.rst
@@ -15,7 +15,7 @@ without any "build-from-source" steps.
 1. `Install virtualenv <https://virtualenv.pypa.io/en/stable/installation/>`_,
    then create a fresh python environment and activate it in your shell::
 
-        virtualenv -p python3 venv
+        virtualenv venv  # or: python -m venv
         source venv/bin/activate
 
    Afterwards, invoking ``python`` or ``pip install`` will only
@@ -56,17 +56,16 @@ to core deltachat library::
     cd deltachat-core-rust
     cd python
 
-It is always a good idea to create a python "virtualenv".
-Install "virtualenv" on your system and run::
+If you don't have one active, create and activate a python "virtualenv":
 
-    virtualenv venv
+    python virtualenv venv  # or python -m venv
     source venv/bin/activate
 
 Afterwards ``which python`` tells you that it comes out of the "venv"
 directory that contains all python install artifacts. Let's first
 install test tools::
 
-    pip install pytest pytest-timeout pytest-faulthandler requests
+    pip install pytest pytest-timeout requests
 
 then cargo-build and install the deltachat bindings::
 

--- a/python/install_python_bindings.py
+++ b/python/install_python_bindings.py
@@ -6,29 +6,18 @@
 
 import os
 import subprocess
+import os
 
 if __name__ == "__main__":
     os.environ["DCC_RS_TARGET"] = target = "release"
+    if "DCC_RS_DEV" not in os.environ:
+        dn = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        os.environ["DCC_RS_DEV"] = dn
 
-    toml = os.path.join(os.getcwd(), "..", "Cargo.toml")
-    assert os.path.exists(toml)
-    with open(toml) as f:
-        s = orig = f.read()
-    s += "\n"
-    s += "[profile.release]\n"
-    s += "debug = true\n"
-    with open(toml, "w") as f:
-        f.write(s)
-    print("temporarily modifying Cargo.toml to provide release build with debug symbols ")
-    try:
-        subprocess.check_call([
-            "cargo", "build", "-p", "deltachat_ffi", "--" + target
-        ])
-    finally:
-        with open(toml, "w") as f:
-            f.write(orig)
-        print("\nreseted Cargo.toml to previous original state")
-
+    os.environ["RUSTFLAGS"] = "-g"
+    subprocess.check_call([
+        "cargo", "build", "-p", "deltachat_ffi", "--" + target
+    ])
     subprocess.check_call("rm -rf build/ src/deltachat/*.so" , shell=True)
 
     subprocess.check_call([

--- a/python/src/deltachat/_build.py
+++ b/python/src/deltachat/_build.py
@@ -6,10 +6,15 @@ import platform
 import os
 import cffi
 import shutil
+from os.path import dirname as dn
+from os.path import abspath
 
 
 def ffibuilder():
     projdir = os.environ.get('DCC_RS_DEV')
+    if not projdir:
+        p = dn(dn(dn(dn(abspath(__file__)))))
+        projdir = os.environ["DCC_RS_DEV"] = p
     target = os.environ.get('DCC_RS_TARGET', 'release')
     if projdir:
         if platform.system() == 'Darwin':

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -50,8 +50,9 @@ class Account(object):
         self._configkeys = self.get_config("sys.config_keys").split()
         self._imex_completed = threading.Event()
 
-    def __del__(self):
-        self.shutdown()
+    # XXX this can cause "illegal instructions" at test ends so we omit it for now
+    # def __del__(self):
+    #    self.shutdown()
 
     def _check_config_key(self, name):
         if name not in self._configkeys:

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -8,7 +8,7 @@ envlist =
 
 [testenv]
 commands = 
-    pytest -s -v -rsXx {posargs:tests}
+    pytest -v -rsXx {posargs:tests}
     python tests/package_wheels.py {toxworkdir}/wheelhouse
 passenv = 
     TRAVIS 

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -8,7 +8,7 @@ envlist =
 
 [testenv]
 commands = 
-    pytest -v -rsXx {posargs:tests}
+    pytest -s -v -rsXx {posargs:tests}
     python tests/package_wheels.py {toxworkdir}/wheelhouse
 passenv = 
     TRAVIS 
@@ -19,6 +19,7 @@ deps =
     pytest
     pytest-faulthandler
     pdbpp
+    requests
 
 [testenv:auditwheels]
 skipsdist = True
@@ -51,6 +52,7 @@ commands =
 
 
 [pytest]
+addopts = -v -rs
 python_files = tests/test_*.py 
 norecursedirs = .tox 
 xfail_strict=true

--- a/run-integration-tests.sh
+++ b/run-integration-tests.sh
@@ -23,7 +23,7 @@ if [ $? != 0 ]; then
 fi
 
 pushd python
-if [ -e "./liveconfig" ]; then
+if [ -e "./liveconfig" && -z "$DCC_PY_LIVECONFIG" ]; then
     export DCC_PY_LIVECONFIG=liveconfig
 fi
 tox "$@"


### PR DESCRIPTION
this is a rework of python liveconfig test support, with an improved/simplified readme.  This PR also adds support for DCC_PY_LIVECONFIG pointing to an https-service that will automatically create accounts and can be used from the CI now.  However, the liveconfig tests are disabled for now because  #331 and #326 prohibit clean runs.  I still recommend to merge this PR which does not change rust code or rust-builds/tests.  Once the issues are fixed liveconfig tests will run in the CI if run_all.sh removes the "unset DCC_PY_LIVECONFIG" line which is already set as a hidden variable in circle-ci, and provides a https-url with a token to be able to create accounts on the fly on testrun.org.  The http-service counterpart code is prototyped at https://github.com/deltachat/playground/tree/master/tadm and is deployed on testrun.org.  It works locally and in the CI but again, it is disabled because of the two mentioned issues. 

Also this PRs removes the temporary modification of Cargo.toml during install_python_bindings.py which is replaced by setting the env var "RUSTFLAGS=-g" to allow for release builds with debug symbols.  