### PR TITLE
Implement procedural macro to derive {To,From}Sql traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,7 @@ dependencies = [
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "charset 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "deltachat_derive 0.1.0",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -499,6 +500,14 @@ dependencies = [
  "strum_macros 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread-local-object 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "deltachat_derive"
+version = "0.1.0"
+dependencies = [
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ cc = "1.0.35"
 pkg-config = "0.3"
 
 [dependencies]
+deltachat_derive = { path = "./deltachat_derive" }
 libc = "0.2.51"
 pgp = { version = "0.2", default-features = false }
 hex = "0.3.2"
@@ -53,7 +54,8 @@ pretty_env_logger = "0.3.0"
 
 [workspace]
 members = [
-  "deltachat-ffi"
+  "deltachat-ffi",
+  "deltachat_derive",
 ]
 
 [[example]]

--- a/deltachat_derive/Cargo.toml
+++ b/deltachat_derive/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "deltachat_derive"
+version = "0.1.0"
+authors = ["Dmitry Bogatov <KAction@debian.org>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "0.14.4"
+quote = "0.6.3"

--- a/deltachat_derive/src/lib.rs
+++ b/deltachat_derive/src/lib.rs
@@ -1,0 +1,45 @@
+#![recursion_limit = "128"]
+extern crate proc_macro;
+
+use crate::proc_macro::TokenStream;
+use quote::quote;
+use syn;
+
+// For now, assume (not check) that these macroses are applied to enum without
+// data.  If this assumption is violated, compiler error will point to
+// generated code, which is not very user-friendly.
+
+#[proc_macro_derive(ToSql)]
+pub fn to_sql_derive(input: TokenStream) -> TokenStream {
+    let ast: syn::DeriveInput = syn::parse(input).unwrap();
+    let name = &ast.ident;
+
+    let gen = quote! {
+        impl rusqlite::types::ToSql for #name {
+            fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput> {
+                let num = *self as i64;
+                let value = rusqlite::types::Value::Integer(num);
+                let output = rusqlite::types::ToSqlOutput::Owned(value);
+
+                std::result::Result::Ok(output)
+            }
+        }
+    };
+    gen.into()
+}
+
+#[proc_macro_derive(FromSql)]
+pub fn from_sql_derive(input: TokenStream) -> TokenStream {
+    let ast: syn::DeriveInput = syn::parse(input).unwrap();
+    let name = &ast.ident;
+
+    let gen = quote! {
+        impl rusqlite::types::FromSql for #name {
+            fn column_result(col: rusqlite::types::ValueRef) -> rusqlite::types::FromSqlResult<Self> {
+                let inner = rusqlite::types::FromSql::column_result(col)?;
+                num_traits::FromPrimitive::from_i64(inner).ok_or(rusqlite::types::FromSqlError::InvalidType)
+            }
+        }
+    };
+    gen.into()
+}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,33 +1,16 @@
 //! Constants
 #![allow(non_camel_case_types)]
-use num_traits::{FromPrimitive, ToPrimitive};
-use rusqlite as sql;
-use rusqlite::types::*;
+use deltachat_derive::*;
 
 pub const DC_VERSION_STR: &'static [u8; 14] = b"1.0.0-alpha.3\x00";
 
 #[repr(u8)]
-#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive, ToSql, FromSql)]
 pub enum MoveState {
     Undefined = 0,
     Pending = 1,
     Stay = 2,
     Moving = 3,
-}
-
-impl ToSql for MoveState {
-    fn to_sql(&self) -> sql::Result<ToSqlOutput> {
-        let num = *self as i64;
-
-        Ok(ToSqlOutput::Owned(Value::Integer(num)))
-    }
-}
-
-impl FromSql for MoveState {
-    fn column_result(col: ValueRef) -> FromSqlResult<Self> {
-        let inner = FromSql::column_result(col)?;
-        FromPrimitive::from_i64(inner).ok_or(FromSqlError::InvalidType)
-    }
 }
 
 pub const DC_GCL_ARCHIVED_ONLY: usize = 0x01;
@@ -166,7 +149,7 @@ pub const DC_LP_IMAP_SOCKET_FLAGS: usize =
 pub const DC_LP_SMTP_SOCKET_FLAGS: usize =
     (DC_LP_SMTP_SOCKET_STARTTLS | DC_LP_SMTP_SOCKET_SSL | DC_LP_SMTP_SOCKET_PLAIN);
 
-#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive, FromSql, ToSql)]
 #[repr(i32)]
 pub enum Viewtype {
     Unknown = 0,
@@ -218,23 +201,6 @@ mod tests {
     #[test]
     fn derive_display_works_as_expected() {
         assert_eq!(format!("{}", Viewtype::Audio), "Audio");
-    }
-}
-
-impl ToSql for Viewtype {
-    fn to_sql(&self) -> sql::Result<ToSqlOutput> {
-        let num: i64 = self
-            .to_i64()
-            .expect("impossible: Viewtype -> i64 conversion failed");
-
-        Ok(ToSqlOutput::Owned(Value::Integer(num)))
-    }
-}
-
-impl FromSql for Viewtype {
-    fn column_result(col: ValueRef) -> FromSqlResult<Self> {
-        let inner = FromSql::column_result(col)?;
-        FromPrimitive::from_i64(inner).ok_or(FromSqlError::InvalidType)
     }
 }
 


### PR DESCRIPTION
With this macro it is possible to #[derive(ToSql, FromSql)] for enums, that do
not contain data (C-style).

This pull request is alternative to #317.