### PR TITLE
Safe load_or_generate_self_public_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ $ cargo test --all
 $ cargo build -p deltachat_ffi --release
 ```
 
+### Expensive tests
+
+Some tests are expensive and marked with `#[ignore]`, to run these
+use the `--ignored` argument to the test binary (not to cargo itself):
+```sh
+$ cargo test -- --ignored
+```
+
 ## Features
 
 - `vendored`: When using Openssl for TLS, this bundles a vendored version.

--- a/src/context.rs
+++ b/src/context.rs
@@ -39,6 +39,8 @@ pub struct Context {
     pub bob: Arc<RwLock<BobStatus>>,
     pub last_smeared_timestamp: Arc<RwLock<i64>>,
     pub running_state: Arc<RwLock<RunningState>>,
+    /// Mutex to avoid generating the key for the user more than once.
+    pub generating_key_mutex: Mutex<()>,
 }
 
 unsafe impl std::marker::Send for Context {}
@@ -169,6 +171,7 @@ pub fn dc_context_new(
         ))),
         probe_imap_network: Arc::new(RwLock::new(false)),
         perform_inbox_jobs_needed: Arc::new(RwLock::new(false)),
+        generating_key_mutex: Mutex::new(()),
     }
 }
 


### PR DESCRIPTION
The function is made safe and now returns Result.  Functionally it now
fails when it can not write the newly generated key to the database
whereas before it still returned the key but logged a warning.  There
is no reason this shouldn't be able to store the key and silently not
storing the key may result in later operations assuming the key is
available, so failing seems like a better choice.

The function now also uses a proper mutex to guard against multiple
threads generating keys.  And this mutex is Context-scoped rather than
fully global (static).