### PR TITLE
fix chat name empty when contact has no name

### DIFF
--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -184,15 +184,15 @@ pub fn dc_chat_load_from_db(chat: *mut Chat, chat_id: u32) -> bool {
                         if (*chat).type_0 == DC_CHAT_TYPE_SINGLE {
                             free((*chat).name as *mut libc::c_void);
                             let contacts = dc_get_chat_contacts((*chat).context, (*chat).id);
-                            let mut chat_name = "Err [Name not found]".strdup();
+                            let mut chat_name = "Err [Name not found]".to_owned();
                             if !(*contacts).is_empty() {
                                 if let Ok(contact) =
                                     Contact::get_by_id((*chat).context, (*contacts).get_id(0))
                                 {
-                                    chat_name = contact.get_display_name().strdup();
+                                    chat_name = contact.get_display_name().to_owned();
                                 }
                             }
-                            (*chat).name = chat_name;
+                            (*chat).name = (&chat_name).strdup();
                             dc_array_unref(contacts);
                         }
                     }

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -187,13 +187,12 @@ pub fn dc_chat_load_from_db(chat: *mut Chat, chat_id: u32) -> bool {
                             let mut chat_name = "Err [Name not found]".to_owned();
                             if !(*contacts).is_empty() {
                                 if let Ok(contact) =
-                                    Contact::get_by_id((*chat).context, (*contacts).get_id(0))
+                                    Contact::get_by_id((*chat).context, contacts[0])
                                 {
                                     chat_name = contact.get_display_name().to_owned();
                                 }
                             }
                             (*chat).name = (&chat_name).strdup();
-                            dc_array_unref(contacts);
                         }
                     }
 

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -184,15 +184,15 @@ pub fn dc_chat_load_from_db(chat: *mut Chat, chat_id: u32) -> bool {
                         if (*chat).type_0 == DC_CHAT_TYPE_SINGLE {
                             free((*chat).name as *mut libc::c_void);
                             let contacts = dc_get_chat_contacts((*chat).context, (*chat).id);
-                            if (*contacts).is_empty() {
-                                (*chat).name = "Err [Name not found]".strdup() // two times because #![feature(let_chains)] is deactivated
-                            } else if let Ok(contact) =
-                                Contact::get_by_id((*chat).context, (*contacts).get_id(0))
-                            {
-                                (*chat).name = contact.get_display_name().strdup();
-                            } else {
-                                (*chat).name = "Err [Name not found]".strdup()
+                            let mut chat_name = "Err [Name not found]".strdup();
+                            if !(*contacts).is_empty() {
+                                if let Ok(contact) =
+                                    Contact::get_by_id((*chat).context, (*contacts).get_id(0))
+                                {
+                                    chat_name = contact.get_display_name().strdup();
+                                }
                             }
+                            (*chat).name = chat_name;
                             dc_array_unref(contacts);
                         }
                     }

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -180,6 +180,23 @@ pub fn dc_chat_load_from_db(chat: *mut Chat, chat_id: u32) -> bool {
                         .strdup();
                 },
                 _ => {
+                    unsafe {
+                        if (*chat).type_0 == DC_CHAT_TYPE_SINGLE {
+                            free((*chat).name as *mut libc::c_void);
+                            let contacts = dc_get_chat_contacts((*chat).context, (*chat).id);
+                            if (*contacts).is_empty() {
+                                (*chat).name = "Err [Name not found]".strdup() // two times because #![feature(let_chains)] is deactivated
+                            } else if let Ok(contact) =
+                                Contact::get_by_id((*chat).context, (*contacts).get_id(0))
+                            {
+                                (*chat).name = contact.get_display_name().strdup();
+                            } else {
+                                (*chat).name = "Err [Name not found]".strdup()
+                            }
+                            dc_array_unref(contacts);
+                        }
+                    }
+
                     if unsafe { &(*chat).param }.exists(Param::Selftalk) {
                         unsafe {
                             free((*chat).name as *mut libc::c_void);


### PR DESCRIPTION
...Show the contacts display_name instead as defined in:
https://c.delta.chat/classdc__chat__t.html#a0fb1b4850bcd899eaa06d23648a1efaf
"For one-to-one chats, this is the name of the contact"