### PR TITLE
Cargo fmt: removed two empty lines

### DIFF
--- a/src/dc_array.rs
+++ b/src/dc_array.rs
@@ -437,5 +437,4 @@ mod tests {
             dc_array_unref(arr);
         }
     }
-
 }

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -2114,5 +2114,4 @@ mod tests {
         let grpid = dc_extract_grpid_from_rfc724_mid(mid);
         assert_eq!(grpid, Some("1234567890123456"));
     }
-
 }


### PR DESCRIPTION
They annoyed me because I couldn't stage them in my other branches because they were on files I didn't change.