### PR TITLE
[WIP] Remove dc_open() from the Rust API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,6 +523,7 @@ dependencies = [
  "human-panic 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rental 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1924,6 +1925,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rental"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rental-impl 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rental-impl"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.9.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,6 +3023,8 @@ dependencies = [
 "checksum regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88c3d9193984285d544df4a30c23a4e62ead42edf70a4452ceb76dac1ce05c26"
 "checksum regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b143cceb2ca5e56d5671988ef8b15615733e7ee16cd348e064333b251b89343f"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+"checksum rental 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "01916ebd9fc2e81978a5dc9542a2fa47f5bb2ca3402e14c7cc42d6e3c5123e1f"
+"checksum rental-impl 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "82260d54cf2cbe9608df161f7e7c98e81fae702aa13af9e4d5d39dc2ffb25ab6"
 "checksum reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)" = "1d0777154c2c3eb54f5c480db01de845652d941e47191277cc673634c3853939"
 "checksum ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a"
 "checksum rsa 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6ad8d3632f6745bb671c8637e2aa44015537c5e384789d2ea3235739301ed1e0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -74,17 +74,17 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "autocfg"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.34"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -98,7 +98,7 @@ name = "backtrace-sys"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -122,12 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -232,8 +232,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.40"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -258,7 +258,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "stream-cipher 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stream-cipher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -272,12 +272,12 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding_rs 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chrono"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -296,7 +296,7 @@ name = "clear_on_drop"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -330,8 +330,8 @@ dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "publicsuffix 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -409,8 +409,8 @@ name = "ctor"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -461,13 +461,13 @@ dependencies = [
 name = "deltachat"
 version = "1.0.0-alpha.4"
 dependencies = [
- "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "charset 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "deltachat_derive 0.1.0",
  "escaper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -493,11 +493,11 @@ dependencies = [
  "r2d2 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_sqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -590,7 +590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -617,7 +617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.17"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -644,7 +644,7 @@ dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -653,7 +653,7 @@ name = "error-chain"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -670,7 +670,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -757,7 +757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "futures"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -765,7 +765,7 @@ name = "futures-cpupool"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -774,17 +774,17 @@ name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.1.9"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -800,9 +800,9 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -847,7 +847,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -862,11 +862,11 @@ name = "human-panic"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "os_type 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "termcolor 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -883,11 +883,11 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.12.33"
+version = "0.12.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -916,8 +916,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -930,6 +930,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "idna"
 version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "idna"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -954,12 +964,12 @@ source = "git+https://github.com/jonhoo/rust-imap?rev=281d2eb8ab50dc656ceff2ae74
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "imap-proto 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -972,7 +982,7 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.0.2"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1028,20 +1038,20 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 4.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lexical-core"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "stackvector 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stackvector 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1055,7 +1065,7 @@ name = "libsqlite3-sys"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1140,7 +1150,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1156,7 +1166,7 @@ name = "mime"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1165,7 +1175,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1210,7 +1220,7 @@ version = "0.1.2-alpha.0"
 source = "git+https://github.com/dignifiedquire/mmime?rev=bccd2c2#bccd2c2c89e9241e05f321c963f638affdccad96"
 dependencies = [
  "charset 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1242,7 +1252,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1251,7 +1261,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1276,7 +1286,7 @@ name = "nom"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "lexical-core 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lexical-core 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1311,7 +1321,7 @@ name = "num-integer"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1320,7 +1330,7 @@ name = "num-iter"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1338,7 +1348,7 @@ name = "num-traits"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1377,7 +1387,7 @@ name = "openssl-src"
 version = "111.5.0+1.1.1c"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1385,8 +1395,8 @@ name = "openssl-sys"
 version = "0.9.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-src 111.5.0+1.1.1c (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1398,7 +1408,7 @@ name = "os_type"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1406,7 +1416,7 @@ name = "output_vt100"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1463,7 +1473,7 @@ dependencies = [
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1478,7 +1488,7 @@ dependencies = [
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1492,7 +1502,7 @@ dependencies = [
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1520,7 +1530,7 @@ dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cast5 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfb-mode 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "circular 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc24 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_builder 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1617,7 +1627,7 @@ name = "pretty_env_logger"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1627,9 +1637,9 @@ name = "proc-macro-hack"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1642,7 +1652,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1650,14 +1660,14 @@ dependencies = [
 
 [[package]]
 name = "publicsuffix"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1679,7 +1689,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "derive_more 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding_rs 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1695,10 +1705,10 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1729,7 +1739,7 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1737,7 +1747,7 @@ name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "packed_simd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1748,7 +1758,7 @@ dependencies = [
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1756,10 +1766,10 @@ name = "rand"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_pcg 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1769,7 +1779,7 @@ name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1779,7 +1789,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1797,10 +1807,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand_core"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "getrandom 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1816,7 +1826,7 @@ name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1834,7 +1844,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1847,7 +1857,7 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1855,7 +1865,7 @@ name = "rand_pcg"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1864,8 +1874,8 @@ name = "rand_pcg"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1902,18 +1912,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1921,7 +1931,7 @@ name = "remove_dir_all"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1945,24 +1955,24 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.9.19"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding_rs 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.12.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2023,7 +2033,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "blake2b_simd 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2b_simd 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2051,9 +2061,9 @@ dependencies = [
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2080,7 +2090,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2126,7 +2136,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2136,20 +2146,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2159,7 +2169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ryu 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2169,7 +2179,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2239,7 +2249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2254,7 +2264,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stackvector"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2268,7 +2278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "stream-cipher"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2330,11 +2340,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2368,7 +2378,7 @@ dependencies = [
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2410,7 +2420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2419,7 +2429,7 @@ version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2438,7 +2448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2446,7 +2456,7 @@ name = "tokio-current-thread"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2456,7 +2466,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2465,7 +2475,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2475,7 +2485,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2493,7 +2503,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2502,7 +2512,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2517,7 +2527,7 @@ dependencies = [
  "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2531,7 +2541,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2541,7 +2551,7 @@ name = "toml"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2574,12 +2584,12 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.10.0"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicase"
-version = "2.4.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2608,7 +2618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2645,6 +2655,16 @@ dependencies = [
  "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "url"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2690,7 +2710,7 @@ version = "2.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2699,14 +2719,14 @@ name = "want"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasi"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2716,7 +2736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winapi"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2738,7 +2758,7 @@ name = "winapi-util"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2751,7 +2771,7 @@ name = "wincolor"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2759,7 +2779,7 @@ name = "wincolor"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2768,7 +2788,7 @@ name = "winreg"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2776,7 +2796,7 @@ name = "winutil"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2827,13 +2847,13 @@ dependencies = [
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
 "checksum ascii_utils 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
-"checksum autocfg 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "22130e92352b948e7e82a49cdb0aa94f2211761117f29e052dd397c1ac33542b"
-"checksum backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)" = "b5164d292487f037ece34ec0de2fcede2faa162f085dd96d2385ab81b12765ba"
+"checksum autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b671c8fb71b457dd4ae18c4ba1e59aa81793daacc361d82fcd410cef0d491875"
+"checksum backtrace 0.3.37 (registry+https://github.com/rust-lang/crates.io-index)" = "5180c5a20655b14a819b652fd2378fa5f1697b6c9ddad3e695c2f9cedf6df4e2"
 "checksum backtrace-sys 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "82a830b4ef2d1124a711c71d263c5abdc710ef8e907bd508c88be475cebc422b"
 "checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bitfield 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
-"checksum blake2b_simd 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "461f4b879a8eb70c1debf7d0788a9a5ff15f1ea9d25925fea264ef4258bed6b2"
+"checksum blake2b_simd 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)" = "5850aeee1552f495dd0250014cf64b82b7c8879a89d83b33bbdace2cc4f63182"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
 "checksum block-modes 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "31aa8410095e39fdb732909fb5730a48d5bd7c2e3cd76bd1b07b3dbea130c529"
@@ -2848,15 +2868,15 @@ dependencies = [
 "checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
 "checksum cargo_metadata 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1b4d380e1bab994591a24c2bdd1b054f64b60bef483a8c598c7c345bc3bbe"
 "checksum cast5 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ce5759b4c52ca74f9a98421817c882f1fd9b0071ae41cd61ab9f9d059c04fd6"
-"checksum cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "b548a4ee81fccb95919d4e22cfea83c7693ebfd78f0495493178db20b3139da7"
+"checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfb-mode 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "190e7b55d3a27cf8879becf61035a141cbc783f3258a41d16d1706719f991345"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum charset 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4f426e64df1c3de26cbf44593c6ffff5dbfd43bbf9de0d075058558126b3fc73"
-"checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
+"checksum chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8493056968583b0193c1bb04d6f7684586f3726992d6c573261941a895dbd68"
 "checksum circular 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "82945ea9ff134eba321833377d0c485f5c6fb4c8e26cfec199174e2970d5385a"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
+"checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
@@ -2882,7 +2902,7 @@ dependencies = [
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "81956bcf7ef761fb4e1d88de3fa181358a0d26cbcb9755b587a08f9119824b86"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
-"checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
+"checksum encoding_rs 0.8.19 (registry+https://github.com/rust-lang/crates.io-index)" = "79906e1ad1f7f8bc48864fcc6ffd58336fb5992e627bf61928099cb25fdf4314"
 "checksum entities 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 "checksum enum_primitive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "be4551092f4d519593039259a9ed8daedf0da12e5109c5280338073eaeb81180"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
@@ -2901,10 +2921,10 @@ dependencies = [
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "45dc39533a6cae6da2b56da48edae506bb767ec07370f86f70fc062e9d435869"
+"checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
-"checksum getrandom 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2512b3191f22e2763a5db387f1c9409379772e2050841722eb4a8c4f497bf096"
+"checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
@@ -2915,14 +2935,15 @@ dependencies = [
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum human-panic 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "21638c5955a6daf3ecc42cae702335fc37a72a4abcc6959ce457b31a7d43bbdd"
 "checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
-"checksum hyper 0.12.33 (registry+https://github.com/rust-lang/crates.io-index)" = "7cb44cbce9d8ee4fb36e4c0ad7b794ac44ebaad924b9c8291a63215bb44c2c8f"
+"checksum hyper 0.12.34 (registry+https://github.com/rust-lang/crates.io-index)" = "898a87371a3999b2f731b9af636cd76aa20de10e69c2daf3e71388326b619fe0"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 "checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
+"checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum image-meta 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b00861cbbb254a627d8acc0cec786b484297d896ab8f20fdc8e28536a3e918ef"
 "checksum imap 1.0.2 (git+https://github.com/jonhoo/rust-imap?rev=281d2eb8ab50dc656ceff2ae749ca5045f334e15)" = "<none>"
 "checksum imap-proto 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b92ca529b24c5f80a950abe993d3883df6fe6791d4a46b1fda1eb339796c589"
-"checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
+"checksum indexmap 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a61202fbe46c4a951e9404a720a0180bcf3212c750d735cb5c4ba4dc551299f3"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
@@ -2930,7 +2951,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lettre 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c66afaa5dfadbb81d4e00fd1d1ab057c7cd4c799c5a44e0009386d553587e728"
-"checksum lexical-core 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b8b0f90c979adde96d19eb10eb6431ba0c441e2f9e9bdff868b2f6f5114ff519"
+"checksum lexical-core 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae24b3cd92ad68bf64cc500aeb8445dd9a080a22fd7ecf9ad0a847162da27ab"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum libsqlite3-sys 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5b95e89c330291768dc840238db7f9e204fd208511ab6319b56193a7f2ae25"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
@@ -2992,13 +3013,13 @@ dependencies = [
 "checksum pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "717ee476b1690853d222af4634056d830b5197ffd747726a9a1eee6da9f49074"
 "checksum proc-macro-hack 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e688f31d92ffd7c1ddc57a1b4e6d773c0f2a14ee437a4b0a4f5a69c80eb221c8"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5c2380ae88876faae57698be9e9775e3544decad214599c3a6266cca6ac802"
-"checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
+"checksum proc-macro2 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e98a83a9f9b331f54b924e68a66acb1bb35cb01fb0a23645139967abefb697e8"
+"checksum publicsuffix 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9bf259a81de2b2eb9850ec990ec78e6a25319715584fd7652b9b26f96fcb1510"
 "checksum pulldown-cmark 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eef52fac62d0ea7b9b4dc7da092aa64ea7ec3d90af6679422d3d7e0e14b6ee15"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quick-xml 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c2b074258da4f2ccb1c450380c5bd8e77db2508de2161f574c70930d8e880482"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-"checksum quote 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49d77c41ca8767f2f41394c11a4eebccab83da25e7cc035387a3125f02be90a3"
+"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum r2d2 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bc42ce75d9f4447fb2a04bbe1ed5d18dd949104572850ec19b164e274919f81b"
 "checksum r2d2_sqlite 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "806e268035ce9e5a604bf617ac8a073ef28b59ef2e48e8338db0baf530caef33"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
@@ -3008,7 +3029,7 @@ dependencies = [
 "checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-"checksum rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "615e683324e75af5d43d8f7a39ffe3ee4a9dc42c5c701167a71dc59c3a493aca"
+"checksum rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 "checksum rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
@@ -3020,12 +3041,12 @@ dependencies = [
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 "checksum redox_users 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4ecedbca3bf205f8d8f5c2b44d83cd0690e39ee84b951ed649e9f1841132b66d"
-"checksum regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88c3d9193984285d544df4a30c23a4e62ead42edf70a4452ceb76dac1ce05c26"
-"checksum regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b143cceb2ca5e56d5671988ef8b15615733e7ee16cd348e064333b251b89343f"
+"checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
+"checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum rental 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "01916ebd9fc2e81978a5dc9542a2fa47f5bb2ca3402e14c7cc42d6e3c5123e1f"
 "checksum rental-impl 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "82260d54cf2cbe9608df161f7e7c98e81fae702aa13af9e4d5d39dc2ffb25ab6"
-"checksum reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)" = "1d0777154c2c3eb54f5c480db01de845652d941e47191277cc673634c3853939"
+"checksum reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)" = "0f6d896143a583047512e59ac54a215cb203c29cc941917343edea3be8df9c78"
 "checksum ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a"
 "checksum rsa 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6ad8d3632f6745bb671c8637e2aa44015537c5e384789d2ea3235739301ed1e0"
 "checksum rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2a194373ef527035645a1bc21b10dc2125f73497e6e155771233eb187aedd051"
@@ -3044,8 +3065,8 @@ dependencies = [
 "checksum security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9636f8989cbf61385ae4824b98c1aaa54c994d7d8b41f11c601ed799f0549a56"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2851eb56d010dc9a21b89ca53ee75e6528bab60c11e89d38390904982da9f"
-"checksum serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4dc18c61206b08dc98216c98faa0232f4337e1e1b8574551d5bad29ea1b425"
+"checksum serde 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)" = "f4473e8506b213730ff2061073b48fa51dcc66349219e2e7c5608f0296a1d95a"
+"checksum serde_derive 1.0.100 (registry+https://github.com/rust-lang/crates.io-index)" = "11e410fde43e157d789fc290d26bc940778ad0fdd47836426fbac36573710dbb"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
@@ -3057,9 +3078,9 @@ dependencies = [
 "checksum slice-deque 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ffddf594f5f597f63533d897427a570dbaa9feabaaa06595b74b71b7014507d7"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum stackvector 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4dade1e9ad1ce13baaba168a04cdefb5c0cbc100242a4035d6dfa9c64348f9c5"
+"checksum stackvector 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ce0878389d449018977823b0dfcdc717488e7b732f823f2ad8045fbcec4a448c"
 "checksum static_assertions 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
-"checksum stream-cipher 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8861bc80f649f5b4c9bd38b696ae9af74499d479dbfb327f0607de6b326a36bc"
+"checksum stream-cipher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum strum 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e5d1c33039533f051704951680f1adfd468fd37ac46816ded0d9ee068e60f05f"
@@ -3067,7 +3088,7 @@ dependencies = [
 "checksum subtle 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "01f40907d9ffc762709e4ff3eb4a6f6b41b650375a3f09ac92b641942b7fb082"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2ae5cd13590144ea968ba5d5520da7a4c08415861014399b5b349f74591c375f"
+"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
@@ -3091,17 +3112,18 @@ dependencies = [
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum twofish 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d261e83e727c8e2dbb75dacac67c36e35db36a958ee504f2164fc052434e1"
-"checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
-"checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
+"checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
+"checksum unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2e2e6bd1e59e56598518beb94fd6db628ded570326f0a98c679a304bd9f00150"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-segmentation 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1967f4cdfc355b37fd76d2a954fb2ed3871034eb4f26d60537d88795cfc332a9"
-"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
+"checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum unsafe-any 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
+"checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 "checksum utf8parse 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
 "checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
@@ -3110,9 +3132,9 @@ dependencies = [
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
-"checksum wasi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd5442abcac6525a045cc8c795aedb60da7a2e5e89c7bf18a0d5357849bb23c7"
+"checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
+"checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -19,6 +19,7 @@ deltachat = { path = "../", default-features = false }
 libc = "0.2"
 human-panic = "1.0.1"
 num-traits = "0.2.6"
+rental = "0.5.4"
 
 [features]
 default = ["vendored", "nightly", "ringbuf"]

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -11,13 +11,19 @@
 extern crate human_panic;
 extern crate num_traits;
 
-use num_traits::{FromPrimitive, ToPrimitive};
 use std::convert::TryInto;
+use std::ffi::CString;
 use std::ptr;
 use std::str::FromStr;
 
+use libc::uintptr_t;
+use num_traits::{FromPrimitive, ToPrimitive};
+
+use deltachat::config::Config;
+use deltachat::constants::Event;
 use deltachat::contact::Contact;
-use deltachat::dc_tools::{as_str, dc_strdup, StrExt};
+use deltachat::context::Context;
+use deltachat::dc_tools::{as_path, as_str, to_string, Strdup};
 use deltachat::*;
 
 // as C lacks a good and portable error handling,
@@ -30,12 +36,95 @@ use deltachat::*;
 
 // TODO: constants
 
-// dc_context_t
+/// The FFI callback type that should be passed to [dc_context_new].
+///
+/// @memberof Context
+///
+/// # Parameters
+///
+/// The callback should accept the following arguments:
+///
+/// * `context` - The context object as returned by [dc_context_new].
+/// * `event` - one of the @ref DC_EVENT constants.
+/// * `data1` - depends on the event parameter.
+/// * `data2` - depends on the event parameter.
+///
+/// # Returns
+///
+/// This callback should return 0 unless stated otherwise in the event
+/// parameter documentation.
+pub type dc_callback_t =
+    unsafe extern "C" fn(_: &ContextWrapper, _: Event, _: uintptr_t, _: uintptr_t) -> uintptr_t;
 
-pub type dc_context_t = context::Context;
+pub struct ContextWrapper {
+    cb: Option<dc_callback_t>,
+    userdata: *mut libc::c_void,
+    os_name: *const libc::c_char,
+    inner: Option<context::Context>, // TODO: Wrap this in RwLock
+}
 
-pub type dc_callback_t = types::dc_callback_t;
+/// The FFI context type.
+pub type dc_context_t = ContextWrapper;
 
+impl ContextWrapper {
+    fn error(&self, msg: &str) {
+        if let Some(cb) = self.cb {
+            let msg_c =
+                CString::new(msg).unwrap_or(CString::new("[invalid error message]").unwrap());
+            unsafe { cb(self, Event::ERROR, 0, msg_c.as_ptr() as libc::uintptr_t) };
+        }
+    }
+}
+
+/// Create a new context object.
+///
+/// After creation it is usually opened, connected and mails are
+/// fetched.
+///
+/// @memberof [dc_context_t]
+///
+/// # Parameters
+///
+/// * `cb` - a callback function that is called for events (update,
+///   state changes etc.) and to get some information from the client
+///   (eg. translation for a given string).
+///
+///   See @ref DC_EVENT for a list of possible events that may be passed to the callback.
+///
+///     - The callback MAY be called from _any_ thread, not only the
+///       main/GUI thread!
+///     - The callback MUST NOT call any dc_* and related functions
+///       unless stated otherwise!
+///     - The callback SHOULD return _fast_, for GUI updates etc. you
+///       should post yourself an asynchronous message to your GUI
+///       thread, if needed.
+///     - If not mentioned otherweise, the callback should return 0.
+///
+///   This must have the same lifetime as the context otherwise events
+///   will call garbage.
+///
+/// * `userdata` - can be used by the client for any purpuse.  Can be
+///   retrieved using [dc_get_userdata].  This is never freed by
+///   deltachat itself, even after the context is destroyed.  It is
+///   assumed this has the same lifetime as the context itself,
+///   otherwise [dc_get_userdata] will return a pointer to freed
+///   memory.
+///
+/// * `os_name` - is only for decorative use and is shown eg. in the
+///   `X-Mailer:` header in the form "Delta Chat Core
+///   <version>/<os_name>".  You can give the name of the app, the
+///   operating system, the used environment and/or the version here.
+///   It is okay to give NULL, in this case `X-Mailer:` header is set
+///   to "Delta Chat Core <version>".
+///
+///   This is never freed by deltachat itself.  It can be destroyed as
+///   soon as this function returns.
+///
+/// # Returns
+///
+/// A context object with some public members.  The object must be
+/// passed to the other context functions and must be freed using
+/// [dc_context_unref] after usage.
 #[no_mangle]
 pub unsafe extern "C" fn dc_context_new(
     cb: Option<dc_callback_t>,
@@ -43,20 +132,28 @@ pub unsafe extern "C" fn dc_context_new(
     os_name: *const libc::c_char,
 ) -> *mut dc_context_t {
     setup_panic!();
-
-    let os_name = if os_name.is_null() {
-        None
-    } else {
-        Some(dc_tools::to_string_lossy(os_name))
+    let wrapper = ContextWrapper {
+        cb,
+        userdata,
+        os_name: dc_tools::dc_strdup_keep_null(os_name),
+        inner: None,
     };
-    let ctx = context::dc_context_new(cb, userdata, os_name);
-
-    Box::into_raw(Box::new(ctx))
+    Box::into_raw(Box::new(wrapper))
 }
 
-/// Release the context structure.
+/// Free a context object.
 ///
-/// This function releases the memory of the `dc_context_t` structure.
+/// If app runs can only be terminated by a forced kill, this may be superfluous.
+/// Before the context object is freed, connections to SMTP, IMAP and database
+/// are closed. You can also do this explicitly by calling [dc_close] on your own
+/// before calling [dc_context_unref].
+///
+/// @memberof dc_context_t
+///
+/// # Parameters
+///
+/// * `context` - The context object as created by [dc_context_new].
+///   If `NULL` is given, nothing is done.
 #[no_mangle]
 pub unsafe extern "C" fn dc_context_unref(context: *mut dc_context_t) {
     if context.is_null() {
@@ -64,79 +161,222 @@ pub unsafe extern "C" fn dc_context_unref(context: *mut dc_context_t) {
         return;
     }
 
-    let context = &mut *context;
-    context::dc_close(context);
-    Box::from_raw(context);
+    let wrapper: &mut ContextWrapper = &mut *context;
+    Box::from_raw(context); // Drops the wrapper and contained context
 }
 
+/// Get user data associated with a context object.
+///
+/// @memberof [dc_context_t]
+///
+/// # Parameters
+///
+/// * `context` - The context object as created by [dc_context_new].
+///
+/// # Returns
+///
+/// The user data is returned, this is the second parameter given to
+/// [dc_context_new].
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_userdata(context: *mut dc_context_t) -> *mut libc::c_void {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_userdata()");
         return ptr::null_mut();
     }
-
-    let context = &mut *context;
-
-    context::dc_get_userdata(context)
+    let wrapper = &mut *context;
+    wrapper.userdata
 }
 
+/// Open context database.
+///
+/// If the given file does not exist, it is created and can be set up
+/// using [dc_set_config] afterwards.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+/// @param dbfile The file to use to store the database, something like `~/file` won't
+///     work on all systems, if in doubt, use absolute paths.
+/// @param blobdir A directory to store the blobs in; a trailing slash is not needed.
+///     If you pass NULL or the empty string, deltachat-core creates a directory
+///     beside _dbfile_ with the same name and the suffix `-blobs`.
+///
+/// Returns `1` on success, `0` on failure eg. if the file is not
+/// writable or if there is already a database opened for the context.
 #[no_mangle]
 pub unsafe extern "C" fn dc_open(
     context: *mut dc_context_t,
     dbfile: *mut libc::c_char,
     blobdir: *mut libc::c_char,
 ) -> libc::c_int {
-    if context.is_null() || dbfile.is_null() {
+    if conext.is_null() || dbfile.is_null() {
         eprintln!("ignoring careless call to dc_open()");
         return 0;
     }
-
-    let context = &mut *context;
-
-    let dbfile_str = dc_tools::as_str(dbfile);
-    let blobdir_str = if blobdir.is_null() {
-        None
-    } else {
-        Some(dc_tools::as_str(blobdir))
+    let rust_cb = move |_ctx: &Context, evt: Event, d0: uintptr_t, d1: uintptr_t| {
+        let wrapper: &ContextWrapper = &*context;
+        match wrapper.cb {
+            Some(ffi_cb) => ffi_cb(wrapper, evt, d0, d1),
+            None => 0,
+        }
     };
-    context::dc_open(context, dbfile_str, blobdir_str) as libc::c_int
+    let mut wrapper: &mut ContextWrapper = &mut *context;
+    let new_context = if blobdir.is_null() {
+        Context::new(
+            Box::new(rust_cb),
+            to_string(wrapper.os_name),
+            as_path(dbfile).to_path_buf(),
+        )
+    } else {
+        Context::with_blobdir(
+            Box::new(rust_cb),
+            to_string(wrapper.os_name),
+            as_path(dbfile).to_path_buf(),
+            as_path(blobdir),
+        )
+    };
+    match new_context {
+        Ok(mut ctx) => {
+            // Some structs, e.g. Chatlist, have a reference to the
+            // Context and allow to retrieve the context again.
+            // Because on the C API we need to return the
+            // ContextWrapper rather than the context we store the
+            // wrapper as userdata on the Context.  The actual
+            // userdata exposed by the C API is stored on the
+            // ContextWrapper.
+            let wrapper_ptr: *mut ContextWrapper = wrapper;
+            ctx.userdata = wrapper_ptr as *mut libc::c_void;
+            wrapper.inner = Some(ctx);
+            1
+        }
+        Err(_) => 0,
+    }
 }
 
+/// Close the context.
+///
+/// This will disconnect the IMAP and SMTP connections and free some
+/// structures.  The context will still be using some memory until
+/// [dc_context_unref] is called.
+///
+/// This method is **not** thread safe.
+
+/// Close context database opened by [dc_open].
+///
+/// Before this, connections to SMTP and IMAP are closed; these
+/// connections are started automatically as needed eg. by sending for
+/// fetching messages.  This function is also implicitly called by
+/// [dc_context_unref].  Multiple calls to this functions are okay,
+/// the function takes care not to free objects twice.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
 #[no_mangle]
 pub unsafe extern "C" fn dc_close(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_close()");
         return;
     }
-
-    let context = &mut *context;
-    context::dc_close(context)
+    let wrapper: &mut ContextWrapper = &mut *context;
+    if let Some(ref ctx) = &wrapper.inner {
+        context::dc_close(ctx);
+        wrapper.inner = None;
+    }
 }
 
+/// Checks if the context is open.
+///
+/// Returns `0` if the context is open, `1` if not.
+///
+/// Note that this is inherently race-condition prone.
 #[no_mangle]
 pub unsafe extern "C" fn dc_is_open(context: *mut dc_context_t) -> libc::c_int {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_is_open()");
         return 0;
     }
-
-    let context = &mut *context;
-    context::dc_is_open(context)
+    let wrapper: &mut ContextWrapper = &mut *context;
+    match wrapper.inner {
+        Some(_) => 0,
+        None => 1,
+    }
 }
 
+/// Get the blob directory.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+///
+/// Returns blob directory associated with the context object, empty
+/// string if unset or on errors. NULL is never returned.  The
+/// returned string must be free()'d.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_blobdir(context: *mut dc_context_t) -> *mut libc::c_char {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_blobdir()");
         return dc_strdup(ptr::null());
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     context::dc_get_blobdir(context)
 }
 
+/// Sets a configuration option.
+///
+/// The configuration is handled by key=value pairs as:
+///
+/// * `addr`         - address to display (always needed)
+/// * `mail_server`  - IMAP-server, guessed if left out
+/// * `mail_user`    - IMAP-username, guessed if left out
+/// * `mail_pw`      - IMAP-password (always needed)
+/// * `mail_port`    - IMAP-port, guessed if left out
+/// * `send_server`  - SMTP-server, guessed if left out
+/// * `send_user`    - SMTP-user, guessed if left out
+/// * `send_pw`      - SMTP-password, guessed if left out
+/// * `send_port`    - SMTP-port, guessed if left out
+/// * `server_flags` - IMAP-/SMTP-flags as a combination of @ref DC_LP flags,
+///                    guessed if left out
+/// * `displayname`  - Own name to use when sending messages.  MUAs are allowed
+///                    to spread this way eg. using CC, defaults to empty
+/// * `selfstatus`   - Own status to display eg. in email footers, defaults to
+///                    a standard text
+/// * `selfavatar`   - File containing avatar. Will be copied to blob directory.
+///                    NULL to remove the avatar.
+///                    It is planned for future versions
+///                    to send this image together with the next messages.
+/// * `e2ee_enabled` - 0=no end-to-end-encryption, 1=prefer end-to-end-encryption (default)
+/// * `mdns_enabled` - 0=do not send or request read receipts,
+///                    1=send and request read receipts (default)
+/// * `inbox_watch`  - 1=watch `INBOX`-folder for changes (default),
+///                    0=do not watch the `INBOX`-folder
+/// * `sentbox_watch`- 1=watch `Sent`-folder for changes (default),
+///                    0=do not watch the `Sent`-folder
+/// * `mvbox_watch`  - 1=watch `DeltaChat`-folder for changes (default),
+///                    0=do not watch the `DeltaChat`-folder
+/// * `mvbox_move`   - 1=heuristically detect chat-messages
+///                    and move them to the `DeltaChat`-folder,
+///                    0=do not move chat-messages
+/// * `show_emails`  - DC_SHOW_EMAILS_OFF (0)=
+///                    show direct replies to chats only (default),
+///                    DC_SHOW_EMAILS_ACCEPTED_CONTACTS (1)=
+///                    also show all mails of confirmed contacts,
+///                    DC_SHOW_EMAILS_ALL (2)=
+///                    also show mails of unconfirmed contacts in the deaddrop.
+/// * `save_mime_headers` - 1=save mime headers
+///                    and make dc_get_mime_headers() work for subsequent calls,
+///                    0=do not save mime headers (default)
+///
+/// If you want to retrieve a value, use [dc_get_config].
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object
+/// @param key The option to change, see above.
+/// @param value The value to save for "key"
+///
+/// Returns `0` for failure and `1` for success.
 #[no_mangle]
 pub unsafe extern "C" fn dc_set_config(
     context: *mut dc_context_t,
@@ -147,15 +387,52 @@ pub unsafe extern "C" fn dc_set_config(
         eprintln!("ignoring careless call to dc_set_config()");
         return 0;
     }
-
-    let context = &*context;
-
-    match config::Config::from_str(dc_tools::as_str(key)) {
-        Ok(key) => context.set_config(key, as_opt_str(value)).is_ok() as libc::c_int,
-        Err(_) => 0,
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
+    match Config::from_str(as_str(key)) {
+        // context.set_config() did already log (TODO, it shouldn't)
+        Ok(key) => context
+            .set_config(key, as_opt_str(value))
+            .and(Ok(1))
+            .or(Err(0))
+            .unwrap(),
+        Err(_) => {
+            wrapper.error("dc_set_config(): invalid key");
+            0
+        }
     }
 }
 
+/// Gets a configuration option.
+///
+/// The configuration option is set by dc_set_config() or by the library itself.
+///
+/// Beside the options shown at dc_set_config(), this function can be
+/// used to query some global system values:
+///
+/// * `sys.version` - get the version string eg. as `1.2.3` or as
+///                   `1.2.3special4`
+/// * `sys.msgsize_max_recommended` - maximal recommended attachment
+///                   size in bytes.  All possible overheads are
+///                   already subtracted and this value can be used
+///                   eg. for direct comparison with the size of a
+///                   file the user wants to attach. If an attachment
+///                   is larger than this value, an error (no warning
+///                   as it should be shown to the user) is logged
+///                   but the attachment is sent anyway.
+/// * `sys.config_keys` - get a space-separated list of all
+///                   config-keys available.  The config-keys are the
+///                   keys that can be passed to the parameter `key`
+///                   of this function.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by
+///     dc_context_new(). For querying system values, this can be NULL.
+/// @param key The key to query.
+///
+/// Returns current value of "key", if "key" is unset, the default value is returned.
+///     The returned value must be free()'d, NULL is never returned.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_config(
     context: *mut dc_context_t,
@@ -165,28 +442,63 @@ pub unsafe extern "C" fn dc_get_config(
         eprintln!("ignoring careless call to dc_get_config()");
         return dc_strdup(ptr::null());
     }
-
-    let context = &*context;
-
-    let key = config::Config::from_str(dc_tools::as_str(key)).expect("invalid key");
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
+    let key = Config::from_str(as_str(key)).expect("invalid key");
     // TODO: Translating None to NULL would be more sensible than translating None
     // to "", as it is now.
     context.get_config(key).unwrap_or_default().strdup()
 }
 
+/// Gets information about the context.
+///
+/// The information is returned as a multi-line string and contains
+/// information about the current configuration.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by dc_context_new().
+///
+/// Returns a string which must be free()'d after usage.  Never
+/// returns NULL.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_info(context: *mut dc_context_t) -> *mut libc::c_char {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_info()");
         return dc_strdup(ptr::null());
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     context::dc_get_info(context)
 }
 
+/// Gets url that can be used to initiate an OAuth2 authorisation.
+///
+/// If an OAuth2 authorization is possible for a given e-mail-address,
+/// this function returns the URL that should be opened in a browser.
+///
+/// If the user authorizes access, the given redirect_uri is called by
+/// the provider.  It's up to the UI to handle this call.
+///
+/// The provider will attach some parameters to the url, most
+/// important the parameter `code` that should be set as the
+/// `mail_pw`.  With `server_flags` set to #DC_LP_AUTH_OAUTH2,
+/// dc_configure() can be called as usual afterwards.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+/// @param addr E-mail address the user has entered.
+///     In case the user selects a different e-mail-address during
+///     authorization, this is corrected in [dc_configure]
+/// @param redirect_uri URL that will get `code` that is used as `mail_pw` then.
+///     Not all URLs are allowed here, however, the following should work:
+///     `chat.delta:/PATH`, `http://localhost:PORT/PATH`,
+///     `https://localhost:PORT/PATH`, `urn:ietf:wg:oauth:2.0:oob`
+///     (the latter just displays the code the user can copy+paste then)
+///
+/// Returns URL that can be opened in the browser to start OAuth2.
+///     If OAuth2 is not possible for the given e-mail-address, NULL is returned.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_oauth2_url(
     context: *mut dc_context_t,
@@ -197,213 +509,586 @@ pub unsafe extern "C" fn dc_get_oauth2_url(
         eprintln!("ignoring careless call to dc_get_oauth2_url()");
         return ptr::null_mut(); // NULL explicitly defined as "unknown"
     }
-
-    let context = &*context;
-    let addr = dc_tools::to_string(addr);
-    let redirect = dc_tools::to_string(redirect);
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
+    let addr = to_string(addr);
+    let redirect = to_string(redirect);
     match oauth2::dc_get_oauth2_url(context, addr, redirect) {
         Some(res) => res.strdup(),
         None => std::ptr::null_mut(),
     }
 }
 
+/// Find out the version of the Delta Chat core library.
+///
+/// Deprecated, use dc_get_config() instead.
+///
+/// @memberof [dc_context_t]
+///
+/// Returns string with version number as `major.minor.revision`. The
+/// return value must be free()'d.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_version_str() -> *mut libc::c_char {
     context::dc_get_version_str()
 }
 
+/// Configures a context.
+///
+/// For this purpose, the function creates a job that is executed in
+/// the IMAP-thread then; this requires to call dc_perform_imap_jobs()
+/// regularly.  If the context is already configured, this function
+/// will try to change the configuration.
+///
+/// * Before you call this function, you must set at least `addr` and
+///   `mail_pw` using dc_set_config().
+///
+/// * Use `mail_user` to use a different user name than `addr` and
+///   `send_pw` to use a different password for the SMTP server.
+///
+///     * If _no_ more options are specified,
+///       the function **uses autoconfigure/autodiscover**
+///       to get the full configuration from well-known URLs.
+///
+///     * If _more_ options as `mail_server`, `mail_port`, `send_server`,
+///       `send_port`, `send_user` or `server_flags` are specified,
+///       **autoconfigure/autodiscover is skipped**.
+///
+/// While this function returns immediately, the started
+/// configuration-job may take a while.
+///
+/// During configuration, #DC_EVENT_CONFIGURE_PROGRESS events are
+/// emitted; they indicate a successful configuration as well as
+/// errors and may be used to create a progress bar.
+///
+/// Additional calls to this function while a config-job is running
+/// are ignored.  To interrupt a configuration prematurely, use
+/// [dc_stop_ongoing_process]; this is not needed if
+/// #DC_EVENT_CONFIGURE_PROGRESS reports success.
+///
+/// On a successfull configuration, the core makes a copy of the
+/// parameters mentioned above: the original parameters as are never
+/// modified by the core.
+///
+/// UI-implementors should keep this in mind - eg. if the UI wants to
+/// prefill a configure-edit-dialog with these parameters, the UI
+/// should reset them if the user cancels the dialog after a
+/// configure-attempts has failed.  Otherwise the parameters may not
+/// reflect the current configuration.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+///
+/// There is no need to call [dc_configure] on every program start,
+/// the configuration result is saved in the database and you can use
+/// the connection directly:
+///
+/// ```
+/// if (!dc_is_configured(context)) {
+///     dc_configure(context);
+///     // wait for progress events
+/// }
+/// ```
 #[no_mangle]
 pub unsafe extern "C" fn dc_configure(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_configure()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     configure::configure(context)
 }
 
+/// Checks if the context is already configured.
+///
+/// Typically, for unconfigured accounts, the user is prompted to
+/// enter some settings and [dc_configure] is called in a thread then.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by dc_context_new().
+///
+///Returns `1` if the context is configured and can be used; `0` if
+///    the context is not configured and a configuration by
+///    [dc_configure] is required.
 #[no_mangle]
 pub unsafe extern "C" fn dc_is_configured(context: *mut dc_context_t) -> libc::c_int {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_is_configured()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     configure::dc_is_configured(context)
 }
 
+/// Executes pending imap-jobs.
+///
+/// This function and [dc_perform_imap_fetch] and [dc_perform_imap_idle]
+/// must be called from the same thread, typically in a loop.
+///
+/// Example:
+///
+/// ```
+/// void* imap_thread_func(void* context)
+/// {
+///     while (true) {
+///         dc_perform_imap_jobs(context);
+///         dc_perform_imap_fetch(context);
+///         dc_perform_imap_idle(context);
+///     }
+/// }
+///
+/// // start imap-thread that runs forever
+/// pthread_t imap_thread;
+/// pthread_create(&imap_thread, NULL, imap_thread_func, context);
+///
+/// ... program runs ...
+///
+/// // network becomes available again -
+/// // the interrupt causes dc_perform_imap_idle() in the thread above
+/// // to return so that jobs are executed and messages are fetched.
+/// dc_maybe_network(context);
+/// ```
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
 #[no_mangle]
 pub unsafe extern "C" fn dc_perform_imap_jobs(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_perform_imap_jobs()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     job::perform_imap_jobs(context)
 }
 
+/// Fetches new messages, if any.
+///
+/// This function and [dc_perform_imap_jobs] and
+/// [dc_perform_imap_idle] must be called from the same thread,
+/// typically in a loop.
+///
+/// See [dc_perform_imap_jobs] for an example.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
 #[no_mangle]
 pub unsafe extern "C" fn dc_perform_imap_fetch(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_perform_imap_fetch()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     job::perform_imap_fetch(context)
 }
 
+/// Waits for messages or jobs.
+///
+/// This function and [dc_perform_imap_jobs] and
+/// [dc_perform_imap_fetch] must be called from the same thread,
+/// typically in a loop.
+///
+/// You should call this function directly after calling [dc_perform_imap_fetch].
+///
+/// See [dc_perform_imap_jobs] for an example.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
 #[no_mangle]
 pub unsafe extern "C" fn dc_perform_imap_idle(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_perform_imap_idle()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     job::perform_imap_idle(context)
 }
 
+/// Interrupts waiting for imap-jobs.
+///
+/// If dc_perform_imap_jobs(), dc_perform_imap_fetch() and
+/// dc_perform_imap_idle() are called in a loop, calling this function
+/// causes imap-jobs to be executed and messages to be fetched.
+///
+/// [dc_interrupt_imap_idle] does _not_ [interrupt
+/// dc_perform_imap_jobs] or [dc_perform_imap_fetch].  If the
+/// imap-thread is inside one of these functions when
+/// [dc_interrupt_imap_idle] is called, however, the next call of the
+/// imap-thread to [dc_perform_imap_idle] is interrupted immediately.
+///
+/// Internally, this function is called whenever a imap-jobs should be
+/// processed (delete message, markseen etc.).
+///
+/// When you need to call this function just because to get jobs done
+/// after network changes, use [dc_maybe_network] instead.
+///
+/// @memberof [dc_context_t]
+///
+/// # Parameters
+///
+/// * `context` - The context as created by [dc_context_new].
+///
+/// # Panics
+///
+/// It is safe to call this function on a closed context.
 #[no_mangle]
 pub unsafe extern "C" fn dc_interrupt_imap_idle(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_interrupt_imap_idle()");
         return;
     }
-
-    let context = &*context;
-
-    job::interrupt_imap_idle(context)
+    let wrapper: &ContextWrapper = &*context;
+    if wrapper.inner.is_some() {
+        let context = wrapper.inner.as_ref().expect("context not open");
+        job::interrupt_imap_idle(context);
+    }
 }
 
+/// Fetches new messages from the MVBOX, if any.
+///
+/// The MVBOX is a folder on the account where chat messages are moved
+/// to.  The moving is done to not disturb shared accounts that are
+/// used by both, Delta Chat and a classical MUA.
+///
+/// This function and [dc_perform_mvbox_idle] must be called from the
+/// same thread, typically in a loop.
+///
+/// Example:
+///
+/// ```
+/// void* mvbox_thread_func(void* context)
+/// {
+///     while (true) {
+///         dc_perform_mvbox_fetch(context);
+///         dc_perform_mvbox_idle(context);
+///     }
+/// }
+///
+/// // start mvbox-thread that runs forever
+/// pthread_t mvbox_thread;
+/// pthread_create(&mvbox_thread, NULL, mvbox_thread_func, context);
+///
+/// ... program runs ...
+///
+/// // network becomes available again -
+/// // the interrupt causes dc_perform_mvbox_idle() in the thread above
+/// // to return so that and messages are fetched.
+/// dc_maybe_network(context);
+/// ```
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by dc_context_new().
 #[no_mangle]
 pub unsafe extern "C" fn dc_perform_mvbox_fetch(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_perform_mvbox_fetch()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     job::perform_mvbox_fetch(context)
 }
 
+/// Waits for messages or jobs in the MVBOX-thread.
+///
+/// This function and [dc_perform_mvbox_fetch].  must be called from
+/// the same thread, typically in a loop.
+///
+/// You should call this function directly after calling
+/// [dc_perform_mvbox_fetch].
+///
+/// See [dc_perform_mvbox_fetch] for an example.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
 #[no_mangle]
 pub unsafe extern "C" fn dc_perform_mvbox_idle(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_perform_mvbox_idle()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     job::perform_mvbox_idle(context)
 }
 
+/// Interrupts waiting for MVBOX-fetch.
+///
+/// [dc_interrupt_mvbox_idle] does _not_ interrupt
+/// [dc_perform_mvbox_fetch].  If the MVBOX-thread is inside this
+/// function when [dc_interrupt_mvbox_idle] is called, however, the
+/// next call of the MVBOX-thread to [dc_perform_mvbox_idle] is
+/// interrupted immediately.
+///
+/// Internally, this function is called whenever a imap-jobs should be
+/// processed.
+///
+/// When you need to call this function just because to get jobs done
+/// after network changes, use [dc_maybe_network] instead.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
 #[no_mangle]
 pub unsafe extern "C" fn dc_interrupt_mvbox_idle(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_interrupt_mvbox_idle()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     job::interrupt_mvbox_idle(context)
 }
 
+/// Fetches new messages from the Sent folder, if any.
+///
+/// This function and [dc_perform_sentbox_idle] must be called from
+/// the same thread, typically in a loop.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
 #[no_mangle]
 pub unsafe extern "C" fn dc_perform_sentbox_fetch(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_perform_sentbox_fetch()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     job::perform_sentbox_fetch(context)
 }
 
+/// Waits for messages or jobs in the SENTBOX-thread.
+///
+/// This function and [dc_perform_sentbox_fetch] must be called from
+/// the same thread, typically in a loop.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
 #[no_mangle]
 pub unsafe extern "C" fn dc_perform_sentbox_idle(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_perform_sentbox_idle()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     job::perform_sentbox_idle(context)
 }
 
+/// Interrupts waiting for messages or jobs in the SENTBOX-thread.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
 #[no_mangle]
 pub unsafe extern "C" fn dc_interrupt_sentbox_idle(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_interrupt_sentbox_idle()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     job::interrupt_sentbox_idle(context)
 }
 
+/// Executes pending smtp-jobs.
+///
+/// This function and dc_perform_smtp_idle() must be called from the
+/// same thread, typically in a loop.
+///
+/// Example:
+///
+/// ```
+/// void* smtp_thread_func(void* context)
+/// {
+///     while (true) {
+///         dc_perform_smtp_jobs(context);
+///         dc_perform_smtp_idle(context);
+///     }
+/// }
+///
+/// // start smtp-thread that runs forever
+/// pthread_t smtp_thread;
+/// pthread_create(&smtp_thread, NULL, smtp_thread_func, context);
+///
+/// ... program runs ...
+///
+/// // network becomes available again -
+/// // the interrupt causes dc_perform_smtp_idle() in the thread above
+/// // to return so that jobs are executed
+/// dc_maybe_network(context);
+/// ```
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
 #[no_mangle]
 pub unsafe extern "C" fn dc_perform_smtp_jobs(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_perform_smtp_jobs()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     job::perform_smtp_jobs(context)
 }
 
+/// Waits for smtp-jobs.
+///
+/// This function and [dc_perform_smtp_jobs] must be called from the
+/// same thread, typically in a loop.
+///
+/// See [dc_interrupt_smtp_idle] for an example.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
 #[no_mangle]
 pub unsafe extern "C" fn dc_perform_smtp_idle(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_perform_smtp_idle()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     job::perform_smtp_idle(context)
 }
 
+/// Interrupts waiting for smtp-jobs.
+///
+/// If [dc_perform_smtp_jobs] and [dc_perform_smtp_idle] are called in
+/// a loop, calling this function causes jobs to be executed.
+///
+/// [dc_interrupt_smtp_idle] does _not_ interrupt
+/// [dc_perform_smtp_jobs].  If the smtp-thread is inside this
+/// function when [dc_interrupt_smtp_idle] is called, however, the
+/// next call of the smtp-thread to [dc_perform_smtp_idle] is
+/// interrupted immediately.
+///
+/// Internally, this function is called whenever a message is to be
+/// sent.
+///
+/// When you need to call this function just because to get jobs done
+/// after network changes, use [dc_maybe_network] instead.
+///
+/// @memberof [dc_context_t]
+///
+/// # Arguments
+///
+/// * `context` - The context as created by [dc_context_new].
+///
+/// # Panics
+///
+/// It is safe to call this function on a closed context.
 #[no_mangle]
 pub unsafe extern "C" fn dc_interrupt_smtp_idle(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_interrupt_smtp_idle()");
         return;
     }
-
-    let context = &*context;
-
-    job::interrupt_smtp_idle(context)
+    let wrapper: &ContextWrapper = &*context;
+    if wrapper.inner.is_some() {
+        let context = wrapper.inner.as_ref().expect("context not open");
+        job::interrupt_smtp_idle(context)
+    }
 }
 
+/// Signals possible network availability.
+///
+/// This function can be called whenever there is a hint.  that the
+/// network is available again.  The library will try to send pending
+/// messages out.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
 #[no_mangle]
 pub unsafe extern "C" fn dc_maybe_network(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_maybe_network()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     job::maybe_network(context)
 }
 
+/// Gets a list of chats.
+///
+/// The list can be filtered by query parameters.
+///
+/// The list is already sorted and starts with the most recent chat in
+/// use.  The sorting takes care of invalid sending dates, drafts and
+/// chats without messages.  Clients should not try to re-sort the
+/// list as this would be an expensive action and would result in
+/// inconsistencies between clients.
+///
+/// To get information about each entry, use
+/// eg. [dc_chatlist_get_summary].
+///
+/// By default, the function adds some special entries to the list.
+/// These special entries can be identified by the ID returned by
+/// [dc_chatlist_get_chat_id]:
+///
+/// * DC_CHAT_ID_DEADDROP (1) - this special chat is present if there
+///   are messages from addresses that have no relationship to the
+///   configured account.  The last of these messages is represented
+///   by DC_CHAT_ID_DEADDROP and you can retrieve details about it
+///   with [dc_chatlist_get_msg_id]. Typically, the UI asks the user
+///   "Do you want to chat with NAME?"  and offers the options "Yes"
+///   (call [dc_create_chat_by_msg_id]), "Never" (call
+///   [dc_block_contact]) or "Not now".  The UI can also offer a
+///   "Close" button that calls [dc_marknoticed_contact] then.
+///
+/// * DC_CHAT_ID_ARCHIVED_LINK (6) - this special chat is present if
+///   the user has archived _any_ chat using [dc_archive_chat]. The UI
+///   should show a link as "Show archived chats", if the user clicks
+///   this item, the UI should show a list of all archived chats that
+///   can be created by this function hen using the
+///   DC_GCL_ARCHIVED_ONLY flag.
+///
+/// * DC_CHAT_ID_ALLDONE_HINT (7) - this special chat is present if
+///   DC_GCL_ADD_ALLDONE_HINT is added to listflags and if there are
+///   only archived chats.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned by [dc_context_new]
+/// @param listflags A combination of flags:
+///     - if the flag DC_GCL_ARCHIVED_ONLY is set, only archived chats are returned.
+///       if DC_GCL_ARCHIVED_ONLY is not set, only unarchived chats are returned and
+///       the pseudo-chat DC_CHAT_ID_ARCHIVED_LINK is added if there are _any_ archived
+///       chats
+///     - if the flag DC_GCL_NO_SPECIALS is set, deaddrop and archive link are not added
+///       to the list (may be used eg. for selecting chats on forwarding, the flag is
+///       not needed when DC_GCL_ARCHIVED_ONLY is already set)
+///     - if the flag DC_GCL_ADD_ALLDONE_HINT is set, DC_CHAT_ID_ALLDONE_HINT
+///       is added as needed.
+/// @param query_str An optional query for filtering the list.  Only
+///     chats matching this query are returned.  Give NULL for no
+///     filtering.
+/// @param query_id An optional contact ID for filtering the list.
+///     Only chats including this contact ID are returned.  Give 0 for
+///     no filtering.
+///
+/// Returns a chatlist as a [dc_chatlist_t] object.  On errors, NULL is
+/// returned.  Must be freed using [dc_chatlist_unref] when no longer
+/// used.
+///
+/// See also: [dc_get_chat_msgs] to get the messages of a single chat.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_chatlist<'a>(
     context: *mut dc_context_t,
@@ -415,9 +1100,8 @@ pub unsafe extern "C" fn dc_get_chatlist<'a>(
         eprintln!("ignoring careless call to dc_get_chatlist()");
         return ptr::null_mut();
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let qs = if query_str.is_null() {
         None
     } else {
@@ -430,18 +1114,59 @@ pub unsafe extern "C" fn dc_get_chatlist<'a>(
     }
 }
 
+/// Create a normal chat or a group chat by a messages ID that comes
+/// typically from the deaddrop, DC_CHAT_ID_DEADDROP (1).
+///
+/// If the given message ID already belongs to a normal chat or to a
+/// group chat, the chat ID of this chat is returned and no new chat
+/// is created.  If a new chat is created, the given message ID is
+/// moved to this chat, however, there may be more messages moved to
+/// the chat from the deaddrop. To get the chat messages, use
+/// [dc_get_chat_msgs].
+///
+/// If the user is asked before creation, they should be asked whether
+/// they wants to chat with the _contact_ belonging to the message; the
+/// group names may be really weird when taken from the subject of
+/// implicit groups and this may look confusing.
+///
+/// Moreover, this function also scales up the origin of the contact belonging
+/// to the message and, depending on the contacts origin, messages from the
+/// same group may be shown or not - so, all in all, it is fine to show the
+/// contact name only.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param msg_id The message ID to create the chat for.
+///
+/// Returns the created or reused chat ID on success. `0` on errors.
 #[no_mangle]
 pub unsafe extern "C" fn dc_create_chat_by_msg_id(context: *mut dc_context_t, msg_id: u32) -> u32 {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_create_chat_by_msg_id()");
         return 0;
     }
-
-    let context = &*context;
-
-    chat::create_by_msg_id(context, msg_id).unwrap_or_log_default(context, "Failed to create chat")
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
+    chat::create_by_msg_id(context, msg_id).unwrap_or_log_default(context, "Failed to create chag")
 }
 
+/// Create a normal chat with a single user.
+///
+/// To create group chats, see [dc_create_group_chat].
+///
+/// If a chat already exists, this ID is returned, otherwise a new
+/// chat is created; this new chat may already contain messages,
+/// eg. from the deaddrop, to get the chat messages, use
+/// [dc_get_chat_msgs].
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param contact_id The contact ID to create the chat for.  If there is already
+///     a chat with this contact, the already existing ID is returned.
+///
+/// Returns the created or reused chat ID on success. `0` on errors.
 #[no_mangle]
 pub unsafe extern "C" fn dc_create_chat_by_contact_id(
     context: *mut dc_context_t,
@@ -451,13 +1176,24 @@ pub unsafe extern "C" fn dc_create_chat_by_contact_id(
         eprintln!("ignoring careless call to dc_create_chat_by_contact_id()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     chat::create_by_contact_id(context, contact_id)
         .unwrap_or_log_default(context, "Failed to create chat")
 }
 
+/// Check, if there is a normal chat with a given contact.
+///
+/// To get the chat messages, use [dc_get_chat_msgs].
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param contact_id The contact ID to check.
+///
+/// If there is a normal chat with the given contact_id, this chat_id
+/// is returned.  If there is no normal chat with the contact_id, the
+/// function returns `0`.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_chat_id_by_contact_id(
     context: *mut dc_context_t,
@@ -467,13 +1203,51 @@ pub unsafe extern "C" fn dc_get_chat_id_by_contact_id(
         eprintln!("ignoring careless call to dc_get_chat_id_by_contact_id()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     chat::get_by_contact_id(context, contact_id)
         .unwrap_or_log_default(context, "Failed to get chat")
 }
 
+/// Prepares a message for sending.
+///
+/// Call this function if the file to be sent is still in creation.
+/// Once you're done with creating the file, call [dc_send_msg] as
+/// usual and the message will really be sent.
+///
+/// This is useful as the user can already send the next messages
+/// while e.g. the recoding of a video is not yet finished. Or the
+/// user can even forward the message with the file being still in
+/// creation to other groups.
+///
+/// Files being sent with the increation-method must be placed in the
+/// blob directory, see [dc_get_blobdir].  If the increation-method is
+/// not used - which is probably the normal case - dc_send_msg()
+/// copies the file to the blob directory if it is not yet there.  To
+/// distinguish the two cases, msg->state must be set properly. The
+/// easiest way to ensure this is to re-use the same object for both
+/// calls.
+///
+/// # Example
+///
+/// ```c
+/// dc_msg_t* msg = dc_msg_new(context, DC_MSG_VIDEO);
+/// dc_msg_set_file(msg, "/file/to/send.mp4", NULL);
+/// dc_prepare_msg(context, chat_id, msg);
+/// // ... after /file/to/send.mp4 is ready:
+/// dc_send_msg(context, chat_id, msg);
+/// ```
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param chat_id Chat ID to send the message to.
+/// @param msg Message object to send to the chat defined by the chat ID.
+///     On succcess, `msg_id` and state of the object are set up,
+///     The function does not take ownership of the object,
+///     so you have to free it using [dc_msg_unref] as usual.
+///
+/// Retuns the ID of the message that is being prepared.
 #[no_mangle]
 pub unsafe extern "C" fn dc_prepare_msg(
     context: *mut dc_context_t,
@@ -484,14 +1258,40 @@ pub unsafe extern "C" fn dc_prepare_msg(
         eprintln!("ignoring careless call to dc_prepare_msg()");
         return 0;
     }
-
-    let context = &mut *context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let msg = &mut *msg;
     chat::prepare_msg(context, chat_id, msg)
         .unwrap_or_log_default(context, "Failed to prepare message")
 }
 
+/// Sends a message defined by a dc_msg_t object to a chat.
+///
+/// Sends the event #DC_EVENT_MSGS_CHANGED on succcess.  However, this
+/// does not imply, the message really reached the recipient - sending
+/// may be delayed eg. due to network problems. However, from your
+/// view, you're done with the message. Sooner or later it will find
+/// its way.
+///
+/// # Example
+///
+/// ```c
+/// dc_msg_t* msg = dc_msg_new(context, DC_MSG_IMAGE);
+/// dc_msg_set_file(msg, "/file/to/send.jpg", NULL);
+/// dc_send_msg(context, chat_id, msg);
+/// ```
+///
+/// @memberof [dc_context_t]
+/// @param context The context object as returned from [dc_context_new].
+/// @param chat_id Chat ID to send the message to.
+///     If [dc_prepare_msg] was called before, this parameter can be 0.
+/// @param msg Message object to send to the chat defined by the chat ID.
+///     On succcess, msg_id of the object is set up,
+///     The function does not take ownership of the object,
+///     so you have to free it using [dc_msg_unref] as usual.
+///
+/// Returns the ID of the message that is about to be sent. `0` in
+/// case of errors.
 #[no_mangle]
 pub unsafe extern "C" fn dc_send_msg(
     context: *mut dc_context_t,
@@ -502,13 +1302,32 @@ pub unsafe extern "C" fn dc_send_msg(
         eprintln!("ignoring careless call to dc_send_msg()");
         return 0;
     }
-
-    let context = &mut *context;
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let msg = &mut *msg;
-
     chat::send_msg(context, chat_id, msg).unwrap_or_log_default(context, "Failed to send message")
 }
 
+/// Sends a simple text message a given chat.
+///
+/// Sends the event #DC_EVENT_MSGS_CHANGED on succcess.  However, this
+/// does not imply, the message really reached the recipient - sending
+/// may be delayed eg. due to network problems. However, from your
+/// view, you're done with the message. Sooner or later it will find
+/// its way.
+///
+/// See also [dc_send_msg].
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param chat_id Chat ID to send the text message to.
+/// @param text_to_send Text to send to the chat defined by the chat ID.
+///     Passing an empty text here causes an empty text to be sent,
+///     it's up to the caller to handle this if undesired.
+///     Passing NULL as the text causes the function to return 0.
+///
+/// Returns the ID of the message that is about being sent.
 #[no_mangle]
 pub unsafe extern "C" fn dc_send_text_msg(
     context: *mut dc_context_t,
@@ -519,14 +1338,38 @@ pub unsafe extern "C" fn dc_send_text_msg(
         eprintln!("ignoring careless call to dc_send_text_msg()");
         return 0;
     }
-
-    let context = &*context;
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let text_to_send = dc_tools::to_string_lossy(text_to_send);
-
     chat::send_text_msg(context, chat_id, text_to_send)
         .unwrap_or_log_default(context, "Failed to send text message")
 }
 
+/// Saves a draft for a chat in the database.
+//
+/// The UI should call this function if the user has prepared a
+/// message and exits the compose window without clicking the "send"
+/// button before.  When the user later opens the same chat again, the
+/// UI can load the draft using [dc_get_draft] allowing the user to
+/// continue editing and sending.
+///
+/// Drafts are considered when sorting messages
+/// and are also returned eg. by [dc_chatlist_get_summary].
+///
+/// Each chat can have its own draft but only one draft per chat is
+/// possible.
+///
+/// If the draft is modified, an #DC_EVENT_MSGS_CHANGED will be sent.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
+/// @param chat_id The chat ID to save the draft for.
+/// @param msg The message to save as a draft.
+///     Existing draft will be overwritten.
+///     NULL deletes the existing draft, if any, without sending it.
+///     Currently, also non-text-messages
+///     will delete the existing drafts.
 #[no_mangle]
 pub unsafe extern "C" fn dc_set_draft(
     context: *mut dc_context_t,
@@ -537,13 +1380,24 @@ pub unsafe extern "C" fn dc_set_draft(
         eprintln!("ignoring careless call to dc_set_draft()");
         return;
     }
-
-    let context = &*context;
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let msg = if msg.is_null() { None } else { Some(&mut *msg) };
-
     chat::set_draft(context, chat_id, msg)
 }
 
+/// Gets draft for a chat, if any.
+///
+/// See [dc_set_draft] for more details about drafts.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
+/// @param chat_id The chat ID to get the draft for.
+///
+/// Returns a message object.  Can be passed directly to
+/// [dc_send_msg].  Must be freed using [dc_msg_unref] after usage.
+/// If there is no draft, NULL is returned.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_draft<'a>(
     context: *mut dc_context_t,
@@ -553,12 +1407,36 @@ pub unsafe extern "C" fn dc_get_draft<'a>(
         eprintln!("ignoring careless call to dc_get_draft()");
         return ptr::null_mut(); // NULL explicitly defined as "no draft"
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     chat::get_draft(context, chat_id).into_raw()
 }
 
+/// Gets all message IDs belonging to a chat.
+///
+/// The list is already sorted and starts with the oldest message.
+/// Clients should not try to re-sort the list as this would be an
+/// expensive action and would result in inconsistencies between
+/// clients.
+///
+/// Optionally, some special markers added to the ID-array may help to
+/// implement virtual lists.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param chat_id The chat ID of which the messages IDs should be queried.
+/// @param flags If set to DC_GCM_ADDDAYMARKER, the marker
+///     DC_MSG_ID_DAYMARKER will be added before each day (regarding
+///     the local timezone).  Set this to 0 if you do not want this
+///     behaviour.
+/// @param marker1before An optional message ID.  If set, the id
+///     DC_MSG_ID_MARKER1 will be added just before the given ID in
+///     the returned array.  Set this to 0 if you do not want this
+///     behaviour.
+///
+/// Returns an array of message IDs, must be [dc_array_unref]'d when
+/// no longer used.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_chat_msgs(
     context: *mut dc_context_t,
@@ -570,25 +1448,43 @@ pub unsafe extern "C" fn dc_get_chat_msgs(
         eprintln!("ignoring careless call to dc_get_chat_msgs()");
         return ptr::null_mut();
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let arr = dc_array_t::from(chat::get_chat_msgs(context, chat_id, flags, marker1before));
     Box::into_raw(Box::new(arr))
 }
 
+/// Gets the total number of messages in a chat.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param chat_id The ID of the chat to count the messages for.
+///
+/// Returns the number of total messages in the given chat. `0` for
+/// errors or empty chats.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_msg_cnt(context: *mut dc_context_t, chat_id: u32) -> libc::c_int {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_msg_cnt()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     chat::get_msg_cnt(context, chat_id) as libc::c_int
 }
 
+/// Gets the number of _fresh_ messages in a chat.
+///
+/// Typically used to implement a badge with a number in the chatlist.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param chat_id The ID of the chat to count the messages for.
+///
+/// Returns the number of fresh messages in the given chat. `0` for
+/// errors or if there are no fresh messages.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_fresh_msg_cnt(
     context: *mut dc_context_t,
@@ -598,12 +1494,23 @@ pub unsafe extern "C" fn dc_get_fresh_msg_cnt(
         eprintln!("ignoring careless call to dc_get_fresh_msg_cnt()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     chat::get_fresh_msg_cnt(context, chat_id) as libc::c_int
 }
 
+/// Returns the message IDs of all _fresh_ messages of any chat.
+///
+/// Typically used for implementing notification summaries.  The list
+/// is already sorted and starts with the most recent fresh message.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+///
+/// Returns an array of message IDs, must be [dc_array_unref]'d when
+/// no longer used.  On errors, the list is empty.  NULL is never
+/// returned.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_fresh_msgs(
     context: *mut dc_context_t,
@@ -612,34 +1519,50 @@ pub unsafe extern "C" fn dc_get_fresh_msgs(
         eprintln!("ignoring careless call to dc_get_fresh_msgs()");
         return ptr::null_mut();
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let arr = dc_array_t::from(context::dc_get_fresh_msgs(context));
     Box::into_raw(Box::new(arr))
 }
 
+/// Mark all messages in a chat as _noticed_.
+///
+/// _Noticed_ messages are no longer _fresh_ and do not count as being unseen
+/// but are still waiting for being marked as "seen" using [dc_markseen_msgs]
+/// (IMAP/MDNs is not done for noticed messages).
+///
+/// Calling this function usually results in the event
+/// #DC_EVENT_MSGS_CHANGED.  See also [dc_marknoticed_all_chats],
+/// [dc_marknoticed_contact] and [dc_markseen_msgs].
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param chat_id The chat ID of which all messages should be marked as being noticed.
 #[no_mangle]
 pub unsafe extern "C" fn dc_marknoticed_chat(context: *mut dc_context_t, chat_id: u32) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_marknoticed_chat()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     chat::marknoticed_chat(context, chat_id).log_err(context, "Failed marknoticed chat");
 }
 
+/// Same as dc_marknoticed_chat() but for _all_ chats.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
 #[no_mangle]
 pub unsafe extern "C" fn dc_marknoticed_all_chats(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_marknoticed_all_chats()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     chat::marknoticed_all_chats(context).log_err(context, "Failed marknoticed all chats");
 }
 
@@ -651,6 +1574,26 @@ where
     FromPrimitive::from_i64(s.into())
 }
 
+/// Returns all message IDs of the given types in a chat.
+///
+/// Typically used to show a gallery.
+/// The result must be [dc_array_unref]'d
+///
+/// The list is already sorted and starts with the oldest message.
+/// Clients should not try to re-sort the list as this would be an
+/// expensive action and would result in inconsistencies between
+/// clients.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param chat_id The chat ID to get all messages with media from.
+/// @param msg_type Specify a message type to query here, one of the DC_MSG_* constats.
+/// @param msg_type2 Alternative message type to search for. 0 to skip.
+/// @param msg_type3 Alternative message type to search for. 0 to skip.
+///
+/// Returns an array with messages from the given chat ID that have
+/// the wanted message types.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_chat_media(
     context: *mut dc_context_t,
@@ -663,8 +1606,8 @@ pub unsafe extern "C" fn dc_get_chat_media(
         eprintln!("ignoring careless call to dc_get_chat_media()");
         return ptr::null_mut();
     }
-
-    let context = &*context;
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
 
     let msg_type = from_prim(msg_type).expect(&format!("invalid msg_type = {}", msg_type));
     let or_msg_type2 =
@@ -682,6 +1625,27 @@ pub unsafe extern "C" fn dc_get_chat_media(
     Box::into_raw(Box::new(arr))
 }
 
+/// Search next/previous message based on a given message and a list of types.
+///
+/// The Typically used to implement the "next" and "previous" buttons
+/// in a gallery or in a media player.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param curr_msg_id  This is the current message
+///     from which the next or previous message should be searched.
+/// @param dir 1=get the next message, -1=get the previous one.
+/// @param msg_type Message type to search for.
+///     If 0, the message type from curr_msg_id is used.
+/// @param msg_type2 Alternative message type to search for. 0 to skip.
+/// @param msg_type3 Alternative message type to search for. 0 to skip.
+///
+/// Returns the message ID that should be played next.  The returned
+/// message is in the same chat as the given one and has one of the
+/// given types.  Typically, this result is passed again to
+/// [dc_get_next_media] later on the next swipe.  If there is not
+/// next/previous message, the function returns 0.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_next_media(
     context: *mut dc_context_t,
@@ -695,8 +1659,8 @@ pub unsafe extern "C" fn dc_get_next_media(
         eprintln!("ignoring careless call to dc_get_next_media()");
         return 0;
     }
-
-    let context = &*context;
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
 
     let msg_type = from_prim(msg_type).expect(&format!("invalid msg_type = {}", msg_type));
     let or_msg_type2 =
@@ -707,6 +1671,31 @@ pub unsafe extern "C" fn dc_get_next_media(
     chat::get_next_media(context, msg_id, dir, msg_type, or_msg_type2, or_msg_type3)
 }
 
+/// Archives or unarchives a chat.
+///
+/// Archived chats are not included in the default chatlist returned
+/// by dc_get_chatlist().  Instead, if there are _any_ archived chats,
+/// the pseudo-chat with the chat_id DC_CHAT_ID_ARCHIVED_LINK will be
+/// added the the end of the chatlist.
+///
+/// * To get a list of archived chats, use dc_get_chatlist() with the
+///   flag DC_GCL_ARCHIVED_ONLY.
+///
+/// * To find out the archived state of a given chat, use
+///   [dc_chat_get_archived]
+///
+/// * Messages in archived chats are marked as being noticed, so they
+///   do not count as "fresh"
+///
+/// * Calling this function usually results in the event
+///   #DC_EVENT_MSGS_CHANGED
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param chat_id The ID of the chat to archive or unarchive.
+/// @param archive 1=archive chat, 0=unarchive chat, all other values
+///     are reserved for future use
 #[no_mangle]
 pub unsafe extern "C" fn dc_archive_chat(
     context: *mut dc_context_t,
@@ -717,9 +1706,8 @@ pub unsafe extern "C" fn dc_archive_chat(
         eprintln!("ignoring careless call to dc_archive_chat()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let archive = if archive == 0 {
         false
     } else if archive == 1 {
@@ -727,22 +1715,65 @@ pub unsafe extern "C" fn dc_archive_chat(
     } else {
         return;
     };
-
     chat::archive(context, chat_id, archive).log_err(context, "Failed archive chat");
 }
 
+/// Deletes a chat.
+///
+/// Messages are deleted from the device and the chat database entry
+/// is deleted.  After that, the event #DC_EVENT_MSGS_CHANGED is
+/// posted.
+///
+/// Things that are _not_ done implicitly:
+///
+/// * Messages are **not deleted from the server**.
+/// * The chat or the contact is **not blocked**, so new messages from
+///   the user/the group may appear and the user may create the chat
+///   again.
+/// * **Groups are not left** - this would be unexpected as (1)
+///   deleting a normal chat also does not prevent new mails from
+///   arriving, (2) leaving a group requires sending a message to all
+///   group members - especially for groups not used for a longer
+///   time, this is really unexpected when deletion results in
+///   contacting all members again, (3) only leaving groups is also a
+///   valid usecase.
+///
+/// To leave a chat explicitly, use dc_remove_contact_from_chat() with
+/// chat_id=DC_CONTACT_ID_SELF)
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param chat_id The ID of the chat to delete.
 #[no_mangle]
 pub unsafe extern "C" fn dc_delete_chat(context: *mut dc_context_t, chat_id: u32) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_delete_chat()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     chat::delete(context, chat_id).log_err(context, "Failed chat delete");
 }
 
+/// Gets contact IDs belonging to a chat.
+///
+/// * for normal chats, the function always returns exactly one
+///   contact, DC_CONTACT_ID_SELF is returned only for SELF-chats.
+///
+/// * for group chats all members are returned, DC_CONTACT_ID_SELF is
+///   returned explicitly as it may happen that oneself gets removed
+///   from a still existing group
+///
+/// * for the deaddrop, the list is empty
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param chat_id Chat ID to get the belonging contact IDs for.
+///
+/// Returns an array of contact IDs belonging to the chat; must be
+/// freed using [dc_array_unref] when done.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_chat_contacts(
     context: *mut dc_context_t,
@@ -752,13 +1783,31 @@ pub unsafe extern "C" fn dc_get_chat_contacts(
         eprintln!("ignoring careless call to dc_get_chat_contacts()");
         return ptr::null_mut();
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let arr = dc_array_t::from(chat::get_chat_contacts(context, chat_id));
     Box::into_raw(Box::new(arr))
 }
 
+/// Searches messages containing the given query string.
+///
+/// Searching can be done globally (chat_id=0) or in a specified chat
+/// only (chat_id set).
+///
+/// Global chat results are typically displayed using
+/// [dc_msg_get_summary], chat search results may just hilite the
+/// corresponding messages and present a prev/next button.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as returned from [dc_context_new].
+/// @param chat_id ID of the chat to search messages in.
+///     Set this to 0 for a global search.
+/// @param query The query to search for.
+///
+/// Returns an array of message IDs. Must be freed using
+/// [dc_array_unref] when no longer needed.  If nothing can be found,
+/// the function returns NULL.
 #[no_mangle]
 pub unsafe extern "C" fn dc_search_msgs(
     context: *mut dc_context_t,
@@ -769,13 +1818,20 @@ pub unsafe extern "C" fn dc_search_msgs(
         eprintln!("ignoring careless call to dc_search_msgs()");
         return ptr::null_mut();
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let arr = dc_array_t::from(context::dc_search_msgs(context, chat_id, query));
     Box::into_raw(Box::new(arr))
 }
 
+/// Gets chat object by a chat ID.
+///
+/// @memberof [dc_context_t]
+/// @param context The context object as returned from [dc_context_new].
+/// @param chat_id The ID of the chat to get the chat object for.
+///
+/// Returns a chat object of the type dc_chat_t, must be freed using
+/// [dc_chat_unref] when done.  On errors, NULL is returned.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_chat<'a>(
     context: *mut dc_context_t,
@@ -785,15 +1841,41 @@ pub unsafe extern "C" fn dc_get_chat<'a>(
         eprintln!("ignoring careless call to dc_get_chat()");
         return ptr::null_mut();
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     match chat::Chat::load_from_db(context, chat_id) {
         Ok(chat) => Box::into_raw(Box::new(chat)),
         Err(_) => std::ptr::null_mut(),
     }
 }
 
+/// Creates a new group chat.
+///
+/// After creation, the draft of the chat is set to a default text,
+/// the group has one member with the ID DC_CONTACT_ID_SELF and is in
+/// _unpromoted_ state.  This means, you can add or remove members,
+/// change the name, the group image and so on without messages being
+/// sent to all group members.
+///
+/// This changes as soon as the first message is sent to the group
+/// members and the group becomes _promoted_.  After that, all changes
+/// are synced with all group members by sending status message.
+///
+/// To check, if a chat is still unpromoted, you
+/// [dc_chat_is_unpromoted].  This may be useful if you want to show
+/// some help for just created groups.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
+/// @param verified If set to 1 the function creates a secure verified group.
+///     Only secure-verified members are allowed in these groups
+///     and end-to-end-encryption is always enabled.
+/// @param chat_name The name of the group chat to create.
+///     The name may be changed later using [dc_set_chat_name].
+///     To find out the name of a group later, see [dc_chat_get_name]
+///
+/// Returns the chat ID of the new group chat, `0` on errors.
 #[no_mangle]
 pub unsafe extern "C" fn dc_create_group_chat(
     context: *mut dc_context_t,
@@ -804,19 +1886,28 @@ pub unsafe extern "C" fn dc_create_group_chat(
         eprintln!("ignoring careless call to dc_create_group_chat()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let verified = if let Some(s) = contact::VerifiedStatus::from_i32(verified) {
         s
     } else {
         return 0;
     };
-
     chat::create_group_chat(context, verified, as_str(name))
         .unwrap_or_log_default(context, "Failed to create group chat")
 }
 
+/// Checks if a given contact ID is a member of a group chat.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
+/// @param chat_id The chat ID to check.
+/// @param contact_id The contact ID to check.  To check if yourself is member
+///     of the chat, pass DC_CONTACT_ID_SELF (1) here.
+///
+/// Returns `1` if contact ID is member of chat ID, `0` if contact is
+/// not in chat.
 #[no_mangle]
 pub unsafe extern "C" fn dc_is_contact_in_chat(
     context: *mut dc_context_t,
@@ -827,12 +1918,30 @@ pub unsafe extern "C" fn dc_is_contact_in_chat(
         eprintln!("ignoring careless call to dc_is_contact_in_chat()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     chat::is_contact_in_chat(context, chat_id, contact_id)
 }
 
+/// Adds a member to a group.
+///
+/// If the group is already _promoted_ (any message was sent to the
+/// group), all group members are informed by a special status message
+/// that is sent automatically by this function.
+///
+/// If the group is a verified group, only verified contacts can be
+/// added to the group.
+///
+/// Sends out #DC_EVENT_CHAT_MODIFIED and #DC_EVENT_MSGS_CHANGED if a
+/// status message was sent.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by dc_context_new().
+/// @param chat_id The chat ID to add the contact to.  Must be a group chat.
+/// @param contact_id The contact ID to add to the chat.
+///
+/// Returns `1` if the member added to group, `0` on error.
 #[no_mangle]
 pub unsafe extern "C" fn dc_add_contact_to_chat(
     context: *mut dc_context_t,
@@ -843,12 +1952,27 @@ pub unsafe extern "C" fn dc_add_contact_to_chat(
         eprintln!("ignoring careless call to dc_add_contact_to_chat()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     chat::add_contact_to_chat(context, chat_id, contact_id)
 }
 
+/// Removes a member from a group.
+///
+/// If the group is already _promoted_ (any message was sent to the
+/// group), all group members are informed by a special status message
+/// that is sent automatically by this function.
+///
+/// Sends out #DC_EVENT_CHAT_MODIFIED and #DC_EVENT_MSGS_CHANGED if a
+/// status message was sent.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
+/// @param chat_id The chat ID to remove the contact from.  Must be a group chat.
+/// @param contact_id The contact ID to remove from the chat.
+///
+/// Returns `1` if the member is removed from group, `0` on error.
 #[no_mangle]
 pub unsafe extern "C" fn dc_remove_contact_from_chat(
     context: *mut dc_context_t,
@@ -859,14 +1983,29 @@ pub unsafe extern "C" fn dc_remove_contact_from_chat(
         eprintln!("ignoring careless call to dc_remove_contact_from_chat()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     chat::remove_contact_from_chat(context, chat_id, contact_id)
         .map(|_| 1)
         .unwrap_or_log_default(context, "Failed to remove contact")
 }
 
+/// Sets group name.
+///
+/// If the group is already _promoted_ (any message was sent to the
+/// group), all group members are informed by a special status message
+/// that is sent automatically by this function.
+///
+/// Sends out #DC_EVENT_CHAT_MODIFIED and #DC_EVENT_MSGS_CHANGED if a
+/// status message was sent.
+///
+/// @memberof [dc_context_t]
+///
+/// @param chat_id The chat ID to set the name for.  Must be a group chat.
+/// @param new_name New name of the group.
+/// @param context The context as created by [dc_context_new].
+///
+/// Returns `1` on success, `0` on error.
 #[no_mangle]
 pub unsafe extern "C" fn dc_set_chat_name(
     context: *mut dc_context_t,
@@ -877,14 +2016,34 @@ pub unsafe extern "C" fn dc_set_chat_name(
         eprintln!("ignoring careless call to dc_set_chat_name()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     chat::set_chat_name(context, chat_id, as_str(name))
         .map(|_| 1)
         .unwrap_or_log_default(context, "Failed to set chat name")
 }
 
+/// Sets group profile image.
+///
+/// If the group is already _promoted_ (any message was sent to the
+/// group), all group members are informed by a special status message
+/// that is sent automatically by this function.
+///
+/// Sends out #DC_EVENT_CHAT_MODIFIED and #DC_EVENT_MSGS_CHANGED if a
+/// status message was sent.
+///
+/// To find out the profile image of a chat, use
+/// [dc_chat_get_profile_image].
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
+/// @param chat_id The chat ID to set the image for.
+/// @param new_image Full path of the image to use as the group image.
+///     If you pass NULL here, the group image is deleted (for
+///     promoted groups, all members are informed about this change
+///     anyway).
+/// Returns `1` on success, `0` on error.
 #[no_mangle]
 pub unsafe extern "C" fn dc_set_chat_profile_image(
     context: *mut dc_context_t,
@@ -895,14 +2054,28 @@ pub unsafe extern "C" fn dc_set_chat_profile_image(
         eprintln!("ignoring careless call to dc_set_chat_profile_image()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     chat::set_chat_profile_image(context, chat_id, as_str(image))
         .map(|_| 1)
         .unwrap_or_log_default(context, "Failed to set profile image")
 }
 
+/// Gets an informational text for a single message.
+///
+/// The text is multiline and may contain eg. the raw text of the
+/// message.
+///
+/// The max. text returned is typically longer (about 100000
+/// characters) than the max. text returned by [dc_msg_get_text]
+/// (about 30000 characters).
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+/// @param msg_id The message id for which information should be generated
+///
+/// Returns a text string, must be free()'d after usage.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_msg_info(
     context: *mut dc_context_t,
@@ -912,12 +2085,26 @@ pub unsafe extern "C" fn dc_get_msg_info(
         eprintln!("ignoring careless call to dc_get_msg_info()");
         return dc_strdup(ptr::null());
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     message::dc_get_msg_info(context, msg_id)
 }
 
+/// Get the raw mime-headers of the given message.
+///
+/// Raw headers are saved for incoming messages only if
+/// `dc_set_config(context, "save_mime_headers", "1")` was called
+/// before.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+/// @param msg_id The message id, must be the id of an incoming message.
+///
+/// Returns raw headers as a multi-line string, must be free()'d after
+/// usage.  Returns NULL if there are no headers saved for the given
+/// message, eg. because of save_mime_headers is not set or the
+/// message is not incoming.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_mime_headers(
     context: *mut dc_context_t,
@@ -927,12 +2114,21 @@ pub unsafe extern "C" fn dc_get_mime_headers(
         eprintln!("ignoring careless call to dc_get_mime_headers()");
         return ptr::null_mut(); // NULL explicitly defined as "no mime headers"
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     message::dc_get_mime_headers(context, msg_id)
 }
 
+/// Delete messages.
+///
+/// The messages are deleted on the current device and on the IMAP
+/// server.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new]
+/// @param msg_ids an array of uint32_t containing all message IDs that should be deleted
+/// @param msg_cnt The number of messages IDs in the msg_ids array
 #[no_mangle]
 pub unsafe extern "C" fn dc_delete_msgs(
     context: *mut dc_context_t,
@@ -943,12 +2139,20 @@ pub unsafe extern "C" fn dc_delete_msgs(
         eprintln!("ignoring careless call to dc_delete_msgs()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     message::dc_delete_msgs(context, msg_ids, msg_cnt)
 }
 
+/// Forward messages to another chat.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new]
+/// @param msg_ids An array of uint32_t containing all message IDs
+///     that should be forwarded
+/// @param msg_cnt The number of messages IDs in the msg_ids array
+/// @param chat_id The destination chat ID.
 #[no_mangle]
 pub unsafe extern "C" fn dc_forward_msgs(
     context: *mut dc_context_t,
@@ -964,24 +2168,48 @@ pub unsafe extern "C" fn dc_forward_msgs(
         eprintln!("ignoring careless call to dc_forward_msgs()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     chat::forward_msgs(context, msg_ids, msg_cnt, chat_id)
 }
 
+/// Mark all messages sent by the given contact as _noticed_.
+///
+/// See also [dc_marknoticed_chat] and [dc_markseen_msgs]
+///
+/// Calling this function usually results in the event
+/// #DC_EVENT_MSGS_CHANGED.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new]
+/// @param contact_id The contact ID of which all messages should be
+///     marked as noticed.
 #[no_mangle]
 pub unsafe extern "C" fn dc_marknoticed_contact(context: *mut dc_context_t, contact_id: u32) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_marknoticed_contact()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     Contact::mark_noticed(context, contact_id)
 }
 
+/// Marks a message as _seen_.
+///
+/// Marks a message as seen and updates the IMAP state and sends
+/// MDNs. If the message is not in a real chat (eg. a contact
+/// request), the message is only marked as NOTICED and no IMAP/MDNs
+/// is done.  See also [dc_marknoticed_chat] and
+/// [dc_marknoticed_contact]
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object.
+/// @param msg_ids An array of uint32_t containing all the messages
+///     IDs that should be marked as seen.
+/// @param msg_cnt The number of message IDs in msg_ids.
 #[no_mangle]
 pub unsafe extern "C" fn dc_markseen_msgs(
     context: *mut dc_context_t,
@@ -992,12 +2220,23 @@ pub unsafe extern "C" fn dc_markseen_msgs(
         eprintln!("ignoring careless call to dc_markseen_msgs()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     message::dc_markseen_msgs(context, msg_ids, msg_cnt as usize);
 }
 
+/// Star/unstar messages by setting the last parameter to 0 (unstar) or 1 (star).
+///
+/// Starred messages are collected in a virtual chat that can be shown
+/// using [dc_get_chat_msgs] using the chat_id DC_CHAT_ID_STARRED.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new]
+/// @param msg_ids An array of uint32_t message IDs defining the
+///     messages to star or unstar
+/// @param msg_cnt The number of IDs in msg_ids
+/// @param star 0=unstar the messages in msg_ids, 1=star them
 #[no_mangle]
 pub unsafe extern "C" fn dc_star_msgs(
     context: *mut dc_context_t,
@@ -1009,12 +2248,23 @@ pub unsafe extern "C" fn dc_star_msgs(
         eprintln!("ignoring careless call to dc_star_msgs()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     message::dc_star_msgs(context, msg_ids, msg_cnt, star);
 }
 
+/// Get a single message object of the type dc_msg_t.
+///
+/// For a list of messages in a chat, see [dc_get_chat_msgs]
+/// For a list or chats, see [dc_get_chatlist]
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
+/// @param msg_id The message ID for which the message object should be created.
+///
+/// Returns a dc_msg_t message object.  On errors, NULL is returned.
+/// When done, the object must be freed using [dc_msg_unref].
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_msg<'a>(
     context: *mut dc_context_t,
@@ -1024,12 +2274,25 @@ pub unsafe extern "C" fn dc_get_msg<'a>(
         eprintln!("ignoring careless call to dc_get_msg()");
         return ptr::null_mut();
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     message::dc_get_msg(context, msg_id).into_raw()
 }
 
+/// Rough check if a string may be a valid e-mail address.
+///
+/// The function checks if the string contains a minimal amount of
+/// characters before and after the `@` and `.` characters.
+///
+/// To check if a given address is a contact in the contact database
+/// use [dc_lookup_contact_id_by_addr].
+///
+/// @memberof [dc_context_t]
+///
+/// @param addr The e-mail-address to check.
+///
+/// Returns `1` if the address may be a valid e-mail address, `0` if
+/// address won't be a valid e-mail address.
 #[no_mangle]
 pub unsafe extern "C" fn dc_may_be_valid_addr(addr: *mut libc::c_char) -> libc::c_int {
     if addr.is_null() {
@@ -1040,6 +2303,21 @@ pub unsafe extern "C" fn dc_may_be_valid_addr(addr: *mut libc::c_char) -> libc::
     contact::may_be_valid_addr(as_str(addr)) as libc::c_int
 }
 
+/// Checks if an e-mail address belongs to a known and unblocked contact.
+///
+/// Known and unblocked contacts will be returned by
+/// [dc_get_contacts].
+///
+/// To validate an e-mail address independently of the contact database
+/// use [dc_may_be_valid_addr].
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+/// @param addr The e-mail-address to check.
+///
+/// Returns `1` if address is a contact in use, `0` if address is not
+/// a contact in use.
 #[no_mangle]
 pub unsafe extern "C" fn dc_lookup_contact_id_by_addr(
     context: *mut dc_context_t,
@@ -1049,12 +2327,32 @@ pub unsafe extern "C" fn dc_lookup_contact_id_by_addr(
         eprintln!("ignoring careless call to dc_lookup_contact_id_by_addr()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     Contact::lookup_id_by_addr(context, as_str(addr))
 }
 
+/// Adds a single contact as a result of an _explicit_ user action.
+///
+/// We assume, the contact name, if any, is entered by the user and is
+/// used "as is" therefore, [normalize] is _not_ called for the
+/// name. If the contact is blocked, it is unblocked.
+///
+/// To add a number of contacts, see [dc_add_address_book] which is
+/// much faster for adding a bunch of addresses.
+///
+/// May result in a #DC_EVENT_CONTACTS_CHANGED event.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+/// @param name Name of the contact to add. If you do not know the name belonging
+///     to the address, you can give NULL here.
+/// @param addr E-mail-address of the contact to add. If the email address
+///     already exists, the name is updated and the origin is increased to
+///     "manually created".
+///
+/// Returns a contact ID of the created or reused contact.
 #[no_mangle]
 pub unsafe extern "C" fn dc_create_contact(
     context: *mut dc_context_t,
@@ -1065,17 +2363,40 @@ pub unsafe extern "C" fn dc_create_contact(
         eprintln!("ignoring careless call to dc_create_contact()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let name = if name.is_null() { "" } else { as_str(name) };
-
     match Contact::create(context, name, as_str(addr)) {
         Ok(id) => id,
         Err(_) => 0,
     }
 }
 
+/// Adds a number of contacts.
+///
+/// Typically used to add the whole address book from the OS. As names
+/// here are typically not well formatted, we call normalize() for
+/// each name given.
+///
+/// No email-address is added twice.  Trying to add email-addresses
+/// that are already in the contact list, results in updating the name
+/// unless the name was changed manually by the user.  If any
+/// email-address or any name is really updated, the event
+/// DC_EVENT_CONTACTS_CHANGED is sent.
+///
+/// To add a single contact entered by the user, you should prefer
+/// [dc_create_contact], however, for adding a bunch of addresses,
+/// this function is _much_ faster.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context the context object as created by [dc_context_new].
+/// @param adr_book A multi-line string in the format
+///     `Name one\nAddress one\nName two\nAddress two`.
+///      If an email address already exists, the name is updated
+///      unless it was edited manually by [dc_create_contact] before.
+///
+/// Returns the number of modified or added contacts.
 #[no_mangle]
 pub unsafe extern "C" fn dc_add_address_book(
     context: *mut dc_context_t,
@@ -1085,15 +2406,32 @@ pub unsafe extern "C" fn dc_add_address_book(
         eprintln!("ignoring careless call to dc_add_address_book()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     match Contact::add_address_book(context, as_str(addr_book)) {
         Ok(cnt) => cnt as libc::c_int,
         Err(_) => 0,
     }
 }
 
+/// Returns known and unblocked contacts.
+///
+/// To get information about a single contact, see [dc_get_contact].
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+/// @param listflags A combination of flags:
+///     - if the flag DC_GCL_ADD_SELF is set, SELF is added to the
+///       list unless filtered by other parameters
+///     - if the flag DC_GCL_VERIFIED_ONLY is set, only verified
+///       contacts are returned.  if DC_GCL_VERIFIED_ONLY is not set,
+///       verified and unverified contacts are returned.
+/// @param query A string to filter the list.  Typically used to implement an
+///     incremental search.  NULL for no filtering.
+///
+/// Returns an array containing all contact IDs.  Must be
+/// [dc_array_unref]'d after usage.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_contacts(
     context: *mut dc_context_t,
@@ -1104,33 +2442,45 @@ pub unsafe extern "C" fn dc_get_contacts(
         eprintln!("ignoring careless call to dc_get_contacts()");
         return ptr::null_mut();
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let query = if query.is_null() {
         None
     } else {
         Some(as_str(query))
     };
-
     match Contact::get_all(context, flags, query) {
         Ok(contacts) => Box::into_raw(Box::new(dc_array_t::from(contacts))),
         Err(_) => std::ptr::null_mut(),
     }
 }
 
+/// Gets the number of blocked contacts.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+///
+/// Returns the number of blocked contacts.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_blocked_cnt(context: *mut dc_context_t) -> libc::c_int {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_blocked_cnt()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     Contact::get_blocked_cnt(context) as libc::c_int
 }
 
+/// Get blocked contacts.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+///
+/// Returns an array containing all blocked contact IDs.  Must be
+/// [dc_array_unref]'d after usage.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_blocked_contacts(
     context: *mut dc_context_t,
@@ -1139,14 +2489,22 @@ pub unsafe extern "C" fn dc_get_blocked_contacts(
         eprintln!("ignoring careless call to dc_get_blocked_contacts()");
         return ptr::null_mut();
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     Box::into_raw(Box::new(dc_array_t::from(Contact::get_all_blocked(
         context,
     ))))
 }
 
+/// Block or unblock a contact.
+///
+/// May result in a #DC_EVENT_CONTACTS_CHANGED event.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+/// @param contact_id The ID of the contact to block or unblock.
+/// @param new_blocking 1=block contact, 0=unblock contact
 #[no_mangle]
 pub unsafe extern "C" fn dc_block_contact(
     context: *mut dc_context_t,
@@ -1157,9 +2515,8 @@ pub unsafe extern "C" fn dc_block_contact(
         eprintln!("ignoring careless call to dc_block_contact()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     if block == 0 {
         Contact::unblock(context, contact_id);
     } else {
@@ -1167,6 +2524,18 @@ pub unsafe extern "C" fn dc_block_contact(
     }
 }
 
+/// Gets encryption info for a contact.
+///
+/// Get a multi-line encryption info, containing your fingerprint and
+/// the fingerprint of the contact, used eg. to compare the
+/// fingerprints for a simple out-of-band verification.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+/// @param contact_id ID of the contact to get the encryption info for.
+///
+/// Returns multi-line text, must be free()'d after usage.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_contact_encrinfo(
     context: *mut dc_context_t,
@@ -1176,9 +2545,8 @@ pub unsafe extern "C" fn dc_get_contact_encrinfo(
         eprintln!("ignoring careless call to dc_get_contact_encrinfo()");
         return dc_strdup(ptr::null());
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     Contact::get_encrinfo(context, contact_id)
         .map(|s| s.strdup())
         .unwrap_or_else(|e| {
@@ -1187,6 +2555,20 @@ pub unsafe extern "C" fn dc_get_contact_encrinfo(
         })
 }
 
+/// Deletes a contact.
+///
+/// The contact is deleted from the local device.  It may happen that
+/// this is not possible as the contact is in use.  In this case, the
+/// contact can be blocked.
+///
+/// May result in a #DC_EVENT_CONTACTS_CHANGED event.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+/// @param contact_id ID of the contact to delete.
+///
+/// Returns `1` on success, `0` on error.
 #[no_mangle]
 pub unsafe extern "C" fn dc_delete_contact(
     context: *mut dc_context_t,
@@ -1196,15 +2578,29 @@ pub unsafe extern "C" fn dc_delete_contact(
         eprintln!("ignoring careless call to dc_delete_contact()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     match Contact::delete(context, contact_id) {
         Ok(_) => 1,
         Err(_) => 0,
     }
 }
 
+/// Get a single contact object.
+///
+/// For a list, see eg. [dc_get_contacts].
+///
+/// For contact DC_CONTACT_ID_SELF (1), the function returns sth.
+/// like "Me" in the selected language and the email address defined
+/// by [dc_set_config].
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object as created by [dc_context_new].
+/// @param contact_id ID of the contact to get the object for.
+///
+/// Returns the contact object, must be freed using [dc_contact_unref]
+/// when no longer used.  NULL on errors.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_contact<'a>(
     context: *mut dc_context_t,
@@ -1214,14 +2610,72 @@ pub unsafe extern "C" fn dc_get_contact<'a>(
         eprintln!("ignoring careless call to dc_get_contact()");
         return ptr::null_mut();
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     Contact::get_by_id(context, contact_id)
         .map(|contact| Box::into_raw(Box::new(contact)))
         .unwrap_or_else(|_| std::ptr::null_mut())
 }
 
+/// Import/export things.
+///
+/// For this purpose, the function creates a job that is executed in
+/// the IMAP-thread then; this requires to call [dc_perform_imap_jobs]
+/// regularly.
+///
+/// What to do is defined by the _what_ parameter which may be one of
+/// the following:
+///
+/// - **DC_IMEX_EXPORT_BACKUP** (11) - Export a backup to the
+///   directory given as `param1`.  The backup contains all contacts,
+///   chats, images and other data and device independent settings.
+///   The backup does not contain device dependent settings as
+///   ringtones or LED notification settings.  The name of the backup
+///   is typically `delta-chat.<day>.bak`, if more than one backup is
+///   create on a day, the format is `delta-chat.<day>-<number>.bak`
+///
+/// - **DC_IMEX_IMPORT_BACKUP** (12) - `param1` is the file (not:
+///    directory) to import. The file is normally created by
+///    DC_IMEX_EXPORT_BACKUP and detected by
+///    [dc_imex_has_backup]. Importing a backup is only possible as
+///    long as the context is not configured or used in another way.
+///
+/// - **DC_IMEX_EXPORT_SELF_KEYS** (1) - Export all private keys and
+///   all public keys of the user to the directory given as `param1`.
+///   The default key is written to the files `public-key-default.asc`
+///   and `private-key-default.asc`, if there are more keys, they are
+///   written to files as `public-key-<id>.asc` and
+///   `private-key-<id>.asc`
+///
+/// - **DC_IMEX_IMPORT_SELF_KEYS** (2) - Import private keys found in
+///   the directory given as `param1`.  The last imported key is made
+///   the default keys unless its name contains the string `legacy`.
+///   Public keys are not imported.
+///
+/// While dc_imex() returns immediately, the started job may take a while,
+/// you can stop it using dc_stop_ongoing_process(). During execution of the job,
+/// some events are sent out:
+///
+/// - A number of #DC_EVENT_IMEX_PROGRESS events are sent and may be
+///   used to create a progress bar or stuff like that. Moreover,
+///   you'll be informed when the imex-job is done.
+///
+/// - For each file written on export, the function sends
+///   #DC_EVENT_IMEX_FILE_WRITTEN
+///
+/// Only one import-/export-progress can run at the same time.  To
+/// cancel an import-/export-progress, use [dc_stop_ongoing_process].
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
+/// @param what One of the DC_IMEX_* constants.
+/// @param param1 Meaning depends on the DC_IMEX_* constants. If this
+///     parameter is a directory, it should not end with a slash
+///     (otherwise you'll get double slashes when receiving
+///     #DC_EVENT_IMEX_FILE_WRITTEN). Set to NULL if not used.
+/// @param param2 Meaning depends on the DC_IMEX_* constants. Set to
+///     NULL if not used.
 #[no_mangle]
 pub unsafe extern "C" fn dc_imex(
     context: *mut dc_context_t,
@@ -1233,12 +2687,62 @@ pub unsafe extern "C" fn dc_imex(
         eprintln!("ignoring careless call to dc_imex()");
         return;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     dc_imex::dc_imex(context, what, param1, param2)
 }
 
+/// Check if there is a backup file.
+///
+/// May only be used on fresh installations (eg. [dc_is_configured]
+/// returns 0).
+///
+/// # Example
+///
+/// ```c
+/// char dir[] = "/dir/to/search/backups/in";
+///
+/// void ask_user_for_credentials()
+/// {
+///     // - ask the user for email and password
+///     // - save them using dc_set_config()
+/// }
+///
+/// int ask_user_whether_to_import()
+/// {
+///     // - inform the user that we've found a backup
+///     // - ask if he want to import it
+///     // - return 1 to import, 0 to skip
+///     return 1;
+/// }
+///
+/// if (!dc_is_configured(context))
+/// {
+///     char* file = NULL;
+///     if ((file=dc_imex_has_backup(context, dir))!=NULL && ask_user_whether_to_import())
+///     {
+///         dc_imex(context, DC_IMEX_IMPORT_BACKUP, file, NULL);
+///         // connect
+///     }
+///     else
+///     {
+///         do {
+///             ask_user_for_credentials();
+///         }
+///         while (!configure_succeeded())
+///     }
+///     free(file);
+/// }
+/// ```
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context as created by [dc_context_new].
+/// @param dir_name Directory to search backups in.
+///
+/// Returns a string with the backup file, typically given to
+/// [dc_imex], returned strings must be free()'d.  The function
+/// returns NULL if no backup was found.
 #[no_mangle]
 pub unsafe extern "C" fn dc_imex_has_backup(
     context: *mut dc_context_t,
@@ -1248,24 +2752,98 @@ pub unsafe extern "C" fn dc_imex_has_backup(
         eprintln!("ignoring careless call to dc_imex_has_backup()");
         return ptr::null_mut(); // NULL explicitly defined as "has no backup"
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     dc_imex::dc_imex_has_backup(context, dir)
 }
 
+/// Initiate Autocrypt Setup Transfer.
+///
+/// Before starting the setup transfer with this function, the user
+/// should be asked:
+///
+/// ```text
+
+/// "An 'Autocrypt Setup Message' securely shares your end-to-end
+/// setup with other Autocrypt-compliant apps.  The setup will be
+/// encrypted by a setup code which is displayed here and must be
+/// typed on the other device.
+/// ```
+///
+/// After that, this function should be called to send the Autocrypt
+/// Setup Message.  The function creates the setup message and waits
+/// until it is really sent.  As this may take a while, it is
+/// recommended to start the function in a separate thread; to
+/// interrupt it, you can use [dc_stop_ongoing_process].
+///
+/// After everything succeeded, the required setup code is returned in
+/// the following format:
+///
+/// ```text
+/// 1234-1234-1234-1234-1234-1234-1234-1234-1234
+/// ```
+///
+/// The setup code should be shown to the user then:
+///
+/// ```text
+/// Your key has been sent to yourself. Switch to the other device
+/// and open the setup message. You should be prompted for a setup
+/// code. Type the following digits into the prompt:
+///
+/// 1234 - 1234 - 1234 -
+/// 1234 - 1234 - 1234 -
+/// 1234 - 1234 - 1234
+///
+/// Once you're done, your other device will be ready to use Autocrypt.
+/// ```
+///
+/// On the _other device_ you will call [dc_continue_key_transfer]
+/// then for setup messages identified by [dc_msg_is_setupmessage].
+///
+/// For more details about the Autocrypt setup process, please refer to
+/// https://autocrypt.org/en/latest/level1.html#autocrypt-setup-message
+///
+/// @memberof [dc_context_t]
+/// @param context The context object.
+///
+/// Returns the setup code. Must be free()'d after usage.  On errors,
+/// eg. if the message could not be sent, NULL is returned.
 #[no_mangle]
 pub unsafe extern "C" fn dc_initiate_key_transfer(context: *mut dc_context_t) -> *mut libc::c_char {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_initiate_key_transfer()");
         return ptr::null_mut(); // NULL explicitly defined as "error"
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     dc_imex::dc_initiate_key_transfer(context)
 }
 
+/// Continue the Autocrypt Key Transfer on another device.
+///
+/// If you have started the key transfer on another device using
+/// [dc_initiate_key_transfer] and you've detected a setup message
+/// with [dc_msg_is_setupmessage], you should prompt the user for the
+/// setup code and call this function then.
+///
+/// You can use [dc_msg_get_setupcodebegin] to give the user a hint
+/// about the code (useful if the user has created several messages
+/// and should not enter the wrong code).
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object.
+/// @param msg_id ID of the setup message to decrypt.
+/// @param setup_code Setup code entered by the user. This is the same
+///     setup code as returned from dc_initiate_key_transfer() on the
+///     other device.  There is no need to format the string
+///     correctly, the function will remove all spaces and other
+///     characters and insert the `-` characters at the correct
+///     places.
+///
+/// Returns `1` if the key successfully decrypted and imported; both
+/// devices will use the same key now; `0` if key transfer failed
+/// eg. due to a bad setup code.
 #[no_mangle]
 pub unsafe extern "C" fn dc_continue_key_transfer(
     context: *mut dc_context_t,
@@ -1279,24 +2857,76 @@ pub unsafe extern "C" fn dc_continue_key_transfer(
         eprintln!("ignoring careless call to dc_continue_key_transfer()");
         return 0;
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     dc_imex::dc_continue_key_transfer(context, msg_id, setup_code)
 }
 
+/// Signal an ongoing process to stop.
+///
+/// After that, [dc_stop_ongoing_process] returns _without_ waiting
+/// for the ongoing process to return.
+///
+/// The ongoing process will return ASAP then, however, it may
+/// still take a moment.  If in doubt, the caller may also decide to kill the
+/// thread after a few seconds; eg. the process may hang in a
+/// function not under the control of the core (eg. #DC_EVENT_HTTP_GET). Another
+/// reason for [dc_stop_ongoing_process] not to wait is that otherwise it
+/// would be GUI-blocking and should be started in another thread then; this
+/// would make things even more complicated.
+///
+/// Typical ongoing processes are started by [dc_configure],
+/// [dc_initiate_key_transfer] or [dc_imex]. As there is always at
+/// most only one onging process at the same time, there is no need to
+/// define _which_ process to exit.
+///
+/// @memberof [dc_context_t]
+///
+/// # Parameters
+///
+/// * `context` - The [dc_context_t] object.
+///
+/// # Panics
+///
+/// It is safe to call this function on a closed context, which is a
+/// no-op.
 #[no_mangle]
 pub unsafe extern "C" fn dc_stop_ongoing_process(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_stop_ongoing_process()");
         return;
     }
-
-    let context = &*context;
-
-    configure::dc_stop_ongoing_process(context)
+    let wrapper: &ContextWrapper = &*context;
+    if wrapper.inner.is_some() {
+        let context = wrapper.inner.as_ref().expect("context not open");
+        configure::dc_stop_ongoing_process(context)
+    }
 }
 
+/// Check a scanned QR code.
+///
+/// The function should be called after a QR code is scanned.  The
+/// function takes the raw text scanned and checks what can be done
+/// with it.
+///
+/// The QR code state is returned in dc_lot_t::state as:
+///
+/// - DC_QR_ASK_VERIFYCONTACT with dc_lot_t::id=Contact ID
+/// - DC_QR_ASK_VERIFYGROUP withdc_lot_t::text1=Group name
+/// - DC_QR_FPR_OK with dc_lot_t::id=Contact ID
+/// - DC_QR_FPR_MISMATCH with dc_lot_t::id=Contact ID
+/// - DC_QR_FPR_WITHOUT_ADDR with dc_lot_t::test1=Formatted fingerprint
+/// - DC_QR_ADDR with dc_lot_t::id=Contact ID
+/// - DC_QR_TEXT with dc_lot_t::text1=Text
+/// - DC_QR_URL with dc_lot_t::text1=URL
+/// - DC_QR_ERROR with dc_lot_t::text1=Error string
+///
+/// @memberof [dc_context_t]
+/// @param context The context object.
+/// @param qr The text of the scanned QR code.
+///
+/// Returns the parsed QR code as a [dc_lot_t] object. The returned
+/// object must be freed using [dc_lot_unref] after usage.
 #[no_mangle]
 pub unsafe extern "C" fn dc_check_qr(
     context: *mut dc_context_t,
@@ -1306,13 +2936,32 @@ pub unsafe extern "C" fn dc_check_qr(
         eprintln!("ignoring careless call to dc_check_qr()");
         return ptr::null_mut();
     }
-
-    let context = &*context;
-
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let lot = qr::check_qr(context, as_str(qr));
     Box::into_raw(Box::new(lot))
 }
 
+/// Get QR code text that will offer an secure-join verification.
+///
+/// The QR code is compatible to the OPENPGP4FPR format so that a
+/// basic fingerprint comparison also works eg. with OpenKeychain.
+///
+/// The scanning device will pass the scanned content to [dc_check_qr] then;
+/// if this function returns DC_QR_ASK_VERIFYCONTACT or DC_QR_ASK_VERIFYGROUP
+/// an out-of-band-verification can be joined using [dc_join_securejoin].
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object.
+/// @param group_chat_id If set to a group-chat-id,
+///     the group-join-protocol is offered in the QR code;
+///     works for verified groups as well as for normal groups.
+///     If set to 0, the setup-Verified-contact-protocol is offered in the QR code.
+///
+/// Returns text that should go to the QR code, On errors, an empty QR
+/// code is returned, NULL is never returned.  The returned string
+/// must be free()'d after usage.
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_securejoin_qr(
     context: *mut dc_context_t,
@@ -1322,13 +2971,31 @@ pub unsafe extern "C" fn dc_get_securejoin_qr(
         eprintln!("ignoring careless call to dc_get_securejoin_qr()");
         return "".strdup();
     }
-
-    let context = &*context;
-    securejoin::dc_get_securejoin_qr(context, chat_id)
-        .unwrap_or("".to_string())
-        .strdup()
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
+    dc_securejoin::dc_get_securejoin_qr(context, chat_id)
 }
 
+/// Join an out-of-band-verification initiated on another device with
+/// [dc_get_securejoin_qr].
+///
+/// This function is typically called when dc_check_qr() returns
+/// lot.state=DC_QR_ASK_VERIFYCONTACT or
+/// lot.state=DC_QR_ASK_VERIFYGROUP.
+///
+/// This function takes some time and sends and receives several messages.
+/// You should call it in a separate thread; if you want to abort it, you should
+/// call [dc_stop_ongoing_process].
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object
+/// @param qr The text of the scanned QR code. Typically, the same string as given
+///     to dc_check_qr().
+///
+/// Returns the chat-id of the joined chat, the UI may redirect to the
+/// this chat.  If the out-of-band verification failed or was aborted,
+/// `0` is returned.
 #[no_mangle]
 pub unsafe extern "C" fn dc_join_securejoin(
     context: *mut dc_context_t,
@@ -1338,12 +3005,27 @@ pub unsafe extern "C" fn dc_join_securejoin(
         eprintln!("ignoring careless call to dc_join_securejoin()");
         return 0;
     }
-
-    let context = &*context;
-
-    securejoin::dc_join_securejoin(context, as_str(qr))
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
+    dc_securejoin::dc_join_securejoin(context, qr)
 }
 
+/// Enable or disable location streaming for a chat.
+///
+/// Locations are sent to all members of the chat for the given number
+/// of seconds; after that, location streaming is automatically
+/// disabled for the chat.  The current location streaming state of a
+/// chat can be checked using [dc_is_sending_locations_to_chat].
+///
+/// The locations that should be sent to the chat can be set using
+/// [dc_set_location].
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object.
+/// @param chat_id Chat id to enable location streaming for.
+/// @param seconds >0: enable location streaming for the given number of seconds;
+///     0: disable location streaming.
 #[no_mangle]
 pub unsafe extern "C" fn dc_send_locations_to_chat(
     context: *mut dc_context_t,
@@ -1354,12 +3036,25 @@ pub unsafe extern "C" fn dc_send_locations_to_chat(
         eprintln!("ignoring careless call to dc_send_locations_to_chat()");
         return;
     }
-
-    let context = &*context;
-
-    location::send_locations_to_chat(context, chat_id, seconds as i64)
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
+    dc_location::dc_send_locations_to_chat(context, chat_id, seconds as i64)
 }
 
+/// Check if location streaming is enabled.
+///
+/// Location stream can be enabled or disabled using
+/// [dc_send_locations_to_chat].  If you have already a [dc_chat_t]
+/// object, [dc_chat_is_sending_locations] may be more handy.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object.
+/// @param chat_id >0: Check if location streaming is enabled for the given chat.
+///     0: Check of location streaming is enabled for any chat.
+///
+/// Returns `1`: location streaming is enabled for the given chat(s);
+/// `0`: location streaming is disabled for the given chat(s).
 #[no_mangle]
 pub unsafe extern "C" fn dc_is_sending_locations_to_chat(
     context: *mut dc_context_t,
@@ -1369,12 +3064,39 @@ pub unsafe extern "C" fn dc_is_sending_locations_to_chat(
         eprintln!("ignoring careless call to dc_is_sending_locations_to_chat()");
         return 0;
     }
-
-    let context = &*context;
-
-    location::is_sending_locations_to_chat(context, chat_id) as libc::c_int
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
+    dc_location::dc_is_sending_locations_to_chat(context, chat_id) as libc::c_int
 }
 
+/// Sets current location.
+///
+/// The location is sent to all chats where location streaming is
+/// enabled using [dc_send_locations_to_chat].
+///
+/// Typically results in the event #DC_EVENT_LOCATION_CHANGED with
+/// contact_id set to DC_CONTACT_ID_SELF.
+///
+/// The UI should call this function on all location changes.  The
+/// locations set by this function are not sent immediately, instead a
+/// message with the last locations is sent out every some minutes or
+/// when the user sends out a normal message, the last locations are
+/// attached.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object.
+/// @param latitude North-south position of the location.
+///     Set to 0.0 if the latitude is not known.
+/// @param longitude East-west position of the location.
+///     Set to 0.0 if the longitude is not known.
+/// @param accuracy Estimated accuracy of the location, radial, in meters.
+///     Set to 0.0 if the accuracy is not known.
+///
+/// Returns `1`: location streaming is still enabled for at least one
+/// chat, this dc_set_location() should be called as soon as the
+/// location changes; `0`: location streaming is no longer needed,
+/// [dc_is_sending_locations_to_chat] is false for all chats.
 #[no_mangle]
 pub unsafe extern "C" fn dc_set_location(
     context: *mut dc_context_t,
@@ -1386,12 +3108,72 @@ pub unsafe extern "C" fn dc_set_location(
         eprintln!("ignoring careless call to dc_set_location()");
         return 0;
     }
-
-    let context = &*context;
-
-    location::set(context, latitude, longitude, accuracy)
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
+    dc_location::dc_set_location(context, latitude, longitude, accuracy)
 }
 
+/// Get shared locations from the database.
+///
+/// The locations can be filtered by the chat-id, the contact-id and
+/// by a timespan.
+///
+/// The number of returned locations can be retrieved using
+/// [dc_array_get_cnt].  To get information for each location, use
+/// [dc_array_get_latitude], [dc_array_get_longitude],
+/// [dc_array_get_accuracy], [dc_array_get_timestamp],
+/// [dc_array_get_contact_id] and [dc_array_get_msg_id].  The latter
+/// returns 0 if there is no message bound to the location.
+///
+/// Note that only if [dc_array_is_independent] returns 0, the
+/// location is the current or a past position of the user.  If
+/// [dc_array_is_independent] returns 1, the location is any location
+/// on earth that is marked by the user.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object.
+/// @param chat_id Chat-id to get location information for.
+///     0 to get locations independently of the chat.
+/// @param contact_id Contact-id to get location information for.
+///     If also a chat-id is given, this should be a member of the given chat.
+///     0 to get locations independently of the contact.
+/// @param timestamp_from Start of timespan to return.
+///     Must be given in number of seconds since 00:00 hours, Jan 1, 1970 UTC.
+///     0 for "start from the beginning".
+/// @param timestamp_to End of timespan to return.
+///     Must be given in number of seconds since 00:00 hours, Jan 1, 1970 UTC.
+///     0 for "all up to now".
+///
+/// Returns an array of locations, NULL is never returned.  The array
+/// is sorted decending; the first entry in the array is the location
+/// with the newest timestamp.  Note that this is only realated to the
+/// recent postion of the user if dc_array_is_independent() returns
+/// `0`.  The returned array must be freed using [dc_array_unref].
+///
+/// # Example
+///
+/// ```c
+/// // get locations from the last hour for a global map
+/// dc_array_t* loc = dc_get_locations(context, 0, 0, time(NULL)-60*60, 0);
+/// for (int i=0; i<dc_array_get_cnt(); i++) {
+///     double lat = dc_array_get_latitude(loc, i);
+///     ...
+/// }
+/// dc_array_unref(loc);
+///
+/// // get locations from a contact for a global map
+/// dc_array_t* loc = dc_get_locations(context, 0, contact_id, 0, 0);
+/// ...
+///
+/// // get all locations known for a given chat
+/// dc_array_t* loc = dc_get_locations(context, chat_id, 0, 0, 0);
+/// ...
+///
+/// // get locations from a single contact for a given chat
+/// dc_array_t* loc = dc_get_locations(context, chat_id, contact_id, 0, 0);
+/// ...
+/// ```
 #[no_mangle]
 pub unsafe extern "C" fn dc_get_locations(
     context: *mut dc_context_t,
@@ -1404,10 +3186,9 @@ pub unsafe extern "C" fn dc_get_locations(
         eprintln!("ignoring careless call to dc_get_locations()");
         return ptr::null_mut();
     }
-
-    let context = &*context;
-
-    let res = location::get_range(
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
+    let res = dc_location::dc_get_locations(
         context,
         chat_id,
         contact_id,
@@ -1417,16 +3198,25 @@ pub unsafe extern "C" fn dc_get_locations(
     Box::into_raw(Box::new(dc_array_t::from(res)))
 }
 
+/// Delete all locations on the current device.
+///
+/// Locations already sent cannot be deleted.
+///
+/// Typically results in the event #DC_EVENT_LOCATION_CHANGED with
+/// contact_id set to 0.
+///
+/// @memberof [dc_context_t]
+///
+/// @param context The context object.
 #[no_mangle]
 pub unsafe extern "C" fn dc_delete_all_locations(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_delete_all_locations()");
         return;
     }
-
-    let context = &*context;
-
-    location::delete_all(context).log_err(context, "Failed to delete locations");
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
+    dc_location::dc_delete_all_locations(context);
 }
 
 // dc_array_t
@@ -1704,7 +3494,10 @@ pub unsafe extern "C" fn dc_chatlist_get_context(
 
     let list = &*chatlist;
 
-    list.get_context() as *const _
+    let context: &Context = list.get_context();
+    let userdata_ptr = context.userdata as *const ContextWrapper;
+    let wrapper: &ContextWrapper = &*userdata_ptr;
+    wrapper
 }
 
 // dc_chat_t
@@ -1871,10 +3664,9 @@ pub unsafe extern "C" fn dc_msg_new<'a>(
         eprintln!("ignoring careless call to dc_msg_new()");
         return ptr::null_mut();
     }
-
-    let context = &*context;
+    let wrapper: &ContextWrapper = &*context;
+    let context = wrapper.inner.as_ref().expect("context not open");
     let viewtype = from_prim(viewtype).expect(&format!("invalid viewtype = {}", viewtype));
-
     Box::into_raw(Box::new(message::dc_msg_new(context, viewtype)))
 }
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -4061,11 +4061,10 @@ pub unsafe extern "C" fn dc_msg_get_showpadlock(msg: *mut dc_msg_t) -> libc::c_i
     msg.rent(|m| message::dc_msg_get_showpadlock(m))
 }
 
-// TODO: how does this work?
 #[no_mangle]
-pub unsafe extern "C" fn dc_msg_get_summary<'a>(
-    msg: *mut dc_msg_t<'a>,
-    chat: *mut dc_chat_t<'a>,
+pub unsafe extern "C" fn dc_msg_get_summary(
+    msg: *mut dc_msg_t,
+    chat: *mut dc_chat_t,
 ) -> *mut dc_lot_t {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_summary()");
@@ -4082,10 +4081,6 @@ pub unsafe extern "C" fn dc_msg_get_summary<'a>(
     };
     Box::into_raw(Box::new(lot))
 }
-
-// fn msg_get_summary<'a>(msg: &'a MessageWrapper, chat: Option<&chat::Chat>) -> lot::Lot {
-//     msg.rent_mut(|m: &'a mut message::Message<'a>| message::dc_msg_get_summary(m, chat))
-// }
 
 #[no_mangle]
 pub unsafe extern "C" fn dc_msg_get_summarytext(

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -4072,15 +4072,14 @@ pub unsafe extern "C" fn dc_msg_get_summary<'a>(
         return ptr::null_mut();
     }
     let ffi_msg = &mut *msg;
-    // let lot = ffi_msg.rent_mut(|m| {
-    //     if chat.is_null() {
-    //         message::dc_msg_get_summary(m, None)
-    //     } else {
-    //         let ffi_chat = &*chat;
-    //         ffi_chat.rent(|c| message::dc_msg_get_summary(m, Some(c)))
-    //     }
-    // });
-    let lot = ffi_msg.rent_mut(|m| message::dc_msg_get_summary(m, None));
+    let lot = if chat.is_null() {
+        ffi_msg.rent_mut(|m| message::dc_msg_get_summary(m, None))
+    } else {
+        ffi_msg.rent_mut(|m| {
+            let ffi_chat = &*chat;
+            ffi_chat.rent(|c| message::dc_msg_get_summary(m, Some(c)))
+        })
+    };
     Box::into_raw(Box::new(lot))
 }
 

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -391,8 +391,6 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             _ => println!(
                 "==========================Database commands==\n\
                  info\n\
-                 open <file to open or create>\n\
-                 close\n\
                  set <configuration-key> [<value>]\n\
                  get <configuration-key>\n\
                  oauth2\n\
@@ -455,13 +453,19 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                  ============================================="
             ),
         },
-        "open" => {
-            ensure!(!arg1.is_empty(), "Argument <file> missing");
-            dc_close(context);
-            ensure!(dc_open(context, arg1, None), "Open failed");
-        }
-        "close" => {
-            dc_close(context);
+        "auth" => {
+            if 0 == S_IS_AUTH {
+                let is_pw = context
+                    .get_config(config::Config::MailPw)
+                    .unwrap_or_default();
+                if arg1 == is_pw {
+                    S_IS_AUTH = 1;
+                } else {
+                    println!("Bad password.");
+                }
+            } else {
+                println!("Already authorized.");
+            }
         }
         "initiate-key-transfer" => {
             let setup_code = dc_initiate_key_transfer(context);

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -453,20 +453,6 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                  ============================================="
             ),
         },
-        "auth" => {
-            if 0 == S_IS_AUTH {
-                let is_pw = context
-                    .get_config(config::Config::MailPw)
-                    .unwrap_or_default();
-                if arg1 == is_pw {
-                    S_IS_AUTH = 1;
-                } else {
-                    println!("Bad password.");
-                }
-            } else {
-                println!("Already authorized.");
-            }
-        }
         "initiate-key-transfer" => {
             let setup_code = dc_initiate_key_transfer(context);
             if !setup_code.is_null() {

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -16,7 +16,6 @@ extern crate rusqlite;
 use std::borrow::Cow::{self, Borrowed, Owned};
 use std::io::{self, Write};
 use std::process::Command;
-use std::ptr;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
@@ -388,7 +387,6 @@ impl Highlighter for DcHelper {
 impl Helper for DcHelper {}
 
 fn main_0(args: Vec<String>) -> Result<(), failure::Error> {
-    unsafe { dc_cmdline_skip_auth() };
     if args.len() != 2 {
         println!("Error: Bad arguments, expected [db-name].");
         return Err(format_err!("No db-name specified"));

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -16,9 +16,8 @@ use deltachat::job::{
     perform_imap_fetch, perform_imap_idle, perform_imap_jobs, perform_smtp_idle, perform_smtp_jobs,
 };
 
-extern "C" fn cb(_ctx: &Context, event: Event, data1: usize, data2: usize) -> usize {
+fn cb(_ctx: &Context, event: Event, data1: usize, data2: usize) -> usize {
     println!("[{:?}]", event);
-
     match event {
         Event::CONFIGURE_PROGRESS => {
             println!("  progress: {}", data1);
@@ -39,7 +38,11 @@ extern "C" fn cb(_ctx: &Context, event: Event, data1: usize, data2: usize) -> us
 
 fn main() {
     unsafe {
-        let ctx = dc_context_new(Some(cb), std::ptr::null_mut(), None);
+        let dir = tempdir().unwrap();
+        let dbfile = dir.path().join("db.sqlite");
+        println!("creating database {:?}", dbfile);
+        let ctx =
+            Context::new(Box::new(cb), "FakeOs".into(), dbfile).expect("Failed to create context");
         let running = Arc::new(RwLock::new(true));
         let info = dc_get_info(&ctx);
         let info_s = CStr::from_ptr(info);
@@ -72,13 +75,6 @@ fn main() {
                 }
             }
         });
-
-        let dir = tempdir().unwrap();
-        let dbfile = dir.path().join("db.sqlite");
-
-        println!("opening database {:?}", dbfile);
-
-        assert!(dc_open(&ctx, dbfile.to_str().unwrap(), None));
 
         println!("configuring");
         let args = std::env::args().collect::<Vec<String>>();

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -17,11 +17,19 @@ def test_callback_None2int():
     clear_context_callback(ctx)
 
 
-def test_dc_close_events():
-    ctx = capi.lib.dc_context_new(capi.lib.py_dc_callback, ffi.NULL, ffi.NULL)
+def test_dc_close_events(tmpdir):
+    ctx = ffi.gc(
+        capi.lib.dc_context_new(capi.lib.py_dc_callback, ffi.NULL, ffi.NULL),
+        lib.dc_context_unref,
+    )
     evlog = EventLogger(ctx)
     evlog.set_timeout(5)
-    set_context_callback(ctx, lambda ctx, evt_name, data1, data2: evlog(evt_name, data1, data2))
+    set_context_callback(
+        ctx,
+        lambda ctx, evt_name, data1, data2: evlog(evt_name, data1, data2),
+    )
+    p = tmpdir.join("hello.db")
+    lib.dc_open(ctx, p.strpath.encode("ascii"), ffi.NULL)
     capi.lib.dc_close(ctx)
 
     def find(info_string):

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,3 +1,5 @@
+use std::ffi::OsString;
+use std::path::Path;
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 
 use crate::chat::*;
@@ -6,6 +8,7 @@ use crate::contact::*;
 use crate::dc_loginparam::*;
 use crate::dc_receive_imf::*;
 use crate::dc_tools::*;
+use crate::error::*;
 use crate::imap::*;
 use crate::job::*;
 use crate::job_thread::JobThread;
@@ -21,6 +24,15 @@ use std::ptr;
 
 use std::path::PathBuf;
 
+/// Callback function type for [Context].
+///
+/// @param context The context object as returned by dc_context_new().
+/// @param event one of the @ref DC_EVENT constants
+/// @param data1 depends on the event parameter
+/// @param data2 depends on the event parameter
+/// @return return 0 unless stated otherwise in the event parameter documentation
+pub type ContextCallback = dyn Fn(&Context, Event, uintptr_t, uintptr_t) -> uintptr_t;
+
 pub struct Context {
     pub userdata: *mut libc::c_void,
     pub dbfile: Arc<RwLock<Option<PathBuf>>>,
@@ -34,7 +46,7 @@ pub struct Context {
     pub smtp: Arc<Mutex<Smtp>>,
     pub smtp_state: Arc<(Mutex<SmtpState>, Condvar)>,
     pub oauth2_critical: Arc<Mutex<()>>,
-    pub cb: Option<dc_callback_t>,
+    pub cb: Box<ContextCallback>,
     pub os_name: Option<String>,
     pub cmdline_sel_chat_id: Arc<RwLock<u32>>,
     pub bob: Arc<RwLock<BobStatus>>,
@@ -54,6 +66,76 @@ pub struct RunningState {
 }
 
 impl Context {
+    pub fn new(cb: Box<ContextCallback>, os_name: String, dbfile: PathBuf) -> Result<Context> {
+        let mut blob_fname = OsString::new();
+        blob_fname.push(dbfile.file_name().unwrap_or_default());
+        blob_fname.push("-blobs");
+        let blobdir = dbfile.with_file_name(blob_fname);
+        if !blobdir.exists() {
+            std::fs::create_dir_all(&blobdir)?;
+        }
+        Context::with_blobdir(cb, os_name, dbfile, &blobdir)
+    }
+
+    pub fn with_blobdir(
+        cb: Box<ContextCallback>,
+        os_name: String,
+        dbfile: PathBuf,
+        blobdir: &Path,
+    ) -> Result<Context> {
+        if !blobdir.is_dir() {
+            return Err(format_err!("Blobdir does not exist: {}", blobdir.display()));
+        }
+        let ctx = Context {
+            blobdir: Arc::new(RwLock::new(unsafe { blobdir.strdup() })),
+            dbfile: Arc::new(RwLock::new(Some(dbfile))),
+            inbox: Arc::new(RwLock::new({
+                Imap::new(
+                    cb_get_config,
+                    cb_set_config,
+                    cb_precheck_imf,
+                    cb_receive_imf,
+                )
+            })),
+            userdata: std::ptr::null_mut(),
+            cb,
+            os_name: Some(os_name),
+            running_state: Arc::new(RwLock::new(Default::default())),
+            sql: Sql::new(),
+            smtp: Arc::new(Mutex::new(Smtp::new())),
+            smtp_state: Arc::new((Mutex::new(Default::default()), Condvar::new())),
+            oauth2_critical: Arc::new(Mutex::new(())),
+            bob: Arc::new(RwLock::new(Default::default())),
+            last_smeared_timestamp: Arc::new(RwLock::new(0)),
+            cmdline_sel_chat_id: Arc::new(RwLock::new(0)),
+            sentbox_thread: Arc::new(RwLock::new(JobThread::new(
+                "SENTBOX",
+                "configured_sentbox_folder",
+                Imap::new(
+                    cb_get_config,
+                    cb_set_config,
+                    cb_precheck_imf,
+                    cb_receive_imf,
+                ),
+            ))),
+            mvbox_thread: Arc::new(RwLock::new(JobThread::new(
+                "MVBOX",
+                "configured_mvbox_folder",
+                Imap::new(
+                    cb_get_config,
+                    cb_set_config,
+                    cb_precheck_imf,
+                    cb_receive_imf,
+                ),
+            ))),
+            probe_imap_network: Arc::new(RwLock::new(false)),
+            perform_inbox_jobs_needed: Arc::new(RwLock::new(false)),
+            generating_key_mutex: Mutex::new(()),
+        };
+        ctx.sql.open(&ctx, &ctx.dbfile.read().unwrap().as_ref().unwrap(), 0)?;
+        Ok(ctx)
+    }
+
     pub fn has_dbfile(&self) -> bool {
         self.get_dbfile().is_some()
     }
@@ -73,11 +155,7 @@ impl Context {
     }
 
     pub fn call_cb(&self, event: Event, data1: uintptr_t, data2: uintptr_t) -> uintptr_t {
-        if let Some(cb) = self.cb {
-            unsafe { cb(self, event, data1, data2) }
-        } else {
-            0
-        }
+        (*self.cb)(self, event, data1, data2)
     }
 }
 
@@ -112,60 +190,6 @@ pub struct SmtpState {
     pub doing_jobs: bool,
     pub perform_jobs_needed: i32,
     pub probe_network: bool,
-}
-
-// create/open/config/information
-pub fn dc_context_new(
-    cb: Option<dc_callback_t>,
-    userdata: *mut libc::c_void,
-    os_name: Option<String>,
-) -> Context {
-    Context {
-        blobdir: Arc::new(RwLock::new(std::ptr::null_mut())),
-        dbfile: Arc::new(RwLock::new(None)),
-        inbox: Arc::new(RwLock::new({
-            Imap::new(
-                cb_get_config,
-                cb_set_config,
-                cb_precheck_imf,
-                cb_receive_imf,
-            )
-        })),
-        userdata,
-        cb,
-        os_name,
-        running_state: Arc::new(RwLock::new(Default::default())),
-        sql: Sql::new(),
-        smtp: Arc::new(Mutex::new(Smtp::new())),
-        smtp_state: Arc::new((Mutex::new(Default::default()), Condvar::new())),
-        oauth2_critical: Arc::new(Mutex::new(())),
-        bob: Arc::new(RwLock::new(Default::default())),
-        last_smeared_timestamp: Arc::new(RwLock::new(0)),
-        cmdline_sel_chat_id: Arc::new(RwLock::new(0)),
-        sentbox_thread: Arc::new(RwLock::new(JobThread::new(
-            "SENTBOX",
-            "configured_sentbox_folder",
-            Imap::new(
-                cb_get_config,
-                cb_set_config,
-                cb_precheck_imf,
-                cb_receive_imf,
-            ),
-        ))),
-        mvbox_thread: Arc::new(RwLock::new(JobThread::new(
-            "MVBOX",
-            "configured_mvbox_folder",
-            Imap::new(
-                cb_get_config,
-                cb_set_config,
-                cb_precheck_imf,
-                cb_receive_imf,
-            ),
-        ))),
-        probe_imap_network: Arc::new(RwLock::new(false)),
-        perform_inbox_jobs_needed: Arc::new(RwLock::new(false)),
-        generating_key_mutex: Mutex::new(()),
-    }
 }
 
 unsafe fn cb_receive_imf(
@@ -286,39 +310,8 @@ pub unsafe fn dc_close(context: &Context) {
     *blobdir = ptr::null_mut();
 }
 
-pub unsafe fn dc_is_open(context: &Context) -> libc::c_int {
-    context.sql.is_open() as libc::c_int
-}
-
 pub unsafe fn dc_get_userdata(context: &mut Context) -> *mut libc::c_void {
     context.userdata as *mut _
-}
-
-pub unsafe fn dc_open(context: &Context, dbfile: &str, blobdir: Option<&str>) -> bool {
-    let mut success = false;
-    if 0 != dc_is_open(context) {
-        return false;
-    }
-
-    *context.dbfile.write().unwrap() = Some(PathBuf::from(dbfile));
-    let blobdir = blobdir.unwrap_or_default();
-    if !blobdir.is_empty() {
-        let dir = dc_ensure_no_slash_safe(blobdir).strdup();
-        *context.blobdir.write().unwrap() = dir;
-    } else {
-        let dir = dbfile.to_string() + "-blobs";
-        dc_create_folder(context, &dir);
-        *context.blobdir.write().unwrap() = dir.strdup();
-    }
-    // Create/open sqlite database, this may already use the blobdir
-    let dbfile_path = std::path::Path::new(dbfile);
-    if context.sql.open(context, dbfile_path, 0) {
-        success = true
-    }
-    if !success {
-        dc_close(context);
-    }
-    success
 }
 
 pub unsafe fn dc_get_blobdir(context: &Context) -> *mut libc::c_char {
@@ -617,19 +610,70 @@ pub fn do_heuristics_moves(context: &Context, folder: &str, msg_id: u32) {
 mod tests {
     use super::*;
 
+    use crate::test_utils::*;
+
+    #[test]
+    fn test_wrong_db() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dbfile = tmp.path().join("db.sqlite");
+        std::fs::write(&dbfile, b"123").unwrap();
+        let res = Context::new(Box::new(|_, _, _, _| 0), "FakeOs".into(), dbfile);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_blobdir_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dbfile = tmp.path().join("db.sqlite");
+        Context::new(Box::new(|_, _, _, _| 0), "FakeOS".into(), dbfile).unwrap();
+        let blobdir = tmp.path().join("db.sqlite-blobs");
+        assert!(blobdir.is_dir());
+    }
+
+    #[test]
+    fn test_wrong_blogdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dbfile = tmp.path().join("db.sqlite");
+        let blobdir = tmp.path().join("db.sqlite-blobs");
+        std::fs::write(&blobdir, b"123").unwrap();
+        let res = Context::new(Box::new(|_, _, _, _| 0), "FakeOS".into(), dbfile);
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn test_sqlite_parent_not_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let subdir = tmp.path().join("subdir");
+        let dbfile = subdir.join("db.sqlite");
+        let dbfile2 = dbfile.clone();
+        Context::new(Box::new(|_, _, _, _| 0), "FakeOS".into(), dbfile).unwrap();
+        assert!(subdir.is_dir());
+        assert!(dbfile2.is_file());
+    }
+
+    #[test]
+    fn test_with_blobdir_not_exists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dbfile = tmp.path().join("db.sqlite");
+        let blobdir = tmp.path().join("blobs");
+        let res =
+            Context::with_blobdir(Box::new(|_, _, _, _| 0), "FakeOS".into(), dbfile, &blobdir);
+        assert!(res.is_err());
+    }
+
     #[test]
     fn no_crashes_on_context_deref() {
-        let ctx = dc_context_new(None, std::ptr::null_mut(), Some("Test OS".into()));
-        std::mem::drop(ctx);
+        let t = dummy_context();
+        std::mem::drop(t.ctx);
     }
 
     #[test]
     fn test_context_double_close() {
-        let ctx = dc_context_new(None, std::ptr::null_mut(), None);
+        let t = dummy_context();
         unsafe {
-            dc_close(&ctx);
-            dc_close(&ctx);
+            dc_close(&t.ctx);
+            dc_close(&t.ctx);
         }
-        std::mem::drop(ctx);
+        std::mem::drop(t.ctx);
     }
 }

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -74,7 +74,7 @@ pub unsafe fn dc_imex_has_backup(
                 let name = name.to_string_lossy();
                 if name.starts_with("delta-chat") && name.ends_with(".bak") {
                     let sql = Sql::new();
-                    if sql.open(context, &path, 0x1) {
+                    if sql.open(context, &path, 0x1).is_ok() {
                         let curr_backup_time =
                             sql.get_config_int(context, "backup_time")
                                 .unwrap_or_default() as u64;
@@ -612,9 +612,10 @@ unsafe fn import_backup(context: &Context, backup_to_import: *const libc::c_char
     }
     /* error already logged */
     /* re-open copied database file */
-    if !context
+    if context
         .sql
         .open(&context, &context.get_dbfile().unwrap(), 0)
+        .is_err()
     {
         return 0;
     }
@@ -705,7 +706,7 @@ unsafe fn import_backup(context: &Context, backup_to_import: *const libc::c_char
 /* the FILE_PROGRESS macro calls the callback with the permille of files processed.
 The macro avoids weird values of 0% or 100% while still working. */
 // TODO should return bool /rtn
-#[allow(non_snake_case)]
+#[allow(non_snake_case, unused_must_use)]
 unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_int {
     let mut ok_to_continue: bool;
     let mut success: libc::c_int = 0;
@@ -752,7 +753,7 @@ unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_
         /* add all files as blobs to the database copy (this does not require the source to be locked, neigher the destination as it is used only here) */
         /*for logging only*/
         let sql = Sql::new();
-        if sql.open(context, as_path(dest_pathNfilename), 0) {
+        if sql.open(context, as_path(dest_pathNfilename), 0).is_ok() {
             if !sql.table_exists("backup_blobs") {
                 if sql::execute(
                     context,
@@ -1141,7 +1142,7 @@ mod tests {
 
     #[test]
     fn test_render_setup_file() {
-        let t = test_context(Some(logging_cb));
+        let t = test_context(Some(Box::new(logging_cb)));
 
         configure_alice_keypair(&t.ctx);
         let msg = dc_render_setup_file(&t.ctx, "hello").unwrap();
@@ -1159,14 +1160,9 @@ mod tests {
         assert!(msg.contains("-----END PGP MESSAGE-----\n"));
     }
 
-    unsafe extern "C" fn ac_setup_msg_cb(
-        ctx: &Context,
-        evt: Event,
-        d1: uintptr_t,
-        d2: uintptr_t,
-    ) -> uintptr_t {
+    fn ac_setup_msg_cb(ctx: &Context, evt: Event, d1: uintptr_t, d2: uintptr_t) -> uintptr_t {
         if evt == Event::GET_STRING && d1 == StockMessage::AcSetupMsgBody.to_usize().unwrap() {
-            "hello\r\nthere".strdup() as usize
+            unsafe { "hello\r\nthere".strdup() as usize }
         } else {
             logging_cb(ctx, evt, d1, d2)
         }
@@ -1174,7 +1170,7 @@ mod tests {
 
     #[test]
     fn test_render_setup_file_newline_replace() {
-        let t = test_context(Some(ac_setup_msg_cb));
+        let t = test_context(Some(Box::new(ac_setup_msg_cb)));
         configure_alice_keypair(&t.ctx);
         let msg = dc_render_setup_file(&t.ctx, "pw").unwrap();
         println!("{}", &msg);

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -8,13 +8,12 @@ use std::{fmt, fs, ptr};
 use chrono::{Local, TimeZone};
 use mmime::mailimf_types::*;
 use rand::{thread_rng, Rng};
+use itertools::max;
 
 use crate::context::Context;
 use crate::error::Error;
 use crate::types::*;
 use crate::x::*;
-
-use itertools::max;
 
 /* Some tools and enhancements to the used libraries, there should be
 no references to Context and other "larger" classes here. */
@@ -1182,7 +1181,7 @@ impl CStringExt for CString {}
 /// Rust strings to raw C strings.  This can be clumsy to do correctly
 /// and the compiler sometimes allows it in an unsafe way.  These
 /// methods make it more succinct and help you get it right.
-pub trait StrExt {
+pub trait Strdup {
     /// Allocate a new raw C `*char` version of this string.
     ///
     /// This allocates a new raw C string which must be freed using
@@ -1199,9 +1198,22 @@ pub trait StrExt {
     unsafe fn strdup(&self) -> *mut libc::c_char;
 }
 
-impl<T: AsRef<str>> StrExt for T {
+impl<T: AsRef<str>> Strdup for T {
     unsafe fn strdup(&self) -> *mut libc::c_char {
         let tmp = CString::yolo(self.as_ref());
+        dc_strdup(tmp.as_ptr())
+    }
+}
+
+impl Strdup for CStr {
+    unsafe fn strdup(&self) -> *mut libc::c_char {
+        dc_strdup(self.as_ptr())
+    }
+}
+
+impl Strdup for std::path::Path {
+    unsafe fn strdup(&self) -> *mut libc::c_char {
+        let tmp = self.to_c_string().unwrap();
         dc_strdup(tmp.as_ptr())
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -733,7 +733,7 @@ pub fn dc_msg_get_showpadlock(msg: &Message) -> libc::c_int {
     0
 }
 
-pub unsafe fn dc_msg_get_summary<'a>(msg: &mut Message<'a>, chat: Option<&Chat<'a>>) -> Lot {
+pub unsafe fn dc_msg_get_summary<'a, 'b>(msg: &mut Message<'a>, chat: Option<&Chat<'b>>) -> Lot {
     let mut ret = Lot::new();
 
     let chat_loaded: Chat;

--- a/src/message.rs
+++ b/src/message.rs
@@ -733,7 +733,7 @@ pub fn dc_msg_get_showpadlock(msg: &Message) -> libc::c_int {
     0
 }
 
-pub unsafe fn dc_msg_get_summary<'a, 'b>(msg: &mut Message<'a>, chat: Option<&Chat<'b>>) -> Lot {
+pub unsafe fn dc_msg_get_summary(msg: &mut Message, chat: Option<&Chat>) -> Lot {
     let mut ret = Lot::new();
 
     let chat_loaded: Chat;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -38,16 +38,13 @@ impl Sql {
         info!(context, 0, "Database closed.");
     }
 
-    // return true on success, false on failure
-    pub fn open(&self, context: &Context, dbfile: &std::path::Path, flags: libc::c_int) -> bool {
-        match open(context, self, dbfile, flags) {
-            Ok(_) => true,
-            Err(Error::SqlAlreadyOpen) => false,
-            Err(_) => {
-                self.close(context);
-                false
-            }
-        }
+    pub fn open(
+        &self,
+        context: &Context,
+        dbfile: &std::path::Path,
+        flags: libc::c_int,
+    ) -> Result<()> {
+        open(context, self, dbfile, flags)
     }
 
     pub fn execute<P>(&self, sql: &str, params: P) -> Result<usize>
@@ -227,7 +224,10 @@ impl Sql {
         match res {
             Ok(_) => Ok(()),
             Err(err) => {
-                error!(context, 0, "set_config(): Cannot change value. {:?}", &err);
+                error!(
+                    context,
+                    0, "set_config(): Cannot change value for {}: {:?}", key, &err
+                );
                 Err(err.into())
             }
         }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,20 +1,8 @@
 #![allow(non_camel_case_types)]
-use crate::constants::Event;
 use crate::context::Context;
 
 pub use mmime::clist::*;
 pub use rusqlite::ffi::*;
-
-/// Callback function that should be given to dc_context_new().
-///
-/// @memberof Context
-/// @param context The context object as returned by dc_context_new().
-/// @param event one of the @ref DC_EVENT constants
-/// @param data1 depends on the event parameter
-/// @param data2 depends on the event parameter
-/// @return return 0 unless stated otherwise in the event parameter documentation
-pub type dc_callback_t =
-    unsafe extern "C" fn(_: &Context, _: Event, _: uintptr_t, _: uintptr_t) -> uintptr_t;
 
 pub type dc_receive_imf_t = unsafe fn(
     _: &Context,

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -695,19 +695,17 @@ fn test_get_contacts() {
 
 #[test]
 fn test_chat() {
-    unsafe {
-        let context = create_test_context();
-        let contact1 = Contact::create(&context.ctx, "bob", "bob@mail.de").unwrap();
-        assert_ne!(contact1, 0);
+    let context = create_test_context();
+    let contact1 = Contact::create(&context.ctx, "bob", "bob@mail.de").unwrap();
+    assert_ne!(contact1, 0);
 
-        let chat_id = chat::create_by_contact_id(&context.ctx, contact1).unwrap();
-        assert!(chat_id > 9, "chat_id too small {}", chat_id);
-        let chat = Chat::load_from_db(&context.ctx, chat_id).unwrap();
+    let chat_id = chat::create_by_contact_id(&context.ctx, contact1).unwrap();
+    assert!(chat_id > 9, "chat_id too small {}", chat_id);
+    let chat = Chat::load_from_db(&context.ctx, chat_id).unwrap();
 
-        let chat2_id = chat::create_by_contact_id(&context.ctx, contact1).unwrap();
-        assert_eq!(chat2_id, chat_id);
-        let chat2 = Chat::load_from_db(&context.ctx, chat2_id).unwrap();
+    let chat2_id = chat::create_by_contact_id(&context.ctx, contact1).unwrap();
+    assert_eq!(chat2_id, chat_id);
+    let chat2 = Chat::load_from_db(&context.ctx, chat2_id).unwrap();
 
-        assert_eq!(chat2.name, chat.name);
-    }
+    assert_eq!(chat2.name, chat.name);
 }

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -32,103 +32,100 @@ static mut S_EM_SETUPFILE: *const libc::c_char =
         as *const u8 as *const libc::c_char;
 
 unsafe fn stress_functions(context: &Context) {
-    if 0 != dc_is_open(context) {
-        if dc_file_exist(context, "$BLOBDIR/foobar")
-            || dc_file_exist(context, "$BLOBDIR/dada")
-            || dc_file_exist(context, "$BLOBDIR/foobar.dadada")
-            || dc_file_exist(context, "$BLOBDIR/foobar-folder")
-        {
-            dc_delete_file(context, "$BLOBDIR/foobar");
-            dc_delete_file(context, "$BLOBDIR/dada");
-            dc_delete_file(context, "$BLOBDIR/foobar.dadada");
-            dc_delete_file(context, "$BLOBDIR/foobar-folder");
-        }
-        dc_write_file(
-            context,
-            b"$BLOBDIR/foobar\x00" as *const u8 as *const libc::c_char,
-            b"content\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
-            7i32 as size_t,
-        );
-        assert!(dc_file_exist(context, "$BLOBDIR/foobar",));
-        assert!(!dc_file_exist(context, "$BLOBDIR/foobarx"));
-        assert_eq!(
-            dc_get_filebytes(context, "$BLOBDIR/foobar",),
-            7i32 as libc::c_ulonglong
-        );
-
-        let abs_path: *mut libc::c_char = dc_mprintf(
-            b"%s/%s\x00" as *const u8 as *const libc::c_char,
-            context.get_blobdir(),
-            b"foobar\x00" as *const u8 as *const libc::c_char,
-        );
-        assert!(dc_is_blobdir_path(context, as_str(abs_path)));
-        assert!(dc_is_blobdir_path(context, "$BLOBDIR/fofo",));
-        assert!(!dc_is_blobdir_path(context, "/BLOBDIR/fofo",));
-        assert!(dc_file_exist(context, as_path(abs_path)));
-        free(abs_path as *mut libc::c_void);
-        assert!(dc_copy_file(context, "$BLOBDIR/foobar", "$BLOBDIR/dada",));
-        assert_eq!(dc_get_filebytes(context, "$BLOBDIR/dada",), 7);
-
-        let mut buf: *mut libc::c_void = ptr::null_mut();
-        let mut buf_bytes: size_t = 0;
-
-        assert_eq!(
-            dc_read_file(
-                context,
-                b"$BLOBDIR/dada\x00" as *const u8 as *const libc::c_char,
-                &mut buf,
-                &mut buf_bytes,
-            ),
-            1
-        );
-        assert_eq!(buf_bytes, 7);
-        assert_eq!(
-            std::str::from_utf8(std::slice::from_raw_parts(buf as *const u8, buf_bytes)).unwrap(),
-            "content"
-        );
-
-        free(buf as *mut _);
-        assert!(dc_delete_file(context, "$BLOBDIR/foobar"));
-        assert!(dc_delete_file(context, "$BLOBDIR/dada"));
-        assert!(dc_create_folder(context, "$BLOBDIR/foobar-folder"));
-        assert!(dc_file_exist(context, "$BLOBDIR/foobar-folder",));
-        assert!(dc_delete_file(context, "$BLOBDIR/foobar-folder"));
-        let fn0: *mut libc::c_char = dc_get_fine_pathNfilename(
-            context,
-            b"$BLOBDIR\x00" as *const u8 as *const libc::c_char,
-            b"foobar.dadada\x00" as *const u8 as *const libc::c_char,
-        );
-        assert!(!fn0.is_null());
-        assert_eq!(
-            strcmp(
-                fn0,
-                b"$BLOBDIR/foobar.dadada\x00" as *const u8 as *const libc::c_char,
-            ),
-            0
-        );
-        dc_write_file(
-            context,
-            fn0,
-            b"content\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
-            7i32 as size_t,
-        );
-        let fn1: *mut libc::c_char = dc_get_fine_pathNfilename(
-            context,
-            b"$BLOBDIR\x00" as *const u8 as *const libc::c_char,
-            b"foobar.dadada\x00" as *const u8 as *const libc::c_char,
-        );
-        assert!(!fn1.is_null());
-        assert_eq!(
-            strcmp(
-                fn1,
-                b"$BLOBDIR/foobar-1.dadada\x00" as *const u8 as *const libc::c_char,
-            ),
-            0
-        );
-        assert!(dc_delete_file(context, as_path(fn0)));
-        free(fn0 as *mut libc::c_void);
-        free(fn1 as *mut libc::c_void);
+    if dc_file_exist(context, "$BLOBDIR/foobar")
+        || dc_file_exist(context, "$BLOBDIR/dada")
+        || dc_file_exist(context, "$BLOBDIR/foobar.dadada")
+        || dc_file_exist(context, "$BLOBDIR/foobar-folder")
+    {
+        dc_delete_file(context, "$BLOBDIR/foobar");
+        dc_delete_file(context, "$BLOBDIR/dada");
+        dc_delete_file(context, "$BLOBDIR/foobar.dadada");
+        dc_delete_file(context, "$BLOBDIR/foobar-folder");
     }
+    dc_write_file(
+        context,
+        b"$BLOBDIR/foobar\x00" as *const u8 as *const libc::c_char,
+        b"content\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
+        7i32 as size_t,
+    );
+    assert!(dc_file_exist(context, "$BLOBDIR/foobar",));
+    assert!(!dc_file_exist(context, "$BLOBDIR/foobarx"));
+    assert_eq!(
+        dc_get_filebytes(context, "$BLOBDIR/foobar",),
+        7i32 as libc::c_ulonglong
+    );
+    let abs_path: *mut libc::c_char = dc_mprintf(
+        b"%s/%s\x00" as *const u8 as *const libc::c_char,
+        context.get_blobdir(),
+        b"foobar\x00" as *const u8 as *const libc::c_char,
+    );
+    assert!(dc_is_blobdir_path(context, as_str(abs_path)));
+    assert!(dc_is_blobdir_path(context, "$BLOBDIR/fofo"));
+    assert!(!dc_is_blobdir_path(context, "/BLOBDIR/fofo"));
+    assert!(dc_file_exist(context, as_path(abs_path)));
+    free(abs_path as *mut libc::c_void);
+    assert!(dc_copy_file(context, "$BLOBDIR/foobar", "$BLOBDIR/dada",));
+    assert_eq!(dc_get_filebytes(context, "$BLOBDIR/dada",), 7);
+
+    let mut buf: *mut libc::c_void = ptr::null_mut();
+    let mut buf_bytes: size_t = 0;
+
+    assert_eq!(
+        dc_read_file(
+            context,
+            b"$BLOBDIR/dada\x00" as *const u8 as *const libc::c_char,
+            &mut buf,
+            &mut buf_bytes,
+        ),
+        1
+    );
+    assert_eq!(buf_bytes, 7);
+    assert_eq!(
+        std::str::from_utf8(std::slice::from_raw_parts(buf as *const u8, buf_bytes)).unwrap(),
+        "content"
+    );
+
+    free(buf as *mut _);
+    assert!(dc_delete_file(context, "$BLOBDIR/foobar"));
+    assert!(dc_delete_file(context, "$BLOBDIR/dada"));
+    assert!(dc_create_folder(context, "$BLOBDIR/foobar-folder"));
+    assert!(dc_file_exist(context, "$BLOBDIR/foobar-folder",));
+    assert!(dc_delete_file(context, "$BLOBDIR/foobar-folder"));
+    let fn0: *mut libc::c_char = dc_get_fine_pathNfilename(
+        context,
+        b"$BLOBDIR\x00" as *const u8 as *const libc::c_char,
+        b"foobar.dadada\x00" as *const u8 as *const libc::c_char,
+    );
+    assert!(!fn0.is_null());
+    assert_eq!(
+        strcmp(
+            fn0,
+            b"$BLOBDIR/foobar.dadada\x00" as *const u8 as *const libc::c_char,
+        ),
+        0
+    );
+    dc_write_file(
+        context,
+        fn0,
+        b"content\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
+        7i32 as size_t,
+    );
+    let fn1: *mut libc::c_char = dc_get_fine_pathNfilename(
+        context,
+        b"$BLOBDIR\x00" as *const u8 as *const libc::c_char,
+        b"foobar.dadada\x00" as *const u8 as *const libc::c_char,
+    );
+    assert!(!fn1.is_null());
+    assert_eq!(
+        strcmp(
+            fn1,
+            b"$BLOBDIR/foobar-1.dadada\x00" as *const u8 as *const libc::c_char,
+        ),
+        0
+    );
+    assert!(dc_delete_file(context, as_path(fn0)));
+    free(fn0 as *mut libc::c_void);
+    free(fn1 as *mut libc::c_void);
 
     let res = context.get_config(config::Config::SysConfigKeys).unwrap();
 
@@ -625,12 +622,7 @@ fn test_encryption_decryption() {
     }
 }
 
-unsafe extern "C" fn cb(
-    _context: &Context,
-    _event: Event,
-    _data1: uintptr_t,
-    _data2: uintptr_t,
-) -> uintptr_t {
+fn cb(_context: &Context, _event: Event, _data1: uintptr_t, _data2: uintptr_t) -> uintptr_t {
     0
 }
 
@@ -640,21 +632,16 @@ struct TestContext {
     dir: TempDir,
 }
 
-unsafe fn create_test_context() -> TestContext {
-    let mut ctx = dc_context_new(Some(cb), std::ptr::null_mut(), None);
+fn create_test_context() -> TestContext {
     let dir = tempdir().unwrap();
     let dbfile = dir.path().join("db.sqlite");
-    assert!(
-        dc_open(&mut ctx, dbfile.to_str().unwrap(), None),
-        "Failed to open {}",
-        dbfile.display()
-    );
+    let ctx = Context::new(Box::new(cb), "FakeOs".into(), dbfile).unwrap();
     TestContext { ctx: ctx, dir: dir }
 }
 
 #[test]
 fn test_dc_get_oauth2_url() {
-    let ctx = unsafe { create_test_context() };
+    let ctx = create_test_context();
     let addr = "dignifiedquire@gmail.com";
     let redirect_uri = "chat.delta:/com.b44t.messenger";
     let res = dc_get_oauth2_url(&ctx.ctx, addr, redirect_uri);
@@ -664,7 +651,7 @@ fn test_dc_get_oauth2_url() {
 
 #[test]
 fn test_dc_get_oauth2_addr() {
-    let ctx = unsafe { create_test_context() };
+    let ctx = create_test_context();
     let addr = "dignifiedquire@gmail.com";
     let code = "fail";
     let res = dc_get_oauth2_addr(&ctx.ctx, addr, code);
@@ -674,7 +661,7 @@ fn test_dc_get_oauth2_addr() {
 
 #[test]
 fn test_dc_get_oauth2_token() {
-    let ctx = unsafe { create_test_context() };
+    let ctx = create_test_context();
     let addr = "dignifiedquire@gmail.com";
     let code = "fail";
     let res = dc_get_oauth2_access_token(&ctx.ctx, addr, code, 0);
@@ -692,20 +679,18 @@ fn test_stress_tests() {
 
 #[test]
 fn test_get_contacts() {
-    unsafe {
-        let context = create_test_context();
-        let contacts = Contact::get_all(&context.ctx, 0, Some("some2")).unwrap();
-        assert_eq!(contacts.len(), 0);
+    let context = create_test_context();
+    let contacts = Contact::get_all(&context.ctx, 0, Some("some2")).unwrap();
+    assert_eq!(contacts.len(), 0);
 
-        let id = Contact::create(&context.ctx, "bob", "bob@mail.de").unwrap();
-        assert_ne!(id, 0);
+    let id = Contact::create(&context.ctx, "bob", "bob@mail.de").unwrap();
+    assert_ne!(id, 0);
 
-        let contacts = Contact::get_all(&context.ctx, 0, Some("bob")).unwrap();
-        assert_eq!(contacts.len(), 1);
+    let contacts = Contact::get_all(&context.ctx, 0, Some("bob")).unwrap();
+    assert_eq!(contacts.len(), 1);
 
-        let contacts = Contact::get_all(&context.ctx, 0, Some("alice")).unwrap();
-        assert_eq!(contacts.len(), 0);
-    }
+    let contacts = Contact::get_all(&context.ctx, 0, Some("alice")).unwrap();
+    assert_eq!(contacts.len(), 0);
 }
 
 #[test]
@@ -724,18 +709,5 @@ fn test_chat() {
         let chat2 = Chat::load_from_db(&context.ctx, chat2_id).unwrap();
 
         assert_eq!(chat2.name, chat.name);
-    }
-}
-
-#[test]
-fn test_wrong_db() {
-    unsafe {
-        let mut ctx = dc_context_new(Some(cb), std::ptr::null_mut(), None);
-        let dir = tempdir().unwrap();
-        let dbfile = dir.path().join("db.sqlite");
-        std::fs::write(&dbfile, b"123").unwrap();
-
-        let res = dc_open(&mut ctx, dbfile.to_str().unwrap(), None);
-        assert!(!res);
     }
 }


### PR DESCRIPTION
This means the Context becomes a struct following the normal Rust
conventions where when it is created it is usable.  This will over
time allow removing a lot of runtime checks and simplify code.  Many
members will no longer need to be Options or similar.

Still todo: The C API needs to remain compatible so hides the implementation of
this behind another struct which can be opened and closed.