### PR TITLE
fix 'chats' command in cmdline tool

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -604,7 +604,12 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
         }
         "listchats" | "listarchived" | "chats" => {
             let listflags = if arg0 == "listarchived" { 0x01 } else { 0 };
-            let chatlist = Chatlist::try_load(context, listflags, Some(arg1), None)?;
+            let chatlist = Chatlist::try_load(
+                context,
+                listflags,
+                if arg1.is_empty() { None } else { Some(arg1) },
+                None,
+            )?;
 
             let cnt = chatlist.len();
             if cnt > 0 {

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -606,7 +606,6 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             let listflags = if arg0 == "listarchived" { 0x01 } else { 0 };
             let chatlist = Chatlist::try_load(context, listflags, Some(arg1), None)?;
 
-            let mut i: usize;
             let cnt = chatlist.len();
             if cnt > 0 {
                 info!(
@@ -614,9 +613,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                     "================================================================================"
                 );
 
-                i = cnt - 1;
-
-                while i > 0 {
+                for i in (0..cnt).rev() {
                     let chat = dc_get_chat(context, chatlist.get_chat_id(i));
                     let temp_subtitle = dc_chat_get_subtitle(chat);
                     let temp_name = dc_chat_get_name(chat);
@@ -670,8 +667,6 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                         context, 0,
                         "================================================================================"
                     );
-
-                    i -= 1
                 }
             }
             if dc_is_sending_locations_to_chat(context, 0 as uint32_t) {


### PR DESCRIPTION
this pr fixes the `chats` command in the cmdline tool.

- show all chats if no query is given
- show whole result if a query is given