### PR TITLE
WIP: Reimplement `dc_mprintf' function in Rust

### DIFF
--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -661,11 +661,7 @@ unsafe fn prepare_msg_raw(
                         && !parent_rfc724_mid.is_null()
                         && 0 != *parent_rfc724_mid.offset(0isize) as libc::c_int
                     {
-                        new_references = dc_mprintf(
-                            b"%s %s\x00" as *const u8 as *const libc::c_char,
-                            parent_in_reply_to,
-                            parent_rfc724_mid,
-                        )
+                        new_references = dc_mprintf!("{} {}", parent_in_reply_to, parent_rfc724_mid)
                     } else if !parent_in_reply_to.is_null()
                         && 0 != *parent_in_reply_to.offset(0isize) as libc::c_int
                     {

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -651,11 +651,7 @@ unsafe fn prepare_msg_raw(
                         && !parent_rfc724_mid.is_null()
                         && 0 != *parent_rfc724_mid.offset(0isize) as libc::c_int
                     {
-                        new_references = dc_mprintf(
-                            b"%s %s\x00" as *const u8 as *const libc::c_char,
-                            parent_references,
-                            parent_rfc724_mid,
-                        )
+                        new_references = dc_mprintf!("{} {}", parent_references, parent_rfc724_mid)
                     } else if !parent_references.is_null()
                         && 0 != *parent_references.offset(0isize) as libc::c_int
                     {

--- a/src/dc_location.rs
+++ b/src/dc_location.rs
@@ -373,19 +373,19 @@ pub unsafe fn dc_get_message_kml(
     let latitude_str = dc_ftoa(latitude);
     let longitude_str = dc_ftoa(longitude);
 
-    let ret = dc_mprintf(
-        b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+    let ret = dc_mprintf!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
          <kml xmlns=\"http://www.opengis.net/kml/2.2\">\n\
          <Document>\n\
          <Placemark>\
-         <Timestamp><when>%s</when></Timestamp>\
-         <Point><coordinates>%s,%s</coordinates></Point>\
+         <Timestamp><when>{}</when></Timestamp>\
+         <Point><coordinates>{},{}</coordinates></Point>\
          </Placemark>\n\
          </Document>\n\
-         </kml>\x00" as *const u8 as *const libc::c_char,
+         </kml>",
         timestamp_str,
         longitude_str, // reverse order!
-        latitude_str,
+        latitude_str
     );
 
     free(latitude_str as *mut libc::c_void);

--- a/src/dc_msg.rs
+++ b/src/dc_msg.rs
@@ -904,7 +904,8 @@ pub unsafe fn dc_msg_get_summarytext_by_raw(
         && !text.is_null()
         && 0 != *text.offset(0isize) as libc::c_int
     {
-        ret = dc_mprintf!("{} – {}", prefix, text);
+        let endash = b"\xe2\x80\x93\x00" as *const u8 as *const libc::c_char;
+        ret = dc_mprintf!("{} {} {}", prefix, endash, text);
         dc_truncate_n_unwrap_str(ret, approx_characters, 1i32);
     } else if 0 != append_text && !text.is_null() && 0 != *text.offset(0isize) as libc::c_int {
         ret = dc_strdup(text);

--- a/src/dc_msg.rs
+++ b/src/dc_msg.rs
@@ -904,11 +904,7 @@ pub unsafe fn dc_msg_get_summarytext_by_raw(
         && !text.is_null()
         && 0 != *text.offset(0isize) as libc::c_int
     {
-        ret = dc_mprintf(
-            b"%s \xe2\x80\x93 %s\x00" as *const u8 as *const libc::c_char,
-            prefix,
-            text,
-        );
+        ret = dc_mprintf!("{} – {}", prefix, text);
         dc_truncate_n_unwrap_str(ret, approx_characters, 1i32);
     } else if 0 != append_text && !text.is_null() && 0 != *text.offset(0isize) as libc::c_int {
         ret = dc_strdup(text);

--- a/src/dc_msg.rs
+++ b/src/dc_msg.rs
@@ -889,11 +889,7 @@ pub unsafe fn dc_msg_get_summarytext_by_raw(
                         .as_ref(),
                 )
                 .unwrap();
-                prefix = dc_mprintf(
-                    b"%s \xe2\x80\x93 %s\x00" as *const u8 as *const libc::c_char,
-                    label.as_ptr(),
-                    value,
-                )
+                prefix = dc_mprintf!("{} – {}", label.as_ptr(), value)
             }
         }
         _ => {

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -107,7 +107,7 @@ pub unsafe fn dc_str_replace(
 
 pub unsafe fn dc_ftoa(f: libc::c_double) -> *mut libc::c_char {
     // hack around printf(%f) that may return `,` as decimal point on mac
-    let test: *mut libc::c_char = dc_mprintf(b"%f\x00" as *const u8 as *const libc::c_char, 1.2f64);
+    let test: *mut libc::c_char = format!("{}", 1.2f64).strdup();
     *test.offset(2isize) = 0 as libc::c_char;
     let mut str: *mut libc::c_char = dc_mprintf(b"%f\x00" as *const u8 as *const libc::c_char, f);
     dc_str_replace(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod smtp;
 pub mod sql;
 pub mod stock;
 pub mod types;
+#[macro_use]
 pub mod x;
 
 pub mod dc_array;

--- a/src/x.rs
+++ b/src/x.rs
@@ -85,7 +85,8 @@ pub(crate) unsafe fn strncasecmp(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dc_tools::to_string;
+    use crate::dc_tools::*;
+    use std::ffi::CString;
 
     #[test]
     fn test_strndup() {
@@ -97,6 +98,24 @@ mod tests {
             );
             assert_eq!(strlen(res), 4);
             free(res as *mut _);
+        }
+    }
+
+    #[test]
+    fn dc_mprintf_macro_equivalent_to_function() {
+        unsafe {
+            let arg1 = CString::yolo("привет");
+            let arg2 = CString::yolo("мир");
+            let res1 = dc_mprintf(
+                b"%s \xe2\x80\x93 %s\x00".as_ptr() as *const libc::c_char,
+                arg1.as_ptr(),
+                arg2.as_ptr(),
+            );
+            let res2 = dc_mprintf!("{} – {}", arg1.as_ptr(), arg2.as_ptr());
+            assert!(strcmp(res1, res2) == 0);
+
+            free(res1 as *mut _);
+            free(res2 as *mut _);
         }
     }
 }

--- a/src/x.rs
+++ b/src/x.rs
@@ -40,6 +40,13 @@ extern "C" {
     pub fn dc_mprintf(format: *const libc::c_char, _: ...) -> *mut libc::c_char;
 }
 
+#[macro_export]
+macro_rules! dc_mprintf {
+    ($fmt:expr, $($x:expr),*) => {
+        format!($fmt, $(to_string($x), )*).strdup()
+    }
+}
+
 pub(crate) unsafe fn strcasecmp(s1: *const libc::c_char, s2: *const libc::c_char) -> libc::c_int {
     let s1 = std::ffi::CStr::from_ptr(s1)
         .to_string_lossy()


### PR DESCRIPTION
Replace `dc_mprintf' C varrags functions with Rust macro to improve type-safety
and drop dependency on C compiler.

 * misc.h, misc.c: remove, no longer needed.
 * build.rs: remove rules to compiler `misc.c'.
 * src/x.rs: remove `dc_mprintf' function, add `dc_mprintf!' macro.
   Adjust call sites accordingly.
 * src/dc_qr.rs: fix type error, where Option<String> was passed instead of
   `const char *'.

Upd: tests somewhy fail. Okay, here will be heap of commits, converting `dc_mprintf` to `dc_mprintf!` on item at time.