### PR TITLE
add quit command as alias to exit in cmdline

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -471,7 +471,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                  event <event-id to test>\n\
                  fileinfo <file>\n\
                  clear -- clear screen\n\
-                 exit\n\
+                 exit or quit\n\
                  ============================================="
             ),
         },

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -335,8 +335,8 @@ const CONTACT_COMMANDS: [&'static str; 6] = [
     "delcontact",
     "cleanupcontacts",
 ];
-const MISC_COMMANDS: [&'static str; 8] = [
-    "getqr", "getbadqr", "checkqr", "event", "fileinfo", "clear", "exit", "help",
+const MISC_COMMANDS: [&'static str; 9] = [
+    "getqr", "getbadqr", "checkqr", "event", "fileinfo", "clear", "exit", "quit", "help",
 ];
 
 impl Hinter for DcHelper {
@@ -550,7 +550,7 @@ unsafe fn handle_cmd(line: &str, ctx: Arc<RwLock<Context>>) -> Result<ExitResult
                 dc_join_securejoin(&ctx.read().unwrap(), arg1_c);
             }
         }
-        "exit" => return Ok(ExitResult::Exit),
+        "exit" | "quit" => return Ok(ExitResult::Exit),
         _ => dc_cmdline(&ctx.read().unwrap(), line)?,
     }
 


### PR DESCRIPTION
This might me controversial, but I like to have it.
Let's use :+1: and :-1: to vote for it.