### PR TITLE
Remove magic number

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -87,8 +87,6 @@ pub const DC_CHAT_TYPE_SINGLE: i32 = 100;
 pub const DC_CHAT_TYPE_GROUP: i32 = 120;
 pub const DC_CHAT_TYPE_VERIFIED_GROUP: i32 = 130;
 
-pub const DC_CHAT_MAGIC: u32 = 0xc4a7c4a7;
-
 pub const DC_MSG_ID_MARKER1: usize = 1;
 pub const DC_MSG_ID_DAYMARKER: usize = 9;
 pub const DC_MSG_ID_LAST_SPECIAL: usize = 9;

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -24,7 +24,6 @@ use crate::x::*;
  */
 #[derive(Clone)]
 pub struct Chat<'a> {
-    magic: u32,
     pub id: uint32_t,
     pub type_0: libc::c_int,
     pub name: *mut libc::c_char,
@@ -65,7 +64,6 @@ pub unsafe fn dc_create_chat_by_msg_id(context: &Context, msg_id: uint32_t) -> u
 
 pub unsafe fn dc_chat_new<'a>(context: &'a Context) -> *mut Chat<'a> {
     let chat = Chat {
-        magic: DC_CHAT_MAGIC,
         id: 0,
         type_0: 0,
         name: std::ptr::null_mut(),
@@ -81,17 +79,16 @@ pub unsafe fn dc_chat_new<'a>(context: &'a Context) -> *mut Chat<'a> {
     Box::into_raw(Box::new(chat))
 }
 
-pub unsafe fn dc_chat_unref(mut chat: *mut Chat) {
-    if chat.is_null() || (*chat).magic != DC_CHAT_MAGIC {
+pub unsafe fn dc_chat_unref(chat: *mut Chat) {
+    if chat.is_null() {
         return;
     }
     dc_chat_empty(chat);
-    (*chat).magic = 0;
     Box::from_raw(chat);
 }
 
 pub unsafe fn dc_chat_empty(mut chat: *mut Chat) {
-    if chat.is_null() || (*chat).magic != DC_CHAT_MAGIC {
+    if chat.is_null() {
         return;
     }
     free((*chat).name as *mut libc::c_void);
@@ -120,7 +117,7 @@ pub fn dc_block_chat(context: &Context, chat_id: u32, new_blocking: libc::c_int)
 }
 
 pub fn dc_chat_load_from_db(chat: *mut Chat, chat_id: u32) -> bool {
-    if chat.is_null() || unsafe { (*chat).magic != DC_CHAT_MAGIC } {
+    if chat.is_null() {
         return false;
     }
     unsafe { dc_chat_empty(chat) };
@@ -810,7 +807,7 @@ unsafe fn get_parent_mime_headers(
 }
 
 pub unsafe fn dc_chat_is_self_talk(chat: *const Chat) -> libc::c_int {
-    if chat.is_null() || (*chat).magic != DC_CHAT_MAGIC {
+    if chat.is_null() {
         return 0;
     }
     (*chat).param.exists(Param::Selftalk) as libc::c_int
@@ -2020,21 +2017,21 @@ pub unsafe fn dc_forward_msgs(
 }
 
 pub unsafe fn dc_chat_get_id(chat: *const Chat) -> uint32_t {
-    if chat.is_null() || (*chat).magic != DC_CHAT_MAGIC {
+    if chat.is_null() {
         return 0i32 as uint32_t;
     }
     (*chat).id
 }
 
 pub unsafe fn dc_chat_get_type(chat: *const Chat) -> libc::c_int {
-    if chat.is_null() || (*chat).magic != DC_CHAT_MAGIC {
+    if chat.is_null() {
         return 0i32;
     }
     (*chat).type_0
 }
 
 pub unsafe fn dc_chat_get_name(chat: *const Chat) -> *mut libc::c_char {
-    if chat.is_null() || (*chat).magic != DC_CHAT_MAGIC {
+    if chat.is_null() {
         return dc_strdup(b"Err\x00" as *const u8 as *const libc::c_char);
     }
     dc_strdup((*chat).name)
@@ -2042,7 +2039,7 @@ pub unsafe fn dc_chat_get_name(chat: *const Chat) -> *mut libc::c_char {
 
 pub unsafe fn dc_chat_get_subtitle(chat: *const Chat) -> *mut libc::c_char {
     /* returns either the address or the number of chat members */
-    if chat.is_null() || (*chat).magic != DC_CHAT_MAGIC {
+    if chat.is_null() {
         return dc_strdup(b"Err\x00" as *const u8 as *const libc::c_char);
     }
 
@@ -2101,7 +2098,7 @@ pub unsafe fn dc_chat_get_profile_image(chat: *const Chat) -> *mut libc::c_char 
     let mut image_abs: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut contacts: *mut dc_array_t = 0 as *mut dc_array_t;
 
-    if !(chat.is_null() || (*chat).magic != DC_CHAT_MAGIC) {
+    if !chat.is_null() {
         image_rel = (*chat)
             .param
             .get(Param::ProfileImage)
@@ -2131,7 +2128,7 @@ pub unsafe fn dc_chat_get_color(chat: *const Chat) -> uint32_t {
     let mut color: uint32_t = 0i32 as uint32_t;
     let mut contacts: *mut dc_array_t = 0 as *mut dc_array_t;
 
-    if !(chat.is_null() || (*chat).magic != DC_CHAT_MAGIC) {
+    if !chat.is_null() {
         if (*chat).type_0 == DC_CHAT_TYPE_SINGLE {
             contacts = dc_get_chat_contacts((*chat).context, (*chat).id);
             if !(*contacts).is_empty() {
@@ -2151,7 +2148,7 @@ pub unsafe fn dc_chat_get_color(chat: *const Chat) -> uint32_t {
 
 // TODO should return bool /rtn
 pub unsafe fn dc_chat_get_archived(chat: *const Chat) -> libc::c_int {
-    if chat.is_null() || (*chat).magic != DC_CHAT_MAGIC {
+    if chat.is_null() {
         return 0i32;
     }
     (*chat).archived
@@ -2159,7 +2156,7 @@ pub unsafe fn dc_chat_get_archived(chat: *const Chat) -> libc::c_int {
 
 // TODO should return bool /rtn
 pub unsafe fn dc_chat_is_unpromoted(chat: *const Chat) -> libc::c_int {
-    if chat.is_null() || (*chat).magic != DC_CHAT_MAGIC {
+    if chat.is_null() {
         return 0;
     }
     (*chat).param.get_int(Param::Unpromoted).unwrap_or_default() as libc::c_int
@@ -2167,7 +2164,7 @@ pub unsafe fn dc_chat_is_unpromoted(chat: *const Chat) -> libc::c_int {
 
 // TODO should return bool /rtn
 pub unsafe fn dc_chat_is_verified(chat: *const Chat) -> libc::c_int {
-    if chat.is_null() || (*chat).magic != DC_CHAT_MAGIC {
+    if chat.is_null() {
         return 0i32;
     }
     ((*chat).type_0 == 130i32) as libc::c_int
@@ -2175,7 +2172,8 @@ pub unsafe fn dc_chat_is_verified(chat: *const Chat) -> libc::c_int {
 
 // TODO should return bool /rtn
 pub unsafe fn dc_chat_is_sending_locations(chat: *const Chat) -> libc::c_int {
-    if chat.is_null() || (*chat).magic != DC_CHAT_MAGIC {
+    if chat.is_null() {
+
         return 0i32;
     }
     (*chat).is_sending_locations

--- a/src/dc_lot.rs
+++ b/src/dc_lot.rs
@@ -11,7 +11,6 @@ use crate::x::*;
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct dc_lot_t {
-    pub magic: uint32_t,
     pub text1_meaning: libc::c_int,
     pub text1: *mut libc::c_char,
     pub text2: *mut libc::c_char,
@@ -38,14 +37,13 @@ pub unsafe fn dc_lot_new() -> *mut dc_lot_t {
     lot = calloc(1, ::std::mem::size_of::<dc_lot_t>()) as *mut dc_lot_t;
     assert!(!lot.is_null());
 
-    (*lot).magic = 0x107107i32 as uint32_t;
     (*lot).text1_meaning = 0i32;
 
     lot
 }
 
 pub unsafe fn dc_lot_empty(mut lot: *mut dc_lot_t) {
-    if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint {
+    if lot.is_null() {
         return;
     }
     free((*lot).text1 as *mut libc::c_void);
@@ -64,17 +62,16 @@ pub unsafe fn dc_lot_empty(mut lot: *mut dc_lot_t) {
     (*lot).id = 0i32 as uint32_t;
 }
 
-pub unsafe fn dc_lot_unref(mut set: *mut dc_lot_t) {
-    if set.is_null() || (*set).magic != 0x107107i32 as libc::c_uint {
+pub unsafe fn dc_lot_unref(set: *mut dc_lot_t) {
+    if set.is_null() {
         return;
     }
     dc_lot_empty(set);
-    (*set).magic = 0i32 as uint32_t;
     free(set as *mut libc::c_void);
 }
 
 pub unsafe fn dc_lot_get_text1(lot: *const dc_lot_t) -> *mut libc::c_char {
-    if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint {
+    if lot.is_null() {
         return 0 as *mut libc::c_char;
     }
 
@@ -82,7 +79,7 @@ pub unsafe fn dc_lot_get_text1(lot: *const dc_lot_t) -> *mut libc::c_char {
 }
 
 pub unsafe fn dc_lot_get_text2(lot: *const dc_lot_t) -> *mut libc::c_char {
-    if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint {
+    if lot.is_null() {
         return 0 as *mut libc::c_char;
     }
 
@@ -90,7 +87,7 @@ pub unsafe fn dc_lot_get_text2(lot: *const dc_lot_t) -> *mut libc::c_char {
 }
 
 pub unsafe fn dc_lot_get_text1_meaning(lot: *const dc_lot_t) -> libc::c_int {
-    if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint {
+    if lot.is_null() {
         return 0i32;
     }
 
@@ -98,7 +95,7 @@ pub unsafe fn dc_lot_get_text1_meaning(lot: *const dc_lot_t) -> libc::c_int {
 }
 
 pub unsafe fn dc_lot_get_state(lot: *const dc_lot_t) -> libc::c_int {
-    if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint {
+    if lot.is_null() {
         return 0i32;
     }
 
@@ -106,7 +103,7 @@ pub unsafe fn dc_lot_get_state(lot: *const dc_lot_t) -> libc::c_int {
 }
 
 pub unsafe fn dc_lot_get_id(lot: *const dc_lot_t) -> uint32_t {
-    if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint {
+    if lot.is_null() {
         return 0i32 as uint32_t;
     }
 
@@ -114,7 +111,7 @@ pub unsafe fn dc_lot_get_id(lot: *const dc_lot_t) -> uint32_t {
 }
 
 pub unsafe fn dc_lot_get_timestamp(lot: *const dc_lot_t) -> i64 {
-    if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint {
+    if lot.is_null() {
         return 0;
     }
 
@@ -130,7 +127,7 @@ pub unsafe fn dc_lot_fill(
     contact: Option<&Contact>,
     context: &Context,
 ) {
-    if lot.is_null() || (*lot).magic != 0x107107i32 as libc::c_uint || msg.is_null() {
+    if lot.is_null() || msg.is_null() {
         return;
     }
     if (*msg).state == 19i32 {

--- a/src/dc_msg.rs
+++ b/src/dc_msg.rs
@@ -20,7 +20,6 @@ use std::ptr;
 #[derive(Clone)]
 #[repr(C)]
 pub struct dc_msg_t<'a> {
-    pub magic: uint32_t,
     pub id: uint32_t,
     pub from_id: uint32_t,
     pub to_id: uint32_t,
@@ -222,7 +221,6 @@ pub unsafe fn dc_msg_new_untyped<'a>(context: &'a Context) -> *mut dc_msg_t<'a> 
 // approx. max. length returned by dc_get_msg_info()
 pub unsafe fn dc_msg_new<'a>(context: &'a Context, viewtype: Viewtype) -> *mut dc_msg_t<'a> {
     let msg = dc_msg_t {
-        magic: 0x11561156,
         id: 0,
         from_id: 0,
         to_id: 0,
@@ -250,17 +248,16 @@ pub unsafe fn dc_msg_new<'a>(context: &'a Context, viewtype: Viewtype) -> *mut d
     Box::into_raw(Box::new(msg))
 }
 
-pub unsafe fn dc_msg_unref(mut msg: *mut dc_msg_t) {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+pub unsafe fn dc_msg_unref(msg: *mut dc_msg_t) {
+    if msg.is_null() {
         return;
     }
     dc_msg_empty(msg);
-    (*msg).magic = 0i32 as uint32_t;
     Box::from_raw(msg);
 }
 
 pub unsafe fn dc_msg_empty(mut msg: *mut dc_msg_t) {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return;
     }
     free((*msg).rfc724_mid as *mut libc::c_void);
@@ -274,7 +271,7 @@ pub unsafe fn dc_msg_empty(mut msg: *mut dc_msg_t) {
 pub unsafe fn dc_msg_get_filemime(msg: *const dc_msg_t) -> *mut libc::c_char {
     let mut ret = 0 as *mut libc::c_char;
 
-    if !(msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint) {
+    if !msg.is_null() {
         match (*msg).param.get(Param::MimeType) {
             Some(m) => {
                 ret = m.strdup();
@@ -358,7 +355,7 @@ pub unsafe fn dc_msg_guess_msgtype_from_suffix(
 pub unsafe fn dc_msg_get_file(msg: *const dc_msg_t) -> *mut libc::c_char {
     let mut file_abs = 0 as *mut libc::c_char;
 
-    if !(msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint) {
+    if !msg.is_null() {
         if let Some(file_rel) = (*msg).param.get(Param::File) {
             let file_rel_c = CString::yolo(file_rel);
             file_abs = dc_get_abs_path((*msg).context, file_rel_c.as_ptr());
@@ -381,7 +378,7 @@ pub unsafe fn dc_msg_get_file(msg: *const dc_msg_t) -> *mut libc::c_char {
  * @return 1=Message has location bound to it, 0=No location bound to message.
  */
 pub unsafe fn dc_msg_has_location(msg: *const dc_msg_t) -> bool {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return false;
     }
 
@@ -411,7 +408,6 @@ pub unsafe fn dc_msg_set_location(
     longitude: libc::c_double,
 ) {
     if msg.is_null()
-        || (*msg).magic != 0x11561156i32 as libc::c_uint
         || (latitude == 0.0 && longitude == 0.0)
     {
         return;
@@ -422,7 +418,7 @@ pub unsafe fn dc_msg_set_location(
 }
 
 pub unsafe fn dc_msg_get_timestamp(msg: *const dc_msg_t) -> i64 {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return 0;
     }
     return if 0 != (*msg).timestamp_sent {
@@ -638,7 +634,7 @@ pub unsafe fn dc_get_msg<'a>(context: &'a Context, msg_id: uint32_t) -> *mut dc_
 }
 
 pub unsafe fn dc_msg_get_id(msg: *const dc_msg_t) -> uint32_t {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return 0i32 as uint32_t;
     }
 
@@ -646,7 +642,7 @@ pub unsafe fn dc_msg_get_id(msg: *const dc_msg_t) -> uint32_t {
 }
 
 pub unsafe fn dc_msg_get_from_id(msg: *const dc_msg_t) -> uint32_t {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return 0i32 as uint32_t;
     }
 
@@ -654,7 +650,7 @@ pub unsafe fn dc_msg_get_from_id(msg: *const dc_msg_t) -> uint32_t {
 }
 
 pub unsafe fn dc_msg_get_chat_id(msg: *const dc_msg_t) -> uint32_t {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return 0i32 as uint32_t;
     }
     return if 0 != (*msg).chat_blocked {
@@ -665,7 +661,7 @@ pub unsafe fn dc_msg_get_chat_id(msg: *const dc_msg_t) -> uint32_t {
 }
 
 pub unsafe fn dc_msg_get_viewtype(msg: *const dc_msg_t) -> Viewtype {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return Viewtype::Unknown;
     }
 
@@ -673,7 +669,7 @@ pub unsafe fn dc_msg_get_viewtype(msg: *const dc_msg_t) -> Viewtype {
 }
 
 pub unsafe fn dc_msg_get_state(msg: *const dc_msg_t) -> libc::c_int {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return 0i32;
     }
 
@@ -681,7 +677,7 @@ pub unsafe fn dc_msg_get_state(msg: *const dc_msg_t) -> libc::c_int {
 }
 
 pub unsafe fn dc_msg_get_received_timestamp(msg: *const dc_msg_t) -> i64 {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return 0;
     }
 
@@ -689,7 +685,7 @@ pub unsafe fn dc_msg_get_received_timestamp(msg: *const dc_msg_t) -> i64 {
 }
 
 pub unsafe fn dc_msg_get_sort_timestamp(msg: *const dc_msg_t) -> i64 {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return 0;
     }
 
@@ -697,7 +693,7 @@ pub unsafe fn dc_msg_get_sort_timestamp(msg: *const dc_msg_t) -> i64 {
 }
 
 pub unsafe fn dc_msg_get_text(msg: *const dc_msg_t) -> *mut libc::c_char {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return dc_strdup(0 as *const libc::c_char);
     }
     if let Some(ref text) = (*msg).text {
@@ -711,7 +707,7 @@ pub unsafe fn dc_msg_get_text(msg: *const dc_msg_t) -> *mut libc::c_char {
 pub unsafe fn dc_msg_get_filename(msg: *const dc_msg_t) -> *mut libc::c_char {
     let mut ret = 0 as *mut libc::c_char;
 
-    if !(msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint) {
+    if !msg.is_null() {
         if let Some(file) = (*msg).param.get(Param::File) {
             let file_c = CString::yolo(file);
             ret = dc_get_filename(file_c.as_ptr());
@@ -725,7 +721,7 @@ pub unsafe fn dc_msg_get_filename(msg: *const dc_msg_t) -> *mut libc::c_char {
 }
 
 pub unsafe fn dc_msg_get_filebytes(msg: *const dc_msg_t) -> uint64_t {
-    if !(msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint) {
+    if !msg.is_null() {
         if let Some(file) = (*msg).param.get(Param::File) {
             return dc_get_filebytes((*msg).context, &file);
         }
@@ -735,7 +731,7 @@ pub unsafe fn dc_msg_get_filebytes(msg: *const dc_msg_t) -> uint64_t {
 }
 
 pub unsafe fn dc_msg_get_width(msg: *const dc_msg_t) -> libc::c_int {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return 0;
     }
 
@@ -743,7 +739,7 @@ pub unsafe fn dc_msg_get_width(msg: *const dc_msg_t) -> libc::c_int {
 }
 
 pub unsafe fn dc_msg_get_height(msg: *const dc_msg_t) -> libc::c_int {
-    if msg.is_null() || (*msg).magic != 0x11561156 as libc::c_uint {
+    if msg.is_null() {
         return 0;
     }
 
@@ -751,7 +747,7 @@ pub unsafe fn dc_msg_get_height(msg: *const dc_msg_t) -> libc::c_int {
 }
 
 pub unsafe fn dc_msg_get_duration(msg: *const dc_msg_t) -> libc::c_int {
-    if msg.is_null() || (*msg).magic != 0x11561156 as libc::c_uint {
+    if msg.is_null() {
         return 0;
     }
 
@@ -760,7 +756,7 @@ pub unsafe fn dc_msg_get_duration(msg: *const dc_msg_t) -> libc::c_int {
 
 // TODO should return bool /rtn
 pub unsafe fn dc_msg_get_showpadlock(msg: *const dc_msg_t) -> libc::c_int {
-    if msg.is_null() || (*msg).magic != 0x11561156 as libc::c_uint {
+    if msg.is_null() {
         return 0;
     }
     if (*msg)
@@ -783,7 +779,7 @@ pub unsafe fn dc_msg_get_summary<'a>(
     let ret: *mut dc_lot_t = dc_lot_new();
     let mut chat_to_delete: *mut Chat = 0 as *mut Chat;
 
-    if !(msg.is_null() || (*msg).magic != 0x11561156 as libc::c_uint) {
+    if !msg.is_null() {
         if chat.is_null() {
             chat_to_delete = dc_get_chat((*msg).context, (*msg).chat_id);
             if chat_to_delete.is_null() {
@@ -814,7 +810,7 @@ pub unsafe fn dc_msg_get_summarytext(
     msg: *mut dc_msg_t,
     approx_characters: libc::c_int,
 ) -> *mut libc::c_char {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return dc_strdup(0 as *const libc::c_char);
     }
 
@@ -925,7 +921,7 @@ pub unsafe fn dc_msg_has_deviating_timestamp(msg: *const dc_msg_t) -> libc::c_in
 
 // TODO should return bool /rtn
 pub unsafe fn dc_msg_is_sent(msg: *const dc_msg_t) -> libc::c_int {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return 0;
     }
     if (*msg).state >= DC_STATE_OUT_DELIVERED {
@@ -936,7 +932,7 @@ pub unsafe fn dc_msg_is_sent(msg: *const dc_msg_t) -> libc::c_int {
 }
 
 pub unsafe fn dc_msg_is_starred(msg: *const dc_msg_t) -> bool {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return false;
     }
     0 != (*msg).starred
@@ -944,7 +940,7 @@ pub unsafe fn dc_msg_is_starred(msg: *const dc_msg_t) -> bool {
 
 // TODO should return bool /rtn
 pub unsafe fn dc_msg_is_forwarded(msg: *const dc_msg_t) -> libc::c_int {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return 0;
     }
     if 0 != (*msg).param.get_int(Param::Forwarded).unwrap_or_default() {
@@ -956,7 +952,7 @@ pub unsafe fn dc_msg_is_forwarded(msg: *const dc_msg_t) -> libc::c_int {
 
 // TODO should return bool /rtn
 pub unsafe fn dc_msg_is_info(msg: *const dc_msg_t) -> libc::c_int {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return 0;
     }
     let cmd = (*msg).param.get_int(Param::Cmd).unwrap_or_default();
@@ -972,7 +968,7 @@ pub unsafe fn dc_msg_is_info(msg: *const dc_msg_t) -> libc::c_int {
 
 // TODO should return bool /rtn
 pub unsafe fn dc_msg_is_increation(msg: *const dc_msg_t) -> libc::c_int {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return 0;
     }
 
@@ -985,7 +981,6 @@ pub unsafe fn dc_msg_is_increation(msg: *const dc_msg_t) -> libc::c_int {
 
 pub unsafe fn dc_msg_is_setupmessage(msg: *const dc_msg_t) -> bool {
     if msg.is_null()
-        || (*msg).magic != 0x11561156i32 as libc::c_uint
         || (*msg).type_0 != Viewtype::File
     {
         return false;
@@ -1043,7 +1038,7 @@ pub unsafe fn dc_msg_get_setupcodebegin(msg: *const dc_msg_t) -> *mut libc::c_ch
 }
 
 pub unsafe fn dc_msg_set_text(mut msg: *mut dc_msg_t, text: *const libc::c_char) {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return;
     }
     (*msg).text = if text.is_null() {
@@ -1058,7 +1053,7 @@ pub unsafe fn dc_msg_set_file(
     file: *const libc::c_char,
     filemime: *const libc::c_char,
 ) {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return;
     }
     if !file.is_null() {
@@ -1070,7 +1065,7 @@ pub unsafe fn dc_msg_set_file(
 }
 
 pub unsafe fn dc_msg_set_dimension(msg: *mut dc_msg_t, width: libc::c_int, height: libc::c_int) {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return;
     }
     (*msg).param.set_int(Param::Width, width);
@@ -1078,7 +1073,7 @@ pub unsafe fn dc_msg_set_dimension(msg: *mut dc_msg_t, width: libc::c_int, heigh
 }
 
 pub unsafe fn dc_msg_set_duration(msg: *mut dc_msg_t, duration: libc::c_int) {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return;
     }
     (*msg).param.set_int(Param::Duration, duration);
@@ -1090,7 +1085,7 @@ pub unsafe fn dc_msg_latefiling_mediasize(
     height: libc::c_int,
     duration: libc::c_int,
 ) {
-    if !(msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint) {
+    if !msg.is_null() {
         if width > 0 && height > 0 {
             (*msg).param.set_int(Param::Width, width);
             (*msg).param.set_int(Param::Height, height);
@@ -1103,7 +1098,7 @@ pub unsafe fn dc_msg_latefiling_mediasize(
 }
 
 pub unsafe fn dc_msg_save_param_to_disk(msg: *mut dc_msg_t) -> bool {
-    if msg.is_null() || (*msg).magic != 0x11561156i32 as libc::c_uint {
+    if msg.is_null() {
         return false;
     }
 


### PR DESCRIPTION
at two files there is still a reference to C `#[repr(C)]` so I'm not sure at the last two commits.
If I understood @link2xt correctly it's obsolete, but as there is still some freeing involved so I don't know if now the right time to do it for the **lot** and **message**.
If it isn't, but `remove chat magic` looks good we can only merge that one and drop the rest.