### PR TITLE
dc_get_chat_contacts should always return an array and never null

### DIFF
--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -1410,8 +1410,6 @@ pub fn dc_get_chat_contacts(context: &Context, chat_id: u32) -> *mut dc_array_t 
     /* Normal chats do not include SELF.  Group chats do (as it may happen that one is deleted from a
     groupchat but the chats stays visible, moreover, this makes displaying lists easier) */
 
-
-
     let ret = if chat_id != 1 {
         // we could also create a list for all contacts in the deaddrop by searching contacts belonging to chats with
         // chats.blocked=2, however, currently this is not needed
@@ -1433,18 +1431,17 @@ pub fn dc_get_chat_contacts(context: &Context, chat_id: u32) -> *mut dc_array_t 
 
                     Ok(ret.into_raw())
                 },
-            ).ok()
+            )
+            .ok()
     } else {
         None
     };
-
 
     if let Some(chat_contacts) = ret {
         chat_contacts
     } else {
         dc_array_t::new(0).into_raw()
     }
-
 }
 
 pub unsafe fn dc_get_chat(context: &Context, chat_id: uint32_t) -> *mut Chat {

--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -1410,32 +1410,41 @@ pub fn dc_get_chat_contacts(context: &Context, chat_id: u32) -> *mut dc_array_t 
     /* Normal chats do not include SELF.  Group chats do (as it may happen that one is deleted from a
     groupchat but the chats stays visible, moreover, this makes displaying lists easier) */
 
-    if chat_id == 1 {
-        return std::ptr::null_mut();
+
+
+    let ret = if chat_id != 1 {
+        // we could also create a list for all contacts in the deaddrop by searching contacts belonging to chats with
+        // chats.blocked=2, however, currently this is not needed
+
+        context
+            .sql
+            .query_map(
+                "SELECT cc.contact_id FROM chats_contacts cc \
+                 LEFT JOIN contacts c ON c.id=cc.contact_id WHERE cc.chat_id=? \
+                 ORDER BY c.id=1, LOWER(c.name||c.addr), c.id;",
+                params![chat_id as i32],
+                |row| row.get::<_, i32>(0),
+                |ids| {
+                    let mut ret = dc_array_t::new(100);
+
+                    for id in ids {
+                        ret.add_id(id? as u32);
+                    }
+
+                    Ok(ret.into_raw())
+                },
+            ).ok()
+    } else {
+        None
+    };
+
+
+    if let Some(chat_contacts) = ret {
+        chat_contacts
+    } else {
+        dc_array_t::new(0).into_raw()
     }
 
-    // we could also create a list for all contacts in the deaddrop by searching contacts belonging to chats with
-    // chats.blocked=2, however, currently this is not needed
-
-    context
-        .sql
-        .query_map(
-            "SELECT cc.contact_id FROM chats_contacts cc \
-             LEFT JOIN contacts c ON c.id=cc.contact_id WHERE cc.chat_id=? \
-             ORDER BY c.id=1, LOWER(c.name||c.addr), c.id;",
-            params![chat_id as i32],
-            |row| row.get::<_, i32>(0),
-            |ids| {
-                let mut ret = dc_array_t::new(100);
-
-                for id in ids {
-                    ret.add_id(id? as u32);
-                }
-
-                Ok(ret.into_raw())
-            },
-        )
-        .unwrap_or_else(|_| std::ptr::null_mut())
 }
 
 pub unsafe fn dc_get_chat(context: &Context, chat_id: uint32_t) -> *mut Chat {


### PR DESCRIPTION
pointer otherwise we break the ffi api

https://c.delta.chat/classdc__context__t.html#a9939ef09de5a5026dbac6fe209186969
> Returns
>    An array of contact IDs belonging to the chat; must be freed using dc_array_unref() when done. 
