### PR TITLE
fix failing array asserts #355

### DIFF
--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -1307,7 +1307,9 @@ pub unsafe fn dc_get_next_media(
         }
     }
 
-    dc_array_unref(list);
+    if !list.is_null() {
+        dc_array_unref(list);
+    }
     dc_msg_unref(msg);
     ret_msg_id
 }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1506,8 +1506,12 @@ unsafe fn create_or_lookup_adhoc_group(
                    ret_chat_id_blocked: *mut libc::c_int,
                    chat_id: u32,
                    chat_id_blocked: i32| {
-        dc_array_unref(member_ids);
-        dc_array_unref(chat_ids);
+        if !member_ids.is_null() {
+            dc_array_unref(member_ids);
+        }
+        if !chat_ids.is_null() {
+            dc_array_unref(chat_ids);
+        }
         free(chat_ids_str as *mut libc::c_void);
         free(grpid as *mut libc::c_void);
         free(grpname as *mut libc::c_void);


### PR DESCRIPTION
fix #355 -- these were unconvered by "rg dc_array_unref" which turned up valid cases for the array being null.  cc @kaction 