### PR TITLE
send DC_EVENT_CONFIGURE_PROGRESS(0) on failure and only on failure

### DIFF
--- a/src/dc_configure.rs
+++ b/src/dc_configure.rs
@@ -17,8 +17,8 @@ macro_rules! progress {
     ($context:tt, $progress:expr) => {
         $context.call_cb(
             Event::CONFIGURE_PROGRESS,
-            (if $progress < 1 {
-                1
+            (if $progress < 0 {
+                0
             } else if $progress > 1000 {
                 1000
             } else {
@@ -151,7 +151,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: *mut dc_j
             let s = s_a.read().unwrap();
 
             if !s.shall_stop_ongoing {
-                progress!(context, 0);
+                progress!(context, 1);
 
                 let mut param = dc_loginparam_read(context, &context.sql, "");
                 if param.addr.is_empty() {


### PR DESCRIPTION
DC_EVENT_CONFIGURE_PROGRESS shall send out 0 for failure, 1..999 for progress information and 1000 on success.
 
- as all DC_EVENT_CONFIGURE_PROGRESS  events are emmited by the `progress!` macro, this macro must allow all values from 0..1000

- moreover, the fist progress must not be `0` as this would indicate failure (in the c-core the progress macro was _only_ used for progress, so [calling progress(0)](https://github.com/deltachat/deltachat-core/blob/master/src/dc_configure.c#L726) worked _there_)

so, with this pr and the already merged #354 everythingShouldBeFine(tm)