### PR TITLE
feat: load package version during build

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -71,7 +71,7 @@ impl Context {
                 let rel_path = self.sql.get_config(self, key);
                 rel_path.map(|p| dc_get_abs_path_safe(self, &p).to_str().unwrap().to_string())
             }
-            Config::SysVersion => Some(std::str::from_utf8(DC_VERSION_STR).unwrap().into()),
+            Config::SysVersion => Some((&*DC_VERSION_STR).clone()),
             Config::SysMsgsizeMaxRecommended => Some(format!("{}", 24 * 1024 * 1024 / 4 * 3)),
             Config::SysConfigKeys => Some(get_config_keys_string()),
             _ => self.sql.get_config(self, key),

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,8 +1,13 @@
 //! Constants
 #![allow(non_camel_case_types)]
+
+use lazy_static::lazy_static;
+
 use deltachat_derive::*;
 
-pub const DC_VERSION_STR: &[u8; 14] = b"1.0.0-alpha.3\x00";
+lazy_static! {
+    pub static ref DC_VERSION_STR: String = env!("CARGO_PKG_VERSION").to_string();
+}
 
 #[repr(u8)]
 #[derive(Debug, Display, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive, ToSql, FromSql)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -437,7 +437,7 @@ pub unsafe fn dc_get_info(context: &Context) -> *mut libc::c_char {
          public_key_count={}\n\
          fingerprint={}\n\
          level=awesome\n",
-        as_str(DC_VERSION_STR as *const u8 as *const _),
+        &*DC_VERSION_STR,
         rusqlite::version(),
         sqlite3_threadsafe(),
         // arch
@@ -479,7 +479,7 @@ pub unsafe fn dc_get_info(context: &Context) -> *mut libc::c_char {
 }
 
 pub unsafe fn dc_get_version_str() -> *mut libc::c_char {
-    dc_strdup(DC_VERSION_STR as *const u8 as *const libc::c_char)
+    (&*DC_VERSION_STR).strdup()
 }
 
 pub fn dc_get_fresh_msgs(context: &Context) -> *mut dc_array_t {


### PR DESCRIPTION
This removes the duplication of the version string between the `Cargo.toml` and `constants.rs`