### PR TITLE
Fix panic in dc_set_chat_profile_image because of missing

### DIFF
--- a/src/dc_chat.rs
+++ b/src/dc_chat.rs
@@ -1882,6 +1882,8 @@ pub unsafe fn dc_set_chat_profile_image(
                     if !dc_make_rel_and_copy(context, &mut new_image_rel) {
                         OK_TO_CONTINUE = false;
                     }
+                } else {
+                    OK_TO_CONTINUE = false;
                 }
                 if OK_TO_CONTINUE {
                     (*chat)


### PR DESCRIPTION
ok_to_continue=false

Got very likely introduced by https://github.com/deltachat/deltachat-core-rust/pull/229