### PR TITLE
Refactor dc_set_chat_profile_image, make it a bit rustier and fix bug…

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -645,7 +645,7 @@ pub unsafe extern "C" fn dc_set_chat_profile_image(
     assert!(chat_id > constants::DC_CHAT_ID_LAST_SPECIAL as u32);
     let context = &*context;
 
-    dc_chat::dc_set_chat_profile_image(context, chat_id, image)
+    dc_chat::dc_set_chat_profile_image(context, chat_id, &dc_tools::to_string(image)) as libc::c_int
 }
 
 #[no_mangle]

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -810,15 +810,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             ensure!(!sel_chat.is_null(), "No chat selected.");
             ensure!(!arg1.is_empty(), "Argument <image> missing.");
 
-            if 0 != dc_set_chat_profile_image(
-                context,
-                dc_chat_get_id(sel_chat),
-                if !arg1.is_empty() {
-                    arg1_c
-                } else {
-                    std::ptr::null_mut()
-                },
-            ) {
+            if dc_set_chat_profile_image(context, dc_chat_get_id(sel_chat), arg1) {
                 println!("Chat image set");
             } else {
                 bail!("Failed to set chat image");


### PR DESCRIPTION
… of not being able to

unset profile_image

Very likely conflicts with https://github.com/deltachat/deltachat-core-rust/pull/374/
@dignifiedquire i can implement it on top of your pr if you want to.