### PR TITLE
declare void function as such

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -594,7 +594,7 @@ int             dc_contact_is_verified       (dc_contact_t*);
 #define         DC_TEXT1_SELF      3
 
 
-dc_lot_t*       dc_lot_new               ();
+dc_lot_t*       dc_lot_new               (void);
 void            dc_lot_empty             (dc_lot_t*);
 void            dc_lot_unref             (dc_lot_t*);
 char*           dc_lot_get_text1         (const dc_lot_t*);


### PR DESCRIPTION
`void func();` is correct in C++ but not really correct in C, some compilers throw a warning.

the correct semantic in C is `void func(void)`.

we did this correctly for most functions, but for some reason it was forgotten for dc_lot_new(). this pr fixes that.