### PR TITLE
allow passing empty arrays to ffi

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -721,7 +721,7 @@ pub unsafe extern "C" fn dc_delete_msgs(
 ) {
     assert!(!context.is_null());
     assert!(!msg_ids.is_null());
-    assert!(msg_cnt > 0);
+    assert!(msg_cnt >= 0);
     let context = &*context;
 
     message::dc_delete_msgs(context, msg_ids, msg_cnt)
@@ -736,7 +736,7 @@ pub unsafe extern "C" fn dc_forward_msgs(
 ) {
     assert!(!context.is_null());
     assert!(!msg_ids.is_null());
-    assert!(msg_cnt > 0);
+    assert!(msg_cnt >= 0);
     assert!(chat_id > constants::DC_CHAT_ID_LAST_SPECIAL as u32);
     let context = &*context;
 
@@ -759,7 +759,7 @@ pub unsafe extern "C" fn dc_markseen_msgs(
 ) {
     assert!(!context.is_null());
     assert!(!msg_ids.is_null());
-    assert!(msg_cnt > 0);
+    assert!(msg_cnt >= 0);
     let context = &*context;
 
     message::dc_markseen_msgs(context, msg_ids, msg_cnt as usize);
@@ -774,7 +774,7 @@ pub unsafe extern "C" fn dc_star_msgs(
 ) {
     assert!(!context.is_null());
     assert!(!msg_ids.is_null());
-    assert!(msg_cnt > 0);
+    assert!(msg_cnt >= 0);
 
     let context = &*context;
 


### PR DESCRIPTION
for convenience, it should be possible to pass an empty list of messages for eg. being marked as seen.

in fact, the functions are used this way in the past and it also feels natural to allow that.

of course, the uis could also check such things, however, this is easy to forget and a panic! is a bit harsh.

a related discussion is whether to allow null-pointers eg. for messages which may easyly happen with a 

```
dc_msg_t* msg = dc_get_msg(id); // id does not exist
dc_delete_msg(msg); // currently this will fail - the old c-core just does nothing in this case
```

also here, it is hard for the ui to catch all cases and it might be better to just do nothing (in the ffi, rust-core can be different)

however, the pointer-thingie is a different dicussion that should proably be done somewhere else and should not block this pr :)

closes https://github.com/deltachat/deltachat-ios/issues/189