### PR TITLE
Refactor clist-related functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,7 +479,7 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lettre 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "mmime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mmime 0.1.2-alpha.0 (git+https://github.com/dignifiedquire/mmime?rev=bccd2c2)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1192,8 +1192,8 @@ dependencies = [
 
 [[package]]
 name = "mmime"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.1.2-alpha.0"
+source = "git+https://github.com/dignifiedquire/mmime?rev=bccd2c2#bccd2c2c89e9241e05f321c963f638affdccad96"
 dependencies = [
  "charset 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2884,7 +2884,7 @@ dependencies = [
 "checksum miniz_oxide 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7108aff85b876d06f22503dcce091e29f76733b2bfdd91eebce81f5e68203a10"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum mmime 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a1246fa340840c36f1fca1507db82463fbc4c2f7763fe84bfde666c7381e0593"
+"checksum mmime 0.1.2-alpha.0 (git+https://github.com/dignifiedquire/mmime?rev=bccd2c2)" = "<none>"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4dbdc256eaac2e3bd236d93ad999d3479ef775c863dbda3068c4006a92eec51b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ num-traits = "0.2.6"
 native-tls = "0.2.3"
 lettre = "0.9.0"
 imap = "1.0.1"
-mmime = "0.1.0"
+mmime = { git = "https://github.com/dignifiedquire/mmime", rev = "bccd2c2" }
 base64 = "0.10"
 charset = "0.1"
 percent-encoding = "2.0"

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1875,10 +1875,7 @@ unsafe fn dc_is_reply_to_known_message(
     if !field.is_null() && (*field).fld_type == MAILIMF_FIELD_IN_REPLY_TO as libc::c_int {
         let fld_in_reply_to: *mut mailimf_in_reply_to = (*field).fld_data.fld_in_reply_to;
         if !fld_in_reply_to.is_null() {
-            if 0 != is_known_rfc724_mid_in_list(
-                context,
-                (*(*field).fld_data.fld_in_reply_to).mid_list,
-            ) {
+            if is_known_rfc724_mid_in_list(context, (*(*field).fld_data.fld_in_reply_to).mid_list) {
                 return 1;
             }
         }
@@ -1887,10 +1884,7 @@ unsafe fn dc_is_reply_to_known_message(
     if !field.is_null() && (*field).fld_type == MAILIMF_FIELD_REFERENCES as libc::c_int {
         let fld_references: *mut mailimf_references = (*field).fld_data.fld_references;
         if !fld_references.is_null() {
-            if 0 != is_known_rfc724_mid_in_list(
-                context,
-                (*(*field).fld_data.fld_references).mid_list,
-            ) {
+            if is_known_rfc724_mid_in_list(context, (*(*field).fld_data.fld_references).mid_list) {
                 return 1;
             }
         }
@@ -1898,7 +1892,7 @@ unsafe fn dc_is_reply_to_known_message(
     0
 }
 
-unsafe fn is_known_rfc724_mid_in_list(context: &Context, mid_list: *const clist) -> libc::c_int {
+unsafe fn is_known_rfc724_mid_in_list(context: &Context, mid_list: *const clist) -> bool {
     if !mid_list.is_null() {
         let mut cur: *mut clistiter;
         cur = (*mid_list).first;
@@ -1911,7 +1905,7 @@ unsafe fn is_known_rfc724_mid_in_list(context: &Context, mid_list: *const clist)
                     ptr::null_mut()
                 }) as *const libc::c_char,
             ) {
-                return 1;
+                return true;
             }
             cur = if !cur.is_null() {
                 (*cur).next
@@ -1920,7 +1914,7 @@ unsafe fn is_known_rfc724_mid_in_list(context: &Context, mid_list: *const clist)
             }
         }
     }
-    0
+    false
 }
 
 /// Check if a message is a reply to a known message (messenger or non-messenger).

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1893,28 +1893,17 @@ unsafe fn dc_is_reply_to_known_message(
 }
 
 unsafe fn is_known_rfc724_mid_in_list(context: &Context, mid_list: *const clist) -> bool {
-    if !mid_list.is_null() {
-        let mut cur: *mut clistiter;
-        cur = (*mid_list).first;
-        while !cur.is_null() {
-            if 0 != is_known_rfc724_mid(
-                context,
-                (if !cur.is_null() {
-                    (*cur).data
-                } else {
-                    ptr::null_mut()
-                }) as *const libc::c_char,
-            ) {
-                return true;
-            }
-            cur = if !cur.is_null() {
-                (*cur).next
-            } else {
-                ptr::null_mut()
-            }
+    if mid_list.is_null() {
+        return false;
+    }
+
+    for data in &*mid_list {
+        if 0 != is_known_rfc724_mid(context, data.cast()) {
+            return true;
         }
     }
-    false
+
+    return false;
 }
 
 /// Check if a message is a reply to a known message (messenger or non-messenger).


### PR DESCRIPTION
Changes:

5eff6cc (Dmitry Bogatov, 70 seconds ago)
   Refactor is_known_rfc724_mid() to use `clist_iter()`

aa7129d (Dmitry Bogatov, 7 minutes ago)
   Provide Iterator interface for `clist'

     * src/dc_tools.rs(clist_iter): new function that allows iterating data
   (`void*')
      of clist elements.

   This function renders manual pointer assignments unnecessary, makes
   iterating of `clist' look almost like normal Rust code.

19dfa39 (Dmitry Bogatov, 54 minutes ago)
   Change return type of is_known_rfc724_mid_in_list() to bool