### PR TITLE
unbreak master

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -498,7 +498,7 @@ pub unsafe extern "C" fn dc_send_msg(
     chat_id: u32,
     msg: *mut dc_msg_t,
 ) -> u32 {
-    if context.is_null() || chat_id == 0 || msg.is_null() {
+    if context.is_null() || msg.is_null() {
         eprintln!("ignoring careless call to dc_send_msg()");
         return 0;
     }


### PR DESCRIPTION
#414 broke tests, but I fail to see oblivious mistake. Let's split c71589a710d9dcc034153c79fe90a313649d0ff0 into many small commits and see, what exactly is causing problems.

PS. Does anybody know how to prevent  CI from aborting build when HEAD moves? 