### PR TITLE
set correct default value for inbox_watch

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,7 @@ pub enum Config {
     E2eeEnabled,
     #[strum(props(default = "1"))]
     MdnsEnabled,
+    #[strum(props(default = "1"))]
     InboxWatch,
     #[strum(props(default = "1"))]
     SentboxWatch,


### PR DESCRIPTION
this pr set the correct default value for `inbox_watch` in the same way as done for `mvbox_watch` and `sentbox_watch`.

without the default value, internally, the inbox seems to be watched anyway, but the exposed setting via `dc_get_config(inbox_watch)` returns `false` if there is no entry in the database (which is typically the case until the user plays around with some options)

fixes https://github.com/deltachat/deltachat-ios/issues/222