### PR TITLE
Support new chat$group RFC724 message identifier

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,7 @@ pub enum Config {
     SysVersion,
     #[strum(serialize = "sys.msgsize_max_recommended")]
     SysMsgsizeMaxRecommended,
+    Rfc724MsgIdPrefix,   // To be removed when chat$ prefix has become the sole convention
     #[strum(serialize = "sys.config_keys")]
     SysConfigKeys,
 }

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -328,7 +328,8 @@ pub unsafe fn dc_mimefactory_load_mdn<'a>(
     );
     load_from(&mut factory);
     factory.timestamp = dc_create_smeared_timestamp(factory.context);
-    factory.rfc724_mid = dc_create_outgoing_rfc724_mid(0 as *const libc::c_char, factory.from_addr);
+    factory.rfc724_mid =
+        dc_create_outgoing_rfc724_mid(factory.context, None, as_str(factory.from_addr)).strdup();
     factory.loaded = DC_MF_MDN_LOADED;
 
     Ok(factory)


### PR DESCRIPTION
Previously only "Gr." prefixes were recoginized. This commit adds support for COI prefix "chat$group".