### PR TITLE
Fix msg loading

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -428,7 +428,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                  send <text>\n\
                  send-garbage\n\
                  sendimage <file> [<text>]\n\
-                 sendfile <file>\n\
+                 sendfile <file> [<text>]\n\
                  draft [<text>]\n\
                  listmedia\n\
                  archive <chat-id>\n\
@@ -862,7 +862,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
         }
         "sendimage" | "sendfile" => {
             ensure!(sel_chat.is_some(), "No chat selected.");
-            ensure!(!arg1.is_empty() && !arg2.is_empty(), "No file given.");
+            ensure!(!arg1.is_empty(), "No file given.");
 
             let mut msg = dc_msg_new(
                 context,
@@ -873,7 +873,9 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                 },
             );
             dc_msg_set_file(&mut msg, arg1_c, ptr::null());
-            dc_msg_set_text(&mut msg, arg2_c);
+            if !arg2.is_empty() {
+                dc_msg_set_text(&mut msg, arg2_c);
+            }
             chat::send_msg(context, sel_chat.as_ref().unwrap().get_id(), &mut msg)?;
         }
         "listmsgs" => {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -502,7 +502,7 @@ impl<'a> Chat<'a> {
                             timestamp,
                             msg.type_0,
                             msg.state,
-                            msg.text,
+                            msg.text.as_ref().map_or("", String::as_str),
                             msg.param.to_string(),
                             msg.hidden,
                             to_string(new_in_reply_to),

--- a/src/message.rs
+++ b/src/message.rs
@@ -478,8 +478,7 @@ pub fn dc_msg_load_from_db<'a>(context: &'a Context, id: u32) -> Result<Message<
                         text = String::from_utf8_lossy(buf).into_owned();
                     }
                 } else {
-                    warn!(context, 0, "dc_msg_load_from_db: could not get text column for id {}", id);
-                    text = "[ Could not read from db ]".to_string();
+                    text = "".to_string();
                 }
                 msg.text = Some(text);
 


### PR DESCRIPTION
this pr unifies the presentation of "no message text" in the database to an empty string.  
the empty string was used also in core-c and in core-rust for incoming messages and as the database-default-value. only outgoing messages in core-rust used NULL for that.

moreover, the message-loading-from-database becomes tolerant against invalid NULL values for message-text; this is also what core-c does in this case.

finally, this pr fixes a bug in the cmdline util that prevents sending images without text (in fact, the main reason for "no message text") 

tackles #443 
