### PR TITLE
Remove the context reference from Message struct

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -476,7 +476,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             let msg_id: u32 = arg1.parse()?;
             let msg = dc_get_msg(context, msg_id)?;
             if dc_msg_is_setupmessage(&msg) {
-                let setupcodebegin = dc_msg_get_setupcodebegin(&msg);
+                let setupcodebegin = dc_msg_get_setupcodebegin(context, &msg);
                 println!(
                     "The setup code for setup message Msg#{} starts with: {}",
                     msg_id,
@@ -836,14 +836,11 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             ensure!(sel_chat.is_some(), "No chat selected.");
             ensure!(!arg1.is_empty(), "No file given.");
 
-            let mut msg = dc_msg_new(
-                context,
-                if arg0 == "sendimage" {
-                    Viewtype::Image
-                } else {
-                    Viewtype::File
-                },
-            );
+            let mut msg = dc_msg_new(if arg0 == "sendimage" {
+                Viewtype::Image
+            } else {
+                Viewtype::File
+            });
             dc_msg_set_file(&mut msg, arg1_c, ptr::null());
             if !arg2.is_empty() {
                 dc_msg_set_text(&mut msg, arg2_c);
@@ -868,7 +865,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             ensure!(sel_chat.is_some(), "No chat selected.");
 
             if !arg1.is_empty() {
-                let mut draft = dc_msg_new(context, Viewtype::Text);
+                let mut draft = dc_msg_new(Viewtype::Text);
                 dc_msg_set_text(&mut draft, arg1_c);
                 chat::set_draft(
                     context,

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -138,7 +138,7 @@ pub unsafe fn dc_initiate_key_transfer(context: &Context) -> *mut libc::c_char {
                     ))
                 {
                     if let Ok(chat_id) = chat::create_by_contact_id(context, 1) {
-                        msg = dc_msg_new_untyped(context);
+                        msg = dc_msg_new_untyped();
                         msg.type_0 = Viewtype::File;
                         msg.param.set(Param::File, as_str(setup_file_name));
 
@@ -281,7 +281,7 @@ pub unsafe fn dc_continue_key_transfer(
     if msg.is_err()
         || !dc_msg_is_setupmessage(msg.as_ref().unwrap())
         || {
-            filename = dc_msg_get_file(msg.as_ref().unwrap());
+            filename = dc_msg_get_file(context, msg.as_ref().unwrap());
             filename.is_null()
         }
         || *filename.offset(0isize) as libc::c_int == 0i32

--- a/src/job.rs
+++ b/src/job.rs
@@ -677,12 +677,12 @@ pub unsafe fn job_send_msg(context: &Context, msg_id: uint32_t) -> libc::c_int {
                             mimefactory.msg.param.set_int(Param::Height, height as i32);
                         }
                     }
-                    dc_msg_save_param_to_disk(&mut mimefactory.msg);
+                    dc_msg_save_param_to_disk(context, &mut mimefactory.msg);
                 }
             }
         }
         /* create message */
-        if 0 == dc_mimefactory_render(&mut mimefactory) {
+        if 0 == dc_mimefactory_render(context, &mut mimefactory) {
             dc_set_msg_failed(context, msg_id, as_opt_str(mimefactory.error));
         } else if 0
             != mimefactory
@@ -745,7 +745,7 @@ pub unsafe fn job_send_msg(context: &Context, msg_id: uint32_t) -> libc::c_int {
                     == 0
             {
                 mimefactory.msg.param.set_int(Param::GuranteeE2ee, 1);
-                dc_msg_save_param_to_disk(&mut mimefactory.msg);
+                dc_msg_save_param_to_disk(context, &mut mimefactory.msg);
             }
             success = add_smtp_job(context, Action::SendMsgToSmtp, &mut mimefactory);
         }
@@ -992,7 +992,7 @@ fn connect_to_inbox(context: &Context, inbox: &Imap) -> libc::c_int {
 
 fn send_mdn(context: &Context, msg_id: uint32_t) {
     if let Ok(mut mimefactory) = unsafe { dc_mimefactory_load_mdn(context, msg_id) } {
-        if 0 != unsafe { dc_mimefactory_render(&mut mimefactory) } {
+        if 0 != unsafe { dc_mimefactory_render(context, &mut mimefactory) } {
             add_smtp_job(context, Action::SendMdn, &mut mimefactory);
         }
     }

--- a/src/location.rs
+++ b/src/location.rs
@@ -215,7 +215,7 @@ pub fn send_locations_to_chat(context: &Context, chat_id: u32, seconds: i64) {
         .is_ok()
         {
             if 0 != seconds && !is_sending_locations_before {
-                msg = dc_msg_new(context, Viewtype::Text);
+                msg = dc_msg_new(Viewtype::Text);
                 msg.text =
                     Some(context.stock_system_msg(StockMessage::MsgLocationEnabled, "", "", 0));
                 msg.param.set_int(Param::Cmd, 8);
@@ -606,7 +606,7 @@ pub fn job_do_DC_JOB_MAYBE_SEND_LOCATIONS(context: &Context, _job: &Job) {
                                 // the easiest way to determine this, is to check for an empty message queue.
                                 // (might not be 100%, however, as positions are sent combined later
                                 // and dc_set_location() is typically called periodically, this is ok)
-                                let mut msg = dc_msg_new(context, Viewtype::Text);
+                                let mut msg = dc_msg_new(Viewtype::Text);
                                 msg.hidden = true;
                                 msg.param.set_int(Param::Cmd, 9);
                                 Some((chat_id, msg))

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -274,7 +274,7 @@ fn send_handshake_msg(
     fingerprint: Option<String>,
     grpid: impl AsRef<str>,
 ) {
-    let mut msg = unsafe { dc_msg_new_untyped(context) };
+    let mut msg = dc_msg_new_untyped();
     msg.type_0 = Viewtype::Text;
     msg.text = Some(format!("Secure-Join: {}", step));
     msg.hidden = true;


### PR DESCRIPTION
The Message struct had a reference to the context which made a few
APIs a little easier.  However it has surprising consequences a long
way down the line as shown in #335: it means any object which has such
a reference needs to keep open a lock if we want to do this refactor
of no longer having a "closed" Context struct on the Rust API (which
has many benefits which will simply that Context struct and is more
the Rust way - RAII etc).

By refactoring away the context reference on the rust API as done in
here however, we push this behaviour of how these references are
handled back to the C-API pointer behaviour: that is unsafe but just
works in a C-like way.  The resulting complexity in the FFI layer is
also notably less than in the #335 alternative.

As a consequence all APIs which require the context, now explicitly
need to get the context passed in as an argument.  It looks like this
is certainly no downside and maybe even beneficial for further API
refactors.

For this strategy to work out the same should be done to
dc_chatlist_t, dc_chat_t and dc_contact_t.  But this working for
dc_msg_t give a reasonable confidence that this is a good approach.