### PR TITLE
Minor refactoring

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -233,7 +233,7 @@ pub unsafe extern "C" fn dc_is_configured(context: *mut dc_context_t) -> libc::c
 
     let context = &*context;
 
-    configure::dc_is_configured(context)
+    configure::dc_is_configured(context) as libc::c_int
 }
 
 #[no_mangle]

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1188,7 +1188,7 @@ pub unsafe extern "C" fn dc_get_contact_encrinfo(
     Contact::get_encrinfo(context, contact_id)
         .map(|s| s.strdup())
         .unwrap_or_else(|e| {
-            error!(context, 0, "{}", e);
+            error!(context, "{}", e);
             std::ptr::null_mut()
         })
 }
@@ -2547,7 +2547,7 @@ impl<T: Default, E: std::fmt::Display> ResultExt<T> for Result<T, E> {
         match self {
             Ok(t) => t,
             Err(err) => {
-                error!(context, 0, "{}: {}", message, err);
+                error!(context, "{}: {}", message, err);
                 Default::default()
             }
         }
@@ -2555,7 +2555,7 @@ impl<T: Default, E: std::fmt::Display> ResultExt<T> for Result<T, E> {
 
     fn log_err(&self, context: &context::Context, message: &str) {
         if let Err(err) = self {
-            error!(context, 0, "{}: {}", message, err);
+            error!(context, "{}: {}", message, err);
         }
     }
 }

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -28,10 +28,10 @@ use num_traits::FromPrimitive;
 /// Argument is a bitmask, executing single or multiple actions in one call.
 /// e.g. bitmask 7 triggers actions definded with bits 1, 2 and 4.
 pub unsafe fn dc_reset_tables(context: &Context, bits: i32) -> i32 {
-    info!(context, 0, "Resetting tables ({})...", bits);
+    info!(context, "Resetting tables ({})...", bits);
     if 0 != bits & 1 {
         sql::execute(context, &context.sql, "DELETE FROM jobs;", params![]).unwrap();
-        info!(context, 0, "(1) Jobs reset.");
+        info!(context, "(1) Jobs reset.");
     }
     if 0 != bits & 2 {
         sql::execute(
@@ -41,11 +41,11 @@ pub unsafe fn dc_reset_tables(context: &Context, bits: i32) -> i32 {
             params![],
         )
         .unwrap();
-        info!(context, 0, "(2) Peerstates reset.");
+        info!(context, "(2) Peerstates reset.");
     }
     if 0 != bits & 4 {
         sql::execute(context, &context.sql, "DELETE FROM keypairs;", params![]).unwrap();
-        info!(context, 0, "(4) Private keypairs reset.");
+        info!(context, "(4) Private keypairs reset.");
     }
     if 0 != bits & 8 {
         sql::execute(
@@ -84,7 +84,7 @@ pub unsafe fn dc_reset_tables(context: &Context, bits: i32) -> i32 {
         )
         .unwrap();
         sql::execute(context, &context.sql, "DELETE FROM leftgrps;", params![]).unwrap();
-        info!(context, 0, "(8) Rest but server config reset.");
+        info!(context, "(8) Rest but server config reset.");
     }
 
     context.call_cb(Event::MSGS_CHANGED, 0, 0);
@@ -122,7 +122,7 @@ unsafe fn dc_poke_eml_file(context: &Context, filename: *const libc::c_char) -> 
 /// @return 1=success, 0=error.
 unsafe fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int {
     if !context.sql.is_open() {
-        error!(context, 0, "Import: Database not opened.");
+        error!(context, "Import: Database not opened.");
         return 0;
     }
 
@@ -143,7 +143,7 @@ unsafe fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int
     } else {
         let rs = context.sql.get_config(context, "import_spec");
         if rs.is_none() {
-            error!(context, 0, "Import: No file or folder given.");
+            error!(context, "Import: No file or folder given.");
             ok_to_continue = false;
         } else {
             ok_to_continue = true;
@@ -166,7 +166,6 @@ unsafe fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int
             if dir.is_err() {
                 error!(
                     context,
-                    0,
                     "Import: Cannot open directory \"{}\".",
                     as_str(real_spec),
                 );
@@ -182,7 +181,7 @@ unsafe fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int
                     let name = name_f.to_string_lossy();
                     if name.ends_with(".eml") {
                         let path_plus_name = format!("{}/{}", as_str(real_spec), name);
-                        info!(context, 0, "Import: {}", path_plus_name);
+                        info!(context, "Import: {}", path_plus_name);
                         let path_plus_name_c = CString::yolo(path_plus_name);
                         if 0 != dc_poke_eml_file(context, path_plus_name_c.as_ptr()) {
                             read_cnt += 1
@@ -195,7 +194,6 @@ unsafe fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int
         if ok_to_continue2 {
             info!(
                 context,
-                0,
                 "Import: {} items read from \"{}\".",
                 read_cnt,
                 as_str(real_spec)
@@ -228,7 +226,6 @@ unsafe fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
     let msgtext = dc_msg_get_text(msg);
     info!(
         context,
-        0,
         "{}#{}{}{}: {} (Contact#{}): {} {}{}{}{} [{}]",
         prefix.as_ref(),
         dc_msg_get_id(msg) as libc::c_int,
@@ -268,7 +265,6 @@ unsafe fn log_msglist(context: &Context, msglist: &Vec<u32>) -> Result<(), Error
         if msg_id == 9 as libc::c_uint {
             info!(
                 context,
-                0,
                 "--------------------------------------------------------------------------------"
             );
 
@@ -276,7 +272,7 @@ unsafe fn log_msglist(context: &Context, msglist: &Vec<u32>) -> Result<(), Error
         } else if msg_id > 0 {
             if lines_out == 0 {
                 info!(
-                    context, 0,
+                    context,
                     "--------------------------------------------------------------------------------",
                 );
                 lines_out += 1
@@ -288,7 +284,7 @@ unsafe fn log_msglist(context: &Context, msglist: &Vec<u32>) -> Result<(), Error
     if lines_out > 0 {
         info!(
             context,
-            0, "--------------------------------------------------------------------------------"
+            "--------------------------------------------------------------------------------"
         );
     }
     Ok(())
@@ -337,7 +333,7 @@ unsafe fn log_contactlist(context: &Context, contacts: &Vec<u32>) {
                 );
             }
 
-            info!(context, 0, "Contact#{}: {}{}", contact_id, line, line2);
+            info!(context, "Contact#{}: {}{}", contact_id, line, line2);
         }
     }
 }
@@ -579,7 +575,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             let cnt = chatlist.len();
             if cnt > 0 {
                 info!(
-                    context, 0,
+                    context,
                     "================================================================================"
                 );
 
@@ -589,7 +585,6 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                     let temp_name = chat.get_name();
                     info!(
                         context,
-                        0,
                         "{}#{}: {} [{}] [{} fresh]",
                         chat_prefix(&chat),
                         chat.get_id(),
@@ -614,7 +609,6 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                     let text2 = lot.get_text2();
                     info!(
                         context,
-                        0,
                         "{}{}{}{} [{}]{}",
                         text1.unwrap_or(""),
                         if text1.is_some() { ": " } else { "" },
@@ -628,13 +622,13 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                         },
                     );
                     info!(
-                        context, 0,
+                        context,
                         "================================================================================"
                     );
                 }
             }
             if location::is_sending_locations_to_chat(context, 0 as uint32_t) {
-                info!(context, 0, "Location streaming enabled.");
+                info!(context, "Location streaming enabled.");
             }
             println!("{} chats", cnt);
         }
@@ -657,7 +651,6 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             let temp_name = sel_chat.get_name();
             info!(
                 context,
-                0,
                 "{}#{}: {} [{}]{}",
                 chat_prefix(sel_chat),
                 sel_chat.get_id(),
@@ -753,7 +746,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             ensure!(sel_chat.is_some(), "No chat selected.");
 
             let contacts = chat::get_chat_contacts(context, sel_chat.as_ref().unwrap().get_id());
-            info!(context, 0, "Memberlist:");
+            info!(context, "Memberlist:");
 
             log_contactlist(context, &contacts);
             println!(
@@ -781,7 +774,6 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                 let marker = location.marker.as_ref().unwrap_or(&default_marker);
                 info!(
                     context,
-                    0,
                     "Loc#{}: {}: lat={} lng={} acc={} Chat#{} Contact#{} Msg#{} {}",
                     location.location_id,
                     dc_timestamp_to_str(location.timestamp),
@@ -795,7 +787,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                 );
             }
             if locations.is_empty() {
-                info!(context, 0, "No locations.");
+                info!(context, "No locations.");
             }
         }
         "sendlocations" => {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -65,7 +65,7 @@ impl<'a> Chat<'a> {
                 _ => {
                     error!(
                         context,
-                        0, "chat: failed to load from db {}: {:?}", chat_id, err
+                        "chat: failed to load from db {}: {:?}", chat_id, err
                     );
                     Err(err)
                 }
@@ -260,7 +260,7 @@ impl<'a> Chat<'a> {
             || self.typ == Chattype::Group
             || self.typ == Chattype::VerifiedGroup)
         {
-            error!(context, 0, "Cannot send to chat type #{}.", self.typ,);
+            error!(context, "Cannot send to chat type #{}.", self.typ,);
             return Ok(0);
         }
 
@@ -296,7 +296,7 @@ impl<'a> Chat<'a> {
                 } else {
                     error!(
                         context,
-                        0, "Cannot send message, contact for chat #{} not found.", self.id,
+                        "Cannot send message, contact for chat #{} not found.", self.id,
                     );
                     return Ok(0);
                 }
@@ -338,7 +338,6 @@ impl<'a> Chat<'a> {
                             if prefer_encrypted != 1 {
                                 info!(
                                     context,
-                                    0,
                                     "[autocrypt] peerstate for {} is {}",
                                     state,
                                     if prefer_encrypted == 0 {
@@ -350,7 +349,7 @@ impl<'a> Chat<'a> {
                                 all_mutual = 0;
                             }
                         } else {
-                            info!(context, 0, "[autocrypt] no peerstate for {}", state,);
+                            info!(context, "[autocrypt] no peerstate for {}", state,);
                             can_encrypt = 0;
                             all_mutual = 0;
                         }
@@ -360,7 +359,7 @@ impl<'a> Chat<'a> {
                 match res {
                     Ok(_) => {}
                     Err(err) => {
-                        warn!(context, 0, "chat: failed to load peerstates: {:?}", err);
+                        warn!(context, "chat: failed to load peerstates: {:?}", err);
                     }
                 }
 
@@ -464,13 +463,12 @@ impl<'a> Chat<'a> {
                     } else {
                         error!(
                             context,
-                            0,
                             "Cannot send message, cannot insert to database (chat #{}).",
                             self.id,
                         );
                     }
         } else {
-            error!(context, 0, "Cannot send message, not configured.",);
+            error!(context, "Cannot send message, not configured.",);
         }
 
         Ok(msg_id)
@@ -541,7 +539,7 @@ pub fn create_by_contact_id(context: &Context, contact_id: u32) -> Result<u32, E
             {
                 warn!(
                     context,
-                    0, "Cannot create chat, contact {} does not exist.", contact_id,
+                    "Cannot create chat, contact {} does not exist.", contact_id,
                 );
                 return Err(err);
             } else {
@@ -718,7 +716,7 @@ fn prepare_msg_common<'a>(
         }
         info!(
             context,
-            0, "Attaching \"{}\" for message type #{}.", &path_filename, msg.type_0
+            "Attaching \"{}\" for message type #{}.", &path_filename, msg.type_0
         );
     } else {
         bail!("Cannot send messages of type #{}.", msg.type_0);
@@ -751,7 +749,7 @@ fn last_msg_in_chat_encrypted(context: &Context, sql: &Sql, chat_id: u32) -> boo
         match packed.parse::<Params>() {
             Ok(param) => param.exists(Param::GuranteeE2ee),
             Err(err) => {
-                error!(context, 0, "invalid params stored: '{}', {:?}", packed, err);
+                error!(context, "invalid params stored: '{}', {:?}", packed, err);
                 false
             }
         }
@@ -1385,7 +1383,7 @@ pub fn add_contact_to_chat_ex(
                         if chat.typ == Chattype::VerifiedGroup {
                             if contact.is_verified() != VerifiedStatus::BidirectVerified {
                                 error!(
-                                    context, 0,
+                                    context,
                                     "Only bidirectional verified contacts can be added to verified groups."
                                 );
                                 OK_TO_CONTINUE = false;
@@ -1451,7 +1449,7 @@ pub fn set_gossiped_timestamp(context: &Context, chat_id: u32, timestamp: i64) {
     if 0 != chat_id {
         info!(
             context,
-            0, "set gossiped_timestamp for chat #{} to {}.", chat_id, timestamp,
+            "set gossiped_timestamp for chat #{} to {}.", chat_id, timestamp,
         );
 
         sql::execute(
@@ -1464,7 +1462,7 @@ pub fn set_gossiped_timestamp(context: &Context, chat_id: u32, timestamp: i64) {
     } else {
         info!(
             context,
-            0, "set gossiped_timestamp for all chats to {}.", timestamp,
+            "set gossiped_timestamp for all chats to {}.", timestamp,
         );
         sql::execute(
             context,

--- a/src/configure/auto_mozilla.rs
+++ b/src/configure/auto_mozilla.rs
@@ -69,7 +69,6 @@ pub unsafe fn moz_autoconfigure(
             Err(e) => {
                 error!(
                     context,
-                    0,
                     "Configure xml: Error at position {}: {:?}",
                     reader.buffer_position(),
                     e
@@ -87,7 +86,7 @@ pub unsafe fn moz_autoconfigure(
         || moz_ac.out.send_port == 0
     {
         let r = moz_ac.out.to_string();
-        warn!(context, 0, "Bad or incomplete autoconfig: {}", r,);
+        warn!(context, "Bad or incomplete autoconfig: {}", r,);
         free(xml_raw as *mut libc::c_void);
         return None;
     }

--- a/src/configure/auto_outlook.rs
+++ b/src/configure/auto_outlook.rs
@@ -75,7 +75,6 @@ pub unsafe fn outlk_autodiscover(
                 Err(e) => {
                     error!(
                         context,
-                        0,
                         "Configure xml: Error at position {}: {:?}",
                         reader.buffer_position(),
                         e
@@ -109,7 +108,7 @@ pub unsafe fn outlk_autodiscover(
             || outlk_ad.out.send_port == 0
         {
             let r = outlk_ad.out.to_string();
-            warn!(context, 0, "Bad or incomplete autoconfig: {}", r,);
+            warn!(context, "Bad or incomplete autoconfig: {}", r,);
             free(url as *mut libc::c_void);
             free(xml_raw as *mut libc::c_void);
             outlk_clean_config(&mut outlk_ad);

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -509,7 +509,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
                             )
                             .ok();
 
-                        context.sql.set_config_int(context, "configured", 1).ok();
+                        context.sql.set_config_bool(context, "configured", true);
                         true
                     }
                     18 => {

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -45,16 +45,16 @@ pub unsafe fn configure(context: &Context) {
 }
 
 /// Check if the context is already configured.
-pub fn dc_is_configured(context: &Context) -> libc::c_int {
+pub fn dc_is_configured(context: &Context) -> bool {
     if context
         .sql
         .get_config_int(context, "configured")
         .unwrap_or_default()
         > 0
     {
-        1
+        true
     } else {
-        0
+        false
     }
 }
 

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -34,10 +34,7 @@ macro_rules! progress {
 // connect
 pub unsafe fn configure(context: &Context) {
     if dc_has_ongoing(context) {
-        warn!(
-            context,
-            0, "There is already another ongoing process running.",
-        );
+        warn!(context, "There is already another ongoing process running.",);
         return;
     }
     job_kill_action(context, Action::ConfigureImap);
@@ -64,7 +61,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
     if dc_alloc_ongoing(context) {
         ongoing_allocated_here = true;
         if !context.sql.is_open() {
-            error!(context, 0, "Cannot configure, database not opened.",);
+            error!(context, "Cannot configure, database not opened.",);
         } else {
             context.inbox.read().unwrap().disconnect(context);
             context
@@ -80,7 +77,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
                 .imap
                 .disconnect(context);
             context.smtp.clone().lock().unwrap().disconnect();
-            info!(context, 0, "Configure ...",);
+            info!(context, "Configure ...",);
 
             let s_a = context.running_state.clone();
             let s = s_a.read().unwrap();
@@ -104,7 +101,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
                     1 => {
                         progress!(context, 1);
                         if param.addr.is_empty() {
-                            error!(context, 0, "Please enter an email address.",);
+                            error!(context, "Please enter an email address.",);
                         }
                         !param.addr.is_empty()
                     }
@@ -137,7 +134,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
                                 utf8_percent_encode(&param.addr, NON_ALPHANUMERIC).to_string();
                             true
                         } else {
-                            error!(context, 0, "Bad email-address.");
+                            error!(context, "Bad email-address.");
                             false
                         }
                     }
@@ -247,7 +244,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
                     12 => {
                         progress!(context, 500);
                         if let Some(ref cfg) = param_autoconfig {
-                            info!(context, 0, "Got autoconfig: {}", &cfg);
+                            info!(context, "Got autoconfig: {}", &cfg);
                             if !cfg.mail_user.is_empty() {
                                 param.mail_user = cfg.mail_user.clone();
                             }
@@ -331,7 +328,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
                             || param.send_pw.is_empty()
                             || param.server_flags == 0
                         {
-                            error!(context, 0, "Account settings incomplete.");
+                            error!(context, "Account settings incomplete.");
                             false
                         } else {
                             true
@@ -348,7 +345,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
                                 ok_to_continue8 = true;
                                 break;
                             }
-                            info!(context, 0, "Trying: {}", &param);
+                            info!(context, "Trying: {}", &param);
 
                             if context.inbox.read().unwrap().connect(context, &param) {
                                 ok_to_continue8 = true;
@@ -366,7 +363,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
                             progress!(context, 650 + username_variation * 30);
                             param.server_flags &= !(0x100 | 0x200 | 0x400);
                             param.server_flags |= 0x100;
-                            info!(context, 0, "Trying: {}", &param);
+                            info!(context, "Trying: {}", &param);
 
                             if context.inbox.read().unwrap().connect(context, &param) {
                                 ok_to_continue8 = true;
@@ -379,7 +376,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
                             }
                             progress!(context, 660 + username_variation * 30);
                             param.mail_port = 143;
-                            info!(context, 0, "Trying: {}", &param);
+                            info!(context, "Trying: {}", &param);
 
                             if context.inbox.read().unwrap().connect(context, &param) {
                                 ok_to_continue8 = true;
@@ -434,7 +431,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
                                 param.server_flags &= !(0x10000 | 0x20000 | 0x40000);
                                 param.server_flags |= 0x10000;
                                 param.send_port = 587;
-                                info!(context, 0, "Trying: {}", &param);
+                                info!(context, "Trying: {}", &param);
 
                                 if !context
                                     .smtp
@@ -450,7 +447,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
                                         param.server_flags &= !(0x10000 | 0x20000 | 0x40000);
                                         param.server_flags |= 0x10000;
                                         param.send_port = 25;
-                                        info!(context, 0, "Trying: {}", &param);
+                                        info!(context, "Trying: {}", &param);
 
                                         if !context
                                             .smtp
@@ -519,13 +516,13 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
                         // (~30 seconds on a Moto G4 play) and might looks as if message sending is always that slow.
                         e2ee::ensure_secret_key_exists(context);
                         success = true;
-                        info!(context, 0, "Configure completed.");
+                        info!(context, "Configure completed.");
                         progress!(context, 940);
                         break; // We are done here
                     }
 
                     _ => {
-                        error!(context, 0, "Internal error: step counter out of bound",);
+                        error!(context, "Internal error: step counter out of bound",);
                         break;
                     }
                 };
@@ -573,10 +570,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context, _job: &Job) {
 
 pub fn dc_alloc_ongoing(context: &Context) -> bool {
     if dc_has_ongoing(context) {
-        warn!(
-            context,
-            0, "There is already another ongoing process running.",
-        );
+        warn!(context, "There is already another ongoing process running.",);
 
         false
     } else {
@@ -619,7 +613,7 @@ pub fn dc_connect_to_configured_imap(context: &Context, imap: &Imap) -> libc::c_
         .unwrap_or_default()
         == 0
     {
-        warn!(context, 0, "Not configured, cannot connect.",);
+        warn!(context, "Not configured, cannot connect.",);
     } else {
         let param = LoginParam::from_database(context, "configured_");
         // the trailing underscore is correct
@@ -642,15 +636,15 @@ pub fn dc_stop_ongoing_process(context: &Context) {
     let mut s = s_a.write().unwrap();
 
     if s.ongoing_running && !s.shall_stop_ongoing {
-        info!(context, 0, "Signaling the ongoing process to stop ASAP.",);
+        info!(context, "Signaling the ongoing process to stop ASAP.",);
         s.shall_stop_ongoing = true;
     } else {
-        info!(context, 0, "No ongoing process to stop.",);
+        info!(context, "No ongoing process to stop.",);
     };
 }
 
 pub fn read_autoconf_file(context: &Context, url: &str) -> *mut libc::c_char {
-    info!(context, 0, "Testing {} ...", url);
+    info!(context, "Testing {} ...", url);
 
     match reqwest::Client::new()
         .get(url)
@@ -659,7 +653,7 @@ pub fn read_autoconf_file(context: &Context, url: &str) -> *mut libc::c_char {
     {
         Ok(res) => unsafe { res.strdup() },
         Err(_err) => {
-            info!(context, 0, "Can\'t read file.",);
+            info!(context, "Can\'t read file.",);
 
             std::ptr::null_mut()
         }

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -46,16 +46,7 @@ pub unsafe fn configure(context: &Context) {
 
 /// Check if the context is already configured.
 pub fn dc_is_configured(context: &Context) -> bool {
-    if context
-        .sql
-        .get_config_int(context, "configured")
-        .unwrap_or_default()
-        > 0
-    {
-        true
-    } else {
-        false
-    }
+    context.sql.get_config_bool(context, "configured")
 }
 
 /*******************************************************************************

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -308,7 +308,6 @@ impl<'a> Contact<'a> {
         if !may_be_valid_addr(&addr) {
             warn!(
                 context,
-                0,
                 "Bad address \"{}\" for contact \"{}\".",
                 addr,
                 if !name.as_ref().is_empty() {
@@ -404,7 +403,7 @@ impl<'a> Contact<'a> {
                 row_id = sql::get_rowid(context, &context.sql, "contacts", "addr", addr);
                 sth_modified = Modifier::Created;
             } else {
-                error!(context, 0, "Cannot add contact.");
+                error!(context, "Cannot add contact.");
             }
         }
 
@@ -683,7 +682,7 @@ impl<'a> Contact<'a> {
                     return Ok(());
                 }
                 Err(err) => {
-                    error!(context, 0, "delete_contact {} failed ({})", contact_id, err);
+                    error!(context, "delete_contact {} failed ({})", contact_id, err);
                     return Err(err);
                 }
             }
@@ -691,7 +690,7 @@ impl<'a> Contact<'a> {
 
         info!(
             context,
-            0, "could not delete contact {}, there are {} messages with it", contact_id, count_msgs
+            "could not delete contact {}, there are {} messages with it", contact_id, count_msgs
         );
         bail!("Could not delete contact with messages in it");
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -208,17 +208,11 @@ unsafe fn cb_precheck_imf(
         if *old_server_folder.offset(0isize) as libc::c_int == 0i32
             && old_server_uid == 0i32 as libc::c_uint
         {
-            info!(
-                context,
-                0,
-                "[move] detected bbc-self {}",
-                as_str(rfc724_mid),
-            );
+            info!(context, "[move] detected bbc-self {}", as_str(rfc724_mid),);
             mark_seen = 1i32
         } else if as_str(old_server_folder) != server_folder {
             info!(
                 context,
-                0,
                 "[move] detected moved message {}",
                 as_str(rfc724_mid),
             );
@@ -258,16 +252,16 @@ fn cb_get_config(context: &Context, key: &str) -> Option<String> {
 }
 
 pub unsafe fn dc_close(context: &Context) {
-    info!(context, 0, "disconnecting INBOX-watch",);
+    info!(context, "disconnecting INBOX-watch",);
     context.inbox.read().unwrap().disconnect(context);
-    info!(context, 0, "disconnecting sentbox-thread",);
+    info!(context, "disconnecting sentbox-thread",);
     context
         .sentbox_thread
         .read()
         .unwrap()
         .imap
         .disconnect(context);
-    info!(context, 0, "disconnecting mvbox-thread",);
+    info!(context, "disconnecting mvbox-thread",);
     context
         .mvbox_thread
         .read()
@@ -275,7 +269,7 @@ pub unsafe fn dc_close(context: &Context) {
         .imap
         .disconnect(context);
 
-    info!(context, 0, "disconnecting SMTP");
+    info!(context, "disconnecting SMTP");
     context.smtp.clone().lock().unwrap().disconnect();
 
     context.sql.close(context);

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -581,7 +581,7 @@ unsafe fn import_backup(context: &Context, backup_to_import: *const libc::c_char
             .map_or("<<None>>", |p| p.to_str().unwrap())
     );
 
-    if 0 != dc_is_configured(context) {
+    if dc_is_configured(context) {
         error!(context, 0, "Cannot import backups to accounts in use.");
         return 0;
     }

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -58,7 +58,6 @@ pub unsafe fn dc_imex_has_backup(
     if dir_iter.is_err() {
         info!(
             context,
-            0,
             "Backup check: Cannot open directory \"{}\".\x00",
             dir_name.display(),
         );
@@ -92,7 +91,7 @@ pub unsafe fn dc_imex_has_backup(
         Some(path) => match path.to_c_string() {
             Ok(cstr) => dc_strdup(cstr.as_ptr()),
             Err(err) => {
-                error!(context, 0, "Invalid backup filename: {}", err);
+                error!(context, "Invalid backup filename: {}", err);
                 std::ptr::null_mut()
             }
         },
@@ -156,7 +155,7 @@ pub unsafe fn dc_initiate_key_transfer(context: &Context) -> *mut libc::c_char {
                             .shall_stop_ongoing
                         {
                             if let Ok(msg_id) = chat::send_msg(context, chat_id, &mut msg) {
-                                info!(context, 0, "Wait for setup message being sent ...",);
+                                info!(context, "Wait for setup message being sent ...",);
                                 loop {
                                     if context
                                         .running_state
@@ -170,7 +169,7 @@ pub unsafe fn dc_initiate_key_transfer(context: &Context) -> *mut libc::c_char {
                                     std::thread::sleep(std::time::Duration::from_secs(1));
                                     if let Ok(msg) = dc_get_msg(context, msg_id) {
                                         if 0 != dc_msg_is_sent(&msg) {
-                                            info!(context, 0, "... setup message sent.",);
+                                            info!(context, "... setup message sent.",);
                                             break;
                                         }
                                     }
@@ -285,7 +284,7 @@ pub unsafe fn dc_continue_key_transfer(
             }
             || *filename.offset(0isize) as libc::c_int == 0i32
         {
-            error!(context, 0, "Message is no Autocrypt Setup Message.",);
+            error!(context, "Message is no Autocrypt Setup Message.",);
         } else if 0
             == dc_read_file(
                 context,
@@ -296,15 +295,15 @@ pub unsafe fn dc_continue_key_transfer(
             || filecontent.is_null()
             || filebytes <= 0
         {
-            error!(context, 0, "Cannot read Autocrypt Setup Message file.",);
+            error!(context, "Cannot read Autocrypt Setup Message file.",);
         } else {
             norm_sc = dc_normalize_setup_code(context, setup_code);
             if norm_sc.is_null() {
-                warn!(context, 0, "Cannot normalize Setup Code.",);
+                warn!(context, "Cannot normalize Setup Code.",);
             } else {
                 armored_key = dc_decrypt_setup_file(context, norm_sc, filecontent);
                 if armored_key.is_null() {
-                    warn!(context, 0, "Cannot decrypt Autocrypt Setup Message.",);
+                    warn!(context, "Cannot decrypt Autocrypt Setup Message.",);
                 } else if set_self_key(context, armored_key, 1) {
                     /*set default*/
                     /* error already logged */
@@ -334,7 +333,7 @@ fn set_self_key(
         .and_then(|(k, h)| k.split_key().map(|pub_key| (k, pub_key, h)));
 
     if keys.is_none() {
-        error!(context, 0, "File does not contain a valid private key.",);
+        error!(context, "File does not contain a valid private key.",);
         return false;
     }
 
@@ -364,13 +363,13 @@ fn set_self_key(
             return false;
         }
     } else {
-        error!(context, 0, "File does not contain a private key.",);
+        error!(context, "File does not contain a private key.",);
     }
 
     let self_addr = context.sql.get_config(context, "configured_addr");
 
     if self_addr.is_none() {
-        error!(context, 0, "Missing self addr");
+        error!(context, "Missing self addr");
         return false;
     }
 
@@ -382,7 +381,7 @@ fn set_self_key(
         set_default,
         &context.sql,
     ) {
-        error!(context, 0, "Cannot save keypair.");
+        error!(context, "Cannot save keypair.");
         return false;
     }
 
@@ -503,19 +502,18 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: &Job) {
         let _param2 = CString::yolo(job.param.get(Param::Arg2).unwrap_or_default());
 
         if strlen(param1.as_ptr()) == 0 {
-            error!(context, 0, "No Import/export dir/file given.",);
+            error!(context, "No Import/export dir/file given.",);
         } else {
-            info!(context, 0, "Import/export process started.",);
+            info!(context, "Import/export process started.",);
             context.call_cb(Event::IMEX_PROGRESS, 10 as uintptr_t, 0 as uintptr_t);
             if !context.sql.is_open() {
-                error!(context, 0, "Import/export: Database not opened.",);
+                error!(context, "Import/export: Database not opened.",);
             } else {
                 if what == 1 || what == 11 {
                     /* before we export anything, make sure the private key exists */
                     if e2ee::ensure_secret_key_exists(context).is_err() {
                         error!(
                             context,
-                            0,
                             "Import/export: Cannot create private key or private key not available.",
                         );
                         ok_to_continue = false;
@@ -527,25 +525,25 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: &Job) {
                     match what {
                         1 => {
                             if 0 != export_self_keys(context, param1.as_ptr()) {
-                                info!(context, 0, "Import/export completed.",);
+                                info!(context, "Import/export completed.",);
                                 success = 1
                             }
                         }
                         2 => {
                             if 0 != import_self_keys(context, param1.as_ptr()) {
-                                info!(context, 0, "Import/export completed.",);
+                                info!(context, "Import/export completed.",);
                                 success = 1
                             }
                         }
                         11 => {
                             if 0 != export_backup(context, param1.as_ptr()) {
-                                info!(context, 0, "Import/export completed.",);
+                                info!(context, "Import/export completed.",);
                                 success = 1
                             }
                         }
                         12 => {
                             if 0 != import_backup(context, param1.as_ptr()) {
-                                info!(context, 0, "Import/export completed.",);
+                                info!(context, "Import/export completed.",);
                                 success = 1
                             }
                         }
@@ -572,7 +570,6 @@ pub unsafe fn dc_job_do_DC_JOB_IMEX_IMAP(context: &Context, job: &Job) {
 unsafe fn import_backup(context: &Context, backup_to_import: *const libc::c_char) -> libc::c_int {
     info!(
         context,
-        0,
         "Import \"{}\" to \"{}\".",
         as_str(backup_to_import),
         context
@@ -582,7 +579,7 @@ unsafe fn import_backup(context: &Context, backup_to_import: *const libc::c_char
     );
 
     if dc_is_configured(context) {
-        error!(context, 0, "Cannot import backups to accounts in use.");
+        error!(context, "Cannot import backups to accounts in use.");
         return 0;
     }
     &context.sql.close(&context);
@@ -590,7 +587,7 @@ unsafe fn import_backup(context: &Context, backup_to_import: *const libc::c_char
     if dc_file_exist(context, context.get_dbfile().unwrap()) {
         error!(
             context,
-            0, "Cannot import backups: Cannot delete the old file.",
+            "Cannot import backups: Cannot delete the old file.",
         );
         return 0;
     }
@@ -617,7 +614,7 @@ unsafe fn import_backup(context: &Context, backup_to_import: *const libc::c_char
         .unwrap_or_default() as usize;
     info!(
         context,
-        0, "***IMPORT-in-progress: total_files_cnt={:?}", total_files_cnt,
+        "***IMPORT-in-progress: total_files_cnt={:?}", total_files_cnt,
     );
 
     let res = context.sql.query_map(
@@ -665,7 +662,6 @@ unsafe fn import_backup(context: &Context, backup_to_import: *const libc::c_char
                 }
                 error!(
                     context,
-                    0,
                     "Storage full? Cannot write file {} with {} bytes.",
                     &pathNfilename,
                     file_blob.len(),
@@ -712,7 +708,7 @@ unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_
     let buffer = CString::yolo(res);
     let dest_pathNfilename = dc_get_fine_pathNfilename(context, dir, buffer.as_ptr());
     if dest_pathNfilename.is_null() {
-        error!(context, 0, "Cannot get backup file name.",);
+        error!(context, "Cannot get backup file name.",);
 
         return success;
     }
@@ -724,7 +720,6 @@ unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_
     let mut closed = true;
     info!(
         context,
-        0,
         "Backup \"{}\" to \"{}\".",
         context
             .get_dbfile()
@@ -768,7 +763,7 @@ unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_
                 if let Ok(dir_handle) = std::fs::read_dir(dir) {
                     total_files_cnt += dir_handle.filter(|r| r.is_ok()).count();
 
-                    info!(context, 0, "EXPORT: total_files_cnt={}", total_files_cnt);
+                    info!(context, "EXPORT: total_files_cnt={}", total_files_cnt);
                     if total_files_cnt > 0 {
                         // scan directory, pass 2: copy files
                         if let Ok(dir_handle) = std::fs::read_dir(dir) {
@@ -814,7 +809,7 @@ unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_
                                                 {
                                                     continue;
                                                 } else {
-                                                    info!(context, 0, "EXPORTing filename={}", name);
+                                                    info!(context, "EXPORTing filename={}", name);
                                                     let curr_pathNfilename = format!(
                                                         "{}/{}",
                                                         as_str(context.get_blobdir()),
@@ -830,7 +825,6 @@ unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_
                                                         if stmt.execute(params![name, buf]).is_err() {
                                                             error!(
                                                                 context,
-                                                                0,
                                                                 "Disk full? Cannot add file \"{}\" to backup.",
                                                                 &curr_pathNfilename,
                                                             );
@@ -850,13 +844,12 @@ unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_
                         } else {
                             error!(
                                 context,
-                                0,
                                 "Backup: Cannot copy from blob-directory \"{}\".",
                                 as_str(context.get_blobdir()),
                             );
                         }
                     } else {
-                        info!(context, 0, "Backup: No files to copy.",);
+                        info!(context, "Backup: No files to copy.",);
                         ok_to_continue = true;
                     }
                     if ok_to_continue {
@@ -875,7 +868,6 @@ unsafe fn export_backup(context: &Context, dir: *const libc::c_char) -> libc::c_
                 } else {
                     error!(
                         context,
-                        0,
                         "Backup: Cannot get info for blob-directory \"{}\".",
                         as_str(context.get_blobdir())
                     );
@@ -940,7 +932,7 @@ unsafe fn import_self_keys(context: &Context, dir_name: *const libc::c_char) -> 
                     dir_name,
                     name_c.as_ptr(),
                 );
-                info!(context, 0, "Checking: {}", as_str(path_plus_name));
+                info!(context, "Checking: {}", as_str(path_plus_name));
                 free(buf as *mut libc::c_void);
                 buf = ptr::null_mut();
                 if 0 == dc_read_file(
@@ -984,7 +976,6 @@ unsafe fn import_self_keys(context: &Context, dir_name: *const libc::c_char) -> 
                 {
                     info!(
                         context,
-                        0,
                         "Treating \"{}\" as a legacy private key.",
                         as_str(path_plus_name),
                     );
@@ -998,7 +989,6 @@ unsafe fn import_self_keys(context: &Context, dir_name: *const libc::c_char) -> 
             if imported_cnt == 0i32 {
                 error!(
                     context,
-                    0,
                     "No private keys found in \"{}\".",
                     as_str(dir_name),
                 );
@@ -1006,7 +996,6 @@ unsafe fn import_self_keys(context: &Context, dir_name: *const libc::c_char) -> 
         } else {
             error!(
                 context,
-                0,
                 "Import: Cannot open directory \"{}\".",
                 as_str(dir_name),
             );
@@ -1106,10 +1095,10 @@ unsafe fn export_key_to_asc_file(
             id,
         )
     }
-    info!(context, 0, "Exporting key {}", as_str(file_name),);
+    info!(context, "Exporting key {}", as_str(file_name),);
     dc_delete_file(context, as_path(file_name));
     if !key.write_asc_to_file(file_name, context) {
-        error!(context, 0, "Cannot write key to {}", as_str(file_name),);
+        error!(context, "Cannot write key to {}", as_str(file_name),);
     } else {
         context.call_cb(
             Event::IMEX_FILE_WRITTEN,

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -225,7 +225,7 @@ pub unsafe fn dc_mimefactory_load_msg(
         Err(err) => {
             error!(
                 context,
-                0, "mimefactory: failed to load mime_in_reply_to: {:?}", err
+                "mimefactory: failed to load mime_in_reply_to: {:?}", err
             );
         }
     }
@@ -587,7 +587,6 @@ pub unsafe fn dc_mimefactory_render(factory: &mut dc_mimefactory_t) -> libc::c_i
                     if 0 != msg.param.get_int(Param::Arg2).unwrap_or_default() & 0x1 {
                         info!(
                             msg.context,
-                            0,
                             "sending secure-join message \'{}\' >>>>>>>>>>>>>>>>>>>>>>>>>",
                             "vg-member-added",
                         );
@@ -656,7 +655,6 @@ pub unsafe fn dc_mimefactory_render(factory: &mut dc_mimefactory_t) -> libc::c_i
                 if strlen(step) > 0 {
                     info!(
                         msg.context,
-                        0,
                         "sending secure-join message \'{}\' >>>>>>>>>>>>>>>>>>>>>>>>>",
                         as_str(step),
                     );
@@ -726,7 +724,7 @@ pub unsafe fn dc_mimefactory_render(factory: &mut dc_mimefactory_t) -> libc::c_i
                 }
             }
             if let Some(grpimage) = grpimage {
-                info!(factory.context, 0, "setting group image '{}'", grpimage);
+                info!(factory.context, "setting group image '{}'", grpimage);
                 let mut meta = dc_msg_new_untyped(factory.context);
                 meta.type_0 = Viewtype::Image;
                 meta.param.set(Param::File, grpimage);

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -460,7 +460,7 @@ unsafe fn dc_mimeparser_parse_mime_recursive(
         {
             info!(
                 mimeparser.context,
-                0, "Protected headers found in text/rfc822-headers attachment: Will be ignored.",
+                "Protected headers found in text/rfc822-headers attachment: Will be ignored.",
             );
             return 0i32;
         }
@@ -474,7 +474,7 @@ unsafe fn dc_mimeparser_parse_mime_recursive(
             ) != MAILIMF_NO_ERROR as libc::c_int
                 || mimeparser.header_protected.is_null()
             {
-                warn!(mimeparser.context, 0, "Protected headers parsing error.",);
+                warn!(mimeparser.context, "Protected headers parsing error.",);
             } else {
                 hash_header(
                     &mut mimeparser.header,
@@ -485,7 +485,6 @@ unsafe fn dc_mimeparser_parse_mime_recursive(
         } else {
             info!(
                 mimeparser.context,
-                0,
                 "Protected headers found in MIME header: Will be ignored as we already found an outer one."
             );
         }
@@ -667,7 +666,6 @@ unsafe fn dc_mimeparser_parse_mime_recursive(
                     if plain_cnt == 1i32 && html_cnt == 1i32 {
                         warn!(
                             mimeparser.context,
-                            0i32,
                             "HACK: multipart/mixed message found with PLAIN and HTML, we\'ll skip the HTML part as this seems to be unwanted."
                         );
                         skip_part = html_part
@@ -1072,7 +1070,7 @@ unsafe fn dc_mimeparser_add_single_part_if_known(
                                 );
 
                                 let (res, _, _) = encoding.decode(data);
-                                info!(mimeparser.context, 0, "decoded message: '{}'", res);
+                                info!(mimeparser.context, "decoded message: '{}'", res);
                                 if res.is_empty() {
                                     /* no error - but nothing to add */
                                     ok_to_continue = false;
@@ -1085,7 +1083,6 @@ unsafe fn dc_mimeparser_add_single_part_if_known(
                             } else {
                                 warn!(
                                     mimeparser.context,
-                                    0,
                                     "Cannot convert {} bytes from \"{}\" to \"utf-8\".",
                                     decoded_data_bytes as libc::c_int,
                                     as_str(charset),

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -132,15 +132,9 @@ pub unsafe fn dc_mimeparser_parse<'a>(context: &'a Context, body: &[u8]) -> dc_m
         dc_mimeparser_parse_mime_recursive(mimeparser_ref, mimeparser_ref.mimeroot);
         let field: *mut mailimf_field = dc_mimeparser_lookup_field(&mimeparser, "Subject");
         if !field.is_null() && (*field).fld_type == MAILIMF_FIELD_SUBJECT as libc::c_int {
-            let decoded = dc_decode_header_words((*(*field).fld_data.fld_subject).sbj_value);
-            if decoded.is_null()
-            /* XXX: can it happen? */
-            {
-                mimeparser.subject = None
-            } else {
-                mimeparser.subject = Some(to_string(decoded));
-                free(decoded.cast());
-            }
+            let subj = (*(*field).fld_data.fld_subject).sbj_value;
+
+            mimeparser.subject = as_opt_str(subj).map(dc_decode_header_words_safe);
         }
         if !dc_mimeparser_lookup_optional_field(&mut mimeparser, "Chat-Version").is_null() {
             mimeparser.is_send_by_messenger = true

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -41,7 +41,6 @@ pub unsafe fn dc_receive_imf(
 ) {
     info!(
         context,
-        0,
         "Receiving message {}/{}...",
         if !server_folder.as_ref().is_empty() {
             server_folder.as_ref()
@@ -61,7 +60,7 @@ pub unsafe fn dc_receive_imf(
 
     if mime_parser.header.is_empty() {
         // Error - even adding an empty record won't help as we do not know the message ID
-        info!(context, 0, "No header.");
+        info!(context, "No header.");
         return;
     }
 
@@ -189,7 +188,7 @@ pub unsafe fn dc_receive_imf(
             &mut created_db_entries,
             &mut create_event_to_send,
         ) {
-            info!(context, 0, "{}", err);
+            info!(context, "{}", err);
 
             cleanup(
                 context,
@@ -243,7 +242,6 @@ pub unsafe fn dc_receive_imf(
 
     info!(
         context,
-        0,
         "received message {} has Message-Id: {}",
         server_uid,
         to_string(rfc724_mid)
@@ -447,10 +445,7 @@ unsafe fn add_parts(
             // check if the message belongs to a mailing list
             if dc_mimeparser_is_mailinglist_message(mime_parser) {
                 *chat_id = 3;
-                info!(
-                    context,
-                    0, "Message belongs to a mailing list and is ignored.",
-                );
+                info!(context, "Message belongs to a mailing list and is ignored.",);
             }
         }
 
@@ -482,7 +477,7 @@ unsafe fn add_parts(
                     Contact::scaleup_origin_by_id(context, *from_id, Origin::IncomingReplyTo);
                     info!(
                         context,
-                        0, "Message is a reply to a known message, mark sender as known.",
+                        "Message is a reply to a known message, mark sender as known.",
                     );
                     if !incoming_origin.is_verified() {
                         *incoming_origin = Origin::IncomingReplyTo;
@@ -724,7 +719,7 @@ unsafe fn add_parts(
 
     info!(
         context,
-        0, "Message has {} parts and is assigned to chat #{}.", icnt, *chat_id,
+        "Message has {} parts and is assigned to chat #{}.", icnt, *chat_id,
     );
 
     // check event to send
@@ -962,7 +957,7 @@ fn save_locations(
                             insert_msg_id,
                             newest_location_id,
                         ) {
-                            error!(context, 0, "Failed to set msg_location_id: {:?}", err);
+                            error!(context, "Failed to set msg_location_id: {:?}", err);
                         }
                     }
                     send_event = true;
@@ -1317,7 +1312,7 @@ unsafe fn create_or_lookup_group(
     if !X_MrAddToGrp.is_null() || !X_MrRemoveFromGrp.is_null() {
         recreate_member_list = 1;
     } else if 0 != X_MrGrpNameChanged && !grpname.is_null() && strlen(grpname) < 200 {
-        info!(context, 0, "updating grpname for chat {}", chat_id);
+        info!(context, "updating grpname for chat {}", chat_id);
         if sql::execute(
             context,
             &context.sql,
@@ -1332,7 +1327,7 @@ unsafe fn create_or_lookup_group(
     if !X_MrGrpImageChanged.is_empty() {
         info!(
             context,
-            0, "grp-image-change {} chat {}", X_MrGrpImageChanged, chat_id
+            "grp-image-change {} chat {}", X_MrGrpImageChanged, chat_id
         );
         let mut changed = false;
         let mut grpimage = "".to_string();
@@ -1346,13 +1341,13 @@ unsafe fn create_or_lookup_group(
                         .get(Param::File)
                         .map(|s| s.to_string())
                         .unwrap_or_else(|| "".to_string());
-                    info!(context, 0, "found image {:?}", grpimage);
+                    info!(context, "found image {:?}", grpimage);
                     changed = true;
                 }
             }
         }
         if changed {
-            info!(context, 0, "New group image set to '{}'.", grpimage);
+            info!(context, "New group image set to '{}'.", grpimage);
             if let Ok(mut chat) = Chat::load_from_db(context, chat_id) {
                 if grpimage.is_empty() {
                     chat.param.remove(Param::ProfileImage);
@@ -1741,7 +1736,7 @@ unsafe fn check_verified_properties(
 ) -> libc::c_int {
     let verify_fail = |reason: String| {
         *failure_reason = format!("{}. See \"Info\" for details.", reason).strdup();
-        warn!(context, 0, "{}", reason);
+        warn!(context, "{}", reason);
     };
 
     let contact = match Contact::load_from_db(context, from_id) {
@@ -1812,13 +1807,7 @@ unsafe fn check_verified_properties(
                 || peerstate.verified_key_fingerprint != peerstate.public_key_fingerprint
                     && peerstate.verified_key_fingerprint != peerstate.gossip_key_fingerprint
             {
-                info!(
-                    context,
-                    0,
-                    "{} has verfied {}.",
-                    contact.get_addr(),
-                    to_addr,
-                );
+                info!(context, "{} has verfied {}.", contact.get_addr(), to_addr,);
                 let fp = peerstate.gossip_key_fingerprint.clone();
                 if let Some(fp) = fp {
                     peerstate.set_verified(0, &fp, 2);

--- a/src/dc_strencode.rs
+++ b/src/dc_strencode.rs
@@ -12,6 +12,20 @@ use crate::dc_tools::*;
 use crate::types::*;
 use crate::x::*;
 
+/**
+ * Encode non-ascii-strings as `=?UTF-8?Q?Bj=c3=b6rn_Petersen?=`.
+ * Belongs to RFC 2047: https://tools.ietf.org/html/rfc2047
+ *
+ * We do not fold at position 72; this would result in empty words as `=?utf-8?Q??=` which are correct,
+ * but cannot be displayed by some mail programs (eg. Android Stock Mail).
+ * however, this is not needed, as long as _one_ word is not longer than 72 characters.
+ * _if_ it is, the display may get weird.  This affects the subject only.
+ * the best solution wor all this would be if libetpan encodes the line as only libetpan knowns when a header line is full.
+ *
+ * @param to_encode Null-terminated UTF-8-string to encode.
+ * @return Returns the encoded string which must be free()'d when no longed needed.
+ *     On errors, NULL is returned.
+ */
 pub unsafe fn dc_encode_header_words(to_encode: *const libc::c_char) -> *mut libc::c_char {
     let mut ok_to_continue = true;
     let mut ret_str: *mut libc::c_char = ptr::null_mut();

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -852,7 +852,7 @@ pub fn dc_delete_file(context: &Context, path: impl AsRef<std::path::Path>) -> b
     match res {
         Ok(_) => true,
         Err(_err) => {
-            warn!(context, 0, "Cannot delete \"{}\".", path.as_ref().display());
+            warn!(context, "Cannot delete \"{}\".", path.as_ref().display());
             false
         }
     }
@@ -870,7 +870,6 @@ pub fn dc_copy_file(
         Err(_) => {
             error!(
                 context,
-                0,
                 "Cannot copy \"{}\" to \"{}\".",
                 src.as_ref().display(),
                 dest.as_ref().display(),
@@ -888,7 +887,6 @@ pub fn dc_create_folder(context: &Context, path: impl AsRef<std::path::Path>) ->
             Err(_err) => {
                 warn!(
                     context,
-                    0,
                     "Cannot create directory \"{}\".",
                     path.as_ref().display(),
                 );
@@ -921,7 +919,6 @@ pub fn dc_write_file_safe<P: AsRef<std::path::Path>>(
     if let Err(_err) = fs::write(&path_abs, buf) {
         warn!(
             context,
-            0,
             "Cannot write {} bytes to \"{}\".",
             buf.len(),
             path.as_ref().display(),
@@ -959,7 +956,6 @@ pub fn dc_read_file_safe<P: AsRef<std::path::Path>>(context: &Context, path: P) 
         Err(_err) => {
             warn!(
                 context,
-                0,
                 "Cannot read \"{}\" or file is empty.",
                 path.as_ref().display()
             );

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -91,7 +91,7 @@ impl E2eeHelper {
 
             if let Some(addr) = addr {
                 let pubkey_ret = load_or_generate_self_public_key(context, &addr).map_err(|err| {
-                    error!(context, 0, "Failed to load public key: {}", err);
+                    error!(context, "Failed to load public key: {}", err);
                     err
                 });
                 if let Ok(public_key) = pubkey_ret {
@@ -113,7 +113,7 @@ impl E2eeHelper {
                                     let peerstate = peerstate.unwrap();
                                     info!(
                                         context,
-                                        0, "dc_e2ee_encrypt {} has peerstate", recipient_addr
+                                        "dc_e2ee_encrypt {} has peerstate", recipient_addr
                                     );
                                     if let Some(key) = peerstate.peek_key(min_verified as usize) {
                                         keyring.add_owned(key.clone());
@@ -122,7 +122,6 @@ impl E2eeHelper {
                                 } else {
                                     info!(
                                         context,
-                                        0,
                                         "dc_e2ee_encrypt {} HAS NO peerstate {}",
                                         recipient_addr,
                                         peerstate.is_some()
@@ -608,7 +607,7 @@ fn load_or_generate_self_public_key(context: &Context, self_addr: impl AsRef<str
     let start = std::time::Instant::now();
     info!(
         context,
-        0, "Generating keypair with {} bits, e={} ...", 2048, 65537,
+        "Generating keypair with {} bits, e={} ...", 2048, 65537,
     );
     match dc_pgp_create_keypair(&self_addr) {
         Some((public_key, private_key)) => {
@@ -623,7 +622,6 @@ fn load_or_generate_self_public_key(context: &Context, self_addr: impl AsRef<str
                 true => {
                     info!(
                         context,
-                        0,
                         "Keypair generated in {:.3}s.",
                         start.elapsed().as_secs()
                     );
@@ -691,7 +689,6 @@ unsafe fn update_gossip_peerstates(
                     } else {
                         info!(
                             context,
-                            0,
                             "Ignoring gossipped \"{}\" as the address is not in To/Cc list.",
                             &header.addr,
                         );

--- a/src/job.rs
+++ b/src/job.rs
@@ -159,7 +159,7 @@ impl Job {
                     if 0 != self.foreign_id && !dc_msg_exists(context, self.foreign_id) {
                         warn!(
                             context,
-                            0, "Message {} for job {} does not exist", self.foreign_id, self.job_id,
+                            "Message {} for job {} does not exist", self.foreign_id, self.job_id,
                         );
                         return;
                     };
@@ -197,7 +197,7 @@ impl Job {
                         }
                     }
                 } else {
-                    warn!(context, 0, "Missing recipients for job {}", self.job_id,);
+                    warn!(context, "Missing recipients for job {}", self.job_id,);
                 }
             }
         }
@@ -277,7 +277,7 @@ impl Job {
                 if dc_rfc724_mid_cnt(context, msg.rfc724_mid) != 1 {
                     info!(
                         context,
-                        0, "The message is deleted from the server when all parts are deleted.",
+                        "The message is deleted from the server when all parts are deleted.",
                     );
                     delete_from_server = 0i32
                 }
@@ -440,18 +440,17 @@ pub fn perform_imap_fetch(context: &Context) {
         .unwrap_or_else(|| 1)
         == 0
     {
-        info!(context, 0, "INBOX-watch disabled.",);
+        info!(context, "INBOX-watch disabled.",);
         return;
     }
-    info!(context, 0, "INBOX-fetch started...",);
+    info!(context, "INBOX-fetch started...",);
     inbox.fetch(context);
     if inbox.should_reconnect() {
-        info!(context, 0, "INBOX-fetch aborted, starting over...",);
+        info!(context, "INBOX-fetch aborted, starting over...",);
         inbox.fetch(context);
     }
     info!(
         context,
-        0,
         "INBOX-fetch done in {:.4} ms.",
         start.elapsed().as_nanos() as f64 / 1000.0,
     );
@@ -465,13 +464,13 @@ pub fn perform_imap_idle(context: &Context) {
     if *context.perform_inbox_jobs_needed.clone().read().unwrap() {
         info!(
             context,
-            0, "INBOX-IDLE will not be started because of waiting jobs."
+            "INBOX-IDLE will not be started because of waiting jobs."
         );
         return;
     }
-    info!(context, 0, "INBOX-IDLE started...");
+    info!(context, "INBOX-IDLE started...");
     inbox.idle(context);
-    info!(context, 0, "INBOX-IDLE ended.");
+    info!(context, "INBOX-IDLE ended.");
 }
 
 pub fn perform_mvbox_fetch(context: &Context) {
@@ -548,16 +547,16 @@ pub fn perform_smtp_jobs(context: &Context) {
         state.perform_jobs_needed = 0;
 
         if state.suspended {
-            info!(context, 0, "SMTP-jobs suspended.",);
+            info!(context, "SMTP-jobs suspended.",);
             return;
         }
         state.doing_jobs = true;
         probe_smtp_network
     };
 
-    info!(context, 0, "SMTP-jobs started...",);
+    info!(context, "SMTP-jobs started...",);
     job_perform(context, Thread::Smtp, probe_smtp_network);
-    info!(context, 0, "SMTP-jobs ended.");
+    info!(context, "SMTP-jobs ended.");
 
     {
         let &(ref lock, _) = &*context.smtp_state.clone();
@@ -568,7 +567,7 @@ pub fn perform_smtp_jobs(context: &Context) {
 }
 
 pub fn perform_smtp_idle(context: &Context) {
-    info!(context, 0, "SMTP-idle started...",);
+    info!(context, "SMTP-idle started...",);
     {
         let &(ref lock, ref cvar) = &*context.smtp_state.clone();
         let mut state = lock.lock().unwrap();
@@ -576,7 +575,7 @@ pub fn perform_smtp_idle(context: &Context) {
         if state.perform_jobs_needed == 1 {
             info!(
                 context,
-                0, "SMTP-idle will not be started because of waiting jobs.",
+                "SMTP-idle will not be started because of waiting jobs.",
             );
         } else {
             let dur = get_next_wakeup_time(context, Thread::Smtp);
@@ -594,7 +593,7 @@ pub fn perform_smtp_idle(context: &Context) {
         }
     }
 
-    info!(context, 0, "SMTP-idle ended.",);
+    info!(context, "SMTP-idle ended.",);
 }
 
 fn get_next_wakeup_time(context: &Context, thread: Thread) -> Duration {
@@ -653,7 +652,7 @@ pub unsafe fn job_send_msg(context: &Context, msg_id: uint32_t) -> libc::c_int {
     if mimefactory.is_err() || mimefactory.as_ref().unwrap().from_addr.is_null() {
         warn!(
             context,
-            0, "Cannot load data to send, maybe the message is deleted in between.",
+            "Cannot load data to send, maybe the message is deleted in between.",
         );
     } else {
         let mut mimefactory = mimefactory.unwrap();
@@ -695,7 +694,6 @@ pub unsafe fn job_send_msg(context: &Context, msg_id: uint32_t) -> libc::c_int {
         {
             warn!(
                 context,
-                0,
                 "e2e encryption unavailable {} - {:?}",
                 msg_id,
                 mimefactory.msg.param.get_int(Param::GuranteeE2ee),
@@ -726,7 +724,7 @@ pub unsafe fn job_send_msg(context: &Context, msg_id: uint32_t) -> libc::c_int {
                 if let Err(err) =
                     location::set_kml_sent_timestamp(context, mimefactory.msg.chat_id, time())
                 {
-                    error!(context, 0, "Failed to set kml sent_timestamp: {:?}", err);
+                    error!(context, "Failed to set kml sent_timestamp: {:?}", err);
                 }
                 if !mimefactory.msg.hidden {
                     if let Err(err) = location::set_msg_location_id(
@@ -734,7 +732,7 @@ pub unsafe fn job_send_msg(context: &Context, msg_id: uint32_t) -> libc::c_int {
                         mimefactory.msg.id,
                         mimefactory.out_last_added_location_id,
                     ) {
-                        error!(context, 0, "Failed to set msg_location_id: {:?}", err);
+                        error!(context, "Failed to set msg_location_id: {:?}", err);
                     }
                 }
             }
@@ -757,14 +755,14 @@ pub unsafe fn job_send_msg(context: &Context, msg_id: uint32_t) -> libc::c_int {
 }
 
 pub fn perform_imap_jobs(context: &Context) {
-    info!(context, 0, "dc_perform_imap_jobs starting.",);
+    info!(context, "dc_perform_imap_jobs starting.",);
 
     let probe_imap_network = *context.probe_imap_network.clone().read().unwrap();
     *context.probe_imap_network.write().unwrap() = false;
     *context.perform_inbox_jobs_needed.write().unwrap() = false;
 
     job_perform(context, Thread::Imap, probe_imap_network);
-    info!(context, 0, "dc_perform_imap_jobs ended.",);
+    info!(context, "dc_perform_imap_jobs ended.",);
 }
 
 fn job_perform(context: &Context, thread: Thread, probe_network: bool) {
@@ -812,14 +810,13 @@ fn job_perform(context: &Context, thread: Thread, probe_network: bool) {
     match jobs {
         Ok(ref _res) => {}
         Err(ref err) => {
-            info!(context, 0, "query failed: {:?}", err);
+            info!(context, "query failed: {:?}", err);
         }
     }
 
     for mut job in jobs.unwrap_or_default() {
         info!(
             context,
-            0,
             "{}-job #{}, action {} started...",
             if thread == Thread::Imap {
                 "INBOX"
@@ -858,7 +855,7 @@ fn job_perform(context: &Context, thread: Thread, probe_network: bool) {
 
             match job.action {
                 Action::Unknown => {
-                    warn!(context, 0, "Unknown job id found");
+                    warn!(context, "Unknown job id found");
                 }
                 Action::SendMsgToSmtp => job.do_DC_JOB_SEND(context),
                 Action::DeleteMsgOnImap => job.do_DC_JOB_DELETE_MSG_ON_IMAP(context),
@@ -902,7 +899,6 @@ fn job_perform(context: &Context, thread: Thread, probe_network: bool) {
             // just try over next loop unconditionally, the ui typically interrupts idle when the file (video) is ready
             info!(
                 context,
-                0,
                 "{}-job #{} not yet ready and will be delayed.",
                 if thread == Thread::Imap {
                     "INBOX"
@@ -920,7 +916,6 @@ fn job_perform(context: &Context, thread: Thread, probe_network: bool) {
                 job.update(context);
                 info!(
                     context,
-                    0,
                     "{}-job #{} not succeeded on try #{}, retry in ADD_TIME+{} (in {} seconds).",
                     if thread == Thread::Imap {
                         "INBOX"
@@ -1019,7 +1014,6 @@ fn add_smtp_job(context: &Context, action: Action, mimefactory: &dc_mimefactory_
     if pathNfilename.is_null() {
         error!(
             context,
-            0,
             "Could not find free file name for message with ID <{}>.",
             to_string(mimefactory.rfc724_mid),
         );
@@ -1035,7 +1029,6 @@ fn add_smtp_job(context: &Context, action: Action, mimefactory: &dc_mimefactory_
     {
         error!(
             context,
-            0,
             "Could not write message <{}> to \"{}\".",
             to_string(mimefactory.rfc724_mid),
             as_str(pathNfilename),
@@ -1079,7 +1072,7 @@ pub fn job_add(
     delay_seconds: i64,
 ) {
     if action == Action::Unknown {
-        error!(context, 0, "Invalid action passed to job_add");
+        error!(context, "Invalid action passed to job_add");
         return;
     }
 
@@ -1108,7 +1101,7 @@ pub fn job_add(
 }
 
 pub fn interrupt_smtp_idle(context: &Context) {
-    info!(context, 0, "Interrupting SMTP-idle...",);
+    info!(context, "Interrupting SMTP-idle...",);
 
     let &(ref lock, ref cvar) = &*context.smtp_state.clone();
     let mut state = lock.lock().unwrap();
@@ -1119,7 +1112,7 @@ pub fn interrupt_smtp_idle(context: &Context) {
 }
 
 pub fn interrupt_imap_idle(context: &Context) {
-    info!(context, 0, "Interrupting IMAP-IDLE...",);
+    info!(context, "Interrupting IMAP-IDLE...",);
 
     *context.perform_inbox_jobs_needed.write().unwrap() = true;
     context.inbox.read().unwrap().interrupt_idle();

--- a/src/job_thread.rs
+++ b/src/job_thread.rs
@@ -30,7 +30,7 @@ impl JobThread {
     }
 
     pub fn suspend(&self, context: &Context) {
-        info!(context, 0, "Suspending {}-thread.", self.name,);
+        info!(context, "Suspending {}-thread.", self.name,);
         {
             self.state.0.lock().unwrap().suspended = true;
         }
@@ -45,7 +45,7 @@ impl JobThread {
     }
 
     pub fn unsuspend(&self, context: &Context) {
-        info!(context, 0, "Unsuspending {}-thread.", self.name);
+        info!(context, "Unsuspending {}-thread.", self.name);
 
         let &(ref lock, ref cvar) = &*self.state.clone();
         let mut state = lock.lock().unwrap();
@@ -60,7 +60,7 @@ impl JobThread {
             self.state.0.lock().unwrap().jobs_needed = 1;
         }
 
-        info!(context, 0, "Interrupting {}-IDLE...", self.name);
+        info!(context, "Interrupting {}-IDLE...", self.name);
 
         self.imap.interrupt_idle();
 
@@ -86,16 +86,15 @@ impl JobThread {
         if use_network {
             let start = std::time::Instant::now();
             if self.connect_to_imap(context) {
-                info!(context, 0, "{}-fetch started...", self.name);
+                info!(context, "{}-fetch started...", self.name);
                 self.imap.fetch(context);
 
                 if self.imap.should_reconnect() {
-                    info!(context, 0, "{}-fetch aborted, starting over...", self.name,);
+                    info!(context, "{}-fetch aborted, starting over...", self.name,);
                     self.imap.fetch(context);
                 }
                 info!(
                     context,
-                    0,
                     "{}-fetch done in {:.3} ms.",
                     self.name,
                     start.elapsed().as_millis(),
@@ -142,7 +141,6 @@ impl JobThread {
             if 0 != state.jobs_needed {
                 info!(
                     context,
-                    0,
                     "{}-IDLE will not be started as it was interrupted while not ideling.",
                     self.name,
                 );
@@ -172,9 +170,9 @@ impl JobThread {
         }
 
         self.connect_to_imap(context);
-        info!(context, 0, "{}-IDLE started...", self.name,);
+        info!(context, "{}-IDLE started...", self.name,);
         self.imap.idle(context);
-        info!(context, 0, "{}-IDLE ended.", self.name);
+        info!(context, "{}-IDLE ended.", self.name);
 
         self.state.0.lock().unwrap().using_handle = false;
     }

--- a/src/key.rs
+++ b/src/key.rs
@@ -245,7 +245,7 @@ impl Key {
                     file_content_c.as_bytes().len(),
                 )
             } {
-            error!(context, 0, "Cannot write key to {}", to_string(file));
+            error!(context, "Cannot write key to {}", to_string(file));
             false
         } else {
             true

--- a/src/location.rs
+++ b/src/location.rs
@@ -84,7 +84,6 @@ impl Kml {
                 Err(e) => {
                     error!(
                         context,
-                        0,
                         "Location parsing: Error at position {}: {:?}",
                         reader.buffer_position(),
                         e
@@ -546,7 +545,7 @@ pub fn job_do_DC_JOB_MAYBE_SEND_LOCATIONS(context: &Context, _job: &Job) {
     let mut continue_streaming: libc::c_int = 1;
     info!(
         context,
-        0, " ----------------- MAYBE_SEND_LOCATIONS -------------- ",
+        " ----------------- MAYBE_SEND_LOCATIONS -------------- ",
     );
 
     context

--- a/src/log.rs
+++ b/src/log.rs
@@ -34,13 +34,11 @@ macro_rules! log_event {
         log_event!($ctx, $data1, $msg,)
     };
     ($ctx:expr, $event:expr, $data1:expr, $msg:expr, $($args:expr),* $(,)?) => {
-        #[allow(unused_unsafe)]
-        unsafe {
-            let formatted = format!($msg, $($args),*);
-            let formatted_c = std::ffi::CString::new(formatted).unwrap();
-            $ctx.call_cb($event, $data1 as libc::uintptr_t,
-                         formatted_c.as_ptr() as libc::uintptr_t);
-    }};
+        let formatted = format!($msg, $($args),*);
+        let formatted_c = std::ffi::CString::new(formatted).unwrap();
+        $ctx.call_cb($event, $data1 as libc::uintptr_t,
+                     formatted_c.as_ptr() as libc::uintptr_t);
+    };
 }
 
 #[macro_export]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,44 +1,44 @@
 #[macro_export]
 macro_rules! info {
-    ($ctx:expr, $data1:expr, $msg:expr) => {
-        info!($ctx, $data1, $msg,)
+    ($ctx:expr,  $msg:expr) => {
+        info!($ctx, $msg,)
     };
-    ($ctx:expr, $data1:expr, $msg:expr, $($args:expr),* $(,)?) => {
+    ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {
         #[allow(unused_unsafe)]
         unsafe {
             let formatted = format!($msg, $($args),*);
             let formatted_c =  std::ffi::CString::new(formatted).unwrap();
-            $ctx.call_cb($crate::constants::Event::INFO, $data1 as libc::uintptr_t,
+            $ctx.call_cb($crate::constants::Event::INFO, 0,
                      formatted_c.as_ptr() as libc::uintptr_t);
     }};
 }
 
 #[macro_export]
 macro_rules! warn {
-    ($ctx:expr, $data1:expr, $msg:expr) => {
-        warn!($ctx, $data1, $msg,)
+    ($ctx:expr, $msg:expr) => {
+        warn!($ctx, $msg,)
     };
-    ($ctx:expr, $data1:expr, $msg:expr, $($args:expr),* $(,)?) => {
+    ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {
         #[allow(unused_unsafe)]
         unsafe {
             let formatted = format!($msg, $($args),*);
             let formatted_c = std::ffi::CString::new(formatted).unwrap();
-            $ctx.call_cb($crate::constants::Event::WARNING, $data1 as libc::uintptr_t,
+            $ctx.call_cb($crate::constants::Event::WARNING, 0,
                          formatted_c.as_ptr() as libc::uintptr_t);
         }};
 }
 
 #[macro_export]
 macro_rules! error {
-    ($ctx:expr, $data1:expr, $msg:expr) => {
-        error!($ctx, $data1, $msg,)
+    ($ctx:expr, $msg:expr) => {
+        error!($ctx, $msg,)
     };
-    ($ctx:expr, $data1:expr, $msg:expr, $($args:expr),* $(,)?) => {
+    ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {
         #[allow(unused_unsafe)]
         unsafe {
         let formatted = format!($msg, $($args),*);
         let formatted_c = std::ffi::CString::new(formatted).unwrap();
-        $ctx.call_cb($crate::constants::Event::ERROR, $data1 as libc::uintptr_t,
+        $ctx.call_cb($crate::constants::Event::ERROR, 0,
                      formatted_c.as_ptr() as libc::uintptr_t);
     }};
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -4,13 +4,8 @@ macro_rules! info {
         info!($ctx, $msg,)
     };
     ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {
-        #[allow(unused_unsafe)]
-        unsafe {
-            let formatted = format!($msg, $($args),*);
-            let formatted_c =  std::ffi::CString::new(formatted).unwrap();
-            $ctx.call_cb($crate::constants::Event::INFO, 0,
-                     formatted_c.as_ptr() as libc::uintptr_t);
-    }};
+        log_event!($ctx, $crate::constants::Event::INFO, 0, $msg, $($args),*);
+    };
 }
 
 #[macro_export]
@@ -19,13 +14,8 @@ macro_rules! warn {
         warn!($ctx, $msg,)
     };
     ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {
-        #[allow(unused_unsafe)]
-        unsafe {
-            let formatted = format!($msg, $($args),*);
-            let formatted_c = std::ffi::CString::new(formatted).unwrap();
-            $ctx.call_cb($crate::constants::Event::WARNING, 0,
-                         formatted_c.as_ptr() as libc::uintptr_t);
-        }};
+        log_event!($ctx, $crate::constants::Event::WARNING, 0, $msg, $($args),*);
+    };
 }
 
 #[macro_export]
@@ -34,13 +24,8 @@ macro_rules! error {
         error!($ctx, $msg,)
     };
     ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {
-        #[allow(unused_unsafe)]
-        unsafe {
-        let formatted = format!($msg, $($args),*);
-        let formatted_c = std::ffi::CString::new(formatted).unwrap();
-        $ctx.call_cb($crate::constants::Event::ERROR, 0,
-                     formatted_c.as_ptr() as libc::uintptr_t);
-    }};
+        log_event!($ctx, $crate::constants::Event::ERROR, 0, $msg, $($args),*);
+    };
 }
 
 #[macro_export]

--- a/src/message.rs
+++ b/src/message.rs
@@ -477,7 +477,7 @@ pub fn dc_msg_load_from_db<'a>(context: &'a Context, id: u32) -> Result<Message<
                     if let Ok(t) = String::from_utf8(buf.to_vec()) {
                         text = t;
                     } else {
-                        warn!(context, 0, "dc_msg_load_from_db: could not get text column as non-lossy utf8 id {}", id);
+                        warn!(context, "dc_msg_load_from_db: could not get text column as non-lossy utf8 id {}", id);
                         text = String::from_utf8_lossy(buf).into_owned();
                     }
                 } else {
@@ -579,7 +579,7 @@ pub fn dc_markseen_msgs(context: &Context, msg_ids: *const u32, msg_cnt: usize) 
     );
 
     if msgs.is_err() {
-        warn!(context, 0, "markseen_msgs failed: {:?}", msgs);
+        warn!(context, "markseen_msgs failed: {:?}", msgs);
         return false;
     }
     let mut send_event = false;
@@ -589,7 +589,7 @@ pub fn dc_markseen_msgs(context: &Context, msg_ids: *const u32, msg_cnt: usize) 
         if curr_blocked == Blocked::Not {
             if curr_state == MessageState::InFresh || curr_state == MessageState::InNoticed {
                 dc_update_msg_state(context, id, MessageState::InSeen);
-                info!(context, 0, "Seen message #{}.", id);
+                info!(context, "Seen message #{}.", id);
 
                 job_add(
                     context,
@@ -1074,7 +1074,7 @@ pub fn dc_set_msg_failed(context: &Context, msg_id: u32, error: Option<impl AsRe
         }
         if let Some(error) = error {
             msg.param.set(Param::Error, error.as_ref());
-            error!(context, 0, "{}", error.as_ref());
+            error!(context, "{}", error.as_ref());
         }
 
         if sql::execute(
@@ -1203,7 +1203,7 @@ pub fn dc_get_real_msg_cnt(context: &Context) -> libc::c_int {
     ) {
         Ok(res) => res,
         Err(err) => {
-            error!(context, 0, "dc_get_real_msg_cnt() failed. {}", err);
+            error!(context, "dc_get_real_msg_cnt() failed. {}", err);
             0
         }
     }
@@ -1219,7 +1219,7 @@ pub fn dc_get_deaddrop_msg_cnt(context: &Context) -> size_t {
     ) {
         Ok(res) => res as size_t,
         Err(err) => {
-            error!(context, 0, "dc_get_deaddrop_msg_cnt() failed. {}", err);
+            error!(context, "dc_get_deaddrop_msg_cnt() failed. {}", err);
             0
         }
     }
@@ -1234,7 +1234,7 @@ pub fn dc_rfc724_mid_cnt(context: &Context, rfc724_mid: *const libc::c_char) -> 
     ) {
         Ok(res) => res,
         Err(err) => {
-            error!(context, 0, "dc_get_rfc724_mid_cnt() failed. {}", err);
+            error!(context, "dc_get_rfc724_mid_cnt() failed. {}", err);
             0
         }
     }
@@ -1288,7 +1288,7 @@ pub fn dc_update_server_uid(
     ) {
         Ok(_) => {}
         Err(err) => {
-            warn!(context, 0, "msg: failed to update server_uid: {}", err);
+            warn!(context, "msg: failed to update server_uid: {}", err);
         }
     }
 }

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -97,10 +97,7 @@ pub fn dc_get_oauth2_access_token(
 
         let (redirect_uri, token_url, update_redirect_uri_on_success) =
             if refresh_token.is_none() || refresh_token_for != code.as_ref() {
-                info!(
-                    context,
-                    0, "Generate OAuth2 refresh_token and access_token...",
-                );
+                info!(context, "Generate OAuth2 refresh_token and access_token...",);
                 (
                     context
                         .sql
@@ -112,7 +109,7 @@ pub fn dc_get_oauth2_access_token(
             } else {
                 info!(
                     context,
-                    0, "Regenerate OAuth2 access_token by refresh_token...",
+                    "Regenerate OAuth2 access_token by refresh_token...",
                 );
                 (
                     context
@@ -134,7 +131,7 @@ pub fn dc_get_oauth2_access_token(
         if response.is_err() {
             warn!(
                 context,
-                0, "Error calling OAuth2 at {}: {:?}", token_url, response
+                "Error calling OAuth2 at {}: {:?}", token_url, response
             );
             return None;
         }
@@ -142,7 +139,6 @@ pub fn dc_get_oauth2_access_token(
         if !response.status().is_success() {
             warn!(
                 context,
-                0,
                 "Error calling OAuth2 at {}: {:?}",
                 token_url,
                 response.status()
@@ -154,7 +150,7 @@ pub fn dc_get_oauth2_access_token(
         if parsed.is_err() {
             warn!(
                 context,
-                0, "Failed to parse OAuth2 JSON response from {}: error: {:?}", token_url, parsed
+                "Failed to parse OAuth2 JSON response from {}: error: {:?}", token_url, parsed
             );
             return None;
         }
@@ -195,12 +191,12 @@ pub fn dc_get_oauth2_access_token(
                     .ok();
             }
         } else {
-            warn!(context, 0, "Failed to find OAuth2 access token");
+            warn!(context, "Failed to find OAuth2 access token");
         }
 
         response.access_token
     } else {
-        warn!(context, 0, "Internal OAuth2 error: 2");
+        warn!(context, "Internal OAuth2 error: 2");
 
         None
     }
@@ -268,17 +264,12 @@ impl Oauth2 {
         // }
         let response = reqwest::Client::new().get(&userinfo_url).send();
         if response.is_err() {
-            warn!(context, 0, "Error getting userinfo: {:?}", response);
+            warn!(context, "Error getting userinfo: {:?}", response);
             return None;
         }
         let mut response = response.unwrap();
         if !response.status().is_success() {
-            warn!(
-                context,
-                0,
-                "Error getting userinfo: {:?}",
-                response.status()
-            );
+            warn!(context, "Error getting userinfo: {:?}", response.status());
             return None;
         }
 
@@ -286,19 +277,19 @@ impl Oauth2 {
         if parsed.is_err() {
             warn!(
                 context,
-                0, "Failed to parse userinfo JSON response: {:?}", parsed
+                "Failed to parse userinfo JSON response: {:?}", parsed
             );
             return None;
         }
         if let Ok(response) = parsed {
             let addr = response.get("email");
             if addr.is_none() {
-                warn!(context, 0, "E-mail missing in userinfo.");
+                warn!(context, "E-mail missing in userinfo.");
             }
 
             addr.map(|addr| addr.to_string())
         } else {
-            warn!(context, 0, "Failed to parse userinfo.");
+            warn!(context, "Failed to parse userinfo.");
             None
         }
     }

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -37,7 +37,7 @@ impl Into<Lot> for Error {
 pub fn check_qr(context: &Context, qr: impl AsRef<str>) -> Lot {
     let qr = qr.as_ref();
 
-    info!(context, 0, "Scanned QR code: {}", qr);
+    info!(context, "Scanned QR code: {}", qr);
 
     if qr.starts_with(OPENPGP4FPR_SCHEME) {
         decode_openpgp(context, qr)

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -45,7 +45,7 @@ impl Smtp {
     /// Connect using the provided login params
     pub fn connect(&mut self, context: &Context, lp: &LoginParam) -> bool {
         if self.is_connected() {
-            warn!(context, 0, "SMTP already connected.");
+            warn!(context, "SMTP already connected.");
             return true;
         }
 
@@ -119,7 +119,7 @@ impl Smtp {
                 true
             }
             Err(err) => {
-                warn!(context, 0, "SMTP: failed to establish connection {:?}", err);
+                warn!(context, "SMTP: failed to establish connection {:?}", err);
                 false
             }
         }
@@ -151,7 +151,7 @@ impl Smtp {
                     1
                 }
                 Err(err) => {
-                    warn!(context, 0, "SMTP failed to send message: {}", err);
+                    warn!(context, "SMTP failed to send message: {}", err);
                     self.error = Some(format!("{}", err));
                     0
                 }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -35,7 +35,7 @@ impl Sql {
         self.in_use.remove();
         // drop closes the connection
 
-        info!(context, 0, "Database closed.");
+        info!(context, "Database closed.");
     }
 
     // return true on success, false on failure
@@ -176,7 +176,7 @@ impl Sql {
                 rusqlite::types::Type::Null,
             ))) => None,
             Err(err) => {
-                error!(context, 0, "sql: Failed query_row: {}", err);
+                error!(context, "sql: Failed query_row: {}", err);
                 None
             }
         }
@@ -193,7 +193,7 @@ impl Sql {
         value: Option<&str>,
     ) -> Result<()> {
         if !self.is_open() {
-            error!(context, 0, "set_config(): Database not ready.");
+            error!(context, "set_config(): Database not ready.");
             return Err(Error::SqlNoConnection);
         }
 
@@ -227,7 +227,7 @@ impl Sql {
         match res {
             Ok(_) => Ok(()),
             Err(err) => {
-                error!(context, 0, "set_config(): Cannot change value. {:?}", &err);
+                error!(context, "set_config(): Cannot change value. {:?}", &err);
                 Err(err.into())
             }
         }
@@ -317,7 +317,6 @@ fn open(
     if sql.is_open() {
         error!(
             context,
-            0,
             "Cannot open, database \"{:?}\" already opened.",
             dbfile.as_ref(),
         );
@@ -351,7 +350,6 @@ fn open(
         if !sql.table_exists("config") {
             info!(
                 context,
-                0,
                 "First time init: creating tables in {:?}.",
                 dbfile.as_ref(),
             );
@@ -467,7 +465,6 @@ fn open(
             {
                 error!(
                     context,
-                    0,
                     "Cannot create tables in new database \"{:?}\".",
                     dbfile.as_ref(),
                 );
@@ -688,7 +685,7 @@ fn open(
             sql.set_config_int(context, "dbversion", 46)?;
         }
         if dbversion < 47 {
-            info!(context, 0, "[migration] v47");
+            info!(context, "[migration] v47");
             sql.execute(
                 "ALTER TABLE jobs ADD COLUMN tries INTEGER DEFAULT 0;",
                 params![],
@@ -697,7 +694,7 @@ fn open(
             sql.set_config_int(context, "dbversion", 47)?;
         }
         if dbversion < 48 {
-            info!(context, 0, "[migration] v48");
+            info!(context, "[migration] v48");
             sql.execute(
                 "ALTER TABLE msgs ADD COLUMN move_state INTEGER DEFAULT 1;",
                 params![],
@@ -707,7 +704,7 @@ fn open(
             sql.set_config_int(context, "dbversion", 48)?;
         }
         if dbversion < 49 {
-            info!(context, 0, "[migration] v49");
+            info!(context, "[migration] v49");
             sql.execute(
                 "ALTER TABLE chats ADD COLUMN gossiped_timestamp INTEGER DEFAULT 0;",
                 params![],
@@ -716,7 +713,7 @@ fn open(
             sql.set_config_int(context, "dbversion", 49)?;
         }
         if dbversion < 50 {
-            info!(context, 0, "[migration] v50");
+            info!(context, "[migration] v50");
             if 0 != exists_before_update {
                 sql.set_config_int(context, "show_emails", 2)?;
             }
@@ -724,7 +721,7 @@ fn open(
             sql.set_config_int(context, "dbversion", 50)?;
         }
         if dbversion < 53 {
-            info!(context, 0, "[migration] v53");
+            info!(context, "[migration] v53");
             sql.execute(
                 "CREATE TABLE locations ( id INTEGER PRIMARY KEY AUTOINCREMENT, latitude REAL DEFAULT 0.0, longitude REAL DEFAULT 0.0, accuracy REAL DEFAULT 0.0, timestamp INTEGER DEFAULT 0, chat_id INTEGER DEFAULT 0, from_id INTEGER DEFAULT 0);",
                 params![]
@@ -757,7 +754,7 @@ fn open(
             sql.set_config_int(context, "dbversion", 53)?;
         }
         if dbversion < 54 {
-            info!(context, 0, "[migration] v54");
+            info!(context, "[migration] v54");
             sql.execute(
                 "ALTER TABLE msgs ADD COLUMN location_id INTEGER DEFAULT 0;",
                 params![],
@@ -797,7 +794,7 @@ fn open(
             // for newer versions, we copy files always to the blob directory and store relative paths.
             // this snippet converts older databases and can be removed after some time.
 
-            info!(context, 0, "[open] update file paths");
+            info!(context, "[open] update file paths");
 
             let repl_from = sql
                 .get_config(context, "backup_for")
@@ -824,7 +821,7 @@ fn open(
         }
     }
 
-    info!(context, 0, "Opened {:?}.", dbfile.as_ref(),);
+    info!(context, "Opened {:?}.", dbfile.as_ref(),);
 
     Ok(())
 }
@@ -839,7 +836,6 @@ where
         Err(err) => {
             error!(
                 context,
-                0,
                 "execute failed: {:?} for {}",
                 &err,
                 querystr.as_ref()
@@ -856,7 +852,6 @@ pub fn try_execute(context: &Context, sql: &Sql, querystr: impl AsRef<str>) -> R
         Err(err) => {
             warn!(
                 context,
-                0,
                 "Try-execute for \"{}\" failed: {}",
                 querystr.as_ref(),
                 &err,
@@ -900,7 +895,7 @@ pub fn get_rowid_with_conn(
         Err(err) => {
             error!(
                 context,
-                0, "sql: Failed to retrieve rowid: {} in {}", err, query
+                "sql: Failed to retrieve rowid: {} in {}", err, query
             );
             0
         }
@@ -947,7 +942,7 @@ pub fn get_rowid2_with_conn(
     ) {
         Ok(id) => id,
         Err(err) => {
-            error!(context, 0, "sql: Failed to retrieve rowid2: {}", err);
+            error!(context, "sql: Failed to retrieve rowid2: {}", err);
             0
         }
     }
@@ -957,7 +952,7 @@ pub fn housekeeping(context: &Context) {
     let mut files_in_use = HashSet::new();
     let mut unreferenced_count = 0;
 
-    info!(context, 0, "Start housekeeping...");
+    info!(context, "Start housekeeping...");
     maybe_add_from_param(
         context,
         &mut files_in_use,
@@ -997,10 +992,10 @@ pub fn housekeeping(context: &Context) {
             },
         )
         .unwrap_or_else(|err| {
-            warn!(context, 0, "sql: failed query: {}", err);
+            warn!(context, "sql: failed query: {}", err);
         });
 
-    info!(context, 0, "{} files in use.", files_in_use.len(),);
+    info!(context, "{} files in use.", files_in_use.len(),);
     /* go through directory and delete unused files */
     let p = std::path::Path::new(as_str(context.get_blobdir()));
     match std::fs::read_dir(p) {
@@ -1039,7 +1034,6 @@ pub fn housekeeping(context: &Context) {
                         if recently_created || recently_modified || recently_accessed {
                             info!(
                                 context,
-                                0,
                                 "Housekeeping: Keeping new unreferenced file #{}: {:?}",
                                 unreferenced_count,
                                 entry.file_name(),
@@ -1051,7 +1045,6 @@ pub fn housekeeping(context: &Context) {
                 }
                 info!(
                     context,
-                    0,
                     "Housekeeping: Deleting unreferenced file #{}: {:?}",
                     unreferenced_count,
                     entry.file_name()
@@ -1063,7 +1056,6 @@ pub fn housekeeping(context: &Context) {
         Err(err) => {
             warn!(
                 context,
-                0,
                 "Housekeeping: Cannot open {}. ({})",
                 as_str(context.get_blobdir()),
                 err
@@ -1071,7 +1063,7 @@ pub fn housekeeping(context: &Context) {
         }
     }
 
-    info!(context, 0, "Housekeeping done.",);
+    info!(context, "Housekeeping done.",);
 }
 
 fn is_file_in_use(files_in_use: &HashSet<String>, namespc_opt: Option<&str>, name: &str) -> bool {
@@ -1119,7 +1111,7 @@ fn maybe_add_from_param(
             },
         )
         .unwrap_or_else(|err| {
-            warn!(context, 0, "sql: failed to add_from_param: {}", err);
+            warn!(context, "sql: failed to add_from_param: {}", err);
         });
 }
 

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -259,6 +259,20 @@ impl Sql {
         self.get_config(context, key).and_then(|s| s.parse().ok())
     }
 
+    pub fn get_config_bool(&self, context: &Context, key: impl AsRef<str>) -> bool {
+        // Not the most obvious way to encode bool as string, but it is matter
+        // of backward compatibility.
+        self.get_config_int(context, key).unwrap_or_default() > 0
+    }
+
+    pub fn set_config_bool<T>(&self, context: &Context, key: T, value: bool) -> Result<()>
+    where
+        T: AsRef<str>,
+    {
+        let value = if value { Some("1") } else { None };
+        self.set_config(context, key, value)
+    }
+
     pub fn set_config_int64(
         &self,
         context: &Context,

--- a/src/top_evil_rs.py
+++ b/src/top_evil_rs.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
         s = re.sub(r"(?m)///.*$", "", s)  # remove comments
         unsafe = s.count("unsafe")
         free = s.count("free(")
-        gotoblocks = s.count("ok_to_continue")
+        gotoblocks = s.count("ok_to_continue") + s.count('OK_TO_CONTINUE')
         filestats.append((fn, unsafe, free, gotoblocks))
 
     sum_unsafe, sum_free, sum_gotoblocks = 0, 0, 0

--- a/src/top_evil_rs.py
+++ b/src/top_evil_rs.py
@@ -6,6 +6,8 @@ import os
 import re
 
 if __name__ == "__main__":
+    if Path('src/top_evil_rs.py').exists():
+        os.chdir('src')
     filestats = []
     for fn in Path(".").glob("**/*.rs"):
         s = fn.read_text()


### PR DESCRIPTION
Changes:

3153d30 (Dmitry Bogatov, 2 minutes ago)
   Use set_config_bool instead of set_config_int in boolean context

7c14a82 (Dmitry Bogatov, 10 minutes ago)
   Use sql.get_config_bool to simplify `dc_is_configured`

c4d4bd2 (Dmitry Bogatov, 13 minutes ago)
   Add Sql.{set,get}_config_bool methods

   Previously, boolean configurations were implemented on top of i32
   (get_config_int, set_config_it) at call sites.

   Having one canonical location, containing boolean <-> database conversion
   may help to avoid serialization issues.

109257c (Dmitry Bogatov, 2 hours ago)
   Change return type of `dc_is_configured' to bool

1576dc1 (Dmitry Bogatov, 2 hours ago)
   top_evil_rs: check for all-caps version of ok_to_continue pattern

4fbb5fb (Dmitry Bogatov, 2 hours ago)
   Make it easier to run src/top_evil_rs.py from git root

   Currently, `src/top_evil_rs.py' script recursively scans current directory
   for Rust sources and print statistics about them.

   When run from git root, it also scans target/ directory, which is useless.

   This commit add cludge that checks if script is run from git root 
   directory, and `chdir' into `src/' before performing actions.

   Unprincipled, but convenient.