### PR TITLE
do not recursive delete folders

### DIFF
--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -843,13 +843,16 @@ pub fn dc_get_filebytes(context: &Context, path: impl AsRef<std::path::Path>) ->
 
 pub fn dc_delete_file(context: &Context, path: impl AsRef<std::path::Path>) -> bool {
     let path_abs = dc_get_abs_path_safe(context, &path);
-    let res = if path_abs.is_file() {
-        fs::remove_file(path_abs)
-    } else {
-        fs::remove_dir_all(path_abs)
-    };
+    if !path_abs.is_file() {
+        warn!(
+            context,
+            "Will not delete directory \"{}\".",
+            path.as_ref().display()
+        );
+        return false;
+    }
 
-    match res {
+    match fs::remove_file(path_abs) {
         Ok(_) => true,
         Err(_err) => {
             warn!(context, "Cannot delete \"{}\".", path.as_ref().display());

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -90,7 +90,7 @@ unsafe fn stress_functions(context: &Context) {
         assert!(dc_delete_file(context, "$BLOBDIR/dada"));
         assert!(dc_create_folder(context, "$BLOBDIR/foobar-folder"));
         assert!(dc_file_exist(context, "$BLOBDIR/foobar-folder",));
-        assert!(dc_delete_file(context, "$BLOBDIR/foobar-folder"));
+        assert!(!dc_delete_file(context, "$BLOBDIR/foobar-folder"));
         let fn0: *mut libc::c_char = dc_get_fine_pathNfilename(
             context,
             b"$BLOBDIR\x00" as *const u8 as *const libc::c_char,


### PR DESCRIPTION
deletion of folders is currently not needed afaik, therefore dc_delete_file() should not implicitly call fs::remove_dir_all()

this pr changes the behavior and adapts the test. 