### PR TITLE
Remove context ref from Chat struct

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -581,7 +581,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
 
                 for i in (0..cnt).rev() {
                     let chat = Chat::load_from_db(context, chatlist.get_chat_id(i))?;
-                    let temp_subtitle = chat.get_subtitle();
+                    let temp_subtitle = chat.get_subtitle(context);
                     let temp_name = chat.get_name();
                     info!(
                         context,
@@ -647,7 +647,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             let sel_chat = sel_chat.as_ref().unwrap();
 
             let msglist = chat::get_chat_msgs(context, sel_chat.get_id(), 0x1, 0);
-            let temp2 = sel_chat.get_subtitle();
+            let temp2 = sel_chat.get_subtitle(context);
             let temp_name = sel_chat.get_name();
             info!(
                 context,

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -247,7 +247,7 @@ impl<'a> Chatlist<'a> {
     /// - dc_lot_t::timestamp: the timestamp of the message.  0 if not applicable.
     /// - dc_lot_t::state: The state of the message as one of the DC_STATE_* constants (see #dc_msg_get_state()).
     //    0 if not applicable.
-    pub fn get_summary(&self, index: usize, chat: Option<&Chat<'a>>) -> Lot {
+    pub fn get_summary(&self, index: usize, chat: Option<&Chat>) -> Lot {
         // The summary is created by the chat, not by the last message.
         // This is because we may want to display drafts here or stuff as
         // "is typing".

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -38,7 +38,7 @@ pub struct dc_mimefactory_t<'a> {
     pub rfc724_mid: *mut libc::c_char,
     pub loaded: dc_mimefactory_loaded_t,
     pub msg: Message,
-    pub chat: Option<Chat<'a>>,
+    pub chat: Option<Chat>,
     pub increation: libc::c_int,
     pub in_reply_to: *mut libc::c_char,
     pub references: *mut libc::c_char,
@@ -995,7 +995,8 @@ pub unsafe fn dc_mimefactory_render(
                     e.as_ptr(),
                 );
             } else {
-                subject_str = get_subject(factory.chat.as_ref(), &mut factory.msg, afwd_email)
+                subject_str =
+                    get_subject(context, factory.chat.as_ref(), &mut factory.msg, afwd_email)
             }
             subject = mailimf_subject_new(dc_encode_header_words(subject_str));
             mailimf_fields_add(
@@ -1061,6 +1062,7 @@ pub unsafe fn dc_mimefactory_render(
 }
 
 unsafe fn get_subject(
+    context: &Context,
     chat: Option<&Chat>,
     msg: &mut Message,
     afwd_email: libc::c_int,
@@ -1070,7 +1072,6 @@ unsafe fn get_subject(
     }
 
     let chat = chat.unwrap();
-    let context = chat.context;
     let ret: *mut libc::c_char;
 
     let raw_subject = {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1354,7 +1354,7 @@ unsafe fn create_or_lookup_group(
                 } else {
                     chat.param.set(Param::ProfileImage, grpimage);
                 }
-                chat.update_param().unwrap();
+                chat.update_param(context).unwrap();
                 send_EVENT_CHAT_MODIFIED = 1;
             }
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -744,7 +744,7 @@ pub fn dc_msg_get_summary(context: &Context, msg: &mut Message, chat: Option<&Ch
     let contact = if msg.from_id != DC_CONTACT_ID_SELF as libc::c_uint
         && ((*chat).typ == Chattype::Group || (*chat).typ == Chattype::VerifiedGroup)
     {
-        Contact::get_by_id((*chat).context, msg.from_id).ok()
+        Contact::get_by_id(context, msg.from_id).ok()
     } else {
         None
     };


### PR DESCRIPTION
Leaving the C API untouched.  See #476 aka
a0b5e32f98eb7f9a4ae2a4432cbb353c2dec8374 for more extensive rationale.