### PR TITLE
Remove context references from structs returned on the FFI API

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -780,19 +780,17 @@ pub unsafe extern "C" fn dc_search_msgs(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_get_chat<'a>(
-    context: *mut dc_context_t,
-    chat_id: u32,
-) -> *mut dc_chat_t<'a> {
+pub unsafe extern "C" fn dc_get_chat(context: *mut dc_context_t, chat_id: u32) -> *mut dc_chat_t {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_chat()");
         return ptr::null_mut();
     }
-
     let context = &*context;
-
     match chat::Chat::load_from_db(context, chat_id) {
-        Ok(chat) => Box::into_raw(Box::new(chat)),
+        Ok(chat) => {
+            let ffi_chat = ChatWrapper { context, chat };
+            Box::into_raw(Box::new(ffi_chat))
+        }
         Err(_) => std::ptr::null_mut(),
     }
 }
@@ -1688,20 +1686,23 @@ pub unsafe extern "C" fn dc_chatlist_get_msg_id(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_chatlist_get_summary<'a>(
-    chatlist: *mut dc_chatlist_t<'a>,
+pub unsafe extern "C" fn dc_chatlist_get_summary(
+    chatlist: *mut dc_chatlist_t,
     index: libc::size_t,
-    chat: *mut dc_chat_t<'a>,
+    chat: *mut dc_chat_t,
 ) -> *mut dc_lot_t {
     if chatlist.is_null() {
         eprintln!("ignoring careless call to dc_chatlist_get_summary()");
         return ptr::null_mut();
     }
-
-    let chat = if chat.is_null() { None } else { Some(&*chat) };
+    let maybe_chat = if chat.is_null() {
+        None
+    } else {
+        let ffi_chat = &*chat;
+        Some(&ffi_chat.chat)
+    };
     let list = &*chatlist;
-
-    let lot = list.get_summary(index as usize, chat);
+    let lot = list.get_summary(index as usize, maybe_chat);
     Box::into_raw(Box::new(lot))
 }
 
@@ -1721,8 +1722,20 @@ pub unsafe extern "C" fn dc_chatlist_get_context(
 
 // dc_chat_t
 
+/// FFI struct for [dc_chat_t]
+///
+/// This is the structure behind [dc_chat_t] which is the opaque
+/// structure representing a chat in the FFI API.  It exists
+/// because the FFI API has a refernce from the message to the
+/// context, but the Rust API does not, so the FFI layer needs to glue
+/// these together.
+pub struct ChatWrapper {
+    context: *const dc_context_t,
+    chat: chat::Chat,
+}
+
 #[no_mangle]
-pub type dc_chat_t<'a> = chat::Chat<'a>;
+pub type dc_chat_t = ChatWrapper;
 
 #[no_mangle]
 pub unsafe extern "C" fn dc_chat_unref(chat: *mut dc_chat_t) {
@@ -1740,10 +1753,8 @@ pub unsafe extern "C" fn dc_chat_get_id(chat: *mut dc_chat_t) -> u32 {
         eprintln!("ignoring careless call to dc_chat_get_id()");
         return 0;
     }
-
-    let chat = &*chat;
-
-    chat.get_id()
+    let ffi_chat = &*chat;
+    ffi_chat.chat.get_id()
 }
 
 #[no_mangle]
@@ -1752,10 +1763,8 @@ pub unsafe extern "C" fn dc_chat_get_type(chat: *mut dc_chat_t) -> libc::c_int {
         eprintln!("ignoring careless call to dc_chat_get_type()");
         return 0;
     }
-
-    let chat = &*chat;
-
-    chat.get_type() as libc::c_int
+    let ffi_chat = &*chat;
+    ffi_chat.chat.get_type() as libc::c_int
 }
 
 #[no_mangle]
@@ -1764,10 +1773,8 @@ pub unsafe extern "C" fn dc_chat_get_name(chat: *mut dc_chat_t) -> *mut libc::c_
         eprintln!("ignoring careless call to dc_chat_get_name()");
         return dc_strdup(ptr::null());
     }
-
-    let chat = &*chat;
-
-    chat.get_name().strdup()
+    let ffi_chat = &*chat;
+    ffi_chat.chat.get_name().strdup()
 }
 
 #[no_mangle]
@@ -1776,10 +1783,8 @@ pub unsafe extern "C" fn dc_chat_get_subtitle(chat: *mut dc_chat_t) -> *mut libc
         eprintln!("ignoring careless call to dc_chat_get_subtitle()");
         return dc_strdup(ptr::null());
     }
-
-    let chat = &*chat;
-
-    chat.get_subtitle().strdup()
+    let ffi_chat = &*chat;
+    ffi_chat.chat.get_subtitle(&*ffi_chat.context).strdup()
 }
 
 #[no_mangle]
@@ -1788,10 +1793,8 @@ pub unsafe extern "C" fn dc_chat_get_profile_image(chat: *mut dc_chat_t) -> *mut
         eprintln!("ignoring careless call to dc_chat_get_profile_image()");
         return ptr::null_mut(); // NULL explicitly defined as "no image"
     }
-
-    let chat = &*chat;
-
-    match chat.get_profile_image() {
+    let ffi_chat = &*chat;
+    match ffi_chat.chat.get_profile_image(&*ffi_chat.context) {
         Some(p) => p.to_str().unwrap().to_string().strdup(),
         None => ptr::null_mut(),
     }
@@ -1803,10 +1806,8 @@ pub unsafe extern "C" fn dc_chat_get_color(chat: *mut dc_chat_t) -> u32 {
         eprintln!("ignoring careless call to dc_chat_get_color()");
         return 0;
     }
-
-    let chat = &*chat;
-
-    chat.get_color()
+    let ffi_chat = &*chat;
+    ffi_chat.chat.get_color(&*ffi_chat.context)
 }
 
 #[no_mangle]
@@ -1815,10 +1816,8 @@ pub unsafe extern "C" fn dc_chat_get_archived(chat: *mut dc_chat_t) -> libc::c_i
         eprintln!("ignoring careless call to dc_chat_get_archived()");
         return 0;
     }
-
-    let chat = &*chat;
-
-    chat.is_archived() as libc::c_int
+    let ffi_chat = &*chat;
+    ffi_chat.chat.is_archived() as libc::c_int
 }
 
 #[no_mangle]
@@ -1827,10 +1826,8 @@ pub unsafe extern "C" fn dc_chat_is_unpromoted(chat: *mut dc_chat_t) -> libc::c_
         eprintln!("ignoring careless call to dc_chat_is_unpromoted()");
         return 0;
     }
-
-    let chat = &*chat;
-
-    chat.is_unpromoted() as libc::c_int
+    let ffi_chat = &*chat;
+    ffi_chat.chat.is_unpromoted() as libc::c_int
 }
 
 #[no_mangle]
@@ -1839,10 +1836,8 @@ pub unsafe extern "C" fn dc_chat_is_self_talk(chat: *mut dc_chat_t) -> libc::c_i
         eprintln!("ignoring careless call to dc_chat_is_self_talk()");
         return 0;
     }
-
-    let chat = &*chat;
-
-    chat.is_self_talk() as libc::c_int
+    let ffi_chat = &*chat;
+    ffi_chat.chat.is_self_talk() as libc::c_int
 }
 
 #[no_mangle]
@@ -1851,10 +1846,8 @@ pub unsafe extern "C" fn dc_chat_is_verified(chat: *mut dc_chat_t) -> libc::c_in
         eprintln!("ignoring careless call to dc_chat_is_verified()");
         return 0;
     }
-
-    let chat = &*chat;
-
-    chat.is_verified() as libc::c_int
+    let ffi_chat = &*chat;
+    ffi_chat.chat.is_verified() as libc::c_int
 }
 
 #[no_mangle]
@@ -1863,10 +1856,8 @@ pub unsafe extern "C" fn dc_chat_is_sending_locations(chat: *mut dc_chat_t) -> l
         eprintln!("ignoring careless call to dc_chat_is_sending_locations()");
         return 0;
     }
-
-    let chat = &*chat;
-
-    chat.is_sending_locations() as libc::c_int
+    let ffi_chat = &*chat;
+    ffi_chat.chat.is_sending_locations() as libc::c_int
 }
 
 // dc_msg_t
@@ -2095,9 +2086,14 @@ pub unsafe extern "C" fn dc_msg_get_summary(
         eprintln!("ignoring careless call to dc_msg_get_summary()");
         return ptr::null_mut();
     }
-    let chat = if chat.is_null() { None } else { Some(&*chat) };
+    let maybe_chat = if chat.is_null() {
+        None
+    } else {
+        let ffi_chat = &*chat;
+        Some(&ffi_chat.chat)
+    };
     let ffi_msg = &mut *msg;
-    let lot = message::dc_msg_get_summary(&*ffi_msg.context, &mut ffi_msg.message, chat);
+    let lot = message::dc_msg_get_summary(&*ffi_msg.context, &mut ffi_msg.message, maybe_chat);
     Box::into_raw(Box::new(lot))
 }
 

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -581,7 +581,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
 
                 for i in (0..cnt).rev() {
                     let chat = Chat::load_from_db(context, chatlist.get_chat_id(i))?;
-                    let temp_subtitle = chat.get_subtitle();
+                    let temp_subtitle = chat.get_subtitle(context);
                     let temp_name = chat.get_name();
                     info!(
                         context,
@@ -647,7 +647,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             let sel_chat = sel_chat.as_ref().unwrap();
 
             let msglist = chat::get_chat_msgs(context, sel_chat.get_id(), 0x1, 0);
-            let temp2 = sel_chat.get_subtitle();
+            let temp2 = sel_chat.get_subtitle(context);
             let temp_name = sel_chat.get_name();
             info!(
                 context,

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -301,7 +301,7 @@ unsafe fn log_contactlist(context: &Context, contacts: &Vec<u32>) {
         if let Ok(contact) = Contact::get_by_id(context, contact_id) {
             let name = contact.get_name();
             let addr = contact.get_addr();
-            let verified_state = contact.is_verified();
+            let verified_state = contact.is_verified(context);
             let verified_str = if VerifiedStatus::Unverified != verified_state {
                 if verified_state == VerifiedStatus::BidirectVerified {
                     " √√"

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -592,7 +592,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                         temp_subtitle,
                         chat::get_fresh_msg_cnt(context, chat.get_id()),
                     );
-                    let lot = chatlist.get_summary(i, Some(&chat));
+                    let lot = chatlist.get_summary(context, i, Some(&chat));
                     let statestr = if chat.is_archived() {
                         " [Archived]"
                     } else {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -101,7 +101,7 @@ fn main() {
         let chats = Chatlist::try_load(&ctx, 0, None, None).unwrap();
 
         for i in 0..chats.len() {
-            let summary = chats.get_summary(0, None);
+            let summary = chats.get_summary(&ctx, 0, None);
             let text1 = summary.get_text1();
             let text2 = summary.get_text2();
             println!("chat: {} - {:?} - {:?}", i, text1, text2,);

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -189,7 +189,7 @@ impl Chat {
             let contacts = get_chat_contacts(context, self.id);
             if !contacts.is_empty() {
                 if let Ok(contact) = Contact::get_by_id(context, contacts[0]) {
-                    return contact.get_profile_image();
+                    return contact.get_profile_image(context);
                 }
             }
         }
@@ -1365,7 +1365,7 @@ pub fn add_contact_to_chat_ex(
                     } else {
                         // else continue and send status mail
                         if chat.typ == Chattype::VerifiedGroup {
-                            if contact.is_verified() != VerifiedStatus::BidirectVerified {
+                            if contact.is_verified(context) != VerifiedStatus::BidirectVerified {
                                 error!(
                                     context,
                                     "Only bidirectional verified contacts can be added to verified groups."

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -247,7 +247,7 @@ impl<'a> Chatlist<'a> {
     /// - dc_lot_t::timestamp: the timestamp of the message.  0 if not applicable.
     /// - dc_lot_t::state: The state of the message as one of the DC_STATE_* constants (see #dc_msg_get_state()).
     //    0 if not applicable.
-    pub fn get_summary(&self, index: usize, chat: Option<&Chat<'a>>) -> Lot {
+    pub fn get_summary(&self, index: usize, chat: Option<&Chat>) -> Lot {
         // The summary is created by the chat, not by the last message.
         // This is because we may want to display drafts here or stuff as
         // "is typing".

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -38,7 +38,7 @@ pub struct dc_mimefactory_t<'a> {
     pub rfc724_mid: *mut libc::c_char,
     pub loaded: dc_mimefactory_loaded_t,
     pub msg: Message,
-    pub chat: Option<Chat<'a>>,
+    pub chat: Option<Chat>,
     pub increation: libc::c_int,
     pub in_reply_to: *mut libc::c_char,
     pub references: *mut libc::c_char,
@@ -995,7 +995,8 @@ pub unsafe fn dc_mimefactory_render(
                     e.as_ptr(),
                 );
             } else {
-                subject_str = get_subject(factory.chat.as_ref(), &mut factory.msg, afwd_email)
+                subject_str =
+                    get_subject(context, factory.chat.as_ref(), &mut factory.msg, afwd_email)
             }
             subject = mailimf_subject_new(dc_encode_header_words(subject_str));
             mailimf_fields_add(
@@ -1061,6 +1062,7 @@ pub unsafe fn dc_mimefactory_render(
 }
 
 unsafe fn get_subject(
+    context: &Context,
     chat: Option<&Chat>,
     msg: &mut Message,
     afwd_email: libc::c_int,
@@ -1070,7 +1072,6 @@ unsafe fn get_subject(
     }
 
     let chat = chat.unwrap();
-    let context = chat.context;
     let ret: *mut libc::c_char;
 
     let raw_subject = {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1354,7 +1354,7 @@ unsafe fn create_or_lookup_group(
                 } else {
                     chat.param.set(Param::ProfileImage, grpimage);
                 }
-                chat.update_param().unwrap();
+                chat.update_param(context).unwrap();
                 send_EVENT_CHAT_MODIFIED = 1;
             }
         }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1760,7 +1760,8 @@ unsafe fn check_verified_properties(
         let peerstate = Peerstate::from_addr(context, &context.sql, contact.get_addr());
 
         if peerstate.is_none()
-            || contact.is_verified_ex(peerstate.as_ref()) != VerifiedStatus::BidirectVerified
+            || contact.is_verified_ex(context, peerstate.as_ref())
+                != VerifiedStatus::BidirectVerified
         {
             verify_fail("The sender of this message is not verified.".into());
             return 0;

--- a/src/message.rs
+++ b/src/message.rs
@@ -744,7 +744,7 @@ pub fn dc_msg_get_summary(context: &Context, msg: &mut Message, chat: Option<&Ch
     let contact = if msg.from_id != DC_CONTACT_ID_SELF as libc::c_uint
         && ((*chat).typ == Chattype::Group || (*chat).typ == Chattype::VerifiedGroup)
     {
-        Contact::get_by_id((*chat).context, msg.from_id).ok()
+        Contact::get_by_id(context, msg.from_id).ok()
     } else {
         None
     };

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -617,7 +617,7 @@ pub fn handle_securejoin_handshake(
             ====  Step 8 in "Out-of-band verified groups" protocol  ====
             ============================================================ */
             if let Ok(contact) = Contact::get_by_id(context, contact_id) {
-                if contact.is_verified() == VerifiedStatus::Unverified {
+                if contact.is_verified(context) == VerifiedStatus::Unverified {
                     warn!(context, "vg-member-added-received invalid.",);
                     return ret;
                 }


### PR DESCRIPTION
This is one PR for Chat, Chatlist and Contact structs, they are separate commits though and each fully works.  It doesn't seem too big so I'm going to collapse all these in one PR and cancel #493.  It's all fairly mechanical once you get the idea.