### PR TITLE
Fix get_draft to just return null and not produce errors if there's no

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -552,15 +552,13 @@ pub unsafe extern "C" fn dc_get_draft(context: *mut dc_context_t, chat_id: u32) 
         return ptr::null_mut(); // NULL explicitly defined as "no draft"
     }
     let context = &*context;
-    let message = match chat::get_draft(context, chat_id) {
-        Ok(msg) => msg,
-        Err(e) => {
-            error!(context, "Failed to get draft for chat #{}: {}", chat_id, e);
-            return ptr::null_mut();
-        }
+   
+    if let Some(message) = chat::get_draft(context, chat_id) {
+        let ffi_msg = MessageWrapper { context, message };
+        return Box::into_raw(Box::new(ffi_msg));
     };
-    let ffi_msg = MessageWrapper { context, message };
-    Box::into_raw(Box::new(ffi_msg))
+
+    ptr::null_mut()
 }
 
 #[no_mangle]

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -552,7 +552,7 @@ pub unsafe extern "C" fn dc_get_draft(context: *mut dc_context_t, chat_id: u32) 
         return ptr::null_mut(); // NULL explicitly defined as "no draft"
     }
     let context = &*context;
-   
+
     if let Some(message) = chat::get_draft(context, chat_id) {
         let ffi_msg = MessageWrapper { context, message };
         return Box::into_raw(Box::new(ffi_msg));

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -663,7 +663,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                 },
             );
             log_msglist(context, &msglist)?;
-            if let Ok(draft) = chat::get_draft(context, sel_chat.get_id()) {
+            if let Some(draft) = chat::get_draft(context, sel_chat.get_id())? {
                 log_msg(context, "Draft", &draft);
             }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -921,12 +921,19 @@ fn get_draft_msg_id(context: &Context, chat_id: u32) -> u32 {
         .unwrap_or_default() as u32
 }
 
-pub unsafe fn get_draft(context: &Context, chat_id: u32) -> Result<Message, Error> {
-    ensure!(chat_id > DC_CHAT_ID_LAST_SPECIAL, "Invalid chat ID");
-    let draft_msg_id = get_draft_msg_id(context, chat_id);
-    ensure!(draft_msg_id != 0, "Invalid draft message ID");
+pub unsafe fn get_draft(context: &Context, chat_id: u32) -> Option<Message> {
+    println!("chat_id {}", chat_id);
+    if chat_id < DC_CHAT_ID_LAST_SPECIAL {
+        warn!(context, "Invalid chat ID");
+        return None;
+    }
 
-    dc_msg_load_from_db(context, draft_msg_id)
+    let draft_msg_id = get_draft_msg_id(context, chat_id);
+    if draft_msg_id == 0 {
+        return None;
+    }
+
+    Some(dc_msg_load_from_db(context, draft_msg_id).unwrap())
 }
 
 pub fn get_chat_msgs(context: &Context, chat_id: u32, flags: u32, marker1before: u32) -> Vec<u32> {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -922,7 +922,6 @@ fn get_draft_msg_id(context: &Context, chat_id: u32) -> u32 {
 }
 
 pub unsafe fn get_draft(context: &Context, chat_id: u32) -> Option<Message> {
-    println!("chat_id {}", chat_id);
     if chat_id < DC_CHAT_ID_LAST_SPECIAL {
         warn!(context, "Invalid chat ID");
         return None;


### PR DESCRIPTION
draft

- [x] ~~write python tests @hpk42 maybe @flub can also help~~ wrote test in rust instead