### PR TITLE
Remove dc_open() from the Rust API

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -393,8 +393,9 @@ int             dc_set_config                (dc_context_t* context, const char*
  * @memberof dc_context_t
  * @param context The context object as created by dc_context_new(). For querying system values, this can be NULL.
  * @param key The key to query.
- * @return Returns current value of "key", if "key" is unset, the default value is returned.
- *     The returned value must be free()'d, NULL is never returned.
+ * @return Returns current value of "key", if "key" is unset, the default
+ *     value is returned.  The returned value must be free()'d, NULL is never
+ *     returned.  If there is an error an empty string will be returned.
  */
 char*           dc_get_config                (dc_context_t* context, const char* key);
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -34,7 +34,16 @@ use deltachat::*;
 
 pub type dc_context_t = context::Context;
 
-pub type dc_callback_t = types::dc_callback_t;
+/// Callback function that should be given to dc_context_new().
+///
+/// @memberof Context
+/// @param context The context object as returned by dc_context_new().
+/// @param event one of the @ref DC_EVENT constants
+/// @param data1 depends on the event parameter
+/// @param data2 depends on the event parameter
+/// @return return 0 unless stated otherwise in the event parameter documentation
+pub type dc_callback_t =
+    unsafe extern "C" fn(_: &Context, _: Event, _: uintptr_t, _: uintptr_t) -> uintptr_t;
 
 #[no_mangle]
 pub unsafe extern "C" fn dc_context_new(

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -447,14 +447,6 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                  ============================================="
             ),
         },
-        "open" => {
-            ensure!(!arg1.is_empty(), "Argument <file> missing");
-            dc_close(context);
-            ensure!(dc_open(context, arg1, None), "Open failed");
-        }
-        "close" => {
-            dc_close(context);
-        }
         "initiate-key-transfer" => {
             let setup_code = dc_initiate_key_transfer(context);
             if !setup_code.is_null() {

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -15,8 +15,8 @@ extern crate rusqlite;
 
 use std::borrow::Cow::{self, Borrowed, Owned};
 use std::io::{self, Write};
+use std::path::Path;
 use std::process::Command;
-use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
@@ -44,7 +44,7 @@ use self::cmdline::*;
 
 // Event Handler
 
-unsafe extern "C" fn receive_event(
+fn receive_event(
     _context: &Context,
     event: Event,
     data1: uintptr_t,
@@ -387,15 +387,15 @@ impl Highlighter for DcHelper {
 impl Helper for DcHelper {}
 
 fn main_0(args: Vec<String>) -> Result<(), failure::Error> {
-    let mut context = dc_context_new(Some(receive_event), ptr::null_mut(), Some("CLI".into()));
-
-    if args.len() == 2 {
-        if unsafe { !dc_open(&mut context, &args[1], None) } {
-            println!("Error: Cannot open {}.", args[0],);
-        }
-    } else if args.len() != 1 {
+    if args.len() < 2 {
         println!("Error: Bad arguments, expected [db-name].");
+        return Err(format_err!("No db-name specified"));
     }
+    let context = Context::new(
+        Box::new(receive_event),
+        "CLI".into(),
+        Path::new(&args[1]).to_path_buf(),
+    )?;
 
     println!("Delta Chat Core is awaiting your commands.");
 

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -17,11 +17,19 @@ def test_callback_None2int():
     clear_context_callback(ctx)
 
 
-def test_dc_close_events():
-    ctx = capi.lib.dc_context_new(capi.lib.py_dc_callback, ffi.NULL, ffi.NULL)
+def test_dc_close_events(tmpdir):
+    ctx = ffi.gc(
+        capi.lib.dc_context_new(capi.lib.py_dc_callback, ffi.NULL, ffi.NULL),
+        lib.dc_context_unref,
+    )
     evlog = EventLogger(ctx)
     evlog.set_timeout(5)
-    set_context_callback(ctx, lambda ctx, evt_name, data1, data2: evlog(evt_name, data1, data2))
+    set_context_callback(
+        ctx,
+        lambda ctx, evt_name, data1, data2: evlog(evt_name, data1, data2)
+    )
+    p = tmpdir.join("hello.db")
+    lib.dc_open(ctx, p.strpath.encode("ascii"), ffi.NULL)
     capi.lib.dc_close(ctx)
 
     def find(info_string):

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -1110,7 +1110,7 @@ mod tests {
 
     #[test]
     fn test_render_setup_file() {
-        let t = test_context(Some(logging_cb));
+        let t = test_context(Some(Box::new(logging_cb)));
 
         configure_alice_keypair(&t.ctx);
         let msg = dc_render_setup_file(&t.ctx, "hello").unwrap();
@@ -1128,14 +1128,9 @@ mod tests {
         assert!(msg.contains("-----END PGP MESSAGE-----\n"));
     }
 
-    unsafe extern "C" fn ac_setup_msg_cb(
-        ctx: &Context,
-        evt: Event,
-        d1: uintptr_t,
-        d2: uintptr_t,
-    ) -> uintptr_t {
+    fn ac_setup_msg_cb(ctx: &Context, evt: Event, d1: uintptr_t, d2: uintptr_t) -> uintptr_t {
         if evt == Event::GET_STRING && d1 == StockMessage::AcSetupMsgBody.to_usize().unwrap() {
-            "hello\r\nthere".strdup() as usize
+            unsafe { "hello\r\nthere".strdup() as usize }
         } else {
             logging_cb(ctx, evt, d1, d2)
         }
@@ -1143,7 +1138,7 @@ mod tests {
 
     #[test]
     fn test_render_setup_file_newline_replace() {
-        let t = test_context(Some(ac_setup_msg_cb));
+        let t = test_context(Some(Box::new(ac_setup_msg_cb)));
         configure_alice_keypair(&t.ctx);
         let msg = dc_render_setup_file(&t.ctx, "pw").unwrap();
         println!("{}", &msg);

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,8 @@ pub enum Error {
     Image(image_meta::ImageError),
     #[fail(display = "{:?}", _0)]
     Utf8(std::str::Utf8Error),
+    #[fail(display = "{:?}", _0)]
+    CStringError(crate::dc_tools::CStringError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -59,6 +61,12 @@ impl From<std::str::Utf8Error> for Error {
 impl From<image_meta::ImageError> for Error {
     fn from(err: image_meta::ImageError) -> Error {
         Error::Image(err)
+    }
+}
+
+impl From<crate::dc_tools::CStringError> for Error {
+    fn from(err: crate::dc_tools::CStringError) -> Error {
+        Error::CStringError(err)
     }
 }
 

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -237,7 +237,6 @@ mod tests {
     use super::*;
     use crate::test_utils::*;
 
-
     use crate::constants::DC_CONTACT_ID_SELF;
     use crate::types::uintptr_t;
 

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -237,10 +237,8 @@ mod tests {
     use super::*;
     use crate::test_utils::*;
 
-    use std::ffi::CString;
 
     use crate::constants::DC_CONTACT_ID_SELF;
-    use crate::context::dc_context_new;
     use crate::types::uintptr_t;
 
     use num_traits::ToPrimitive;
@@ -258,19 +256,18 @@ mod tests {
 
     #[test]
     fn test_stock_str() {
-        let ctx = dc_context_new(None, std::ptr::null_mut(), None);
-        assert_eq!(ctx.stock_str(StockMessage::NoMessages), "No messages.");
+        let t = dummy_context();
+        assert_eq!(t.ctx.stock_str(StockMessage::NoMessages), "No messages.");
     }
 
-    unsafe extern "C" fn test_stock_str_no_fallback_cb(
+    fn test_stock_str_no_fallback_cb(
         _ctx: &Context,
         evt: Event,
         d1: uintptr_t,
         _d2: uintptr_t,
     ) -> uintptr_t {
         if evt == Event::GET_STRING && d1 == StockMessage::NoMessages.to_usize().unwrap() {
-            let tmp = CString::new("Hello there").unwrap();
-            dc_strdup(tmp.as_ptr()) as usize
+            unsafe { "Hello there".strdup() as usize }
         } else {
             0
         }
@@ -278,16 +275,16 @@ mod tests {
 
     #[test]
     fn test_stock_str_no_fallback() {
-        let t = test_context(Some(test_stock_str_no_fallback_cb));
+        let t = test_context(Some(Box::new(test_stock_str_no_fallback_cb)));
         assert_eq!(t.ctx.stock_str(StockMessage::NoMessages), "Hello there");
     }
 
     #[test]
     fn test_stock_string_repl_str() {
-        let ctx = dc_context_new(None, std::ptr::null_mut(), None);
+        let t = dummy_context();
         // uses %1$s substitution
         assert_eq!(
-            ctx.stock_string_repl_str(StockMessage::Member, "42"),
+            t.ctx.stock_string_repl_str(StockMessage::Member, "42"),
             "42 member(s)"
         );
         // We have no string using %1$d to test...
@@ -295,36 +292,38 @@ mod tests {
 
     #[test]
     fn test_stock_string_repl_int() {
-        let ctx = dc_context_new(None, std::ptr::null_mut(), None);
+        let t = dummy_context();
         assert_eq!(
-            ctx.stock_string_repl_int(StockMessage::Member, 42),
+            t.ctx.stock_string_repl_int(StockMessage::Member, 42),
             "42 member(s)"
         );
     }
 
     #[test]
     fn test_stock_string_repl_str2() {
-        let ctx = dc_context_new(None, std::ptr::null_mut(), None);
+        let t = dummy_context();
         assert_eq!(
-            ctx.stock_string_repl_str2(StockMessage::ServerResponse, "foo", "bar"),
+            t.ctx
+                .stock_string_repl_str2(StockMessage::ServerResponse, "foo", "bar"),
             "Response from foo: bar"
         );
     }
 
     #[test]
     fn test_stock_system_msg_simple() {
-        let ctx = dc_context_new(None, std::ptr::null_mut(), None);
+        let t = dummy_context();
         assert_eq!(
-            ctx.stock_system_msg(StockMessage::MsgLocationEnabled, "", "", 0),
+            t.ctx
+                .stock_system_msg(StockMessage::MsgLocationEnabled, "", "", 0),
             "Location streaming enabled."
         )
     }
 
     #[test]
     fn test_stock_system_msg_add_member_by_me() {
-        let ctx = dc_context_new(None, std::ptr::null_mut(), None);
+        let t = dummy_context();
         assert_eq!(
-            ctx.stock_system_msg(
+            t.ctx.stock_system_msg(
                 StockMessage::MsgAddMember,
                 "alice@example.com",
                 "",

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,20 +1,8 @@
 #![allow(non_camel_case_types)]
-use crate::constants::Event;
 use crate::context::Context;
 
 pub use mmime::clist::*;
 pub use rusqlite::ffi::*;
-
-/// Callback function that should be given to dc_context_new().
-///
-/// @memberof Context
-/// @param context The context object as returned by dc_context_new().
-/// @param event one of the @ref DC_EVENT constants
-/// @param data1 depends on the event parameter
-/// @param data2 depends on the event parameter
-/// @return return 0 unless stated otherwise in the event parameter documentation
-pub type dc_callback_t =
-    unsafe extern "C" fn(_: &Context, _: Event, _: uintptr_t, _: uintptr_t) -> uintptr_t;
 
 pub type dc_receive_imf_t = unsafe fn(
     _: &Context,

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -30,103 +30,101 @@ static mut S_EM_SETUPFILE: *const libc::c_char =
         as *const u8 as *const libc::c_char;
 
 unsafe fn stress_functions(context: &Context) {
-    if 0 != dc_is_open(context) {
-        if dc_file_exist(context, "$BLOBDIR/foobar")
-            || dc_file_exist(context, "$BLOBDIR/dada")
-            || dc_file_exist(context, "$BLOBDIR/foobar.dadada")
-            || dc_file_exist(context, "$BLOBDIR/foobar-folder")
-        {
-            dc_delete_file(context, "$BLOBDIR/foobar");
-            dc_delete_file(context, "$BLOBDIR/dada");
-            dc_delete_file(context, "$BLOBDIR/foobar.dadada");
-            dc_delete_file(context, "$BLOBDIR/foobar-folder");
-        }
-        dc_write_file(
-            context,
-            b"$BLOBDIR/foobar\x00" as *const u8 as *const libc::c_char,
-            b"content\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
-            7i32 as size_t,
-        );
-        assert!(dc_file_exist(context, "$BLOBDIR/foobar",));
-        assert!(!dc_file_exist(context, "$BLOBDIR/foobarx"));
-        assert_eq!(
-            dc_get_filebytes(context, "$BLOBDIR/foobar",),
-            7i32 as libc::c_ulonglong
-        );
-
-        let abs_path: *mut libc::c_char = dc_mprintf(
-            b"%s/%s\x00" as *const u8 as *const libc::c_char,
-            context.get_blobdir(),
-            b"foobar\x00" as *const u8 as *const libc::c_char,
-        );
-        assert!(dc_is_blobdir_path(context, as_str(abs_path)));
-        assert!(dc_is_blobdir_path(context, "$BLOBDIR/fofo",));
-        assert!(!dc_is_blobdir_path(context, "/BLOBDIR/fofo",));
-        assert!(dc_file_exist(context, as_path(abs_path)));
-        free(abs_path as *mut libc::c_void);
-        assert!(dc_copy_file(context, "$BLOBDIR/foobar", "$BLOBDIR/dada",));
-        assert_eq!(dc_get_filebytes(context, "$BLOBDIR/dada",), 7);
-
-        let mut buf: *mut libc::c_void = ptr::null_mut();
-        let mut buf_bytes: size_t = 0;
-
-        assert_eq!(
-            dc_read_file(
-                context,
-                b"$BLOBDIR/dada\x00" as *const u8 as *const libc::c_char,
-                &mut buf,
-                &mut buf_bytes,
-            ),
-            1
-        );
-        assert_eq!(buf_bytes, 7);
-        assert_eq!(
-            std::str::from_utf8(std::slice::from_raw_parts(buf as *const u8, buf_bytes)).unwrap(),
-            "content"
-        );
-
-        free(buf as *mut _);
-        assert!(dc_delete_file(context, "$BLOBDIR/foobar"));
-        assert!(dc_delete_file(context, "$BLOBDIR/dada"));
-        assert!(dc_create_folder(context, "$BLOBDIR/foobar-folder"));
-        assert!(dc_file_exist(context, "$BLOBDIR/foobar-folder",));
-        assert!(!dc_delete_file(context, "$BLOBDIR/foobar-folder"));
-        let fn0: *mut libc::c_char = dc_get_fine_pathNfilename(
-            context,
-            b"$BLOBDIR\x00" as *const u8 as *const libc::c_char,
-            b"foobar.dadada\x00" as *const u8 as *const libc::c_char,
-        );
-        assert!(!fn0.is_null());
-        assert_eq!(
-            strcmp(
-                fn0,
-                b"$BLOBDIR/foobar.dadada\x00" as *const u8 as *const libc::c_char,
-            ),
-            0
-        );
-        dc_write_file(
-            context,
-            fn0,
-            b"content\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
-            7i32 as size_t,
-        );
-        let fn1: *mut libc::c_char = dc_get_fine_pathNfilename(
-            context,
-            b"$BLOBDIR\x00" as *const u8 as *const libc::c_char,
-            b"foobar.dadada\x00" as *const u8 as *const libc::c_char,
-        );
-        assert!(!fn1.is_null());
-        assert_eq!(
-            strcmp(
-                fn1,
-                b"$BLOBDIR/foobar-1.dadada\x00" as *const u8 as *const libc::c_char,
-            ),
-            0
-        );
-        assert!(dc_delete_file(context, as_path(fn0)));
-        free(fn0 as *mut libc::c_void);
-        free(fn1 as *mut libc::c_void);
+    if dc_file_exist(context, "$BLOBDIR/foobar")
+        || dc_file_exist(context, "$BLOBDIR/dada")
+        || dc_file_exist(context, "$BLOBDIR/foobar.dadada")
+        || dc_file_exist(context, "$BLOBDIR/foobar-folder")
+    {
+        dc_delete_file(context, "$BLOBDIR/foobar");
+        dc_delete_file(context, "$BLOBDIR/dada");
+        dc_delete_file(context, "$BLOBDIR/foobar.dadada");
+        dc_delete_file(context, "$BLOBDIR/foobar-folder");
     }
+    dc_write_file(
+        context,
+        b"$BLOBDIR/foobar\x00" as *const u8 as *const libc::c_char,
+        b"content\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
+        7i32 as size_t,
+    );
+    assert!(dc_file_exist(context, "$BLOBDIR/foobar",));
+    assert!(!dc_file_exist(context, "$BLOBDIR/foobarx"));
+    assert_eq!(
+        dc_get_filebytes(context, "$BLOBDIR/foobar",),
+        7i32 as libc::c_ulonglong
+    );
+
+    let abs_path: *mut libc::c_char = dc_mprintf(
+        b"%s/%s\x00" as *const u8 as *const libc::c_char,
+        context.get_blobdir(),
+        b"foobar\x00" as *const u8 as *const libc::c_char,
+    );
+    assert!(dc_is_blobdir_path(context, as_str(abs_path)));
+    assert!(dc_is_blobdir_path(context, "$BLOBDIR/fofo",));
+    assert!(!dc_is_blobdir_path(context, "/BLOBDIR/fofo",));
+    assert!(dc_file_exist(context, as_path(abs_path)));
+    free(abs_path as *mut libc::c_void);
+    assert!(dc_copy_file(context, "$BLOBDIR/foobar", "$BLOBDIR/dada",));
+    assert_eq!(dc_get_filebytes(context, "$BLOBDIR/dada",), 7);
+
+    let mut buf: *mut libc::c_void = ptr::null_mut();
+    let mut buf_bytes: size_t = 0;
+
+    assert_eq!(
+        dc_read_file(
+            context,
+            b"$BLOBDIR/dada\x00" as *const u8 as *const libc::c_char,
+            &mut buf,
+            &mut buf_bytes,
+        ),
+        1
+    );
+    assert_eq!(buf_bytes, 7);
+    assert_eq!(
+        std::str::from_utf8(std::slice::from_raw_parts(buf as *const u8, buf_bytes)).unwrap(),
+        "content"
+    );
+
+    free(buf as *mut _);
+    assert!(dc_delete_file(context, "$BLOBDIR/foobar"));
+    assert!(dc_delete_file(context, "$BLOBDIR/dada"));
+    assert!(dc_create_folder(context, "$BLOBDIR/foobar-folder"));
+    assert!(dc_file_exist(context, "$BLOBDIR/foobar-folder",));
+    assert!(!dc_delete_file(context, "$BLOBDIR/foobar-folder"));
+    let fn0: *mut libc::c_char = dc_get_fine_pathNfilename(
+        context,
+        b"$BLOBDIR\x00" as *const u8 as *const libc::c_char,
+        b"foobar.dadada\x00" as *const u8 as *const libc::c_char,
+    );
+    assert!(!fn0.is_null());
+    assert_eq!(
+        strcmp(
+            fn0,
+            b"$BLOBDIR/foobar.dadada\x00" as *const u8 as *const libc::c_char,
+        ),
+        0
+    );
+    dc_write_file(
+        context,
+        fn0,
+        b"content\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
+        7i32 as size_t,
+    );
+    let fn1: *mut libc::c_char = dc_get_fine_pathNfilename(
+        context,
+        b"$BLOBDIR\x00" as *const u8 as *const libc::c_char,
+        b"foobar.dadada\x00" as *const u8 as *const libc::c_char,
+    );
+    assert!(!fn1.is_null());
+    assert_eq!(
+        strcmp(
+            fn1,
+            b"$BLOBDIR/foobar-1.dadada\x00" as *const u8 as *const libc::c_char,
+        ),
+        0
+    );
+    assert!(dc_delete_file(context, as_path(fn0)));
+    free(fn0 as *mut libc::c_void);
+    free(fn1 as *mut libc::c_void);
 
     let res = context.get_config(config::Config::SysConfigKeys).unwrap();
 
@@ -567,12 +565,7 @@ fn test_encryption_decryption() {
     assert_eq!(plain, original_text);
 }
 
-unsafe extern "C" fn cb(
-    _context: &Context,
-    _event: Event,
-    _data1: uintptr_t,
-    _data2: uintptr_t,
-) -> uintptr_t {
+fn cb(_context: &Context, _event: Event, _data1: uintptr_t, _data2: uintptr_t) -> uintptr_t {
     0
 }
 
@@ -582,21 +575,16 @@ struct TestContext {
     dir: TempDir,
 }
 
-unsafe fn create_test_context() -> TestContext {
-    let mut ctx = dc_context_new(Some(cb), std::ptr::null_mut(), None);
+fn create_test_context() -> TestContext {
     let dir = tempdir().unwrap();
     let dbfile = dir.path().join("db.sqlite");
-    assert!(
-        dc_open(&mut ctx, dbfile.to_str().unwrap(), None),
-        "Failed to open {}",
-        dbfile.display()
-    );
+    let ctx = Context::new(Box::new(cb), "FakeOs".into(), dbfile).unwrap();
     TestContext { ctx: ctx, dir: dir }
 }
 
 #[test]
 fn test_dc_get_oauth2_url() {
-    let ctx = unsafe { create_test_context() };
+    let ctx = create_test_context();
     let addr = "dignifiedquire@gmail.com";
     let redirect_uri = "chat.delta:/com.b44t.messenger";
     let res = dc_get_oauth2_url(&ctx.ctx, addr, redirect_uri);
@@ -606,7 +594,7 @@ fn test_dc_get_oauth2_url() {
 
 #[test]
 fn test_dc_get_oauth2_addr() {
-    let ctx = unsafe { create_test_context() };
+    let ctx = create_test_context();
     let addr = "dignifiedquire@gmail.com";
     let code = "fail";
     let res = dc_get_oauth2_addr(&ctx.ctx, addr, code);
@@ -616,7 +604,7 @@ fn test_dc_get_oauth2_addr() {
 
 #[test]
 fn test_dc_get_oauth2_token() {
-    let ctx = unsafe { create_test_context() };
+    let ctx = create_test_context();
     let addr = "dignifiedquire@gmail.com";
     let code = "fail";
     let res = dc_get_oauth2_access_token(&ctx.ctx, addr, code, 0);
@@ -634,50 +622,33 @@ fn test_stress_tests() {
 
 #[test]
 fn test_get_contacts() {
-    unsafe {
-        let context = create_test_context();
-        let contacts = Contact::get_all(&context.ctx, 0, Some("some2")).unwrap();
-        assert_eq!(contacts.len(), 0);
+    let context = create_test_context();
+    let contacts = Contact::get_all(&context.ctx, 0, Some("some2")).unwrap();
+    assert_eq!(contacts.len(), 0);
 
-        let id = Contact::create(&context.ctx, "bob", "bob@mail.de").unwrap();
-        assert_ne!(id, 0);
+    let id = Contact::create(&context.ctx, "bob", "bob@mail.de").unwrap();
+    assert_ne!(id, 0);
 
-        let contacts = Contact::get_all(&context.ctx, 0, Some("bob")).unwrap();
-        assert_eq!(contacts.len(), 1);
+    let contacts = Contact::get_all(&context.ctx, 0, Some("bob")).unwrap();
+    assert_eq!(contacts.len(), 1);
 
-        let contacts = Contact::get_all(&context.ctx, 0, Some("alice")).unwrap();
-        assert_eq!(contacts.len(), 0);
-    }
+    let contacts = Contact::get_all(&context.ctx, 0, Some("alice")).unwrap();
+    assert_eq!(contacts.len(), 0);
 }
 
 #[test]
 fn test_chat() {
-    unsafe {
-        let context = create_test_context();
-        let contact1 = Contact::create(&context.ctx, "bob", "bob@mail.de").unwrap();
-        assert_ne!(contact1, 0);
+    let context = create_test_context();
+    let contact1 = Contact::create(&context.ctx, "bob", "bob@mail.de").unwrap();
+    assert_ne!(contact1, 0);
 
-        let chat_id = chat::create_by_contact_id(&context.ctx, contact1).unwrap();
-        assert!(chat_id > 9, "chat_id too small {}", chat_id);
-        let chat = Chat::load_from_db(&context.ctx, chat_id).unwrap();
+    let chat_id = chat::create_by_contact_id(&context.ctx, contact1).unwrap();
+    assert!(chat_id > 9, "chat_id too small {}", chat_id);
+    let chat = Chat::load_from_db(&context.ctx, chat_id).unwrap();
 
-        let chat2_id = chat::create_by_contact_id(&context.ctx, contact1).unwrap();
-        assert_eq!(chat2_id, chat_id);
-        let chat2 = Chat::load_from_db(&context.ctx, chat2_id).unwrap();
+    let chat2_id = chat::create_by_contact_id(&context.ctx, contact1).unwrap();
+    assert_eq!(chat2_id, chat_id);
+    let chat2 = Chat::load_from_db(&context.ctx, chat2_id).unwrap();
 
-        assert_eq!(chat2.name, chat.name);
-    }
-}
-
-#[test]
-fn test_wrong_db() {
-    unsafe {
-        let mut ctx = dc_context_new(Some(cb), std::ptr::null_mut(), None);
-        let dir = tempdir().unwrap();
-        let dbfile = dir.path().join("db.sqlite");
-        std::fs::write(&dbfile, b"123").unwrap();
-
-        let res = dc_open(&mut ctx, dbfile.to_str().unwrap(), None);
-        assert!(!res);
-    }
+    assert_eq!(chat2.name, chat.name);
 }


### PR DESCRIPTION
This is the new implementation of #335.  It is slightly less complex as it doesn't need the rental crate to keep locks open.  Instead the structs on the FFI store all the unsafe references in raw pointers, not introducing any weird new failures around clients calling dc_close().  It does mean clients could and probably do keep around unsafe objects after the context is closed, but this is the same behaviour as before and as long as they do not use any of them this should be fine.