### PR TITLE
Add test for mime parsing reportedly crash-inducing message

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,10 @@
 # ensures this even if the user has not set core.autocrlf.
 *  text=auto
 
+# This directory contains email messages verbatim, and changing CRLF to
+# LF will corrupt them.
+test-data/* text=false
+
 # binary files should be detected by git, however, to be sure, you can add them here explicitly
 *.png  binary
 *.jpg  binary

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -1788,6 +1788,16 @@ mod tests {
             mailmime_free(mime);
         }
     }
+
+    #[test]
+    fn test_dc_mimeparser_crash() {
+        let context = dummy_context();
+        let raw = include_bytes!("../test-data/message/issue_523.txt");
+        let mimeparser = unsafe { dc_mimeparser_parse(&context.ctx, &raw[..]) };
+        assert_eq!(mimeparser.subject, None);
+        assert_eq!(mimeparser.parts.len(), 1);
+    }
+
     #[test]
     fn test_dc_mimeparser_with_context() {
         unsafe {

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -1714,6 +1714,7 @@ pub unsafe fn mailimf_find_optional_field(
 mod tests {
     use super::*;
     use crate::test_utils::*;
+    use proptest::prelude::*;
     use std::ffi::CStr;
 
     #[test]
@@ -1796,6 +1797,14 @@ mod tests {
         let mimeparser = unsafe { dc_mimeparser_parse(&context.ctx, &raw[..]) };
         assert_eq!(mimeparser.subject, None);
         assert_eq!(mimeparser.parts.len(), 1);
+    }
+
+    proptest! {
+        #[test]
+        fn test_dc_mailmime_parse_crash_fuzzy(data in "[!-~\t ]{2000,}") {
+            let context = dummy_context();
+            unsafe { dc_mimeparser_parse(&context.ctx, data.as_bytes()) }
+        }
     }
 
     #[test]

--- a/test-data/message/issue_523.txt
+++ b/test-data/message/issue_523.txt
@@ -1,0 +1,21 @@
+Return-Path: <x@testrun.org>
+Received: from hq5.merlinux.eu
+	by hq5.merlinux.eu (Dovecot) with LMTP id yRKOBakcfV1AewAAPzvFDg
+	; Sat, 14 Sep 2019 19:00:25 +0200
+Received: from localhost (unknown 7.165.105.24])
+	by hq5.merlinux.eu (Postfix) with ESMTPSA id 8D9844E023;
+	Sat, 14 Sep 2019 19:00:22 +0200 (CEST)
+DKIM-Signature: v=1; a=rsa-sha256; c=simple/simple; d=testrun.org;
+	s=testrun; t=1568480425;
+	bh=GrziQ9bkbioILHZ1tEn81B53bDgaZK+ENbW4MUBiMUM=;
+	h=Date:From:To:In-Reply-To:References:Subject:From;
+	b=eHP/GdBQD1cq601Gaqpz7fd+nQvBJLH7c+bk9KGGC3BKZrRAzehEDOaFlGP2+9oFq
+	 cl+y11nGowenVAw7M5ljjxCpOVy0Aa+atn3e7iZeufgOJPr5Hggg2nPe4qfyP6OmOJ
+	 i9RazyXN1rp4fY7ku9x29g818UL8aWiloJHJ9wqDhMe8OXtIAhJA0gpHDCT1SLgo/a
+	 Kv7/Yj4CA8XS/mRxkbBmpWgcF7SluNjuXU9Npo3aTfjQQ5xSzn72Jsai4n0ppLcQ5k
+	 KobttFy+gkmfQRAe8v7vx51qn82BSsGRlxZWevOB9zit/uk7zb8ZbBqPMeCoWsihRM
+	 LdSqwIpokmYmQ==
+Date: Sat, 14 Sep 2019 19:00:13 +0200
+From: lmn <x@tux.org>
+To: abc <abc@bcd.com>, def <def@def.de>, 
+ jik


### PR DESCRIPTION
Unfortunately, crash as reported in #523 does not reproduce.
Research in progress.