### PR TITLE
streamline python fixtures to simplify actual test code 

### DIFF
--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -50,9 +50,8 @@ class Account(object):
         self._configkeys = self.get_config("sys.config_keys").split()
         self._imex_completed = threading.Event()
 
-    # XXX this can cause "illegal instructions" at test ends so we omit it for now
-    # def __del__(self):
-    #    self.shutdown()
+    def __del__(self):
+        self.shutdown()
 
     def _check_config_key(self, name):
         if name not in self._configkeys:
@@ -397,7 +396,8 @@ class Account(object):
     def shutdown(self, wait=True):
         """ stop threads and close and remove underlying dc_context and callbacks. """
         if hasattr(self, "_dc_context") and hasattr(self, "_threads"):
-            self.stop_threads(wait=False)  # to interrupt idle and tell python threads to stop
+            print("SHUTDOWN", self)
+            self.stop_threads(wait=False)
             lib.dc_close(self._dc_context)
             self.stop_threads(wait=wait)  # to wait for threads
             deltachat.clear_context_callback(self._dc_context)

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -396,7 +396,7 @@ class Account(object):
     def shutdown(self, wait=True):
         """ stop threads and close and remove underlying dc_context and callbacks. """
         if hasattr(self, "_dc_context") and hasattr(self, "_threads"):
-            print("SHUTDOWN", self)
+            # print("SHUTDOWN", self)
             self.stop_threads(wait=False)
             lib.dc_close(self._dc_context)
             self.stop_threads(wait=wait)  # to wait for threads

--- a/python/src/deltachat/chatting.py
+++ b/python/src/deltachat/chatting.py
@@ -305,7 +305,6 @@ class Chat(object):
     def get_contacts(self):
         """ get all contacts for this chat.
         :params: contact object.
-        :raises ValueError: if contact could not be added
         :returns: list of :class:`deltachat.chatting.Contact` objects for this chat
 
         """

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -24,17 +24,6 @@ def pytest_configure(config):
             config.option.liveconfig = cfg
 
 
-@pytest.hookimpl(trylast=True)
-def pytest_runtest_call(item):
-    # perform early finalization because we otherwise get cloberred
-    # output from concurrent threads printing between execution
-    # of the test function and the teardown phase of that test function
-    if "acfactory" in item.funcargs:
-        print("*"*30, "finalizing", "*"*30)
-        acfactory = item.funcargs["acfactory"]
-        acfactory.finalize()
-
-
 def pytest_report_header(config, startdir):
     summary = []
 
@@ -184,7 +173,9 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig):
             self._finalizers.append(ac.shutdown)
             return ac
 
-    return AccountMaker()
+    am = AccountMaker()
+    request.addfinalizer(am.finalize)
+    return am
 
 
 @pytest.fixture

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -1626,7 +1626,8 @@ mod tests {
     fn test_dc_mimeparser_crash() {
         let context = dummy_context();
         let raw = include_bytes!("../test-data/message/issue_523.txt");
-        let mimeparser = unsafe { dc_mimeparser_parse(&context.ctx, &raw[..]) };
+        let mut mimeparser = MimeParser::new(&context.ctx);
+        unsafe { mimeparser.parse(&raw[..]) };
         assert_eq!(mimeparser.subject, None);
         assert_eq!(mimeparser.parts.len(), 1);
     }
@@ -1635,7 +1636,8 @@ mod tests {
         #[test]
         fn test_dc_mailmime_parse_crash_fuzzy(data in "[!-~\t ]{2000,}") {
             let context = dummy_context();
-            unsafe { dc_mimeparser_parse(&context.ctx, data.as_bytes()) }
+            let mut mimeparser = MimeParser::new(&context.ctx);
+            unsafe { mimeparser.parse(data.as_bytes()) };
         }
     }
 


### PR DESCRIPTION
- do not use a hack to teardown online configured accounts eagerly as it was not called on test failures and led to crashes.  Threads might produce some uncaptured logging between "setup/call/teardown" phases of a test but it's bearable in my test runs. 
- remove redundancy for the online two-account setups
- add a helper to create a chat between two online accounts 