### PR TITLE
fix #538 -- don't crash on wrong setup codes for ac-message, added test

### DIFF
--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -110,7 +110,13 @@ class Message(object):
 
     def continue_key_transfer(self, setup_code):
         """ extract key and use it as primary key for this account. """
-        lib.dc_continue_key_transfer(self._dc_context, self.id, as_dc_charpointer(setup_code))
+        res = lib.dc_continue_key_transfer(
+                self._dc_context,
+                self.id,
+                as_dc_charpointer(setup_code)
+        )
+        if res == 0:
+            raise ValueError("could not decrypt")
 
     @props.with_doc
     def time_sent(self):

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -537,6 +537,9 @@ class TestOnlineAccount:
         ev = ac2._evlogger.get_matching("DC_EVENT_INCOMING_MSG|DC_EVENT_MSGS_CHANGED")
         msg = ac2.get_message_by_id(ev[2])
         assert msg.is_setup_message()
+        # first try a bad setup code
+        with pytest.raises(ValueError):
+            msg.continue_key_transfer(str(reversed(setup_code)))
         print("*************** Incoming ASM File at: ", msg.filename)
         print("*************** Setup Code: ", setup_code)
         msg.continue_key_transfer(setup_code)

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -196,8 +196,8 @@ pub fn dc_render_setup_file(context: &Context, passphrase: &str) -> Result<Strin
         _ => Some(("Autocrypt-Prefer-Encrypt", "mutual")),
     };
     let private_key_asc = private_key.to_asc(ac_headers);
-    let encr = dc_pgp_symm_encrypt(&passphrase, private_key_asc.as_bytes())
-        .ok_or(format_err!("Failed to encrypt private key."))?;
+    let encr = dc_pgp_symm_encrypt(&passphrase, private_key_asc.as_bytes())?;
+
     let replacement = format!(
         concat!(
             "-----BEGIN PGP MESSAGE-----\r\n",
@@ -385,7 +385,7 @@ fn set_self_key(
 }
 
 pub unsafe fn dc_decrypt_setup_file(
-    _context: &Context,
+    context: &Context,
     passphrase: *const libc::c_char,
     filecontent: *const libc::c_char,
 ) -> *mut libc::c_char {
@@ -424,12 +424,17 @@ pub unsafe fn dc_decrypt_setup_file(
             || binary_bytes == 0)
         {
             /* decrypt symmetrically */
-            if let Some(plain) = dc_pgp_symm_decrypt(
+            match dc_pgp_symm_decrypt(
                 as_str(passphrase),
                 std::slice::from_raw_parts(binary as *const u8, binary_bytes),
             ) {
-                let payload_c = CString::new(plain).unwrap();
-                payload = strdup(payload_c.as_ptr());
+                Ok(plain) => {
+                    let payload_c = CString::new(plain).unwrap();
+                    payload = strdup(payload_c.as_ptr());
+                }
+                Err(err) => {
+                    error!(context, "Failed to decrypt message: {:?}", err);
+                }
             }
         }
     }

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -296,7 +296,7 @@ impl E2eeHelper {
                             if (*plain).str_0.is_null() || (*plain).len <= 0 {
                                 ok_to_continue = false;
                             } else {
-                                if let Some(ctext_v) = dc_pgp_pk_encrypt(
+                                if let Ok(ctext_v) = dc_pgp_pk_encrypt(
                                     std::slice::from_raw_parts(
                                         (*plain).str_0 as *const u8,
                                         (*plain).len,
@@ -908,7 +908,7 @@ unsafe fn decrypt_part(
                 };
 
                 /*if we already have fingerprints, do not add more; this ensures, only the fingerprints from the outer-most part are collected */
-                if let Some(plain) = dc_pgp_pk_decrypt(
+                if let Ok(plain) = dc_pgp_pk_decrypt(
                     std::slice::from_raw_parts(decoded_data as *const u8, decoded_data_bytes),
                     &private_keyring,
                     &public_keyring_for_validate,

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
     Utf8(std::str::Utf8Error),
     #[fail(display = "{:?}", _0)]
     CStringError(crate::dc_tools::CStringError),
+    #[fail(display = "PGP: {:?}", _0)]
+    Pgp(pgp::errors::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -67,6 +69,12 @@ impl From<image_meta::ImageError> for Error {
 impl From<crate::dc_tools::CStringError> for Error {
     fn from(err: crate::dc_tools::CStringError) -> Error {
         Error::CStringError(err)
+    }
+}
+
+impl From<pgp::errors::Error> for Error {
+    fn from(err: pgp::errors::Error) -> Error {
+        Error::Pgp(err)
     }
 }
 

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -289,10 +289,11 @@ pub fn dc_pgp_symm_decrypt(passphrase: &str, ctext: &[u8]) -> Option<Vec<u8>> {
 
     enc_msg
         .and_then(|msg| {
-            let mut decryptor = msg
-                .decrypt_with_password(|| passphrase.into())
-                .expect("failed decryption");
-            decryptor.next().expect("no message")
+            let mut decryptor = msg.decrypt_with_password(|| passphrase.into())?;
+            match decryptor.next() {
+                Some(x) => x,
+                None => Err(pgp::errors::Error::InvalidInput),
+            }
         })
         .and_then(|msg| msg.get_content())
         .ok()


### PR DESCRIPTION
fix #538 (i think you need to have in the comment here, the title is not scanned by the github-auto-close-issue code) 