### PR TITLE
Refine signature of dc_get_oauth2_access_token()

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -20,7 +20,6 @@ use crate::oauth2::dc_get_oauth2_access_token;
 use crate::param::Params;
 
 const DC_IMAP_SEEN: usize = 0x0001;
-const DC_REGENERATE: usize = 0x01;
 
 const DC_SUCCESS: usize = 3;
 const DC_ALREADY_DONE: usize = 2;
@@ -418,9 +417,7 @@ impl Imap {
                 if (server_flags & DC_LP_AUTH_OAUTH2) != 0 {
                     let addr: &str = config.addr.as_ref();
 
-                    if let Some(token) =
-                        dc_get_oauth2_access_token(context, addr, imap_pw, DC_REGENERATE as usize)
-                    {
+                    if let Some(token) = dc_get_oauth2_access_token(context, addr, imap_pw, true) {
                         let auth = OAuth2 {
                             user: imap_user.into(),
                             access_token: token,

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -74,14 +74,14 @@ pub fn dc_get_oauth2_access_token(
     context: &Context,
     addr: impl AsRef<str>,
     code: impl AsRef<str>,
-    flags: usize,
+    regenerate: bool,
 ) -> Option<String> {
     if let Some(oauth2) = Oauth2::from_address(addr) {
         let lock = context.oauth2_critical.clone();
         let _l = lock.lock().unwrap();
 
         // read generated token
-        if 0 == flags & 0x1 && !is_expired(context) {
+        if !regenerate && !is_expired(context) {
             let access_token = context.sql.get_config(context, "oauth2_access_token");
             if access_token.is_some() {
                 // success
@@ -216,12 +216,13 @@ pub fn dc_get_oauth2_addr(
         return None;
     }
 
-    if let Some(access_token) = dc_get_oauth2_access_token(context, addr.as_ref(), code.as_ref(), 0)
+    if let Some(access_token) =
+        dc_get_oauth2_access_token(context, addr.as_ref(), code.as_ref(), false)
     {
         let addr_out = oauth2.get_addr(context, access_token);
         if addr_out.is_none() {
             // regenerate
-            if let Some(access_token) = dc_get_oauth2_access_token(context, addr, code, 0x1) {
+            if let Some(access_token) = dc_get_oauth2_access_token(context, addr, code, true) {
                 oauth2.get_addr(context, access_token)
             } else {
                 None

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -82,7 +82,7 @@ impl Smtp {
             // oauth2
             let addr = &lp.addr;
             let send_pw = &lp.send_pw;
-            let access_token = dc_get_oauth2_access_token(context, addr, send_pw, 0);
+            let access_token = dc_get_oauth2_access_token(context, addr, send_pw, false);
             if access_token.is_none() {
                 return false;
             }

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -573,7 +573,7 @@ fn test_dc_get_oauth2_token() {
     let ctx = create_test_context();
     let addr = "dignifiedquire@gmail.com";
     let code = "fail";
-    let res = dc_get_oauth2_access_token(&ctx.ctx, addr, code, 0);
+    let res = dc_get_oauth2_access_token(&ctx.ctx, addr, code, false);
     // this should fail as it is an invalid password
     assert_eq!(res, None);
 }


### PR DESCRIPTION
Previously, `dc_get_oauth2_access_token` accepted "flags" argument,
that actually had only one possible field: 0x1 == DC_REGENERATE.

This change replaces "flags" argument with single boolean argument
"regenerate".
