### PR TITLE
Fix ffi interoperability issue

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -233,7 +233,7 @@ pub unsafe extern "C" fn dc_open(
     let ffi_context = &*context;
     let rust_cb = move |_ctx: &Context, evt: Event| ffi_context.translate_cb(evt);
 
-    let ctx = if blobdir.is_null() {
+    let ctx = if blobdir.is_null() || *blobdir == 0 {
         Context::new(
             Box::new(rust_cb),
             ffi_context.os_name.clone(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -476,6 +476,15 @@ mod tests {
     }
 
     #[test]
+    fn test_with_empty_blobdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dbfile = tmp.path().join("db.sqlite");
+        let blobdir = PathBuf::new();
+        let res = Context::with_blobdir(Box::new(|_, _| 0), "FakeOS".into(), dbfile, blobdir);
+        assert!(res.is_err());
+    }
+
+    #[test]
     fn test_with_blobdir_not_exists() {
         let tmp = tempfile::tempdir().unwrap();
         let dbfile = tmp.path().join("db.sqlite");


### PR DESCRIPTION
Clients expect empty "dbfile" argument to be treated as NULL value.
This change fulfills their expectations.

Closes: #530