### PR TITLE
fix configure-panic

### DIFF
--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -18,7 +18,7 @@ use auto_mozilla::moz_autoconfigure;
 macro_rules! progress {
     ($context:tt, $progress:expr) => {
         assert!(
-            $progress > 0 && $progress <= 1000,
+            $progress <= 1000,
             "value in range 0..1000 expected with: 0=error, 1..999=progress, 1000=success"
         );
         $context.call_cb($crate::events::Event::ConfigureProgress($progress));


### PR DESCRIPTION
fixes #544 
tackles https://github.com/deltachat/deltachat-ios/issues/90

nb: adding a check for `progress >= 0` results in a rust compiler warning `comparison is useless due to type limits` - i do not fully agree that this would be useless as it might happen the macro is called with an Int instead of UInt, however, i have no idea how to handle this :)