### PR TITLE
cleanup rfc724_mid handling to avoid char* 

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -362,7 +362,7 @@ impl Context {
             }
 
             if self.is_mvbox(folder) {
-                dc_update_msg_move_state(self, msg.rfc724_mid, MoveState::Stay);
+                dc_update_msg_move_state(self, &msg.rfc724_mid, MoveState::Stay);
             }
 
             // 1 = dc message, 2 = reply to dc message
@@ -374,7 +374,7 @@ impl Context {
                     Params::new(),
                     0,
                 );
-                dc_update_msg_move_state(self, msg.rfc724_mid, MoveState::Moving);
+                dc_update_msg_move_state(self, &msg.rfc724_mid, MoveState::Moving);
             }
         }
     }

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -330,7 +330,7 @@ pub unsafe fn dc_mimefactory_load_mdn<'a>(
     );
     load_from(&mut factory);
     factory.timestamp = dc_create_smeared_timestamp(factory.context);
-    factory.rfc724_mid = dc_create_outgoing_rfc724_mid(0 as *const libc::c_char, factory.from_addr);
+    factory.rfc724_mid = dc_create_outgoing_rfc724_mid(None, as_str(factory.from_addr)).strdup();
     factory.loaded = DC_MF_MDN_LOADED;
 
     Ok(factory)

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -231,7 +231,7 @@ pub unsafe fn dc_mimefactory_load_msg(
 
     factory.loaded = DC_MF_MSG_LOADED;
     factory.timestamp = factory.msg.timestamp_sort;
-    factory.rfc724_mid = as_str(factory.msg.rfc724_mid).to_string();
+    factory.rfc724_mid = factory.msg.rfc724_mid.clone();
     factory.increation = dc_msg_is_increation(&factory.msg);
 
     Ok(factory)
@@ -950,7 +950,7 @@ pub unsafe fn dc_mimefactory_render(context: &Context, factory: &mut dc_mimefact
                 version,
                 as_str(factory.from_addr),
                 as_str(factory.from_addr),
-                as_str(factory.msg.rfc724_mid)
+                factory.msg.rfc724_mid
             ).strdup();
 
             let content_type_0: *mut mailmime_content = mailmime_content_new_with_str(

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -1002,7 +1002,7 @@ impl<'a> MimeParser<'a> {
             unsafe {
                 let fld_message_id = (*field).fld_data.fld_message_id;
                 if !fld_message_id.is_null() {
-                    return Some(as_str((*fld_message_id).mid_value).to_string());
+                    return Some(to_string((*fld_message_id).mid_value));
                 }
             }
         }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -361,14 +361,15 @@ unsafe fn add_parts(
     let mut old_server_folder = std::ptr::null_mut();
     let mut old_server_uid = 0;
 
+    let rfc724_mid_s = as_str(rfc724_mid);
     if 0 != dc_rfc724_mid_exists(
         context,
-        rfc724_mid,
+        &rfc724_mid_s,
         &mut old_server_folder,
         &mut old_server_uid,
     ) {
         if as_str(old_server_folder) != server_folder.as_ref() || old_server_uid != server_uid {
-            dc_update_server_uid(context, rfc724_mid, server_folder.as_ref(), server_uid);
+            dc_update_server_uid(context, &rfc724_mid_s, server_folder.as_ref(), server_uid);
         }
 
         free(old_server_folder.cast());
@@ -867,7 +868,7 @@ unsafe fn handle_reports(
                                         if 0 != dc_mdn_from_ext(
                                             context,
                                             from_id,
-                                            rfc724_mid_0,
+                                            as_str(rfc724_mid_0),
                                             sent_timestamp,
                                             &mut chat_id_0,
                                             &mut msg_id,

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -590,30 +590,8 @@ pub fn dc_create_incoming_rfc724_mid(
 /// Function generates a Message-ID that can be used for a new outgoing message.
 /// - this function is called for all outgoing messages.
 /// - the message ID should be globally unique
-/// - do not add a counter or any private data as as this may give unneeded information to the receiver
-pub unsafe fn dc_create_outgoing_rfc724_mid(
-    grpid: *const libc::c_char,
-    from_addr: *const libc::c_char,
-) -> *mut libc::c_char {
-    let rand2 = dc_create_id();
-
-    let at_hostname = as_opt_str(strchr(from_addr, '@' as i32)).unwrap_or_else(|| "@nohost");
-
-    let ret = if !grpid.is_null() {
-        format!("Gr.{}.{}{}", as_str(grpid), rand2, at_hostname,)
-    } else {
-        let rand1 = dc_create_id();
-        format!("Mr.{}.{}{}", rand1, rand2, at_hostname)
-    };
-
-    ret.strdup()
-}
-
-/// Generate globally-unique message-id for a new outgoing message.
-///
-/// Note: Do not add a counter or any private data as as this may give
-/// unneeded information to the receiver
-pub fn dc_create_outgoing_rfc724_mid_safe(grpid: Option<&str>, from_addr: &str) -> String {
+/// - do not add a counter or any private data as this leaks information unncessarily
+pub fn dc_create_outgoing_rfc724_mid(grpid: Option<&str>, from_addr: &str) -> String {
     let hostname = from_addr
         .find('@')
         .map(|k| &from_addr[k..])

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -572,9 +572,9 @@ pub fn dc_create_incoming_rfc724_mid(
     message_timestamp: i64,
     contact_id_from: u32,
     contact_ids_to: &Vec<u32>,
-) -> *mut libc::c_char {
+) -> Option<String> {
     if contact_ids_to.is_empty() {
-        return ptr::null_mut();
+        return None;
     }
     /* find out the largest receiver ID (we could also take the smallest, but it should be unique) */
     let largest_id_to = contact_ids_to.iter().max().copied().unwrap_or_default();
@@ -583,8 +583,7 @@ pub fn dc_create_incoming_rfc724_mid(
         "{}-{}-{}@stub",
         message_timestamp, contact_id_from, largest_id_to
     );
-
-    unsafe { result.strdup() }
+    Some(result)
 }
 
 /// Function generates a Message-ID that can be used for a new outgoing message.
@@ -1791,10 +1790,6 @@ mod tests {
     #[test]
     fn test_dc_create_incoming_rfc724_mid() {
         let res = dc_create_incoming_rfc724_mid(123, 45, &vec![6, 7]);
-        assert_eq!(as_str(res), "123-45-7@stub");
-
-        unsafe {
-            free(res.cast());
-        }
+        assert_eq!(res, Some("123-45-7@stub".into()));
     }
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -1001,8 +1001,7 @@ fn add_smtp_job(context: &Context, action: Action, mimefactory: &dc_mimefactory_
     let mut success: libc::c_int = 0i32;
     let mut recipients: *mut libc::c_char = ptr::null_mut();
     let mut param = Params::new();
-    let path_filename =
-        dc_get_fine_path_filename(context, "$BLOBDIR", as_str(mimefactory.rfc724_mid));
+    let path_filename = dc_get_fine_path_filename(context, "$BLOBDIR", &mimefactory.rfc724_mid);
     let bytes = unsafe {
         std::slice::from_raw_parts(
             (*mimefactory.out).str_0 as *const u8,
@@ -1013,7 +1012,7 @@ fn add_smtp_job(context: &Context, action: Action, mimefactory: &dc_mimefactory_
         error!(
             context,
             "Could not write message <{}> to \"{}\".",
-            to_string(mimefactory.rfc724_mid),
+            mimefactory.rfc724_mid,
             path_filename.display(),
         );
     } else {

--- a/test-data/message/mail_with_message_id.txt
+++ b/test-data/message/mail_with_message_id.txt
@@ -1,0 +1,13 @@
+Return-Path: <x@testrun.org>
+Received: from hq5.merlinux.eu
+	by hq5.merlinux.eu (Dovecot) with LMTP id yRKOBakcfV1AewAAPzvFDg
+	; Sat, 14 Sep 2019 19:00:25 +0200
+Received: from localhost (unknown 7.165.105.24])
+	by hq5.merlinux.eu (Postfix) with ESMTPSA id 8D9844E023;
+	Sat, 14 Sep 2019 19:00:22 +0200 (CEST)
+message-id: <2dfdbde7@example.org>
+Date: Sat, 14 Sep 2019 19:00:13 +0200
+From: lmn <x@tux.org>
+To: abc <abc@bcd.com>, def <def@def.de>,
+ jik
+


### PR DESCRIPTION
the individual commits each pass tests on their own and maybe make sense to review separately. 

I choose to not use `Option<String>` for rfc724_mid but `String` and initialize to empty-string as there is no difference in interpretation of empty or non-existing message-ids. 

the last commit factors out rfc724_mid parsing from add_parts() into a mimeparser-method and adds tests.  This allows to not need a &mut rfc724_mid. 