### PR TITLE
Make return type of Image::mv an enum

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1262,11 +1262,11 @@ impl Imap {
         }
     }
 
-    pub fn set_seen<S: AsRef<str>>(&self, context: &Context, folder: S, uid: u32) -> usize {
-        let mut res = DC_RETRY_LATER;
+    pub fn set_seen<S: AsRef<str>>(&self, context: &Context, folder: S, uid: u32) -> ImapResult {
+        let mut res = ImapResult::RetryLater;
 
         if uid == 0 {
-            res = DC_FAILED
+            res = ImapResult::Failed
         } else if self.is_connected() {
             info!(
                 context,
@@ -1284,15 +1284,15 @@ impl Imap {
             } else if self.add_flag(context, uid, "\\Seen") == 0 {
                 warn!(context, "Cannot mark message as seen.",);
             } else {
-                res = DC_SUCCESS
+                res = ImapResult::Success
             }
         }
 
-        if res == DC_RETRY_LATER {
+        if res == ImapResult::RetryLater {
             if self.should_reconnect() {
-                DC_RETRY_LATER
+                ImapResult::RetryLater
             } else {
-                DC_FAILED
+                ImapResult::Failed
             }
         } else {
             res

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -19,10 +19,10 @@ use crate::param::Params;
 
 const DC_IMAP_SEEN: usize = 0x0001;
 
-const DC_SUCCESS: usize = 3;
-const DC_ALREADY_DONE: usize = 2;
-const DC_RETRY_LATER: usize = 1;
-const DC_FAILED: usize = 0;
+pub const DC_SUCCESS: usize = 3;
+pub const DC_ALREADY_DONE: usize = 2;
+pub const DC_RETRY_LATER: usize = 1;
+pub const DC_FAILED: usize = 0;
 
 const PREFETCH_FLAGS: &str = "(UID ENVELOPE)";
 const BODY_FLAGS: &str = "(FLAGS BODY.PEEK[])";

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -27,11 +27,6 @@ pub enum ImapResult {
     Success,
 }
 
-pub const DC_SUCCESS: usize = 3;
-pub const DC_ALREADY_DONE: usize = 2;
-pub const DC_RETRY_LATER: usize = 1;
-pub const DC_FAILED: usize = 0;
-
 const PREFETCH_FLAGS: &str = "(UID ENVELOPE)";
 const BODY_FLAGS: &str = "(FLAGS BODY.PEEK[])";
 const FETCH_FLAGS: &str = "(FLAGS)";

--- a/src/job.rs
+++ b/src/job.rs
@@ -332,9 +332,9 @@ impl Job {
         if ok_to_continue {
             if let Ok(msg) = dc_msg_load_from_db(context, self.foreign_id) {
                 let server_folder = msg.server_folder.as_ref().unwrap();
-                match inbox.set_seen(context, server_folder, msg.server_uid) as libc::c_uint {
-                    0 => {}
-                    1 => {
+                match inbox.set_seen(context, server_folder, msg.server_uid) {
+                    ImapResult::Failed => {}
+                    ImapResult::RetryLater => {
                         self.try_again_later(3i32, None);
                     }
                     _ => {
@@ -387,7 +387,7 @@ impl Job {
             ok_to_continue = true;
         }
         if ok_to_continue {
-            if inbox.set_seen(context, &folder, uid) == 0 {
+            if inbox.set_seen(context, &folder, uid) == ImapResult::Failed {
                 self.try_again_later(3i32, None);
             }
             if 0 != self.param.get_int(Param::AlsoMove).unwrap_or_default() {

--- a/src/job.rs
+++ b/src/job.rs
@@ -246,15 +246,14 @@ impl Job {
                         msg.server_uid,
                         &dest_folder,
                         &mut dest_uid,
-                    ) as libc::c_uint
-                    {
-                        1 => {
+                    ) {
+                        DC_RETRY_LATER => {
                             self.try_again_later(3i32, None);
                         }
-                        3 => {
+                        DC_SUCCESS => {
                             dc_update_server_uid(context, &msg.rfc724_mid, &dest_folder, dest_uid);
                         }
-                        0 | 2 | _ => {}
+                        DC_FAILED | DC_ALREADY_DONE | _ => {}
                     }
                 }
             }

--- a/src/job.rs
+++ b/src/job.rs
@@ -247,13 +247,13 @@ impl Job {
                         &dest_folder,
                         &mut dest_uid,
                     ) {
-                        DC_RETRY_LATER => {
+                        ImapResult::RetryLater => {
                             self.try_again_later(3i32, None);
                         }
-                        DC_SUCCESS => {
+                        ImapResult::Success => {
                             dc_update_server_uid(context, &msg.rfc724_mid, &dest_folder, dest_uid);
                         }
-                        DC_FAILED | DC_ALREADY_DONE | _ => {}
+                        ImapResult::Failed | ImapResult::AlreadyDone => {}
                     }
                 }
             }
@@ -401,8 +401,8 @@ impl Job {
                 }
                 let dest_folder = context.sql.get_config(context, "configured_mvbox_folder");
                 if let Some(dest_folder) = dest_folder {
-                    if 1 == inbox.mv(context, folder, uid, dest_folder, &mut dest_uid)
-                        as libc::c_uint
+                    if ImapResult::RetryLater
+                        == inbox.mv(context, folder, uid, dest_folder, &mut dest_uid)
                     {
                         self.try_again_later(3, None);
                     }

--- a/src/job.rs
+++ b/src/job.rs
@@ -346,15 +346,14 @@ impl Job {
                         {
                             let folder = msg.server_folder.as_ref().unwrap();
 
-                            match inbox.set_mdnsent(context, folder, msg.server_uid) as libc::c_uint
-                            {
-                                1 => {
+                            match inbox.set_mdnsent(context, folder, msg.server_uid) {
+                                ImapResult::RetryLater => {
                                     self.try_again_later(3i32, None);
                                 }
-                                3 => {
+                                ImapResult::Success => {
                                     send_mdn(context, msg.id);
                                 }
-                                0 | 2 | _ => {}
+                                ImapResult::Failed | ImapResult::AlreadyDone => {}
                             }
                         }
                     }


### PR DESCRIPTION
Note, that since this enum never pass FFI border, its numeric values does
not need to be specified explicitly and can be left on compiler's 
discretion.