### PR TITLE
add dc_perform_{mvbox,sentbox}_jobs 

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -610,12 +610,8 @@ void            dc_interrupt_imap_idle       (dc_context_t* context);
 
 
 /**
- * Fetch new messages from the MVBOX, if any.
- * The MVBOX is a folder on the account where chat messages are moved to.
- * The moving is done to not disturb shared accounts that are used by both,
- * Delta Chat and a classical MUA.
- *
- * This function and dc_perform_mvbox_idle()
+ * Execute pending mvbox-jobs.
+ * This function and dc_perform_mvbox_fetch() and dc_perform_mvbox_idle()
  * must be called from the same thread, typically in a loop.
  *
  * Example:
@@ -623,6 +619,7 @@ void            dc_interrupt_imap_idle       (dc_context_t* context);
  *     void* mvbox_thread_func(void* context)
  *     {
  *         while (true) {
+ *             dc_perform_mvbox_jobs(context);
  *             dc_perform_mvbox_fetch(context);
  *             dc_perform_mvbox_idle(context);
  *         }
@@ -636,8 +633,21 @@ void            dc_interrupt_imap_idle       (dc_context_t* context);
  *
  *     // network becomes available again -
  *     // the interrupt causes dc_perform_mvbox_idle() in the thread above
- *     // to return so that and messages are fetched.
+ *     // to return so that jobs are executed and messages are fetched.
  *     dc_maybe_network(context);
+ *
+ * @memberof dc_context_t
+ * @param context The context as created by dc_context_new().
+ * @return None.
+ */
+void            dc_perform_mvbox_jobs         (dc_context_t* context);
+
+
+/**
+ * Fetch new messages from the MVBOX, if any.
+ * The MVBOX is a folder on the account where chat messages are moved to.
+ * The moving is done to not disturb shared accounts that are used by both,
+ * Delta Chat and a classical MUA.
  *
  * @memberof dc_context_t
  * @param context The context as created by dc_context_new().
@@ -678,6 +688,39 @@ void            dc_perform_mvbox_idle        (dc_context_t* context);
  * @return None.
  */
 void            dc_interrupt_mvbox_idle      (dc_context_t* context);
+
+/**
+ * Execute pending sentbox-jobs.
+ * This function and dc_perform_sentbox_fetch() and dc_perform_sentbox_idle()
+ * must be called from the same thread, typically in a loop.
+ *
+ * Example:
+ *
+ *     void* sentbox_thread_func(void* context)
+ *     {
+ *         while (true) {
+ *             dc_perform_sentbox_jobs(context);
+ *             dc_perform_sentbox_fetch(context);
+ *             dc_perform_sentbox_idle(context);
+ *         }
+ *     }
+ *
+ *     // start sentbox-thread that runs forever
+ *     pthread_t sentbox_thread;
+ *     pthread_create(&sentbox_thread, NULL, sentbox_thread_func, context);
+ *
+ *     ... program runs ...
+ *
+ *     // network becomes available again -
+ *     // the interrupt causes dc_perform_sentbox_idle() in the thread above
+ *     // to return so that jobs are executed and messages are fetched.
+ *     dc_maybe_network(context);
+ *
+ * @memberof dc_context_t
+ * @param context The context as created by dc_context_new().
+ * @return None.
+ */
+void            dc_perform_sentbox_jobs         (dc_context_t* context);
 
 
 /**

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -472,6 +472,18 @@ pub unsafe extern "C" fn dc_perform_mvbox_fetch(context: *mut dc_context_t) {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_perform_mvbox_jobs(context: *mut dc_context_t) {
+    if context.is_null() {
+        eprintln!("ignoring careless call to dc_perform_mvbox_jobs()");
+        return;
+    }
+    let ffi_context = &*context;
+    ffi_context
+        .with_inner(|ctx| job::perform_mvbox_jobs(ctx))
+        .unwrap_or(())
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_perform_mvbox_idle(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_perform_mvbox_idle()");
@@ -504,6 +516,18 @@ pub unsafe extern "C" fn dc_perform_sentbox_fetch(context: *mut dc_context_t) {
     let ffi_context = &*context;
     ffi_context
         .with_inner(|ctx| job::perform_sentbox_fetch(ctx))
+        .unwrap_or(())
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dc_perform_sentbox_jobs(context: *mut dc_context_t) {
+    if context.is_null() {
+        eprintln!("ignoring careless call to dc_perform_sentbox_jobs()");
+        return;
+    }
+    let ffi_context = &*context;
+    ffi_context
+        .with_inner(|ctx| job::perform_sentbox_jobs(ctx))
         .unwrap_or(())
 }
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -163,10 +163,10 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig):
             ac._evlogger.set_timeout(30)
             return ac, dict(configdict)
 
-        def get_online_configuring_account(self):
+        def get_online_configuring_account(self, mvbox=False, sentbox=False):
             ac, configdict = self.get_online_config()
             ac.configure(**configdict)
-            ac.start_threads()
+            ac.start_threads(mvbox=mvbox, sentbox=sentbox)
             return ac
 
         def get_two_online_accounts(self):

--- a/src/job.rs
+++ b/src/job.rs
@@ -761,6 +761,14 @@ pub fn perform_imap_jobs(context: &Context) {
     info!(context, "dc_perform_imap_jobs ended.",);
 }
 
+pub fn perform_mvbox_jobs(context: &Context) {
+    info!(context, "dc_perform_mbox_jobs EMPTY (for now).",);
+}
+
+pub fn perform_sentbox_jobs(context: &Context) {
+    info!(context, "dc_perform_sentbox_jobs EMPTY (for now).",);
+}
+
 fn job_perform(context: &Context, thread: Thread, probe_network: bool) {
     let query = if !probe_network {
         // processing for first-try and after backoff-timeouts:


### PR DESCRIPTION
as discussed add per-folder "jobs" hooks which, however, for now have an empty implementation.  

dc_perform_mvbox_jobs and dc_perform_sentbox_jobs can already be called from UIs, though.  

Next step after merging this PR is then refactoring imap-job handling to only execute jobs belonging to the respective imap folder. 