### PR TITLE
Rename dc_mimefactory_t -> MimeFactory

### DIFF
--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -44,8 +44,8 @@ pub struct MimeFactory<'a> {
     pub references: *mut libc::c_char,
     pub req_mdn: libc::c_int,
     pub out: *mut MMAPString,
-    pub out_encrypted: libc::c_int,
-    pub out_gossiped: libc::c_int,
+    pub out_encrypted: bool,
+    pub out_gossiped: bool,
     pub out_last_added_location_id: u32,
     pub error: *mut libc::c_char,
     pub context: &'a Context,
@@ -105,8 +105,8 @@ pub unsafe fn dc_mimefactory_load_msg(
         references: ptr::null_mut(),
         req_mdn: 0,
         out: ptr::null_mut(),
-        out_encrypted: 0,
-        out_gossiped: 0,
+        out_encrypted: false,
+        out_gossiped: false,
         out_last_added_location_id: 0,
         error: ptr::null_mut(),
         context,
@@ -295,8 +295,8 @@ pub unsafe fn dc_mimefactory_load_mdn<'a>(
         references: ptr::null_mut(),
         req_mdn: 0,
         out: ptr::null_mut(),
-        out_encrypted: 0,
-        out_gossiped: 0,
+        out_encrypted: false,
+        out_gossiped: false,
         out_last_added_location_id: 0,
         error: ptr::null_mut(),
         context,
@@ -1024,9 +1024,9 @@ pub unsafe fn dc_mimefactory_render(context: &Context, factory: &mut MimeFactory
                 );
             }
             if e2ee_helper.encryption_successfull {
-                factory.out_encrypted = 1;
+                factory.out_encrypted = true;
                 if 0 != do_gossip {
-                    factory.out_gossiped = 1
+                    factory.out_gossiped = true;
                 }
             }
             factory.out = mmap_string_new(b"\x00" as *const u8 as *const libc::c_char);

--- a/src/job.rs
+++ b/src/job.rs
@@ -1003,7 +1003,7 @@ fn send_mdn(context: &Context, msg_id: u32) {
 }
 
 #[allow(non_snake_case)]
-fn add_smtp_job(context: &Context, action: Action, mimefactory: &dc_mimefactory_t) -> libc::c_int {
+fn add_smtp_job(context: &Context, action: Action, mimefactory: &MimeFactory) -> libc::c_int {
     let mut success: libc::c_int = 0i32;
     let mut recipients: *mut libc::c_char = ptr::null_mut();
     let mut param = Params::new();

--- a/src/job.rs
+++ b/src/job.rs
@@ -1033,9 +1033,7 @@ fn add_smtp_job(context: &Context, action: Action, mimefactory: &MimeFactory) ->
         job_add(
             context,
             action,
-            (if mimefactory.loaded as libc::c_uint
-                == DC_MF_MSG_LOADED as libc::c_int as libc::c_uint
-            {
+            (if mimefactory.loaded == Loaded::Message {
                 mimefactory.msg.id
             } else {
                 0

--- a/src/job.rs
+++ b/src/job.rs
@@ -686,7 +686,7 @@ pub unsafe fn job_send_msg(context: &Context, msg_id: u32) -> libc::c_int {
                 .param
                 .get_int(Param::GuranteeE2ee)
                 .unwrap_or_default()
-            && 0 == mimefactory.out_encrypted
+            && !mimefactory.out_encrypted
         {
             warn!(
                 context,
@@ -713,7 +713,7 @@ pub unsafe fn job_send_msg(context: &Context, msg_id: u32) -> libc::c_int {
                     dc_strdup(mimefactory.from_addr) as *mut libc::c_void,
                 );
             }
-            if 0 != mimefactory.out_gossiped {
+            if mimefactory.out_gossiped {
                 chat::set_gossiped_timestamp(context, mimefactory.msg.chat_id, time());
             }
             if 0 != mimefactory.out_last_added_location_id {
@@ -732,7 +732,7 @@ pub unsafe fn job_send_msg(context: &Context, msg_id: u32) -> libc::c_int {
                     }
                 }
             }
-            if 0 != mimefactory.out_encrypted
+            if mimefactory.out_encrypted
                 && mimefactory
                     .msg
                     .param


### PR DESCRIPTION
Changes
-------

###   Change type of MimeFactory.loaded to enum

   * src/dc_mimefactory.rs(MimeFactory): change type of `loaded` field
   * src/dc_mimefactory.rs(Loaded): new enum, describing possible
     values of `loaded` field of `MimeFactory` structure
   * src/dc_mimefactory.rs(dc_mimefactory_loaded_t): remove unused type alias
   * src/job.rs(add_smtp_job): adjust call site by removing multiple casts
   * src/dc_mimefactory.rs(dc_mimefactory_render): ditto

###   Change type of MimeFactory.out_{gossip,encrypted} to bool

###   Rename dc_mimefactory_t -> MimeFactory

   CamelCase naming convention is more natural for Rust.

   https://rust-lang-nursery.github.io/api-guidelines/naming.html