### PR TITLE
Add factory method MimeFactory::new

### DIFF
--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -118,12 +118,9 @@ pub unsafe fn dc_mimefactory_load_msg(
     let msg = dc_msg_load_from_db(context, msg_id)?;
     let chat = Chat::load_from_db(context, msg.chat_id)?;
     let mut factory = MimeFactory::new(context, msg);
-    factory.chat = Some(chat);
+    let chat = factory.chat.get_or_insert(chat);
 
     load_from(&mut factory);
-
-    // just set the chat above
-    let chat = factory.chat.as_ref().unwrap();
 
     if chat.is_self_talk() {
         clist_insert_after(


### PR DESCRIPTION
* * * *

   Simplify dc_mimefactory_load_msg function

   Use Option::get_or_insert method instead of scary-looking unwrap() trick.

* * * *

   Add factory method MimeFactory::new

    * src/dc_mimefactory.rs(new): add factory method to have verbose
      initialization of all (more than 10) MimeFactory fields only in one
      place.
    * src/dc_mimefactory.rc(dc_mimefactory_load_msg, dc_mimefactory_load_mdn):
      simplify code (and reduce linecount) using Mimefactory::new