### PR TITLE
Avoid ok-to-continue pattern in `set_draft_raw`

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -871,7 +871,6 @@ fn maybe_delete_draft(context: &Context, chat_id: u32) -> bool {
 ///
 /// Return true on success, false on database error.
 fn do_set_draft(context: &Context, chat_id: u32, msg: &mut Message) -> bool {
-    let mut sth_changed = false;
 
     match msg.type_0 {
         Viewtype::Unknown => return false,
@@ -891,8 +890,7 @@ fn do_set_draft(context: &Context, chat_id: u32, msg: &mut Message) -> bool {
         }
     }
 
-    {
-        if sql::execute(
+        sql::execute(
             context,
             &context.sql,
             "INSERT INTO msgs (chat_id, from_id, timestamp, type, state, txt, param, hidden) \
@@ -909,11 +907,6 @@ fn do_set_draft(context: &Context, chat_id: u32, msg: &mut Message) -> bool {
             ],
         )
         .is_ok()
-        {
-            sth_changed = true;
-        }
-    }
-    sth_changed
 }
 
 // similar to as dc_set_draft() but does not emit an event


### PR DESCRIPTION
Commits with `cargo-fmt` message are exactly what it says. No need to
review them. I tried to avoid commits that change too much indentation.
So, some of commits will not pass cargo-fmt test, but compile fine.

## Changes

 * Factor part of `set_draft_raw` into new function `maybe_delete_draft`

 * Make message argument to `set_draft_raw` no longer optional

   Previously, `set_draft_raw` function was used with `msg = None` only for 
   side-effect of removing current draft message in chat.

   After draft removal functionality was factored into separate
   `maybe_delete_draft` function, it is used directly in only call site, which
   used to invoke `set_draft_raw` with optional message.

   This function is private, refactoring does not change FFI interface.

 * Factor another part of `set_draft_raw` into separate function.

   As I mentioned, `set_draft_raw` consist of two logical parts --
   removing previous draft and setting new. This commit finishes
   separation.

 * Avoid ok-to-continue pattern in `do_set_draft` function

   **Note**: I strongly suggest reviewing this commit in side-by-side mode.

   Note: This commit fails CI due incorrect formatting. It is done 
   deliberately to simplify review process.

 * Remove last mutable variable from `do_set_draft`

   With all other cases early-returned, result of this function is
   success of sql query.