### PR TITLE
Refactor "dc_split_armored_data" function

### DIFF
--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -17,6 +17,10 @@ use crate::error::Error;
 use crate::key::*;
 use crate::keyring::*;
 
+/* Split data from PGP Armored Data as defined in https://tools.ietf.org/html/rfc4880#section-6.2.
+The given buffer is modified and the returned pointers just point inside the modified buffer,
+no additional data to free therefore.
+(NB: netpgp allows only parsing of Version, Comment, MessageID, Hash and Charset) */
 pub unsafe fn dc_split_armored_data(
     buf: *mut libc::c_char,
     ret_headerline: *mut *const libc::c_char,

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -47,7 +47,12 @@ pub unsafe fn dc_split_armored_data(
     if !ret_base64.is_null() {
         *ret_base64 = ptr::null();
     }
-    if !(buf.is_null() || ret_headerline.is_null()) {
+
+    if buf.is_null() || ret_headerline.is_null() {
+        return false;
+    }
+
+    {
         dc_remove_cr_chars(buf);
         while 0 != *p1 {
             if *p1 as libc::c_int == '\n' as i32 {

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -123,24 +123,22 @@ pub unsafe fn dc_split_armored_data(
         return false;
     }
 
+    /* now, line points to beginning of base64 data, search end */
+    /*the trailing space makes sure, this is not a normal base64 sequence*/
+    p1 = strstr(base64, b"-----END \x00" as *const u8 as *const libc::c_char);
+    if !(p1.is_null()
+        || strncmp(
+            p1.offset(9isize),
+            headerline.offset(11isize),
+            strlen(headerline.offset(11isize)),
+        ) != 0i32)
     {
-        /* now, line points to beginning of base64 data, search end */
-        /*the trailing space makes sure, this is not a normal base64 sequence*/
-        p1 = strstr(base64, b"-----END \x00" as *const u8 as *const libc::c_char);
-        if !(p1.is_null()
-            || strncmp(
-                p1.offset(9isize),
-                headerline.offset(11isize),
-                strlen(headerline.offset(11isize)),
-            ) != 0i32)
-        {
-            *p1 = 0i32 as libc::c_char;
-            dc_trim(base64);
-            if !ret_base64.is_null() {
-                *ret_base64 = base64
-            }
-            success = true;
+        *p1 = 0i32 as libc::c_char;
+        dc_trim(base64);
+        if !ret_base64.is_null() {
+            *ret_base64 = base64
         }
+        success = true;
     }
 
     success

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -119,7 +119,11 @@ pub unsafe fn dc_split_armored_data(
             line_chars = line_chars.wrapping_add(1)
         }
     }
-    if !(headerline.is_null() || base64.is_null()) {
+    if headerline.is_null() || base64.is_null() {
+        return false;
+    }
+
+    {
         /* now, line points to beginning of base64 data, search end */
         /*the trailing space makes sure, this is not a normal base64 sequence*/
         p1 = strstr(base64, b"-----END \x00" as *const u8 as *const libc::c_char);

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -70,9 +70,7 @@ pub unsafe fn dc_split_armored_data(
                     ) == 0i32
                 {
                     headerline = line;
-                    if !ret_headerline.is_null() {
-                        *ret_headerline = headerline
-                    }
+                    *ret_headerline = headerline
                 }
             } else if strspn(line, b"\t\r\n \x00" as *const u8 as *const libc::c_char)
                 == strlen(line)

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -61,7 +61,7 @@ pub unsafe fn dc_split_armored_data(
                 if strncmp(
                     line,
                     b"-----BEGIN \x00" as *const u8 as *const libc::c_char,
-                    1,
+                    11,
                 ) == 0i32
                     && strncmp(
                         &mut *line.offset(strlen(line).wrapping_sub(5) as isize),


### PR DESCRIPTION
Commits with "cargo-fmt" mean exactly this.

Changes
=======

 * Copy comment for `dc_split_armored_data` from C source
 * Early-return from dc_split_armored_data (part 1)
 * Early-return in `dc_split_armored_data` (part 2)

   In both cases, `if (ok) { /* huge block */ }` pattern is replaced
   with `if (!ok) { return false; } /* huge block */`

 * Remove redundant check in `dc_split_armored_data`

   Output argument `ret_headerline` is checked for non-null above.
   Function returns `false` and does nothing in this case.

 * Fix incorrect length argument to strncmp

   In corresponding C code it is 11. One digit seems to got lost during
   transition.