### PR TITLE
rustify dc_mimefactory along with related cleanups

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -784,7 +784,7 @@ pub fn send_msg(context: &Context, chat_id: u32, msg: &mut Message) -> Result<u3
     }
 
     ensure!(
-        unsafe { job_send_msg(context, msg.id) } != 0,
+        job_send_msg(context, msg.id) != 0,
         "Failed to initiate send job"
     );
 
@@ -1787,7 +1787,7 @@ pub fn forward_msgs(context: &Context, msg_ids: &[u32], chat_id: u32) {
                 new_msg_id = chat
                     .prepare_msg_raw(context, &mut msg, fresh10)
                     .unwrap_or_default();
-                unsafe { job_send_msg(context, new_msg_id) };
+                job_send_msg(context, new_msg_id);
             }
             created_db_entries.push(chat_id);
             created_db_entries.push(new_msg_id);

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -60,6 +60,10 @@ const DC_GCM_ADDDAYMARKER: usize = 0x01;
 pub const DC_GCL_VERIFIED_ONLY: usize = 0x01;
 pub const DC_GCL_ADD_SELF: usize = 0x02;
 
+// values for DC_PARAM_FORCE_PLAINTEXT
+pub(crate) const DC_FP_NO_AUTOCRYPT_HEADER: i32 = 2;
+pub(crate) const DC_FP_ADD_AUTOCRYPT_HEADER: i32 = 1;
+
 /// param1 is a directory where the keys are written to
 const DC_IMEX_EXPORT_SELF_KEYS: usize = 1;
 /// param1 is a directory where the keys are searched in and read from

--- a/src/dc_imex.rs
+++ b/src/dc_imex.rs
@@ -909,7 +909,7 @@ unsafe fn import_self_keys(context: &Context, dir_name: *const libc::c_char) -> 
                     }
                 }
                 set_default = 1;
-                if name_f.find("legacy").is_some() {
+                if name_f.contains("legacy") {
                     info!(
                         context,
                         "Treating \"{}\" as a legacy private key.",

--- a/src/dc_mimefactory.rs
+++ b/src/dc_mimefactory.rs
@@ -788,8 +788,10 @@ fn build_body_text(text: &str) -> *mut mailmime {
 }
 
 fn set_body_text(part: *mut mailmime, text: &str) {
+    use libc::strlen;
     unsafe {
-        mailmime_set_body_text(part, text.strdup(), text.len());
+        let text_c = text.strdup();
+        mailmime_set_body_text(part, text_c, strlen(text_c));
     }
 }
 
@@ -909,7 +911,7 @@ fn build_body_file(context: &Context, msg: &Message, base_name: &str) -> (*mut m
 pub(crate) fn vec_contains_lowercase(vec: &Vec<String>, part: &str) -> bool {
     let partlc = part.to_lowercase();
     for cur in vec.iter() {
-        if (*cur).to_lowercase() == partlc {
+        if cur.to_lowercase() == partlc {
             return true;
         }
     }

--- a/src/dc_strencode.rs
+++ b/src/dc_strencode.rs
@@ -25,7 +25,7 @@ use crate::dc_tools::*;
  * @return Returns the encoded string which must be free()'d when no longed needed.
  *     On errors, NULL is returned.
  */
-pub unsafe fn dc_encode_header_words(to_encode_r: impl AsRef<str>) -> *mut libc::c_char {
+pub unsafe fn dc_encode_header_words(to_encode_r: impl AsRef<str>) -> String {
     let to_encode =
         CString::new(to_encode_r.as_ref().as_bytes()).expect("invalid cstring to_encode");
 
@@ -117,7 +117,9 @@ pub unsafe fn dc_encode_header_words(to_encode_r: impl AsRef<str>) -> *mut libc:
         }
     }
 
-    ret_str
+    let s = to_string(ret_str);
+    free(ret_str.cast());
+    s
 }
 
 unsafe fn quote_word(
@@ -337,7 +339,7 @@ unsafe fn print_hex(target: *mut libc::c_char, cur: *const libc::c_char) {
 mod tests {
     use super::*;
 
-    use libc::{strcmp, strncmp};
+    use libc::strcmp;
     use std::ffi::CStr;
 
     #[test]
@@ -360,19 +362,15 @@ mod tests {
             assert_eq!(CStr::from_ptr(buf1).to_str().unwrap(), "just ascii test");
             free(buf1 as *mut libc::c_void);
 
-            buf1 = dc_encode_header_words("abcdef");
-            assert_eq!(CStr::from_ptr(buf1).to_str().unwrap(), "abcdef");
-            free(buf1 as *mut libc::c_void);
+            assert_eq!(dc_encode_header_words("abcdef"), "abcdef");
 
-            buf1 = dc_encode_header_words(
+            let r = dc_encode_header_words(
                 std::string::String::from_utf8(b"test\xc3\xa4\xc3\xb6\xc3\xbc.txt".to_vec())
                     .unwrap(),
             );
-            assert_eq!(
-                strncmp(buf1, b"=?utf-8\x00" as *const u8 as *const libc::c_char, 7),
-                0
-            );
+            assert!(r.starts_with("=?utf-8"));
 
+            buf1 = r.strdup();
             let buf2: *mut libc::c_char = dc_decode_header_words(buf1);
             assert_eq!(
                 strcmp(
@@ -381,7 +379,6 @@ mod tests {
                 ),
                 0
             );
-            free(buf1 as *mut libc::c_void);
             free(buf2 as *mut libc::c_void);
 
             buf1 = dc_decode_header_words(
@@ -395,7 +392,6 @@ mod tests {
                 ),
                 0
             );
-            free(buf1 as *mut libc::c_void);
         }
     }
 

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -548,11 +548,11 @@ fn validate_filename(filename: &str) -> String {
 
 // the returned suffix is lower-case
 #[allow(non_snake_case)]
-pub unsafe fn dc_get_filesuffix_lc(path_filename: impl AsRef<str>) -> *mut libc::c_char {
+pub fn dc_get_filesuffix_lc(path_filename: impl AsRef<str>) -> Option<String> {
     if let Some(p) = Path::new(path_filename.as_ref()).extension() {
-        p.to_string_lossy().to_lowercase().strdup()
+        Some(p.to_string_lossy().to_lowercase())
     } else {
-        ptr::null_mut()
+        None
     }
 }
 

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -49,15 +49,6 @@ pub unsafe fn dc_strdup(s: *const libc::c_char) -> *mut libc::c_char {
     ret
 }
 
-/// Duplicates a string, returns null if given string is null
-pub(crate) unsafe fn dc_strdup_keep_null(s: *const libc::c_char) -> *mut libc::c_char {
-    if !s.is_null() {
-        dc_strdup(s)
-    } else {
-        ptr::null_mut()
-    }
-}
-
 pub(crate) fn dc_atoi_null_is_0(s: *const libc::c_char) -> libc::c_int {
     if !s.is_null() {
         as_str(s).parse().unwrap_or_default()

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -54,10 +54,10 @@ impl E2eeHelper {
         &mut self,
         context: &Context,
         recipients_addr: *const clist,
-        force_unencrypted: libc::c_int,
+        force_unencrypted: bool,
         e2ee_guaranteed: bool,
         min_verified: libc::c_int,
-        do_gossip: libc::c_int,
+        do_gossip: bool,
         mut in_out_message: *mut mailmime,
     ) {
         let mut ok_to_continue = true;
@@ -141,7 +141,7 @@ impl E2eeHelper {
                     } else {
                         None
                     };
-                    if 0 != force_unencrypted {
+                    if force_unencrypted {
                         do_encrypt = 0i32
                     }
                     imffields_unprotected = mailmime_find_mailimf_fields(in_out_message);
@@ -168,7 +168,7 @@ impl E2eeHelper {
                                 imffields_encrypted,
                                 part_to_encrypt,
                             );
-                            if 0 != do_gossip {
+                            if do_gossip {
                                 let i_cnt = peerstates.len() as libc::c_int;
                                 if i_cnt > 1 {
                                     let mut i = 0;

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -55,7 +55,7 @@ impl E2eeHelper {
         context: &Context,
         recipients_addr: *const clist,
         force_unencrypted: libc::c_int,
-        e2ee_guaranteed: libc::c_int,
+        e2ee_guaranteed: bool,
         min_verified: libc::c_int,
         do_gossip: libc::c_int,
         mut in_out_message: *mut mailmime,
@@ -95,7 +95,7 @@ impl E2eeHelper {
                 });
                 if let Ok(public_key) = pubkey_ret {
                     /*only for random-seed*/
-                    if prefer_encrypt == EncryptPreference::Mutual || 0 != e2ee_guaranteed {
+                    if prefer_encrypt == EncryptPreference::Mutual || e2ee_guaranteed {
                         do_encrypt = 1i32;
                         let mut iter1: *mut clistiter;
                         iter1 = (*recipients_addr).first;
@@ -107,7 +107,7 @@ impl E2eeHelper {
                                 if peerstate.is_some()
                                     && (peerstate.as_ref().unwrap().prefer_encrypt
                                         == EncryptPreference::Mutual
-                                        || 0 != e2ee_guaranteed)
+                                        || e2ee_guaranteed)
                                 {
                                     let peerstate = peerstate.unwrap();
                                     info!(

--- a/src/job.rs
+++ b/src/job.rs
@@ -680,8 +680,9 @@ pub unsafe fn job_send_msg(context: &Context, msg_id: u32) -> libc::c_int {
             }
         }
         /* create message */
-        if !dc_mimefactory_render(context, &mut mimefactory) {
-            message::set_msg_failed(context, msg_id, as_opt_str(mimefactory.error));
+        if let Err(msg) = dc_mimefactory_render(context, &mut mimefactory) {
+            let e = msg.to_string();
+            message::set_msg_failed(context, msg_id, Some(e));
         } else if 0
             != mimefactory
                 .msg
@@ -998,7 +999,7 @@ fn connect_to_inbox(context: &Context, inbox: &Imap) -> libc::c_int {
 
 fn send_mdn(context: &Context, msg_id: u32) {
     if let Ok(mut mimefactory) = unsafe { dc_mimefactory_load_mdn(context, msg_id) } {
-        if unsafe { dc_mimefactory_render(context, &mut mimefactory) } {
+        if unsafe { dc_mimefactory_render(context, &mut mimefactory) }.is_ok() {
             add_smtp_job(context, Action::SendMdn, &mut mimefactory);
         }
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -680,6 +680,7 @@ pub fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)> {
         "mp4"   => (Viewtype::Video, "video/mp4"),
         "jpg"   => (Viewtype::Image, "image/jpeg"),
         "jpeg"  => (Viewtype::Image, "image/jpeg"),
+        "jpe"  => (Viewtype::Image, "image/jpeg"),
         "png"   => (Viewtype::Image, "image/png"),
         "webp"  => (Viewtype::Image, "image/webp"),
         "gif"   => (Viewtype::Gif,   "image/gif"),
@@ -687,7 +688,6 @@ pub fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)> {
         "vcard" => (Viewtype::File,  "text/vcard"),
     };
     let extension: &str = &path.extension()?.to_str()?.to_lowercase();
-
     KNOWN.get(extension).map(|x| *x)
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -680,7 +680,7 @@ pub fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)> {
         "mp4"   => (Viewtype::Video, "video/mp4"),
         "jpg"   => (Viewtype::Image, "image/jpeg"),
         "jpeg"  => (Viewtype::Image, "image/jpeg"),
-        "jpe"  => (Viewtype::Image, "image/jpeg"),
+        "jpe"   => (Viewtype::Image, "image/jpeg"),
         "png"   => (Viewtype::Image, "image/png"),
         "webp"  => (Viewtype::Image, "image/webp"),
         "gif"   => (Viewtype::Gif,   "image/gif"),
@@ -688,6 +688,7 @@ pub fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)> {
         "vcard" => (Viewtype::File,  "text/vcard"),
     };
     let extension: &str = &path.extension()?.to_str()?.to_lowercase();
+
     KNOWN.get(extension).map(|x| *x)
 }
 


### PR DESCRIPTION
this PR grew a bit more then i wanted to -- but achieves its aims and passes all cargo/python tests locally.  The cleanup involves 

- safer more readable looping over clists 
- rustify mimefactory struct strings: references and in_reply_to 
- turn recipients_addr,recipients_names into Vec's instead of clists
- boolify various vars 
- shift var usage to where it's needed to avoid large let-headers up-front
- removing several helpers or moving them to the tests

