### PR TITLE
Simplify dc_encode_header_words function

### DIFF
--- a/proptest-regressions/dc_strencode.txt
+++ b/proptest-regressions/dc_strencode.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 679506fe9ac59df773f8cfa800fdab5f0a32fe49d2ab370394000a1aa5bc2a72 # shrinks to buf = "%0A"
+cc e34960438edb2426904b44fb4215154e7e2880f2fd1c3183b98bfcc76fec4882 # shrinks to input = " 0"

--- a/src/dc_strencode.rs
+++ b/src/dc_strencode.rs
@@ -383,5 +383,13 @@ mod tests {
             // make sure this never panics
             let _decoded = dc_decode_ext_header(&buf);
         }
+
+        #[test]
+        fn test_dc_header_roundtrip(input: String) {
+            let encoded = unsafe { dc_encode_header_words(&input) };
+            let decoded = dc_decode_header_words_safe(&encoded);
+
+            assert_eq!(input, decoded);
+        }
     }
 }

--- a/src/dc_strencode.rs
+++ b/src/dc_strencode.rs
@@ -267,15 +267,6 @@ pub fn dc_decode_ext_header(to_decode: &[u8]) -> Cow<str> {
     String::from_utf8_lossy(to_decode)
 }
 
-unsafe fn print_hex(target: *mut libc::c_char, cur: *const libc::c_char) {
-    assert!(!target.is_null());
-    assert!(!cur.is_null());
-
-    let bytes = std::slice::from_raw_parts(cur as *const _, strlen(cur));
-    let raw = CString::yolo(format!("={}", &hex::encode_upper(bytes)[..2]));
-    libc::memcpy(target as *mut _, raw.as_ptr() as *const _, 4);
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -375,18 +366,6 @@ mod tests {
         assert_eq!(dc_needs_ext_header(""), false);
         assert_eq!(dc_needs_ext_header(" "), true);
         assert_eq!(dc_needs_ext_header("a b"), true);
-    }
-
-    #[test]
-    fn test_print_hex() {
-        let mut hex: [libc::c_char; 4] = [0; 4];
-        let cur = b"helloworld" as *const u8 as *const libc::c_char;
-        unsafe { print_hex(hex.as_mut_ptr(), cur) };
-        assert_eq!(to_string(hex.as_ptr() as *const _), "=68");
-
-        let cur = b":" as *const u8 as *const libc::c_char;
-        unsafe { print_hex(hex.as_mut_ptr(), cur) };
-        assert_eq!(to_string(hex.as_ptr() as *const _), "=3A");
     }
 
     use proptest::prelude::*;


### PR DESCRIPTION
Changes
-------

 * Use rust strings instead of MMapString in src/dc_strencode.rs

   Since Rust strings operations are assumed to never fail, this commit
   removes a lot of checking, whether appending to mmapstring fails. Now it is
   Rust runtime burden.

 * Rename local variables to not misleadingly refer to MMAPString

   Replace variable name `mmapstr` with more generic `result` and
   `dest`.

 * Implement safe version of `quote_word` with Strings and slices
   instead of raw pointers.

PS. First commit is better looking in side-by-side mode, last in unified.