### PR TITLE
Cleanup/e2ee and mimefactory-outsending and encryption

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -353,18 +353,6 @@ class TestOnlineAccount:
         ev = ac1._evlogger.get_matching("DC_EVENT_INCOMING_MSG|DC_EVENT_MSGS_CHANGED")
         assert ev[1] == msg_out.id
 
-    def test_two_accounts_send_receive(self, acfactory):
-        ac1, ac2 = acfactory.get_two_online_accounts()
-        chat = self.get_chat(ac1, ac2)
-
-        msg_out = chat.send_text("message1")
-
-        # wait for other account to receive
-        ev = ac2._evlogger.get_matching("DC_EVENT_INCOMING_MSG|DC_EVENT_MSGS_CHANGED")
-        assert ev[2] == msg_out.id
-        msg_in = ac2.get_message_by_id(msg_out.id)
-        assert msg_in.text == "message1"
-
     def test_mvbox_sentbox_threads(self, acfactory):
         ac1 = acfactory.get_online_configuring_account(mvbox=True, sentbox=True)
         ac2 = acfactory.get_online_configuring_account()
@@ -400,7 +388,7 @@ class TestOnlineAccount:
         ac2.delete_messages(messages)
         assert not chat3.get_messages()
 
-    def test_send_and_receive_message(self, acfactory, lp):
+    def test_send_and_receive_message_markseen(self, acfactory, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()
 
         lp.sec("ac1: create chat with ac2")

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -652,6 +652,17 @@ unsafe fn add_parts(
                             .set_int(Param::Cmd, mime_parser.is_system_message as i32);
                     }
 
+                    /*
+                    info!(
+                        context,
+                        "received mime message {:?}",
+                        String::from_utf8_lossy(std::slice::from_raw_parts(
+                            imf_raw_not_terminated as *const u8,
+                            imf_raw_bytes,
+                        ))
+                    );
+                    */
+
                     stmt.execute(params![
                         rfc724_mid,
                         server_folder.as_ref(),

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -61,11 +61,7 @@ impl E2eeHelper {
         do_gossip: bool,
         mut in_out_message: *mut mailmime,
     ) -> Result<bool> {
-        let mut col: libc::c_int = 0i32;
-        let mut do_encrypt = false;
-        let mut keyring = Keyring::default();
-        let mut peerstates: Vec<Peerstate> = Vec::new();
-
+        /* libEtPan's pgp_encrypt_mime() takes the parent as the new root. We just expect the root as being given to this function. */
         if in_out_message.is_null() || !(*in_out_message).mm_parent.is_null() {
             bail!("invalid inputs");
         }
@@ -80,228 +76,221 @@ impl E2eeHelper {
         let public_key = match load_or_generate_self_public_key(context, &addr) {
             Err(err) => {
                 bail!("Failed to load own public key: {}", err);
-            } 
-            Ok(public_key) => public_key
+            }
+            Ok(public_key) => public_key,
         };
 
-        /* libEtPan's pgp_encrypt_mime() takes the parent as the new root. We just expect the root as being given to this function. */
-        let prefer_encrypt = if 0
-            != context
-                .sql
-                .get_config_int(context, "e2ee_enabled")
-                .unwrap_or_default()
-        {
+        let e2ee = context.sql.get_config_int(&context, "e2ee_enabled");
+
+        let prefer_encrypt = if 0 != e2ee.unwrap_or_default() {
             EncryptPreference::Mutual
         } else {
             EncryptPreference::NoPreference
         };
 
+        let mut encryption_successfull = false;
+        let mut do_encrypt = false;
+        let mut keyring = Keyring::default();
+        let mut peerstates: Vec<Peerstate> = Vec::new();
 
-        let plain: *mut MMAPString = mmap_string_new(b"\x00" as *const u8 as *const libc::c_char);
-            /*only for random-seed*/
-            if prefer_encrypt == EncryptPreference::Mutual || e2ee_guaranteed {
-                do_encrypt = true;
-                for recipient_addr in recipients_addr.iter() {
-                    if *recipient_addr != addr {
-                        let peerstate =
-                            Peerstate::from_addr(context, &context.sql, &recipient_addr);
-                        if peerstate.is_some()
-                            && (peerstate.as_ref().unwrap().prefer_encrypt
-                                == EncryptPreference::Mutual
-                                || e2ee_guaranteed)
-                        {
-                            let peerstate = peerstate.unwrap();
-                            info!(context, "dc_e2ee_encrypt {} has peerstate", recipient_addr);
-                            if let Some(key) = peerstate.peek_key(min_verified as usize) {
-                                keyring.add_owned(key.clone());
-                                peerstates.push(peerstate);
-                            }
-                        } else {
-                            info!(
-                                context,
-                                "dc_e2ee_encrypt {} HAS NO peerstate {}",
-                                recipient_addr,
-                                peerstate.is_some()
-                            );
-                            do_encrypt = false;
-                            /* if we cannot encrypt to a single recipient, we cannot encrypt the message at all */
-                            break;
+        /*only for random-seed*/
+        if prefer_encrypt == EncryptPreference::Mutual || e2ee_guaranteed {
+            do_encrypt = true;
+            for recipient_addr in recipients_addr.iter() {
+                if *recipient_addr != addr {
+                    let peerstate = Peerstate::from_addr(context, &context.sql, &recipient_addr);
+                    if peerstate.is_some()
+                        && (peerstate.as_ref().unwrap().prefer_encrypt == EncryptPreference::Mutual
+                            || e2ee_guaranteed)
+                    {
+                        let peerstate = peerstate.unwrap();
+                        info!(context, "dc_e2ee_encrypt {} has peerstate", recipient_addr);
+                        if let Some(key) = peerstate.peek_key(min_verified as usize) {
+                            keyring.add_owned(key.clone());
+                            peerstates.push(peerstate);
                         }
+                    } else {
+                        info!(
+                            context,
+                            "dc_e2ee_encrypt {} HAS NO peerstate {}",
+                            recipient_addr,
+                            peerstate.is_some()
+                        );
+                        do_encrypt = false;
+                        /* if we cannot encrypt to a single recipient, we cannot encrypt the message at all */
+                        break;
                     }
                 }
             }
-            let sign_key = if do_encrypt {
-                keyring.add_ref(&public_key);
-                let key = Key::from_self_private(context, addr.clone(), &context.sql);
+        }
+        let sign_key = if do_encrypt {
+            keyring.add_ref(&public_key);
+            let key = Key::from_self_private(context, addr.clone(), &context.sql);
 
-                if key.is_none() {
-                    do_encrypt = false;
-                }
-                key
-            } else {
-                None
-            };
-            if force_unencrypted {
+            if key.is_none() {
                 do_encrypt = false;
             }
-            /*just a pointer into mailmime structure, must not be freed*/
-            let imffields_unprotected = mailmime_find_mailimf_fields(in_out_message);
-            if !imffields_unprotected.is_null() {
-                /* encrypt message, if possible */
-                if do_encrypt {
-                    mailprivacy_prepare_mime(in_out_message);
-                    let mut part_to_encrypt: *mut mailmime =
-                        (*in_out_message).mm_data.mm_message.mm_msg_mime;
-                    (*part_to_encrypt).mm_parent = ptr::null_mut();
-                    let imffields_encrypted: *mut mailimf_fields = mailimf_fields_new_empty();
-                    /* mailmime_new_message_data() calls mailmime_fields_new_with_version() which would add the unwanted MIME-Version:-header */
-                    let message_to_encrypt: *mut mailmime = mailmime_new(
-                        MAILMIME_MESSAGE as libc::c_int,
-                        ptr::null(),
-                        0 as libc::size_t,
-                        mailmime_fields_new_empty(),
-                        mailmime_get_content_message(),
-                        ptr::null_mut(),
-                        ptr::null_mut(),
-                        ptr::null_mut(),
-                        ptr::null_mut(),
-                        imffields_encrypted,
-                        part_to_encrypt,
-                    );
-                    if do_gossip {
-                        for peerstate in peerstates {
-                            peerstate.render_gossip_header(min_verified as usize).map(|header| {
-                                wrapmime::new_custom_field(
-                                    imffields_encrypted,
-                                    "Autocrypt-Gossip",
-                                    &header
-                                )
-                            });
-                        }
-                    }
-                    /* memoryhole headers */
-                    // XXX we can't use clist's into_iter()
-                    // because the loop body also removes items
-                    let mut cur: *mut clistiter = (*(*imffields_unprotected).fld_list).first;
-                    while !cur.is_null() {
-                        let field: *mut mailimf_field = (*cur).data as *mut mailimf_field;
-                        let mut move_to_encrypted = false;
-                        if !field.is_null() {
-                            if (*field).fld_type == MAILIMF_FIELD_SUBJECT as libc::c_int {
-                                move_to_encrypted = true;
-                            } else if (*field).fld_type
-                                == MAILIMF_FIELD_OPTIONAL_FIELD as libc::c_int
+            key
+        } else {
+            None
+        };
+        if force_unencrypted {
+            do_encrypt = false;
+        }
+        /*just a pointer into mailmime structure, must not be freed*/
+        let imffields_unprotected = mailmime_find_mailimf_fields(in_out_message);
+        if imffields_unprotected.is_null() {
+            bail!("could not find mime fields");
+        }
+        /* encrypt message, if possible */
+        if do_encrypt {
+            mailprivacy_prepare_mime(in_out_message);
+            let mut part_to_encrypt: *mut mailmime =
+                (*in_out_message).mm_data.mm_message.mm_msg_mime;
+            (*part_to_encrypt).mm_parent = ptr::null_mut();
+            let imffields_encrypted: *mut mailimf_fields = mailimf_fields_new_empty();
+            /* mailmime_new_message_data() calls mailmime_fields_new_with_version() which would add the unwanted MIME-Version:-header */
+            let message_to_encrypt: *mut mailmime = mailmime_new(
+                MAILMIME_MESSAGE as libc::c_int,
+                ptr::null(),
+                0 as libc::size_t,
+                mailmime_fields_new_empty(),
+                mailmime_get_content_message(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                imffields_encrypted,
+                part_to_encrypt,
+            );
+            if do_gossip {
+                for peerstate in peerstates {
+                    peerstate
+                        .render_gossip_header(min_verified as usize)
+                        .map(|header| {
+                            wrapmime::new_custom_field(
+                                imffields_encrypted,
+                                "Autocrypt-Gossip",
+                                &header,
+                            )
+                        });
+                }
+            }
+            /* memoryhole headers */
+            // XXX we can't use clist's into_iter()
+            // because the loop body also removes items
+            let mut cur: *mut clistiter = (*(*imffields_unprotected).fld_list).first;
+            while !cur.is_null() {
+                let field: *mut mailimf_field = (*cur).data as *mut mailimf_field;
+                let mut move_to_encrypted = false;
+                if !field.is_null() {
+                    if (*field).fld_type == MAILIMF_FIELD_SUBJECT as libc::c_int {
+                        move_to_encrypted = true;
+                    } else if (*field).fld_type == MAILIMF_FIELD_OPTIONAL_FIELD as libc::c_int {
+                        let opt_field = (*field).fld_data.fld_optional_field;
+                        if !opt_field.is_null() && !(*opt_field).fld_name.is_null() {
+                            let fld_name = to_string_lossy((*opt_field).fld_name);
+                            if fld_name.starts_with("Secure-Join") || fld_name.starts_with("Chat-")
                             {
-                                let opt_field = (*field).fld_data.fld_optional_field;
-                                if !opt_field.is_null() && !(*opt_field).fld_name.is_null() {
-                                    let fld_name = to_string_lossy((*opt_field).fld_name);
-                                    if fld_name.starts_with("Secure-Join")
-                                        || fld_name.starts_with("Chat-")
-                                    {
-                                        move_to_encrypted = true;
-                                    }
-                                }
+                                move_to_encrypted = true;
                             }
                         }
-                        if move_to_encrypted {
-                            mailimf_fields_add(imffields_encrypted, field);
-                            cur = clist_delete((*imffields_unprotected).fld_list, cur);
-                        } else {
-                            cur = (*cur).next;
-                        }
-                    }
-                    let subject: *mut mailimf_subject = mailimf_subject_new("...".strdup());
-                    mailimf_fields_add(
-                        imffields_unprotected,
-                        mailimf_field_new(
-                            MAILIMF_FIELD_SUBJECT as libc::c_int,
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            subject,
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                            ptr::null_mut(),
-                        ),
-                    );
-                    wrapmime::append_ct_param(
-                        (*part_to_encrypt).mm_content_type,
-                        "protected-headers",
-                        "v1",
-                    )?;
-                    mailmime_write_mem(plain, &mut col, message_to_encrypt);
-                    if (*plain).str_0.is_null() || (*plain).len <= 0 {
-                        bail!("could not write/allocate");
-                    }
-                    if let Ok(ctext_v) = dc_pgp_pk_encrypt(
-                        std::slice::from_raw_parts((*plain).str_0 as *const u8, (*plain).len),
-                        &keyring,
-                        sign_key.as_ref(),
-                    ) {
-                        let ctext_bytes = ctext_v.len();
-                        let ctext = ctext_v.strdup();
-                        self.cdata_to_free = Some(Box::new(ctext));
-
-                        /* create MIME-structure that will contain the encrypted text */
-                        let mut encrypted_part: *mut mailmime = new_data_part(
-                            ptr::null_mut(),
-                            0 as libc::size_t,
-                            "multipart/encrypted",
-                            -1,
-                        );
-                        let content: *mut mailmime_content = (*encrypted_part).mm_content_type;
-                        wrapmime::append_ct_param(
-                            content,
-                            "protocol",
-                            "application/pgp-encrypted",
-                        )?;
-                        static mut VERSION_CONTENT: [libc::c_char; 13] =
-                            [86, 101, 114, 115, 105, 111, 110, 58, 32, 49, 13, 10, 0];
-                        let version_mime: *mut mailmime = new_data_part(
-                            VERSION_CONTENT.as_mut_ptr() as *mut libc::c_void,
-                            strlen(VERSION_CONTENT.as_mut_ptr()),
-                            "application/pgp-encrypted",
-                            MAILMIME_MECHANISM_7BIT as i32,
-                        );
-                        mailmime_smart_add_part(encrypted_part, version_mime);
-                        let ctext_part: *mut mailmime = new_data_part(
-                            ctext as *mut libc::c_void,
-                            ctext_bytes,
-                            "application/octet-stream",
-                            MAILMIME_MECHANISM_7BIT as i32,
-                        );
-                        mailmime_smart_add_part(encrypted_part, ctext_part);
-                        (*in_out_message).mm_data.mm_message.mm_msg_mime = encrypted_part;
-                        (*encrypted_part).mm_parent = in_out_message;
-                        mailmime_free(message_to_encrypt);
-                        if !plain.is_null() {
-                            mmap_string_free(plain);
-                        }
-                        return Ok(true);
                     }
                 }
-                let aheader = Aheader::new(addr, public_key, prefer_encrypt).to_string();
-                new_custom_field(imffields_unprotected, "Autocrypt", &aheader);
+                if move_to_encrypted {
+                    mailimf_fields_add(imffields_encrypted, field);
+                    cur = clist_delete((*imffields_unprotected).fld_list, cur);
+                } else {
+                    cur = (*cur).next;
+                }
             }
-        if !plain.is_null() {
+            let subject: *mut mailimf_subject = mailimf_subject_new("...".strdup());
+            mailimf_fields_add(
+                imffields_unprotected,
+                mailimf_field_new(
+                    MAILIMF_FIELD_SUBJECT as libc::c_int,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    subject,
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                    ptr::null_mut(),
+                ),
+            );
+            wrapmime::append_ct_param(
+                (*part_to_encrypt).mm_content_type,
+                "protected-headers",
+                "v1",
+            )?;
+            let plain: *mut MMAPString =
+                mmap_string_new(b"\x00" as *const u8 as *const libc::c_char);
+            let mut col: libc::c_int = 0i32;
+            mailmime_write_mem(plain, &mut col, message_to_encrypt);
+            if (*plain).str_0.is_null() || (*plain).len <= 0 {
+                bail!("could not write/allocate");
+            }
+            let ctext = dc_pgp_pk_encrypt(
+                std::slice::from_raw_parts((*plain).str_0 as *const u8, (*plain).len),
+                &keyring,
+                sign_key.as_ref(),
+            );
             mmap_string_free(plain);
+
+            if let Ok(ctext_v) = ctext {
+                let ctext_bytes = ctext_v.len();
+                let ctext = ctext_v.strdup();
+                self.cdata_to_free = Some(Box::new(ctext));
+
+                /* create MIME-structure that will contain the encrypted text */
+                let mut encrypted_part: *mut mailmime = new_data_part(
+                    ptr::null_mut(),
+                    0 as libc::size_t,
+                    "multipart/encrypted",
+                    -1,
+                );
+                let content: *mut mailmime_content = (*encrypted_part).mm_content_type;
+                wrapmime::append_ct_param(content, "protocol", "application/pgp-encrypted")?;
+                static mut VERSION_CONTENT: [libc::c_char; 13] =
+                    [86, 101, 114, 115, 105, 111, 110, 58, 32, 49, 13, 10, 0];
+                let version_mime: *mut mailmime = new_data_part(
+                    VERSION_CONTENT.as_mut_ptr() as *mut libc::c_void,
+                    strlen(VERSION_CONTENT.as_mut_ptr()),
+                    "application/pgp-encrypted",
+                    MAILMIME_MECHANISM_7BIT as i32,
+                );
+                mailmime_smart_add_part(encrypted_part, version_mime);
+                let ctext_part: *mut mailmime = new_data_part(
+                    ctext as *mut libc::c_void,
+                    ctext_bytes,
+                    "application/octet-stream",
+                    MAILMIME_MECHANISM_7BIT as i32,
+                );
+                mailmime_smart_add_part(encrypted_part, ctext_part);
+                (*in_out_message).mm_data.mm_message.mm_msg_mime = encrypted_part;
+                (*encrypted_part).mm_parent = in_out_message;
+                mailmime_free(message_to_encrypt);
+                encryption_successfull = true;
+            }
         }
-        Ok(false)
+        let aheader = Aheader::new(addr, public_key, prefer_encrypt).to_string();
+        new_custom_field(imffields_unprotected, "Autocrypt", &aheader);
+        Ok(encryption_successfull)
     }
 
     pub unsafe fn decrypt(&mut self, context: &Context, in_out_message: *mut mailmime) {

--- a/src/job.rs
+++ b/src/job.rs
@@ -1016,6 +1016,7 @@ fn add_smtp_job(context: &Context, action: Action, mimefactory: &MimeFactory) ->
             path_filename.display(),
         );
     } else {
+        info!(context, "add_smtp_job file written: {:?}", path_filename);
         let recipients = mimefactory.recipients_addr.join("\x1e");
         param.set(Param::File, path_filename.to_string_lossy());
         param.set(Param::Recipients, &recipients);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,8 @@ pub mod dc_tools;
 mod login_param;
 pub mod securejoin;
 mod token;
+#[macro_use]
+pub(crate) mod wrapmime;
 
 #[cfg(test)]
 mod test_utils;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ mod login_param;
 pub mod securejoin;
 mod token;
 #[macro_use]
-pub(crate) mod wrapmime;
+mod wrapmime;
 
 #[cfg(test)]
 mod test_utils;

--- a/src/wrapmime.rs
+++ b/src/wrapmime.rs
@@ -78,18 +78,16 @@ pub fn append_ct_param(
     value: &str,
 ) -> Result<(), Error> {
     unsafe {
-        let name_c = name.strdup();
-        let value_c = value.strdup();
+        let name_c = CString::new(name).unwrap();
+        let value_c = CString::new(value).unwrap();
 
         clist_append!(
             (*content).ct_parameters,
             mailmime_param_new_with_data(
-                name_c as *const u8 as *const libc::c_char as *mut libc::c_char,
-                value_c as *const u8 as *const libc::c_char as *mut libc::c_char
+                name_c.as_ptr() as *const u8 as *const libc::c_char as *mut libc::c_char,
+                value_c.as_ptr() as *const u8 as *const libc::c_char as *mut libc::c_char
             )
         );
-        libc::free(name_c as *mut libc::c_void);
-        libc::free(value_c as *mut libc::c_void);
     }
     Ok(())
 }

--- a/src/wrapmime.rs
+++ b/src/wrapmime.rs
@@ -78,8 +78,8 @@ pub fn append_ct_param(
     value: &str,
 ) -> Result<(), Error> {
     unsafe {
-        let name_c = CString::new(name).unwrap().as_ptr();
-        let value_c = CString::new(value).unwrap().as_ptr();
+        let name_c = name.strdup();
+        let value_c = value.strdup();
 
         clist_append!(
             (*content).ct_parameters,
@@ -88,6 +88,8 @@ pub fn append_ct_param(
                 value_c as *const u8 as *const libc::c_char as *mut libc::c_char
             )
         );
+        libc::free(name_c as *mut libc::c_void);
+        libc::free(value_c as *mut libc::c_void);
     }
     Ok(())
 }

--- a/src/wrapmime.rs
+++ b/src/wrapmime.rs
@@ -56,7 +56,6 @@ pub fn new_custom_field(fields: *mut mailimf_fields, name: &str, value: &str) {
     }
 }
 
-
 pub fn build_body_text(text: &str) -> Result<*mut mailmime, Error> {
     let mime_fields: *mut mailmime_fields;
     let message_part: *mut mailmime;

--- a/src/wrapmime.rs
+++ b/src/wrapmime.rs
@@ -1,0 +1,119 @@
+use std::ffi::CString;
+
+use crate::dc_tools::*;
+use crate::error::Error;
+use mmime::clist::*;
+use mmime::mailimf_types::*;
+use mmime::mailimf_types_helper::*;
+use mmime::mailmime_disposition::*;
+use mmime::mailmime_types::*;
+use mmime::mailmime_types_helper::*;
+use mmime::other::*;
+
+#[macro_export]
+macro_rules! clist_append {
+    ($clist:expr,  $item:expr) => {
+        if clist_insert_after(
+            $clist as *mut clist,
+            (*$clist).last,
+            $item as *mut libc::c_void,
+        ) != 0
+        {
+            bail!("could not allocate or append list item");
+        }
+    };
+}
+
+pub fn add_filename_part(
+    message: *mut mailmime,
+    basename: &str,
+    mime_type: &str,
+    file_content: &str,
+) -> Result<(), Error> {
+    let mime_type_c = CString::new(mime_type.to_string()).expect("failed to create CString");
+    unsafe {
+        let content_type = mailmime_content_new_with_str(mime_type_c.as_ptr());
+        let mime_fields = mailmime_fields_new_filename(
+            MAILMIME_DISPOSITION_TYPE_ATTACHMENT as libc::c_int,
+            basename.strdup(),
+            MAILMIME_MECHANISM_8BIT as libc::c_int,
+        );
+        let file_mime_part = mailmime_new_empty(content_type, mime_fields);
+        set_body_text(file_mime_part, file_content)?;
+        mailmime_smart_add_part(message, file_mime_part);
+    }
+    Ok(())
+}
+
+pub fn new_custom_field(fields: *mut mailimf_fields, name: &str, value: &str) {
+    unsafe {
+        let field = mailimf_field_new_custom(name.strdup(), value.strdup());
+        let res = mailimf_fields_add(fields, field);
+        assert!(
+            res as u32 == MAILIMF_NO_ERROR,
+            "could not create mailimf field"
+        );
+    }
+}
+
+
+pub fn build_body_text(text: &str) -> Result<*mut mailmime, Error> {
+    let mime_fields: *mut mailmime_fields;
+    let message_part: *mut mailmime;
+
+    let content = new_mailmime_content_type("text/plain");
+    append_ct_param(content, "charset", "utf-8")?;
+
+    unsafe {
+        mime_fields = mailmime_fields_new_encoding(MAILMIME_MECHANISM_8BIT as libc::c_int);
+        message_part = mailmime_new_empty(content, mime_fields);
+    }
+    set_body_text(message_part, text)?;
+
+    Ok(message_part)
+}
+
+pub fn append_ct_param(
+    content: *mut mailmime_content,
+    name: &str,
+    value: &str,
+) -> Result<(), Error> {
+    unsafe {
+        let name_c = CString::new(name).unwrap().as_ptr();
+        let value_c = CString::new(value).unwrap().as_ptr();
+
+        clist_append!(
+            (*content).ct_parameters,
+            mailmime_param_new_with_data(
+                name_c as *const u8 as *const libc::c_char as *mut libc::c_char,
+                value_c as *const u8 as *const libc::c_char as *mut libc::c_char
+            )
+        );
+    }
+    Ok(())
+}
+
+pub fn new_mailmime_content_type(content_type: &str) -> *mut mailmime_content {
+    let ct = CString::new(content_type).unwrap();
+    let content: *mut mailmime_content;
+    // mailmime_content_new_with_str only parses but does not retain/own ct
+    //
+    unsafe {
+        content = mailmime_content_new_with_str(ct.as_ptr());
+    }
+    if content.is_null() {
+        panic!("mailimf failed to allocate");
+    }
+    content
+}
+
+pub fn set_body_text(part: *mut mailmime, text: &str) -> Result<(), Error> {
+    use libc::strlen;
+    unsafe {
+        let text_c = text.strdup();
+        if 0 != mailmime_set_body_text(part, text_c, strlen(text_c)) {
+            bail!("could not set body text on mime-structure");
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
- create wrapmime module for providing some initial safe functions with mmime
- cleanup message-encryption finalization, no cdata_to_free tricks for encryption, avoid one strdup() in the outgoing message path 
- more safe code 

