### PR TITLE
Return Ok(None) when get_draft is called with a special chat id

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1888,8 +1888,8 @@ mod tests {
     #[test]
     fn test_get_draft_special_chat_id() {
         let t = dummy_context();
-        let draft = get_draft(&t.ctx, DC_CHAT_ID_LAST_SPECIAL);
-        assert!(draft.is_err());
+        let draft = get_draft(&t.ctx, DC_CHAT_ID_LAST_SPECIAL).unwrap();
+        assert!(draft.is_none());
     }
 
     #[test]

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -925,7 +925,9 @@ fn get_draft_msg_id(context: &Context, chat_id: u32) -> u32 {
 }
 
 pub fn get_draft(context: &Context, chat_id: u32) -> Result<Option<Message>, Error> {
-    ensure!(chat_id > DC_CHAT_ID_LAST_SPECIAL, "Invalid chat ID");
+    if chat_id <= DC_CHAT_ID_LAST_SPECIAL {
+        return Ok(None);
+    }
     let draft_msg_id = get_draft_msg_id(context, chat_id);
     if draft_msg_id == 0 {
         return Ok(None);


### PR DESCRIPTION
Currently we emit an error event when we call get_draft with a special chat id, this breaks api compatibility with c-core.