### PR TITLE
Support new chat$group RFC724 message identifier

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -268,7 +268,7 @@ impl Chat {
                     Chattype::Group | Chattype::VerifiedGroup => Some(self.grpid.as_str()),
                     _ => None,
                 };
-                dc_create_outgoing_rfc724_mid(grpid, &from)
+                dc_create_outgoing_rfc724_mid(grpid, &from, use_rfc724_msgid_prefix(context))
             };
 
             if self.typ == Chattype::Single {
@@ -1849,7 +1849,8 @@ pub fn get_chat_id_by_grpid(context: &Context, grpid: impl AsRef<str>) -> (u32, 
 }
 
 pub fn add_device_msg(context: &Context, chat_id: u32, text: impl AsRef<str>) {
-    let rfc724_mid = dc_create_outgoing_rfc724_mid(None, "@device");
+    let rfc724_mid =
+        dc_create_outgoing_rfc724_mid(None, "@device", use_rfc724_msgid_prefix(context));
 
     if context.sql.execute(
         "INSERT INTO msgs (chat_id,from_id,to_id, timestamp,type,state, txt,rfc724_mid) VALUES (?,?,?, ?,?,?, ?,?);",

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,8 @@ pub enum Config {
     SysVersion,
     #[strum(serialize = "sys.msgsize_max_recommended")]
     SysMsgsizeMaxRecommended,
+    #[strum(serialize = "rfc724_msg_id_prefix")]
+    Rfc724MsgIdPrefix, // To be removed when chat$ prefix has become the sole convention
     #[strum(serialize = "sys.config_keys")]
     SysConfigKeys,
 }

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -501,14 +501,6 @@ const NEW_GROUP_ID_PREFIX: &str = "chat$group.";
 ///
 /// * `mid` - A string that holds the message id
 ///
-/// # Examples
-///
-/// ```ignore
-/// use crate::dc_tools::dc_extract_grpid_from_rfc724_mid;
-/// let mid = "Gr.12345678901.morerandom@domain.de";
-/// let grpid = dc_extract_grpid_from_rfc724_mid(mid);
-/// assert_eq!(grpid, Some("12345678901"));
-/// ```
 pub(crate) fn dc_extract_grpid_from_rfc724_mid(mid: &str) -> Option<&str> {
     if mid.len() < 9 {
         return None;

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -525,6 +525,7 @@ pub(crate) fn dc_extract_grpid_from_rfc724_mid(mid: &str) -> Option<&str> {
         return suffix
             .split('.')
             .next()
+            // strict length comparison, the 'Gr.' magic is weak enough
             .filter(|old_grpid| old_grpid.len() == 11 || old_grpid.len() == 16);
     }
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -134,7 +134,11 @@ impl<'a> MimeFactory<'a> {
             .push(contact.get_authname().to_string());
         factory.recipients_addr.push(contact.get_addr().to_string());
         factory.timestamp = dc_create_smeared_timestamp(factory.context);
-        factory.rfc724_mid = dc_create_outgoing_rfc724_mid(None, &factory.from_addr);
+        factory.rfc724_mid = dc_create_outgoing_rfc724_mid(
+            None,
+            &factory.from_addr,
+            use_rfc724_msgid_prefix(context),
+        );
         factory.loaded = Loaded::MDN;
 
         Ok(factory)


### PR DESCRIPTION
Previously only "Gr." prefixes were recognized. This commit adds support for COI prefix "chat$group".

Obsoletes #439.