### PR TITLE
rustify dc_imex, fix bug

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1580,7 +1580,13 @@ pub unsafe extern "C" fn dc_continue_key_transfer(
     let ffi_context = &*context;
     ffi_context
         .with_inner(|ctx| {
-            dc_imex::dc_continue_key_transfer(ctx, msg_id, as_str(setup_code)) as libc::c_int
+            match dc_imex::dc_continue_key_transfer(ctx, msg_id, as_str(setup_code)) {
+                Ok(()) => 1,
+                Err(err) => {
+                    error!(ctx, "dc_continue_key_transfer: {}", err);
+                    0
+                }
+            }
         })
         .unwrap_or(0)
 }

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1519,7 +1519,7 @@ pub unsafe extern "C" fn dc_imex(
     context: *mut dc_context_t,
     what: libc::c_int,
     param1: *mut libc::c_char,
-    param2: *mut libc::c_char,
+    _param2: *mut libc::c_char,
 ) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_imex()");
@@ -1527,7 +1527,7 @@ pub unsafe extern "C" fn dc_imex(
     }
     let ffi_context = &*context;
     ffi_context
-        .with_inner(|ctx| dc_imex::dc_imex(ctx, what, as_opt_str(param1), as_opt_str(param2)))
+        .with_inner(|ctx| dc_imex::dc_imex(ctx, what, as_opt_str(param1)))
         .ok();
 }
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1527,7 +1527,7 @@ pub unsafe extern "C" fn dc_imex(
     }
     let ffi_context = &*context;
     ffi_context
-        .with_inner(|ctx| dc_imex::dc_imex(ctx, what, as_opt_str(param1), param2))
+        .with_inner(|ctx| dc_imex::dc_imex(ctx, what, as_opt_str(param1), as_opt_str(param2)))
         .ok();
 }
 
@@ -1542,7 +1542,13 @@ pub unsafe extern "C" fn dc_imex_has_backup(
     }
     let ffi_context = &*context;
     ffi_context
-        .with_inner(|ctx| dc_imex::dc_imex_has_backup(ctx, as_str(dir)))
+        .with_inner(|ctx| match dc_imex::dc_imex_has_backup(ctx, as_str(dir)) {
+            Ok(res) => res.strdup(),
+            Err(err) => {
+                error!(ctx, "dc_imex_has_backup: {}", err);
+                ptr::null_mut()
+            }
+        })
         .unwrap_or_else(|_| ptr::null_mut())
 }
 

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -1,5 +1,4 @@
 use std::path::Path;
-use std::ptr;
 use std::str::FromStr;
 
 use deltachat::chat::{self, Chat};
@@ -328,6 +327,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
     };
     let arg2 = args.next().unwrap_or_default();
 
+    let blobdir = context.get_blobdir();
     match arg0 {
         "help" | "?" => match arg1 {
             // TODO: reuse commands definition in main.rs.
@@ -451,27 +451,24 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             }
         }
         "has-backup" => {
-            let ret = dc_imex_has_backup(context, context.get_blobdir());
-            if ret.is_null() {
-                println!("No backup found.");
-            }
+            dc_imex_has_backup(context, blobdir)?;
         }
         "export-backup" => {
-            dc_imex(context, 11, Some(context.get_blobdir()), ptr::null());
+            dc_imex(context, 11, Some(blobdir));
         }
         "import-backup" => {
             ensure!(!arg1.is_empty(), "Argument <backup-file> missing.");
-            dc_imex(context, 12, Some(arg1), ptr::null());
+            dc_imex(context, 12, Some(arg1));
         }
         "export-keys" => {
-            dc_imex(context, 1, Some(context.get_blobdir()), ptr::null());
+            dc_imex(context, 1, Some(blobdir));
         }
         "import-keys" => {
-            dc_imex(context, 2, Some(context.get_blobdir()), ptr::null());
+            dc_imex(context, 2, Some(blobdir));
         }
         "export-setup" => {
             let setup_code = dc_create_setup_code(context);
-            let file_name = context.get_blobdir().join("autocrypt-setup-message.html");
+            let file_name = blobdir.join("autocrypt-setup-message.html");
             let file_content = dc_render_setup_file(context, &setup_code)?;
             std::fs::write(&file_name, file_content)?;
             println!(

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -446,9 +446,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
                 !arg1.is_empty() && !arg2.is_empty(),
                 "Arguments <msg-id> <setup-code> expected"
             );
-            if !dc_continue_key_transfer(context, arg1.parse()?, &arg2) {
-                bail!("Continue key transfer failed");
-            }
+            dc_continue_key_transfer(context, arg1.parse()?, &arg2)?;
         }
         "has-backup" => {
             dc_imex_has_backup(context, blobdir)?;

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function
 import threading
-import os
 import re
 import time
 from array import array
@@ -298,10 +297,10 @@ class Account(object):
         (chats, contacts, keys, media, ...). The file is created in the
         the `path` directory.
         """
-        l = self._export(path, 11)
-        if len(l) != 1:
+        export_files = self._export(path, 11)
+        if len(export_files) != 1:
             raise RuntimeError("found more than one new file")
-        return l[0]
+        return export_files[0]
 
     def _imex_events_clear(self):
         try:
@@ -311,7 +310,6 @@ class Account(object):
             pass
 
     def _export(self, path, imex_cmd):
-        snap_files = os.listdir(path)
         self._imex_events_clear()
         lib.dc_imex(self._dc_context, imex_cmd, as_dc_charpointer(path), ffi.NULL)
         if not self._threads.is_started():
@@ -463,6 +461,7 @@ class Account(object):
 
     def on_dc_event_imex_file_written(self, data1, data2):
         self._imex_events.put(data1)
+
 
 class IOThreads:
     def __init__(self, dc_context, log_event=lambda *args: None):

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -340,6 +340,13 @@ class TestOnlineAccount:
         assert chat.id > const.DC_CHAT_ID_LAST_SPECIAL
         return chat
 
+    def test_export_import_self_keys(self, acfactory, tmpdir):
+        ac1, ac2 = acfactory.get_two_online_accounts()
+        dir = tmpdir.mkdir("exportdir")
+        tmpfile = ac1.export_self_keys(dir.strpath)
+        ac1.consume_events()
+        assert ac1.import_self_keys(tmpfile)
+
     def test_one_account_send(self, acfactory):
         ac1 = acfactory.get_online_configuring_account()
         c2 = ac1.create_contact(email=ac1.get_config("addr"))
@@ -501,7 +508,7 @@ class TestOnlineAccount:
         assert os.path.exists(msg_in.filename)
         assert os.stat(msg_in.filename).st_size == os.stat(path).st_size
 
-    def test_import_export_online(self, acfactory, tmpdir):
+    def test_import_export_online_all(self, acfactory, tmpdir):
         ac1 = acfactory.get_online_configuring_account()
         wait_configuration_progress(ac1, 1000)
 
@@ -509,11 +516,11 @@ class TestOnlineAccount:
         chat = ac1.create_chat_by_contact(contact1)
         chat.send_text("msg1")
         backupdir = tmpdir.mkdir("backup")
-        path = ac1.export_to_dir(backupdir.strpath)
+        path = ac1.export_all(backupdir.strpath)
         assert os.path.exists(path)
 
         ac2 = acfactory.get_unconfigured_account()
-        ac2.import_from_file(path)
+        ac2.import_all(path)
         contacts = ac2.get_contacts(query="some1")
         assert len(contacts) == 1
         contact2 = contacts[0]

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -343,9 +343,12 @@ class TestOnlineAccount:
     def test_export_import_self_keys(self, acfactory, tmpdir):
         ac1, ac2 = acfactory.get_two_online_accounts()
         dir = tmpdir.mkdir("exportdir")
-        tmpfile = ac1.export_self_keys(dir.strpath)
-        ac1.consume_events()
-        assert ac1.import_self_keys(tmpfile)
+        l = ac1.export_self_keys(dir.strpath)
+        assert len(l) == 2
+        for x in l:
+            assert x.startswith(dir.strpath)
+        ac1._evlogger.consume_events()
+        ac1.import_self_keys(dir.strpath)
 
     def test_one_account_send(self, acfactory):
         ac1 = acfactory.get_online_configuring_account()

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -293,10 +293,10 @@ class TestOfflineChat:
         assert contact == ac1.get_self_contact()
         assert not backupdir.listdir()
 
-        path = ac1.export_to_dir(backupdir.strpath)
+        path = ac1.export_all(backupdir.strpath)
         assert os.path.exists(path)
         ac2 = acfactory.get_unconfigured_account()
-        ac2.import_from_file(path)
+        ac2.import_all(path)
         contacts = ac2.get_contacts(query="some1")
         assert len(contacts) == 1
         contact2 = contacts[0]
@@ -343,9 +343,9 @@ class TestOnlineAccount:
     def test_export_import_self_keys(self, acfactory, tmpdir):
         ac1, ac2 = acfactory.get_two_online_accounts()
         dir = tmpdir.mkdir("exportdir")
-        l = ac1.export_self_keys(dir.strpath)
-        assert len(l) == 2
-        for x in l:
+        export_files = ac1.export_self_keys(dir.strpath)
+        assert len(export_files) == 2
+        for x in export_files:
             assert x.startswith(dir.strpath)
         ac1._evlogger.consume_events()
         ac1.import_self_keys(dir.strpath)

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -533,7 +533,7 @@ class TestOnlineAccount:
         assert len(messages) == 1
         assert messages[0].text == "msg1"
 
-    def test_ac_setup_message(self, acfactory):
+    def test_ac_setup_message(self, acfactory, lp):
         # note that the receiving account needs to be configured and running
         # before ther setup message is send. DC does not read old messages
         # as of Jul2019
@@ -541,6 +541,7 @@ class TestOnlineAccount:
         ac2 = acfactory.clone_online_account(ac1)
         wait_configuration_progress(ac2, 1000)
         wait_configuration_progress(ac1, 1000)
+        lp.sec("trigger ac setup message and return setupcode")
         assert ac1.get_info()["fingerprint"] != ac2.get_info()["fingerprint"]
         setup_code = ac1.initiate_key_transfer()
         ac2._evlogger.set_timeout(30)
@@ -548,9 +549,10 @@ class TestOnlineAccount:
         msg = ac2.get_message_by_id(ev[2])
         assert msg.is_setup_message()
         assert msg.get_setupcodebegin() == setup_code[:2]
-        # first try a bad setup code
+        lp.sec("try a bad setup code")
         with pytest.raises(ValueError):
             msg.continue_key_transfer(str(reversed(setup_code)))
+        lp.sec("try a good setup code")
         print("*************** Incoming ASM File at: ", msg.filename)
         print("*************** Setup Code: ", setup_code)
         msg.continue_key_transfer(setup_code)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -65,13 +65,13 @@ pub(crate) const DC_FP_NO_AUTOCRYPT_HEADER: i32 = 2;
 pub(crate) const DC_FP_ADD_AUTOCRYPT_HEADER: i32 = 1;
 
 /// param1 is a directory where the keys are written to
-const DC_IMEX_EXPORT_SELF_KEYS: usize = 1;
+pub const DC_IMEX_EXPORT_SELF_KEYS: i32 = 1;
 /// param1 is a directory where the keys are searched in and read from
-const DC_IMEX_IMPORT_SELF_KEYS: usize = 2;
+pub const DC_IMEX_IMPORT_SELF_KEYS: i32 = 2;
 /// param1 is a directory where the backup is written to
-const DC_IMEX_EXPORT_BACKUP: usize = 11;
+pub const DC_IMEX_EXPORT_BACKUP: i32 = 11;
 /// param1 is the file with the backup to import
-const DC_IMEX_IMPORT_BACKUP: usize = 12;
+pub const DC_IMEX_IMPORT_BACKUP: i32 = 12;
 
 /// virtual chat showing all messages belonging to chats flagged with chats.blocked=2
 pub(crate) const DC_CHAT_ID_DEADDROP: u32 = 1;

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -536,7 +536,7 @@ pub(crate) fn dc_delete_file(context: &Context, path: impl AsRef<std::path::Path
     if !path_abs.is_file() {
         warn!(
             context,
-            "refusing to deleting non-file \"{}\".",
+            "refusing to delete non-file \"{}\".",
             path.as_ref().display()
         );
         return false;

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -530,10 +530,13 @@ pub(crate) fn dc_get_filebytes(context: &Context, path: impl AsRef<std::path::Pa
 
 pub(crate) fn dc_delete_file(context: &Context, path: impl AsRef<std::path::Path>) -> bool {
     let path_abs = dc_get_abs_path(context, &path);
+    if !path_abs.exists() {
+        return false;
+    }
     if !path_abs.is_file() {
         warn!(
             context,
-            "Will not delete directory \"{}\".",
+            "refusing to deleting non-file \"{}\".",
             path.as_ref().display()
         );
         return false;
@@ -1499,6 +1502,7 @@ mod tests {
         let t = dummy_context();
         let context = &t.ctx;
 
+        assert!(!dc_delete_file(context, "$BLOBDIR/lkqwjelqkwlje"));
         if dc_file_exist(context, "$BLOBDIR/foobar")
             || dc_file_exist(context, "$BLOBDIR/dada")
             || dc_file_exist(context, "$BLOBDIR/foobar.dadada")
@@ -1521,6 +1525,7 @@ mod tests {
             .to_string();
 
         assert!(dc_is_blobdir_path(context, &abs_path));
+
         assert!(dc_is_blobdir_path(context, "$BLOBDIR/fofo",));
         assert!(!dc_is_blobdir_path(context, "/BLOBDIR/fofo",));
         assert!(dc_file_exist(context, &abs_path));

--- a/src/job.rs
+++ b/src/job.rs
@@ -824,7 +824,12 @@ fn job_perform(context: &Context, thread: Thread, probe_network: bool) {
                 Action::MoveMsg => job.do_DC_JOB_MOVE_MSG(context),
                 Action::SendMdn => job.do_DC_JOB_SEND(context),
                 Action::ConfigureImap => unsafe { dc_job_do_DC_JOB_CONFIGURE_IMAP(context) },
-                Action::ImexImap => unsafe { dc_job_do_DC_JOB_IMEX_IMAP(context, &job) },
+                Action::ImexImap => match dc_job_do_DC_JOB_IMEX_IMAP(context, &job) {
+                    Ok(()) => {}
+                    Err(err) => {
+                        error!(context, "{}", err);
+                    }
+                },
                 Action::MaybeSendLocations => {
                     location::job_do_DC_JOB_MAYBE_SEND_LOCATIONS(context, &job)
                 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::ptr;
 
 use deltachat_derive::{FromSql, ToSql};
-use libc::{free, strcmp};
+use libc::free;
 
 use crate::chat::{self, Chat};
 use crate::constants::*;
@@ -353,7 +353,7 @@ impl Message {
             if let Ok(mut buf) = dc_read_file(context, filename) {
                 unsafe {
                     // just a pointer inside buf, MUST NOT be free()'d
-                    let mut buf_headerline = ptr::null();
+                    let mut buf_headerline = String::default();
                     // just a pointer inside buf, MUST NOT be free()'d
                     let mut buf_setupcodebegin = ptr::null();
 
@@ -363,10 +363,7 @@ impl Message {
                         &mut buf_setupcodebegin,
                         ptr::null_mut(),
                         ptr::null_mut(),
-                    ) && strcmp(
-                        buf_headerline,
-                        b"-----BEGIN PGP MESSAGE-----\x00" as *const u8 as *const libc::c_char,
-                    ) == 0
+                    ) && buf_headerline == "-----BEGIN PGP MESSAGE-----"
                         && !buf_setupcodebegin.is_null()
                     {
                         return Some(to_string(buf_setupcodebegin));

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -19,7 +19,7 @@ use crate::keyring::*;
 
 pub unsafe fn dc_split_armored_data(
     buf: *mut libc::c_char,
-    ret_headerline: *mut *const libc::c_char,
+    ret_headerline: *mut String,
     ret_setupcodebegin: *mut *const libc::c_char,
     ret_preferencrypt: *mut *const libc::c_char,
     ret_base64: *mut *const libc::c_char,
@@ -31,9 +31,6 @@ pub unsafe fn dc_split_armored_data(
     let mut p2: *mut libc::c_char;
     let mut headerline: *mut libc::c_char = ptr::null_mut();
     let mut base64: *mut libc::c_char = ptr::null_mut();
-    if !ret_headerline.is_null() {
-        *ret_headerline = ptr::null()
-    }
     if !ret_setupcodebegin.is_null() {
         *ret_setupcodebegin = ptr::null_mut();
     }
@@ -43,7 +40,7 @@ pub unsafe fn dc_split_armored_data(
     if !ret_base64.is_null() {
         *ret_base64 = ptr::null();
     }
-    if !(buf.is_null() || ret_headerline.is_null()) {
+    if !buf.is_null() {
         dc_remove_cr_chars(buf);
         while 0 != *p1 {
             if *p1 as libc::c_int == '\n' as i32 {
@@ -62,9 +59,7 @@ pub unsafe fn dc_split_armored_data(
                         ) == 0i32
                     {
                         headerline = line;
-                        if !ret_headerline.is_null() {
-                            *ret_headerline = headerline
-                        }
+                        *ret_headerline = as_str(headerline).to_string();
                     }
                 } else if strspn(line, b"\t\r\n \x00" as *const u8 as *const libc::c_char)
                     == strlen(line)

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -59,7 +59,7 @@ unsafe fn stress_functions(context: &Context) {
     assert!(res.contains(" configured_server_flags "));
 
     let mut buf_0: *mut libc::c_char;
-    let mut headerline: *const libc::c_char = ptr::null();
+    let mut headerline = String::default();
     let mut setupcodebegin: *const libc::c_char = ptr::null();
     let mut preferencrypt: *const libc::c_char = ptr::null();
     let mut base64: *const libc::c_char = ptr::null();
@@ -75,14 +75,8 @@ unsafe fn stress_functions(context: &Context) {
         &mut base64,
     );
     assert!(ok);
-    assert!(!headerline.is_null());
-    assert_eq!(
-        strcmp(
-            headerline,
-            b"-----BEGIN PGP MESSAGE-----\x00" as *const u8 as *const libc::c_char,
-        ),
-        0
-    );
+    assert!(!headerline.is_empty());
+    assert_eq!(headerline, "-----BEGIN PGP MESSAGE-----");
 
     assert!(!base64.is_null());
     assert_eq!(as_str(base64 as *const libc::c_char), "data",);
@@ -101,14 +95,7 @@ unsafe fn stress_functions(context: &Context) {
     );
 
     assert!(ok);
-    assert!(!headerline.is_null());
-    assert_eq!(
-        strcmp(
-            headerline,
-            b"-----BEGIN PGP MESSAGE-----\x00" as *const u8 as *const libc::c_char,
-        ),
-        0
-    );
+    assert_eq!(headerline, "-----BEGIN PGP MESSAGE-----");
 
     assert!(!base64.is_null());
     assert_eq!(as_str(base64 as *const libc::c_char), "dat1",);
@@ -128,14 +115,7 @@ unsafe fn stress_functions(context: &Context) {
     );
 
     assert!(ok);
-    assert!(!headerline.is_null());
-    assert_eq!(
-        strcmp(
-            headerline,
-            b"-----BEGIN PGP MESSAGE-----\x00" as *const u8 as *const libc::c_char,
-        ),
-        0
-    );
+    assert_eq!(headerline, "-----BEGIN PGP MESSAGE-----");
     assert!(setupcodebegin.is_null());
 
     assert!(!base64.is_null());
@@ -165,14 +145,7 @@ unsafe fn stress_functions(context: &Context) {
         &mut base64,
     );
     assert!(ok);
-    assert!(!headerline.is_null());
-    assert_eq!(
-        strcmp(
-            headerline,
-            b"-----BEGIN PGP MESSAGE-----\x00" as *const u8 as *const libc::c_char,
-        ),
-        0
-    );
+    assert_eq!(headerline, "-----BEGIN PGP MESSAGE-----");
 
     assert!(!setupcodebegin.is_null());
     assert_eq!(
@@ -199,15 +172,7 @@ unsafe fn stress_functions(context: &Context) {
         &mut base64,
     );
     assert!(ok);
-    assert!(!headerline.is_null());
-    assert_eq!(
-        strcmp(
-            headerline,
-            b"-----BEGIN PGP PRIVATE KEY BLOCK-----\x00" as *const u8 as *const libc::c_char,
-        ),
-        0
-    );
-
+    assert_eq!(headerline, "-----BEGIN PGP PRIVATE KEY BLOCK-----");
     assert!(!preferencrypt.is_null());
     assert_eq!(
         strcmp(
@@ -223,7 +188,7 @@ unsafe fn stress_functions(context: &Context) {
     free(buf_0 as *mut libc::c_void);
 
     let mut buf_1: *mut libc::c_char;
-    let mut headerline_0: *const libc::c_char = ptr::null();
+    let mut headerline_0 = String::default();
     let mut setupcodebegin_0: *const libc::c_char = ptr::null();
     let mut preferencrypt_0: *const libc::c_char = ptr::null();
     buf_1 = strdup(S_EM_SETUPFILE);
@@ -234,14 +199,7 @@ unsafe fn stress_functions(context: &Context) {
         &mut preferencrypt_0,
         ptr::null_mut(),
     ));
-    assert!(!headerline_0.is_null());
-    assert_eq!(
-        0,
-        strcmp(
-            headerline_0,
-            b"-----BEGIN PGP MESSAGE-----\x00" as *const u8 as *const libc::c_char,
-        )
-    );
+    assert_eq!(headerline_0, "-----BEGIN PGP MESSAGE-----");
     assert!(!setupcodebegin_0.is_null());
     assert!(strlen(setupcodebegin_0) < strlen(S_EM_SETUPCODE));
     assert_eq!(
@@ -260,14 +218,7 @@ unsafe fn stress_functions(context: &Context) {
         &mut preferencrypt_0,
         ptr::null_mut(),
     ));
-    assert!(!headerline_0.is_null());
-    assert_eq!(
-        strcmp(
-            headerline_0,
-            b"-----BEGIN PGP PRIVATE KEY BLOCK-----\x00" as *const u8 as *const libc::c_char,
-        ),
-        0
-    );
+    assert_eq!(headerline_0, "-----BEGIN PGP PRIVATE KEY BLOCK-----");
     assert!(setupcodebegin_0.is_null());
     assert!(!preferencrypt_0.is_null());
     assert_eq!(


### PR DESCRIPTION
this started from trying to fix #596 and resulted in: 

- turning several key-related functions from unsafe to safe
- adding export_self_keys and import_self_keys python API, testing roundtrip
- removing lots of char-* stuff 

and the #596 is fixed. 