### PR TITLE
get_filemime() should return an empty string if no mimetype is present

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2359,7 +2359,11 @@ pub unsafe extern "C" fn dc_msg_get_filemime(msg: *mut dc_msg_t) -> *mut libc::c
         return dc_strdup(ptr::null());
     }
     let ffi_msg = &*msg;
-    ffi_msg.message.get_filemime().strdup()
+    if let Some(x) = ffi_msg.message.get_filemime() {
+        x.strdup()
+    } else {
+        return dc_strdup(ptr::null());
+    }
 }
 
 #[no_mangle]

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -93,8 +93,9 @@ class TestOfflineContact:
         ac1 = acfactory.get_configured_offline_account()
         contact1 = ac1.create_contact(email="some1@example.com", name="some1")
         chat = ac1.create_chat_by_contact(contact1)
-        chat.send_text("one messae")
+        msg = chat.send_text("one messae")
         assert not ac1.delete_contact(contact1)
+        assert not msg.filemime
 
 
 class TestOfflineChat:

--- a/src/message.rs
+++ b/src/message.rs
@@ -150,9 +150,10 @@ impl Message {
             if let Some((_, mime)) = guess_msgtype_from_suffix(Path::new(file)) {
                 return mime.to_string();
             }
+            return "application/octet-stream".to_string()
         }
+        "".to_string()
 
-        "application/octet-stream".to_string()
     }
 
     pub fn get_file(&self, context: &Context) -> Option<PathBuf> {


### PR DESCRIPTION
and not default to `applicatopm/octet-stream`

I think in rustland a Result/Option would be a better return value, not sure. I like to keep things simple and return an empty string, can change it if people think it's important.