### PR TITLE
Make dc_get_info() work on a closed context

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -405,8 +405,13 @@ char*           dc_get_config                (dc_context_t* context, const char*
 
 /**
  * Get information about the context.
+ *
  * The information is returned by a multi-line string
  * and contains information about the current configuration.
+ *
+ * If the context is not open or configured only a subset of the information
+ * will be available.  There is no guarantee about which information will be
+ * included when however.
  *
  * @memberof dc_context_t
  * @param context The context as created by dc_context_new().

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -347,9 +347,12 @@ pub unsafe extern "C" fn dc_get_info(context: *mut dc_context_t) -> *mut libc::c
         return dc_strdup(ptr::null());
     }
     let ffi_context = &*context;
-    ffi_context
-        .with_inner(|ctx| render_info(ctx.get_info()).unwrap_or_default().strdup())
-        .unwrap_or_else(|_| "".strdup())
+    let guard = ffi_context.inner.read().unwrap();
+    let info = match guard.as_ref() {
+        Some(ref ctx) => ctx.get_info(),
+        None => context::get_info(),
+    };
+    render_info(info).unwrap_or_default().strdup()
 }
 
 fn render_info(

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -108,3 +108,25 @@ def test_provider_info():
 
 def test_provider_info_none():
     assert lib.dc_provider_new_from_email(cutil.as_dc_charpointer("email@unexistent.no")) == ffi.NULL
+
+
+def test_get_info_closed():
+    ctx = ffi.gc(
+        lib.dc_context_new(lib.py_dc_callback, ffi.NULL, ffi.NULL),
+        lib.dc_context_unref,
+    )
+    info = cutil.from_dc_charpointer(lib.dc_get_info(ctx))
+    assert 'deltachat_core_version' in info
+    assert 'database_dir' not in info
+
+
+def test_get_info_open(tmpdir):
+    ctx = ffi.gc(
+        lib.dc_context_new(lib.py_dc_callback, ffi.NULL, ffi.NULL),
+        lib.dc_context_unref,
+    )
+    db_fname = tmpdir.join("test.db")
+    lib.dc_open(ctx, db_fname.strpath.encode("ascii"), ffi.NULL)
+    info = cutil.from_dc_charpointer(lib.dc_get_info(ctx))
+    assert 'deltachat_core_version' in info
+    assert 'database_dir' in info


### PR DESCRIPTION
@hpk42 could you check if this is the best way to do the FFI-level tests?

@r10s could you check if the FFI API decisions I'm taking here are somewhat reasonable to you?

@dignifiedquire could you check if you're happy with the Rust-level API.  It certainly works but I don't find it particularly elegant.  My brain is only working at a rather reduced capacity currently though.

@Jikstra could you check this actually fixes your problem in the desktop?

Of course anyone can comment on anything they so desire :)


Commit message:

There is very little API guarantees about this, but clients seem to
expect *something* to work on a closed context.  So split this up into
static info an more dynamic context-related info, but let's not
provide any guarantees about what keys are available when.

Fixes #599