### PR TITLE
Revert back to only ffi-level checking of open context

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -276,9 +276,11 @@ pub unsafe extern "C" fn dc_is_open(context: *mut dc_context_t) -> libc::c_int {
         return 0;
     }
     let ffi_context = &*context;
-    ffi_context
-        .with_inner(|ctx| ctx.sql.is_open() as libc::c_int)
-        .unwrap_or(0)
+    let inner_guard = ffi_context.inner.read().unwrap();
+    match *inner_guard {
+        Some(_) => 1,
+        None => 0,
+    }
 }
 
 #[no_mangle]

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -130,3 +130,21 @@ def test_get_info_open(tmpdir):
     info = cutil.from_dc_charpointer(lib.dc_get_info(ctx))
     assert 'deltachat_core_version' in info
     assert 'database_dir' in info
+
+
+def test_is_open_closed():
+    ctx = ffi.gc(
+        lib.dc_context_new(lib.py_dc_callback, ffi.NULL, ffi.NULL),
+        lib.dc_context_unref,
+    )
+    assert lib.dc_is_open(ctx) == 0
+
+
+def test_is_open_actually_open(tmpdir):
+    ctx = ffi.gc(
+        lib.dc_context_new(lib.py_dc_callback, ffi.NULL, ffi.NULL),
+        lib.dc_context_unref,
+    )
+    db_fname = tmpdir.join("test.db")
+    lib.dc_open(ctx, db_fname.strpath.encode("ascii"), ffi.NULL)
+    assert lib.dc_is_open(ctx) == 1


### PR DESCRIPTION
The Rust context is always open, the return value of this function was
simply the wrong way around.