### PR TITLE
do not truncate messages in contact requests

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -2,7 +2,6 @@ use std::path::{Path, PathBuf};
 use std::ptr;
 
 use deltachat_derive::{FromSql, ToSql};
-use libc::free;
 
 use crate::chat::{self, Chat};
 use crate::constants::*;
@@ -108,18 +107,6 @@ impl Message {
             msg.hidden = row.get(18)?;
             msg.location_id = row.get(19)?;
             msg.chat_blocked = row.get::<_, Option<Blocked>>(20)?.unwrap_or_default();
-            if msg.chat_blocked == Blocked::Deaddrop {
-                if let Some(ref text) = msg.text {
-                    unsafe {
-                        let ptr = text.strdup();
-
-                        dc_truncate_n_unwrap_str(ptr, 256, 0);
-
-                        msg.text = Some(to_string(ptr));
-                        free(ptr.cast());
-                    }
-                }
-            };
             Ok(msg)
         })
     }


### PR DESCRIPTION
core-c has truncated messages in the contact requests.
this is questionable in general, as
- all messages, including contact requests,
  are already truncated, unquoted, simplified etc.
- the ui should be capable of showing the full text anyway
  (when the contact request is accepted, the whole messase is shown)
- also, all current ui show the contact requests by name only in the
  chatlist; the user often does not even come to the contact request view.
- if the ui wants to show the contact request is a special way,
  it is probably better to leave this truncation up to the ui