### PR TITLE
fix #615 -- like with c-core Chat-Version is left in unprotected head…

### DIFF
--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -182,7 +182,8 @@ impl EncryptHelper {
                         let opt_field = (*field).fld_data.fld_optional_field;
                         if !opt_field.is_null() && !(*opt_field).fld_name.is_null() {
                             let fld_name = to_string_lossy((*opt_field).fld_name);
-                            if fld_name.starts_with("Secure-Join") || fld_name.starts_with("Chat-")
+                            if fld_name.starts_with("Secure-Join")
+                                || (fld_name.starts_with("Chat-") && fld_name != "Chat-Version")
                             {
                                 move_to_encrypted = true;
                             }


### PR DESCRIPTION
…ers because

it's eg used in server-filters for detecting DC messages