### PR TITLE
allow invalid certs for smtp and imap connections 

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -110,6 +110,8 @@ impl Client {
     ) -> imap::error::Result<Self> {
         let stream = net::TcpStream::connect(addr)?;
         let tls = native_tls::TlsConnector::builder()
+            // see also: https://github.com/deltachat/deltachat-core-rust/issues/203
+            .danger_accept_invalid_certs(true)
             .danger_accept_invalid_hostnames(true)
             .build()
             .unwrap();

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -70,8 +70,9 @@ impl Smtp {
         let port = lp.send_port as u16;
 
         let tls = native_tls::TlsConnector::builder()
-            // FIXME: unfortunately this is needed to make things work on macos + testrun.org
+            // see also: https://github.com/deltachat/deltachat-core-rust/issues/203
             .danger_accept_invalid_hostnames(true)
+            .danger_accept_invalid_certs(true)
             .min_protocol_version(Some(DEFAULT_TLS_PROTOCOLS[0]))
             .build()
             .unwrap();


### PR DESCRIPTION
this is the behaviour of C-core ASFAIK. 

fixes  #616 

Note that To make this behaviour configurable there is #203 