### PR TITLE
Drop unsafe version of dc_decode_header_words

### DIFF
--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -120,7 +120,7 @@ impl<'a> MimeParser<'a> {
                 if (*field).fld_type == MAILIMF_FIELD_SUBJECT as libc::c_int {
                     let subj = (*(*field).fld_data.fld_subject).sbj_value;
 
-                    self.subject = as_opt_str(subj).map(dc_decode_header_words_safe);
+                    self.subject = as_opt_str(subj).map(dc_decode_header_words);
                 }
             }
 
@@ -697,7 +697,7 @@ impl<'a> MimeParser<'a> {
                                         // might be a wrongly encoded filename
                                         let s = to_string_lossy((*dsp_param).pa_data.pa_filename);
                                         // this is used only if the parts buffer stays empty
-                                        desired_filename = dc_decode_header_words_safe(&s)
+                                        desired_filename = dc_decode_header_words(&s)
                                     }
                                 }
                             }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1971,7 +1971,7 @@ unsafe fn add_or_lookup_contact_by_addr(
     /* add addr_spec if missing, update otherwise */
     let mut display_name_dec = "".to_string();
     if !display_name_enc.is_null() {
-        let tmp = as_str(dc_decode_header_words(display_name_enc));
+        let tmp = dc_decode_header_words_safe(as_str(display_name_enc));
         display_name_dec = normalize_name(&tmp);
     }
     /*can be NULL*/

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1079,7 +1079,7 @@ unsafe fn create_or_lookup_group(
     }
 
     if let Some(optional_field) = mime_parser.lookup_optional_field("Chat-Group-Name") {
-        grpname = Some(dc_decode_header_words_safe(&optional_field));
+        grpname = Some(dc_decode_header_words(&optional_field));
     }
     if let Some(optional_field) = mime_parser.lookup_optional_field("Chat-Group-Member-Removed") {
         X_MrRemoveFromGrp = Some(optional_field);
@@ -1971,7 +1971,7 @@ unsafe fn add_or_lookup_contact_by_addr(
     /* add addr_spec if missing, update otherwise */
     let mut display_name_dec = "".to_string();
     if !display_name_enc.is_null() {
-        let tmp = dc_decode_header_words_safe(as_str(display_name_enc));
+        let tmp = dc_decode_header_words(as_str(display_name_enc));
         display_name_dec = normalize_name(&tmp);
     }
     /*can be NULL*/

--- a/src/dc_strencode.rs
+++ b/src/dc_strencode.rs
@@ -68,7 +68,7 @@ fn quote_word(word: &[u8]) -> String {
  * Encode/decode header words, RFC 2047
  ******************************************************************************/
 
-pub fn dc_decode_header_words_safe(input: &str) -> String {
+pub(crate) fn dc_decode_header_words(input: &str) -> String {
     static FROM_ENCODING: &[u8] = b"iso-8859-1\x00";
     static TO_ENCODING: &[u8] = b"utf-8\x00";
     let mut out = ptr::null_mut();
@@ -159,14 +159,11 @@ mod tests {
     #[test]
     fn test_dc_decode_header_words() {
         assert_eq!(
-            dc_decode_header_words_safe("=?utf-8?B?dGVzdMOkw7bDvC50eHQ=?="),
+            dc_decode_header_words("=?utf-8?B?dGVzdMOkw7bDvC50eHQ=?="),
             std::string::String::from_utf8(b"test\xc3\xa4\xc3\xb6\xc3\xbc.txt".to_vec()).unwrap(),
         );
 
-        assert_eq!(
-            dc_decode_header_words_safe("just ascii test"),
-            "just ascii test"
-        );
+        assert_eq!(dc_decode_header_words("just ascii test"), "just ascii test");
 
         assert_eq!(dc_encode_header_words("abcdef"), "abcdef");
 
@@ -176,12 +173,12 @@ mod tests {
         assert!(r.starts_with("=?utf-8"));
 
         assert_eq!(
-            dc_decode_header_words_safe(&r),
+            dc_decode_header_words(&r),
             std::string::String::from_utf8(b"test\xc3\xa4\xc3\xb6\xc3\xbc.txt".to_vec()).unwrap(),
         );
 
         assert_eq!(
-                dc_decode_header_words_safe("=?ISO-8859-1?Q?attachment=3B=0D=0A_filename=3D?= =?ISO-8859-1?Q?=22test=E4=F6=FC=2Etxt=22=3B=0D=0A_size=3D39?="),
+                dc_decode_header_words("=?ISO-8859-1?Q?attachment=3B=0D=0A_filename=3D?= =?ISO-8859-1?Q?=22test=E4=F6=FC=2Etxt=22=3B=0D=0A_size=3D39?="),
                 std::string::String::from_utf8(b"attachment;\r\n filename=\"test\xc3\xa4\xc3\xb6\xc3\xbc.txt\";\r\n size=39".to_vec()).unwrap(),
             );
     }
@@ -246,7 +243,7 @@ mod tests {
         #[test]
         fn test_dc_header_roundtrip(input: String) {
             let encoded = dc_encode_header_words(&input);
-            let decoded = dc_decode_header_words_safe(&encoded);
+            let decoded = dc_decode_header_words(&encoded);
 
             assert_eq!(input, decoded);
         }


### PR DESCRIPTION
Changes:
-------

 * Replace all call sites with safe version and adjust tests as apporiate.
 * s/dc_decode_header_words_safe/dc_decode_header_words/