### PR TITLE
cleanup blob-file creation and copying

### DIFF
--- a/src/imex.rs
+++ b/src/imex.rs
@@ -129,14 +129,15 @@ pub fn initiate_key_transfer(context: &Context) -> Result<String> {
                 .unwrap()
                 .shall_stop_ongoing
             {
-                let setup_file_name =
-                    dc_get_fine_path_filename(context, "$BLOBDIR", "autocrypt-setup-message.html");
-                if dc_write_file(context, &setup_file_name, setup_file_content.as_bytes()) {
+                let setup_file_name = context.new_blob_file(
+                    "autocrypt-setup-message.html",
+                    setup_file_content.as_bytes(),
+                )?;
+                {
                     if let Ok(chat_id) = chat::create_by_contact_id(context, 1) {
                         msg = Message::default();
                         msg.type_0 = Viewtype::File;
-                        msg.param
-                            .set(Param::File, setup_file_name.to_string_lossy());
+                        msg.param.set(Param::File, setup_file_name);
 
                         msg.param
                             .set(Param::MimeType, "application/autocrypt-setup");
@@ -579,6 +580,7 @@ fn export_backup(context: &Context, dir: impl AsRef<Path>) -> Result<()> {
         .format("delta-chat-%Y-%m-%d.bak")
         .to_string();
 
+    // let dest_path_filename = dc_get_next_backup_file(context, dir, res);
     let dest_path_filename = dc_get_fine_path_filename(context, dir, res);
 
     sql::housekeeping(context);

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -574,14 +574,10 @@ fn export_backup(context: &Context, dir: impl AsRef<Path>) -> Result<()> {
 
     let mut delete_dest_file: libc::c_int = 0;
     // get a fine backup file name (the name includes the date so that multiple backup instances are possible)
-    // FIXME: we should write to a temporary file first and rename it on success. this would guarantee the backup is complete. however, currently it is not clear it the import exists in the long run (may be replaced by a restore-from-imap)
-    let now = time();
-    let res = chrono::NaiveDateTime::from_timestamp(now as i64, 0)
-        .format("delta-chat-%Y-%m-%d.bak")
-        .to_string();
-
+    // FIXME: we should write to a temporary file first and rename it on success. this would guarantee the backup is complete.
     // let dest_path_filename = dc_get_next_backup_file(context, dir, res);
-    let dest_path_filename = dc_get_fine_path_filename(context, dir, res);
+    let now = time();
+    let dest_path_filename = dc_get_next_backup_path(dir, now)?;
 
     sql::housekeeping(context);
 


### PR DESCRIPTION
this aims to fix #597 by removing the dc_get_fine_path_filename method and introducing two helpers:

- context.new_blob_file(orig_path, data) which creates a new file in the blobdir, with the filename based on orig_path. 

- context.copy_to_blobdir(path) which copies a path into the blobdir, also with filename mangling if necessary 

the two new methods return both $BLOBDIR/<filename> strings, as they are then used to be written to the database which expects $BLOBDIR, and not absolute paths. 
