### PR TITLE
some incoming-message cleanups, and possibly a fix for a crash

### DIFF
--- a/mmime/src/display.rs
+++ b/mmime/src/display.rs
@@ -123,7 +123,7 @@ unsafe fn display_mime_discrete_type(mut discrete_type: *mut mailmime_discrete_t
         _ => {}
     };
 }
-unsafe fn display_mime_data(mut data: *mut mailmime_data) {
+pub unsafe fn display_mime_data(mut data: *mut mailmime_data) {
     match (*data).dt_type {
         0 => {
             println!(

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -29,6 +29,7 @@ use crate::peerstate::*;
 use crate::securejoin::handle_securejoin_handshake;
 use crate::sql;
 use crate::stock::StockMessage;
+use crate::wrapmime;
 
 #[derive(Debug, PartialEq, Eq)]
 enum CreateEvent {
@@ -795,7 +796,7 @@ unsafe fn handle_reports(
                         b"disposition-notification\x00" as *const u8 as *const libc::c_char,
                     ) == 0
                 {
-                    if let Ok(report_body) = mailmime_transfer_decode(report_data) {
+                    if let Ok(report_body) = wrapmime::mailmime_transfer_decode(report_data) {
                         let mut report_parsed = std::ptr::null_mut();
                         let mut dummy = 0;
 
@@ -807,13 +808,14 @@ unsafe fn handle_reports(
                         ) == MAIL_NO_ERROR as libc::c_int
                             && !report_parsed.is_null()
                         {
-                            let report_fields = mailmime_find_mailimf_fields(report_parsed);
+                            let report_fields =
+                                wrapmime::mailmime_find_mailimf_fields(report_parsed);
                             if !report_fields.is_null() {
-                                let of_disposition = mailimf_find_optional_field(
+                                let of_disposition = wrapmime::mailimf_find_optional_field(
                                     report_fields,
                                     b"Disposition\x00" as *const u8 as *const libc::c_char,
                                 );
-                                let of_org_msgid = mailimf_find_optional_field(
+                                let of_org_msgid = wrapmime::mailimf_find_optional_field(
                                     report_fields,
                                     b"Original-Message-ID\x00" as *const u8 as *const libc::c_char,
                                 );

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -16,7 +16,7 @@ use crate::chat::{self, Chat};
 use crate::constants::*;
 use crate::contact::*;
 use crate::context::{get_version_str, Context};
-use crate::dc_mimeparser::{mailmime_find_mailimf_fields, SystemMessage};
+use crate::dc_mimeparser::SystemMessage;
 use crate::dc_strencode::*;
 use crate::dc_tools::*;
 use crate::e2ee::*;
@@ -645,7 +645,7 @@ impl<'a> MimeFactory<'a> {
         );
 
         /*just a pointer into mailmime structure, must not be freed*/
-        let imffields_unprotected = mailmime_find_mailimf_fields(message);
+        let imffields_unprotected = wrapmime::mailmime_find_mailimf_fields(message);
         ensure!(
             !imffields_unprotected.is_null(),
             "could not find mime fields"


### PR DESCRIPTION
- shifted several mmime-helpers to wrapmime. helper methods are always called as wrapmime::... to make it obvious in the code where mmime comes in.  wrapmime-methods can be called safe but they do invoke unsafe code which depends on the overall allocation/free handling of all the unsafe-parts.   

- the only real functionality change happened with the removal of redundant code, of which 
  one version was like leaking things or worse.  This is in commit https://github.com/deltachat/deltachat-core-rust/commit/fdd21edf0bd06b6842931f6e06be720b12564224 

this is part of an ongoing attempt to make the incoming-message pipeline safer and easier to debug ... still some way to go.  It'd be intersesting to run ios/desktop with my most two recent PRs (also the blobfile-one) ... 


