### PR TITLE
add sticker type

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3720,6 +3720,14 @@ int64_t          dc_lot_get_timestamp     (const dc_lot_t* lot);
 
 
 /**
+ * Message containing a sticker, similar to image.
+ * If possible, the ui should display the image without borders in a transparent way.
+ * A click on a sticker will offer to install the sticker set in some future.
+ */
+#define DC_MSG_STICKER     23
+
+
+/**
  * Message containing an Audio file.
  * File and duration are set via dc_msg_set_file(), dc_msg_set_duration()
  * and retrieved via dc_msg_get_file(), dc_msg_get_duration().

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -646,6 +646,7 @@ pub fn msgtype_has_file(msgtype: Viewtype) -> bool {
     match msgtype {
         Viewtype::Image => true,
         Viewtype::Gif => true,
+        Viewtype::Sticker => true,
         Viewtype::Audio => true,
         Viewtype::Voice => true,
         Viewtype::Video => true,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -195,6 +195,11 @@ pub enum Viewtype {
     /// and retrieved via dc_msg_get_file(), dc_msg_get_width(), dc_msg_get_height().
     Gif = 21,
 
+    /// Message containing a sticker, similar to image.
+    /// If possible, the ui should display the image without borders in a transparent way.
+    /// A click on a sticker will offer to install the sticker set in some future.
+    Sticker = 23,
+
     /// Message containing an Audio file.
     /// File and duration are set via dc_msg_set_file(), dc_msg_set_duration()
     /// and retrieved via dc_msg_get_file(), dc_msg_get_duration().
@@ -299,7 +304,8 @@ const DC_STR_MSGACTIONBYME: usize = 63;
 const DC_STR_MSGLOCATIONENABLED: usize = 64;
 const DC_STR_MSGLOCATIONDISABLED: usize = 65;
 const DC_STR_LOCATION: usize = 66;
-const DC_STR_COUNT: usize = 66;
+const DC_STR_STICKER: usize = 67;
+const DC_STR_COUNT: usize = 67;
 
 pub const DC_JOB_DELETE_MSG_ON_IMAP: i32 = 110;
 

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -189,6 +189,7 @@ impl<'a> MimeParser<'a> {
                     textpart.typ == Viewtype::Text
                         && (filepart.typ == Viewtype::Image
                             || filepart.typ == Viewtype::Gif
+                            || filepart.typ == Viewtype::Sticker
                             || filepart.typ == Viewtype::Audio
                             || filepart.typ == Viewtype::Voice
                             || filepart.typ == Viewtype::Video
@@ -254,6 +255,14 @@ impl<'a> MimeParser<'a> {
                     if self.lookup_optional_field("Chat-Voice-Message").is_some() {
                         let part_mut = &mut self.parts[0];
                         part_mut.typ = Viewtype::Voice;
+                    }
+                }
+                if self.parts[0].typ == Viewtype::Image {
+                    if let Some(content_type) = self.lookup_optional_field("Chat-Content") {
+                        if content_type == "sticker".to_string() {
+                            let part_mut = &mut self.parts[0];
+                            part_mut.typ = Viewtype::Sticker;
+                        }
                     }
                 }
                 let part = &self.parts[0];

--- a/src/message.rs
+++ b/src/message.rs
@@ -818,6 +818,7 @@ pub fn get_summarytext_by_raw(
     let prefix = match viewtype {
         Viewtype::Image => context.stock_str(StockMessage::Image).into_owned(),
         Viewtype::Gif => context.stock_str(StockMessage::Gif).into_owned(),
+        Viewtype::Sticker => context.stock_str(StockMessage::Sticker).into_owned(),
         Viewtype::Video => context.stock_str(StockMessage::Video).into_owned(),
         Viewtype::Voice => context.stock_str(StockMessage::VoiceMessage).into_owned(),
         Viewtype::Audio | Viewtype::File => {

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -435,8 +435,7 @@ impl<'a> MimeFactory<'a> {
                     }
                 }
 
-                if self.msg.type_0 == Viewtype::Sticker
-                {
+                if self.msg.type_0 == Viewtype::Sticker {
                     wrapmime::new_custom_field(imf_fields, "Chat-Content", "sticker");
                 }
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -435,6 +435,11 @@ impl<'a> MimeFactory<'a> {
                     }
                 }
 
+                if self.msg.type_0 == Viewtype::Sticker
+                {
+                    wrapmime::new_custom_field(imf_fields, "Chat-Content", "sticker");
+                }
+
                 if self.msg.type_0 == Viewtype::Voice
                     || self.msg.type_0 == Viewtype::Audio
                     || self.msg.type_0 == Viewtype::Video

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -109,6 +109,8 @@ pub enum StockMessage {
     MsgLocationDisabled = 65,
     #[strum(props(fallback = "Location"))]
     Location = 66,
+    #[strum(props(fallback = "Sticker"))]
+    Sticker = 67,
 }
 
 impl StockMessage {


### PR DESCRIPTION
this pr adds the message type 'sticker'.
stickers are handled as normal images
but tagged with the header `Chat-Content: sticker`
it's up to the ui to render these stickers appropriate.