### PR TITLE
don't let save_to_db() crash the process 

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1672,7 +1672,7 @@ fn check_verified_properties(
                 let fp = peerstate.gossip_key_fingerprint.clone();
                 if let Some(fp) = fp {
                     peerstate.set_verified(0, &fp, 2);
-                    peerstate.save_to_db(&context.sql, false).unwrap();
+                    peerstate.save_to_db(&context.sql, false)?;
                     is_verified = true;
                 }
             }

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -284,16 +284,16 @@ pub fn try_decrypt(
         if let Some(ref mut peerstate) = peerstate {
             if let Some(ref header) = autocryptheader {
                 peerstate.apply_header(&header, message_time);
-                peerstate.save_to_db(&context.sql, false).unwrap();
+                peerstate.save_to_db(&context.sql, false)?;
             } else if message_time > peerstate.last_seen_autocrypt
                 && !contains_report(in_out_message)
             {
                 peerstate.degrade_encryption(message_time);
-                peerstate.save_to_db(&context.sql, false).unwrap();
+                peerstate.save_to_db(&context.sql, false)?;
             }
         } else if let Some(ref header) = autocryptheader {
             let p = Peerstate::from_header(context, header, message_time);
-            p.save_to_db(&context.sql, true).unwrap();
+            p.save_to_db(&context.sql, true)?;
             peerstate = Some(p);
         }
     }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -777,7 +777,7 @@ fn open(
                         if let Some(ref mut peerstate) = Peerstate::from_addr(context, sql, &addr?)
                         {
                             peerstate.recalc_fingerprint();
-                            peerstate.save_to_db(sql, false).unwrap();
+                            peerstate.save_to_db(sql, false)?;
                         }
                     }
                     Ok(())


### PR DESCRIPTION
on some call sites fixed: peerstate.save_to_db() should bubble up errors instead of crashing.  @adbenitez had reported a crash on one of them. 

also write a test that double-creation of an addr-row is fine. 