### PR TITLE
move contact-requests to the beginning of chatlists

### DIFF
--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -182,7 +182,7 @@ impl Chatlist {
             if 0 == listflags & DC_GCL_NO_SPECIALS {
                 let last_deaddrop_fresh_msg_id = get_last_deaddrop_fresh_msg(context);
                 if last_deaddrop_fresh_msg_id > 0 {
-                    ids.push((1, last_deaddrop_fresh_msg_id));
+                    ids.insert(0, (DC_CHAT_ID_DEADDROP, last_deaddrop_fresh_msg_id));
                 }
                 add_archived_link_item = 1;
             }


### PR DESCRIPTION
contact-requests of non-blocked senders are shown in the chatlist,
so that the user gets aware of them without opening the contact-request-chat.
however, for that, the contact-request virtual-chat-id
must be added to the beginning of the list,
otherwise it won't get noticed by the user.

fixes #657
and finally fixes https://github.com/deltachat/deltachat-ios/issues/261
desktop has the same issue, however, seems not to written down somewhere :)