### PR TITLE
introduce bcc-self setting, cleanup config access, fix e2ee, rustify outoing pipeline

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1246,7 +1246,7 @@ pub unsafe extern "C" fn dc_forward_msgs(
     let ffi_context = &*context;
     ffi_context
         .with_inner(|ctx| chat::forward_msgs(ctx, ids, chat_id))
-        .unwrap_or(())
+        .unwrap_or_log_default(ctx, "Failed to forard message")
 }
 
 #[no_mangle]

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1245,8 +1245,11 @@ pub unsafe extern "C" fn dc_forward_msgs(
 
     let ffi_context = &*context;
     ffi_context
-        .with_inner(|ctx| chat::forward_msgs(ctx, ids, chat_id))
-        .unwrap_or_log_default(ctx, "Failed to forard message")
+        .with_inner(|ctx| {
+            chat::forward_msgs(ctx, ids, chat_id)
+                .unwrap_or_log_default(ctx, "Failed to forward message")
+        })
+        .unwrap_or_default()
 }
 
 #[no_mangle]

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -864,7 +864,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             let mut msg_ids = [0; 1];
             let chat_id = arg2.parse()?;
             msg_ids[0] = arg1.parse()?;
-            chat::forward_msgs(context, &msg_ids, chat_id);
+            chat::forward_msgs(context, &msg_ids, chat_id)?;
         }
         "markseen" => {
             ensure!(!arg1.is_empty(), "Argument <msg-id> missing.");

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -299,11 +299,7 @@ impl Chat {
             so that E2EE is no longer available at a later point (reset, changed settings),
             we do not send the message out at all */
             do_guarantee_e2ee = false;
-            e2ee_enabled = context
-                .sql
-                .get_config_int(context, "e2ee_enabled")
-                .unwrap_or_else(|| 1)
-                == 1;
+            e2ee_enabled = context.get_config_bool(Config::E2eeEnabled);
             if e2ee_enabled && msg.param.get_int(Param::ForcePlaintext).unwrap_or_default() == 0 {
                 let mut can_encrypt = 1;
                 let mut all_mutual = 1;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -805,8 +805,7 @@ pub fn send_msg(context: &Context, chat_id: u32, msg: &mut Message) -> Result<u3
                     break;
                 } else {
                     if let Ok(mut copy) = Message::load_from_db(context, id as u32) {
-                        // TODO: handle cleanup and return early instead
-                        send_msg(context, 0, &mut copy).unwrap();
+                        send_msg(context, 0, &mut copy)?;
                     }
                 }
             }
@@ -1421,7 +1420,7 @@ pub(crate) fn add_contact_to_chat_ex(
         msg.param.set_int(Param::Cmd, 4);
         msg.param.set(Param::Arg, contact.get_addr());
         msg.param.set_int(Param::Arg2, from_handshake.into());
-        msg.id = send_msg(context, chat_id, &mut msg).unwrap_or_default();
+        msg.id = send_msg(context, chat_id, &mut msg)?;
         context.call_cb(Event::MsgsChanged {
             chat_id,
             msg_id: msg.id,
@@ -1532,7 +1531,7 @@ pub fn remove_contact_from_chat(
                         }
                         msg.param.set_int(Param::Cmd, 5);
                         msg.param.set(Param::Arg, contact.get_addr());
-                        msg.id = send_msg(context, chat_id, &mut msg).unwrap_or_default();
+                        msg.id = send_msg(context, chat_id, &mut msg)?;
                         context.call_cb(Event::MsgsChanged {
                             chat_id,
                             msg_id: msg.id,
@@ -1629,7 +1628,7 @@ pub fn set_chat_name(
                     if !chat.name.is_empty() {
                         msg.param.set(Param::Arg, &chat.name);
                     }
-                    msg.id = send_msg(context, chat_id, &mut msg).unwrap_or_default();
+                    msg.id = send_msg(context, chat_id, &mut msg)?;
                     context.call_cb(Event::MsgsChanged {
                         chat_id,
                         msg_id: msg.id,
@@ -1698,7 +1697,7 @@ pub fn set_chat_profile_image(
                     "",
                     DC_CONTACT_ID_SELF,
                 ));
-                msg.id = send_msg(context, chat_id, &mut msg).unwrap_or_default();
+                msg.id = send_msg(context, chat_id, &mut msg)?;
                 emit_event!(
                     context,
                     Event::MsgsChanged {

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,8 @@ pub enum Config {
     Selfstatus,
     Selfavatar,
     #[strum(props(default = "1"))]
+    BccSelf,
+    #[strum(props(default = "1"))]
     E2eeEnabled,
     #[strum(props(default = "1"))]
     MdnsEnabled,
@@ -90,6 +92,14 @@ impl Context {
             Config::Selfstatus => Some(self.stock_str(StockMessage::StatusLine).into_owned()),
             _ => key.get_str("default").map(|s| s.to_string()),
         }
+    }
+
+    pub fn get_config_int(&self, key: Config) -> i32 {
+        self.get_config(key).and_then(|s| s.parse().ok()).unwrap()
+    }
+
+    pub fn get_config_bool(&self, key: Config) -> bool {
+        self.get_config_int(key) != 0
     }
 
     /// Set the given config key.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -25,7 +25,6 @@ impl Default for MoveState {
 
 // some defaults
 const DC_E2EE_DEFAULT_ENABLED: i32 = 1;
-pub const DC_MDNS_DEFAULT_ENABLED: i32 = 1;
 const DC_INBOX_WATCH_DEFAULT: i32 = 1;
 const DC_SENTBOX_WATCH_DEFAULT: i32 = 1;
 const DC_MVBOX_WATCH_DEFAULT: i32 = 1;

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, Condvar, Mutex, RwLock};
 use libc::uintptr_t;
 
 use crate::chat::*;
+use crate::config::Config;
 use crate::constants::*;
 use crate::contact::*;
 use crate::dc_tools::{dc_copy_file, dc_derive_safe_stem_ext};
@@ -234,14 +235,10 @@ impl Context {
             .sql
             .get_config_int(self, "dbversion")
             .unwrap_or_default();
-        let e2ee_enabled = self
-            .sql
-            .get_config_int(self, "e2ee_enabled")
-            .unwrap_or_else(|| 1);
-        let mdns_enabled = self
-            .sql
-            .get_config_int(self, "mdns_enabled")
-            .unwrap_or_else(|| 1);
+
+        let e2ee_enabled = self.get_config_int(Config::E2eeEnabled);
+        let mdns_enabled = self.get_config_int(Config::MdnsEnabled);
+        let bcc_self = self.get_config_int(Config::BccSelf);
 
         let prv_key_cnt: Option<isize> =
             self.sql
@@ -259,26 +256,15 @@ impl Context {
             "<Not yet calculated>".into()
         };
 
-        let inbox_watch = self
-            .sql
-            .get_config_int(self, "inbox_watch")
-            .unwrap_or_else(|| 1);
-        let sentbox_watch = self
-            .sql
-            .get_config_int(self, "sentbox_watch")
-            .unwrap_or_else(|| 1);
-        let mvbox_watch = self
-            .sql
-            .get_config_int(self, "mvbox_watch")
-            .unwrap_or_else(|| 1);
-        let mvbox_move = self
-            .sql
-            .get_config_int(self, "mvbox_move")
-            .unwrap_or_else(|| 1);
+        let inbox_watch = self.get_config_int(Config::InboxWatch);
+        let sentbox_watch = self.get_config_int(Config::SentboxWatch);
+        let mvbox_watch = self.get_config_int(Config::MvboxWatch);
+        let mvbox_move = self.get_config_int(Config::MvboxMove);
         let folders_configured = self
             .sql
             .get_config_int(self, "folders_configured")
             .unwrap_or_default();
+
         let configured_sentbox_folder = self
             .sql
             .get_config(self, "configured_sentbox_folder")
@@ -309,6 +295,7 @@ impl Context {
         res.insert("configured_mvbox_folder", configured_mvbox_folder);
         res.insert("mdns_enabled", mdns_enabled.to_string());
         res.insert("e2ee_enabled", e2ee_enabled.to_string());
+        res.insert("bcc_self", bcc_self.to_string());
         res.insert(
             "private_key_count",
             prv_key_cnt.unwrap_or_default().to_string(),

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -13,6 +13,7 @@ use mmime::other::*;
 use sha2::{Digest, Sha256};
 
 use crate::chat::{self, Chat};
+use crate::config::Config;
 use crate::constants::*;
 use crate::contact::*;
 use crate::context::Context;
@@ -371,10 +372,7 @@ unsafe fn add_parts(
     // maybe this can be optimized later, by checking the state before the message body is downloaded
     let mut allow_creation = 1;
     if mime_parser.is_system_message != SystemMessage::AutocryptSetupMessage && msgrmsg == 0 {
-        let show_emails = context
-            .sql
-            .get_config_int(context, "show_emails")
-            .unwrap_or_default();
+        let show_emails = context.get_config_int(Config::ShowEmails);
         if show_emails == 0 {
             *chat_id = 3;
             allow_creation = 0
@@ -737,10 +735,7 @@ unsafe fn handle_reports(
     server_folder: impl AsRef<str>,
     server_uid: u32,
 ) {
-    let mdns_enabled = context
-        .sql
-        .get_config_int(context, "mdns_enabled")
-        .unwrap_or_else(|| DC_MDNS_DEFAULT_ENABLED);
+    let mdns_enabled = context.get_config_bool(Config::MdnsEnabled);
 
     for report_root in &mime_parser.reports {
         let report_root = *report_root;
@@ -759,7 +754,7 @@ unsafe fn handle_reports(
             && (*(*report_root).mm_data.mm_multipart.mm_mp_list).count >= 2
         {
             // to get a clear functionality, do not show incoming MDNs if the options is disabled
-            if 0 != mdns_enabled {
+            if mdns_enabled {
                 let report_data = (if !if !(*(*report_root).mm_data.mm_multipart.mm_mp_list)
                     .first
                     .is_null()

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -46,12 +46,8 @@ pub struct EncryptHelper {
 
 impl EncryptHelper {
     pub fn new(context: &Context) -> Result<EncryptHelper> {
-        let prefer_encrypt = context
-            .sql
-            .get_config_int(&context, "e2ee_enabled")
-            .and_then(EncryptPreference::from_i32)
-            .unwrap_or_default();
-
+        let prefer_encrypt =
+            EncryptPreference::from_i32(context.get_config_int(Config::E2eeEnabled)).unwrap();
         let addr = match context.get_config(Config::ConfiguredAddr) {
             None => {
                 bail!("addr not configured!");

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -195,13 +195,9 @@ pub fn render_setup_file(context: &Context, passphrase: &str) -> Result<String> 
     let self_addr = e2ee::ensure_secret_key_exists(context)?;
     let private_key = Key::from_self_private(context, self_addr, &context.sql)
         .ok_or(format_err!("Failed to get private key."))?;
-    let ac_headers = match context
-        .sql
-        .get_config_int(context, Config::E2eeEnabled)
-        .unwrap_or(1)
-    {
-        0 => None,
-        _ => Some(("Autocrypt-Prefer-Encrypt", "mutual")),
+    let ac_headers = match context.get_config_bool(Config::E2eeEnabled) {
+        false => None,
+        true => Some(("Autocrypt-Prefer-Encrypt", "mutual")),
     };
     let private_key_asc = private_key.to_asc(ac_headers);
     let encr = dc_pgp_symm_encrypt(&passphrase, private_key_asc.as_bytes())?;

--- a/src/job.rs
+++ b/src/job.rs
@@ -4,6 +4,7 @@ use deltachat_derive::{FromSql, ToSql};
 use rand::{thread_rng, Rng};
 
 use crate::chat;
+use crate::config::Config;
 use crate::configure::*;
 use crate::constants::*;
 use crate::context::Context;
@@ -666,11 +667,13 @@ pub fn job_send_msg(context: &Context, msg_id: u32) -> Result<(), Error> {
             mimefactory.msg.param.get_int(Param::GuranteeE2ee),
         );
     }
-    if !vec_contains_lowercase(&mimefactory.recipients_addr, &mimefactory.from_addr) {
-        mimefactory.recipients_names.push("".to_string());
-        mimefactory
-            .recipients_addr
-            .push(mimefactory.from_addr.to_string());
+    if context.get_config_bool(Config::BccSelf) {
+        if !vec_contains_lowercase(&mimefactory.recipients_addr, &mimefactory.from_addr) {
+            mimefactory.recipients_names.push("".to_string());
+            mimefactory
+                .recipients_addr
+                .push(mimefactory.from_addr.to_string());
+        }
     }
 
     if mimefactory.recipients_addr.is_empty() {

--- a/src/job.rs
+++ b/src/job.rs
@@ -318,10 +318,7 @@ impl Job {
                 }
                 _ => {
                     if 0 != msg.param.get_int(Param::WantsMdn).unwrap_or_default()
-                        && 0 != context
-                            .sql
-                            .get_config_int(context, "mdns_enabled")
-                            .unwrap_or_else(|| 1)
+                        && context.get_config_bool(Config::MdnsEnabled)
                     {
                         let folder = msg.server_folder.as_ref().unwrap();
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -143,16 +143,11 @@ impl<'a> MimeFactory<'a> {
     /*******************************************************************************
      * Render a basic email
      ******************************************************************************/
-    // restrict unsafe to parts, introduce wrapmime helpers where appropriate
+    // XXX restrict unsafe to parts, introduce wrapmime helpers where appropriate
     pub unsafe fn render(&mut self) -> Result<(), Error> {
         if self.loaded == Loaded::Nothing || !self.out.is_null() {
             bail!("Invalid use of mimefactory-object.");
         }
-        ensure!(
-            !self.recipients_names.is_empty() && !self.recipients_addr.is_empty(),
-            "message has no recipients"
-        );
-
         let context = &self.context;
         let from = wrapmime::new_mailbox_list(&self.from_displayname, &self.from_addr);
 

--- a/src/wrapmime.rs
+++ b/src/wrapmime.rs
@@ -3,6 +3,7 @@ use std::ffi::CString;
 use std::ptr;
 
 use crate::contact::addr_normalize;
+use crate::dc_strencode::*;
 use crate::dc_tools::*;
 use crate::error::Error;
 use mmime::clist::*;
@@ -478,6 +479,24 @@ pub fn content_type_needs_encoding(content: *const mailmime_content) -> bool {
             true
         }
     }
+}
+
+pub fn new_mailbox_list(displayname: &str, addr: &str) -> *mut mailimf_mailbox_list {
+    let mbox: *mut mailimf_mailbox_list = unsafe { mailimf_mailbox_list_new_empty() };
+    unsafe {
+        mailimf_mailbox_list_add(
+            mbox,
+            mailimf_mailbox_new(
+                if !displayname.is_empty() {
+                    dc_encode_header_words(&displayname).strdup()
+                } else {
+                    ptr::null_mut()
+                },
+                addr.strdup(),
+            ),
+        );
+    }
+    mbox
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- test and fix #662 introduces a new "bcc_self" bool with which you can control whether mails are BCCed out
  
- resultify several methods related to the outgoing-mail pipeline, better error-reporting and more precise SMTP events. 

- introduce new "context.get_config_int" and "context.get_config_bool" helpers that respect the defaults which are declared with the Config enum in config.rs ... and refactor mdns_enabled and e2ee_enabled access to use the new methods, thereby fixes #661 (in e2ee the default was wrong).  Note that by far not all usages of "sql.get_config_int" were replaced -- that's for another PR and might prevent further "default-wrong" bugs. 
