### PR TITLE
tweak config

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -125,7 +125,7 @@ fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int {
             .set_config(context, "import_spec", Some(&real_spec))
             .unwrap();
     } else {
-        let rs = context.sql.get_config(context, "import_spec");
+        let rs = context.sql.get_raw_config(context, "import_spec");
         if rs.is_none() {
             error!(context, "Import: No file or folder given.");
             return 0;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -951,10 +951,7 @@ pub fn get_chat_msgs(context: &Context, chat_id: u32, flags: u32, marker1before:
     };
 
     let success = if chat_id == 1 {
-        let show_emails = context
-            .sql
-            .get_config_int(context, "show_emails")
-            .unwrap_or_default();
+        let show_emails = context.get_config_int(Config::ShowEmails);
         context.sql.query_map(
             "SELECT m.id, m.timestamp FROM msgs m \
              LEFT JOIN chats ON m.chat_id=chats.id \
@@ -1373,8 +1370,7 @@ pub(crate) fn add_contact_to_chat_ex(
         chat.update_param(context).unwrap();
     }
     let self_addr = context
-        .sql
-        .get_config(context, "configured_addr")
+        .get_config(Config::ConfiguredAddr)
         .unwrap_or_default();
     if contact.get_addr() == &self_addr {
         bail!("invalid attempt to add self e-mail address to group");

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,13 +78,13 @@ impl Context {
     pub fn get_config(&self, key: Config) -> Option<String> {
         let value = match key {
             Config::Selfavatar => {
-                let rel_path = self.sql.get_config(self, key);
+                let rel_path = self.sql.get_raw_config(self, key);
                 rel_path.map(|p| dc_get_abs_path(self, &p).to_str().unwrap().to_string())
             }
             Config::SysVersion => Some((&*DC_VERSION_STR).clone()),
             Config::SysMsgsizeMaxRecommended => Some(format!("{}", 24 * 1024 * 1024 / 4 * 3)),
             Config::SysConfigKeys => Some(get_config_keys_string()),
-            _ => self.sql.get_config(self, key),
+            _ => self.sql.get_raw_config(self, key),
         };
 
         if value.is_some() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,7 +99,9 @@ impl Context {
     }
 
     pub fn get_config_int(&self, key: Config) -> i32 {
-        self.get_config(key).and_then(|s| s.parse().ok()).unwrap()
+        self.get_config(key)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_default()
     }
 
     pub fn get_config_bool(&self, key: Config) -> bool {

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -38,7 +38,7 @@ pub unsafe fn configure(context: &Context) {
 
 /// Check if the context is already configured.
 pub fn dc_is_configured(context: &Context) -> bool {
-    context.sql.get_config_bool(context, "configured")
+    context.sql.get_raw_config_bool(context, "configured")
 }
 
 /*******************************************************************************
@@ -604,7 +604,7 @@ pub fn dc_connect_to_configured_imap(context: &Context, imap: &Imap) -> libc::c_
         ret_connected = 1
     } else if context
         .sql
-        .get_config_int(context, "configured")
+        .get_raw_config_int(context, "configured")
         .unwrap_or_default()
         == 0
     {

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -1,5 +1,6 @@
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
+use crate::config::Config;
 use crate::constants::*;
 use crate::context::Context;
 use crate::dc_tools::*;
@@ -476,15 +477,8 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context) {
                     }
                     16 => {
                         progress!(context, 900);
-                        let flags: libc::c_int = if 0
-                            != context
-                                .sql
-                                .get_config_int(context, "mvbox_watch")
-                                .unwrap_or_else(|| 1)
-                            || 0 != context
-                                .sql
-                                .get_config_int(context, "mvbox_move")
-                                .unwrap_or_else(|| 1)
+                        let flags: libc::c_int = if 0 != context.get_config_int(Config::MvboxWatch)
+                            || 0 != context.get_config_int(Config::MvboxMove)
                         {
                             DC_CREATE_MVBOX as i32
                         } else {

--- a/src/context.rs
+++ b/src/context.rs
@@ -222,15 +222,12 @@ impl Context {
         let unset = "0";
         let l = LoginParam::from_database(self, "");
         let l2 = LoginParam::from_database(self, "configured_");
-        let displayname = self.sql.get_config(self, "displayname");
+        let displayname = self.get_config(Config::Displayname);
         let chats = get_chat_cnt(self) as usize;
         let real_msgs = message::get_real_msg_cnt(self) as usize;
         let deaddrop_msgs = message::get_deaddrop_msg_cnt(self) as usize;
         let contacts = Contact::get_real_cnt(self) as usize;
-        let is_configured = self
-            .sql
-            .get_config_int(self, "configured")
-            .unwrap_or_default();
+        let is_configured = self.get_config_int(Config::Configured);
         let dbversion = self
             .sql
             .get_config_int(self, "dbversion")
@@ -394,12 +391,7 @@ impl Context {
     }
 
     pub fn do_heuristics_moves(&self, folder: &str, msg_id: u32) {
-        if self
-            .sql
-            .get_config_int(self, "mvbox_move")
-            .unwrap_or_else(|| 1)
-            == 0
-        {
+        if self.get_config_int(Config::MvboxMove) == 0 {
             return;
         }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -230,7 +230,7 @@ impl Context {
         let is_configured = self.get_config_int(Config::Configured);
         let dbversion = self
             .sql
-            .get_config_int(self, "dbversion")
+            .get_raw_config_int(self, "dbversion")
             .unwrap_or_default();
 
         let e2ee_enabled = self.get_config_int(Config::E2eeEnabled);
@@ -259,16 +259,16 @@ impl Context {
         let mvbox_move = self.get_config_int(Config::MvboxMove);
         let folders_configured = self
             .sql
-            .get_config_int(self, "folders_configured")
+            .get_raw_config_int(self, "folders_configured")
             .unwrap_or_default();
 
         let configured_sentbox_folder = self
             .sql
-            .get_config(self, "configured_sentbox_folder")
+            .get_raw_config(self, "configured_sentbox_folder")
             .unwrap_or_else(|| "<unset>".to_string());
         let configured_mvbox_folder = self
             .sql
-            .get_config(self, "configured_mvbox_folder")
+            .get_raw_config(self, "configured_mvbox_folder")
             .unwrap_or_else(|| "<unset>".to_string());
 
         let mut res = get_info();
@@ -372,7 +372,7 @@ impl Context {
     }
 
     pub fn is_sentbox(&self, folder_name: impl AsRef<str>) -> bool {
-        let sentbox_name = self.sql.get_config(self, "configured_sentbox_folder");
+        let sentbox_name = self.sql.get_raw_config(self, "configured_sentbox_folder");
         if let Some(name) = sentbox_name {
             name == folder_name.as_ref()
         } else {
@@ -381,7 +381,7 @@ impl Context {
     }
 
     pub fn is_mvbox(&self, folder_name: impl AsRef<str>) -> bool {
-        let mvbox_name = self.sql.get_config(self, "configured_mvbox_folder");
+        let mvbox_name = self.sql.get_raw_config(self, "configured_mvbox_folder");
 
         if let Some(name) = mvbox_name {
             name == folder_name.as_ref()

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -585,7 +585,7 @@ unsafe fn add_parts(
 
     // if the mime-headers should be saved, find out its size
     // (the mime-header ends with an empty line)
-    let save_mime_headers = context.sql.get_config_bool(context, "save_mime_headers");
+    let save_mime_headers = context.get_config_bool(Config::SaveMimeHeaders);
     if let Some(field) = mime_parser.lookup_field_typ("In-Reply-To", MAILIMF_FIELD_IN_REPLY_TO) {
         let fld_in_reply_to = (*field).fld_data.fld_in_reply_to;
         if !fld_in_reply_to.is_null() {
@@ -853,10 +853,7 @@ unsafe fn handle_reports(
                 param.set(Param::ServerFolder, server_folder.as_ref());
                 param.set_int(Param::ServerUid, server_uid as i32);
                 if mime_parser.is_send_by_messenger
-                    && 0 != context
-                        .sql
-                        .get_config_int(context, "mvbox_move")
-                        .unwrap_or_else(|| 1)
+                    && 0 != context.get_config_int(Config::MvboxMove)
                 {
                     param.set_int(Param::AlsoMove, 1);
                 }
@@ -1159,8 +1156,7 @@ unsafe fn create_or_lookup_group(
     group_explicitly_left = chat::is_group_explicitly_left(context, &grpid).unwrap_or_default();
 
     let self_addr = context
-        .sql
-        .get_config(context, "configured_addr")
+        .get_config(Config::ConfiguredAddr)
         .unwrap_or_default();
     if chat_id == 0
             && !mime_parser.is_mailinglist_message()
@@ -1490,8 +1486,7 @@ fn create_adhoc_grp_id(context: &Context, member_ids: &[u32]) -> String {
      */
     let member_ids_str = join(member_ids.iter().map(|x| x.to_string()), ",");
     let member_cs = context
-        .sql
-        .get_config(context, "configured_addr")
+        .get_config(Config::ConfiguredAddr)
         .unwrap_or_else(|| "no-self".to_string())
         .to_lowercase();
 
@@ -1942,8 +1937,7 @@ unsafe fn add_or_lookup_contact_by_addr(
     }
     *check_self = 0;
     let self_addr = context
-        .sql
-        .get_config(context, "configured_addr")
+        .get_config(Config::ConfiguredAddr)
         .unwrap_or_default();
 
     if addr_cmp(self_addr, as_str(addr_spec)) {

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -693,7 +693,7 @@ impl Imap {
 
     fn get_config_last_seen_uid<S: AsRef<str>>(&self, context: &Context, folder: S) -> (u32, u32) {
         let key = format!("imap.mailbox.{}", folder.as_ref());
-        if let Some(entry) = context.sql.get_config(context, &key) {
+        if let Some(entry) = context.sql.get_raw_config(context, &key) {
             // the entry has the format `imap.mailbox.<folder>=<uidvalidity>:<lastseenuid>`
             let mut parts = entry.split(':');
             (

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -90,7 +90,7 @@ pub fn has_backup(context: &Context, dir_name: impl AsRef<Path>) -> Result<Strin
                     let sql = Sql::new();
                     if sql.open(context, &path, 0x1) {
                         let curr_backup_time =
-                            sql.get_config_int(context, "backup_time")
+                            sql.get_raw_config_int(context, "backup_time")
                                 .unwrap_or_default() as u64;
                         if curr_backup_time > newest_backup_time {
                             newest_backup_path = Some(path);

--- a/src/job.rs
+++ b/src/job.rs
@@ -219,13 +219,13 @@ impl Job {
         if let Ok(msg) = Message::load_from_db(context, self.foreign_id) {
             if context
                 .sql
-                .get_config_int(context, "folders_configured")
+                .get_raw_config_int(context, "folders_configured")
                 .unwrap_or_default()
                 < 3
             {
                 inbox.configure_folders(context, 0x1i32);
             }
-            let dest_folder = context.sql.get_config(context, "configured_mvbox_folder");
+            let dest_folder = context.sql.get_raw_config(context, "configured_mvbox_folder");
 
             if let Some(dest_folder) = dest_folder {
                 let server_folder = msg.server_folder.as_ref().unwrap();
@@ -327,13 +327,13 @@ impl Job {
         if 0 != self.param.get_int(Param::AlsoMove).unwrap_or_default() {
             if context
                 .sql
-                .get_config_int(context, "folders_configured")
+                .get_raw_config_int(context, "folders_configured")
                 .unwrap_or_default()
                 < 3
             {
                 inbox.configure_folders(context, 0x1i32);
             }
-            let dest_folder = context.sql.get_config(context, "configured_mvbox_folder");
+            let dest_folder = context.sql.get_raw_config(context, "configured_mvbox_folder");
             if let Some(dest_folder) = dest_folder {
                 let mut dest_uid = 0;
                 if ImapResult::RetryLater

--- a/src/job.rs
+++ b/src/job.rs
@@ -364,12 +364,7 @@ pub fn perform_imap_fetch(context: &Context) {
     if 0 == connect_to_inbox(context, &inbox) {
         return;
     }
-    if context
-        .sql
-        .get_config_int(context, "inbox_watch")
-        .unwrap_or_else(|| 1)
-        == 0
-    {
+    if context.get_config_int(Config::InboxWatch) == 0 {
         info!(context, "INBOX-watch disabled.",);
         return;
     }
@@ -404,10 +399,7 @@ pub fn perform_imap_idle(context: &Context) {
 }
 
 pub fn perform_mvbox_fetch(context: &Context) {
-    let use_network = context
-        .sql
-        .get_config_int(context, "mvbox_watch")
-        .unwrap_or_else(|| 1);
+    let use_network = context.get_config_int(Config::MvboxWatch);
 
     context
         .mvbox_thread
@@ -417,10 +409,7 @@ pub fn perform_mvbox_fetch(context: &Context) {
 }
 
 pub fn perform_mvbox_idle(context: &Context) {
-    let use_network = context
-        .sql
-        .get_config_int(context, "mvbox_watch")
-        .unwrap_or_else(|| 1);
+    let use_network = context.get_config_int(Config::MvboxWatch);
 
     context
         .mvbox_thread
@@ -434,10 +423,7 @@ pub fn interrupt_mvbox_idle(context: &Context) {
 }
 
 pub fn perform_sentbox_fetch(context: &Context) {
-    let use_network = context
-        .sql
-        .get_config_int(context, "sentbox_watch")
-        .unwrap_or_else(|| 1);
+    let use_network = context.get_config_int(Config::SentboxWatch);
 
     context
         .sentbox_thread
@@ -447,10 +433,7 @@ pub fn perform_sentbox_fetch(context: &Context) {
 }
 
 pub fn perform_sentbox_idle(context: &Context) {
-    let use_network = context
-        .sql
-        .get_config_int(context, "sentbox_watch")
-        .unwrap_or_else(|| 1);
+    let use_network = context.get_config_int(Config::SentboxWatch);
 
     context
         .sentbox_thread

--- a/src/job.rs
+++ b/src/job.rs
@@ -225,7 +225,9 @@ impl Job {
             {
                 inbox.configure_folders(context, 0x1i32);
             }
-            let dest_folder = context.sql.get_raw_config(context, "configured_mvbox_folder");
+            let dest_folder = context
+                .sql
+                .get_raw_config(context, "configured_mvbox_folder");
 
             if let Some(dest_folder) = dest_folder {
                 let server_folder = msg.server_folder.as_ref().unwrap();
@@ -333,7 +335,9 @@ impl Job {
             {
                 inbox.configure_folders(context, 0x1i32);
             }
-            let dest_folder = context.sql.get_raw_config(context, "configured_mvbox_folder");
+            let dest_folder = context
+                .sql
+                .get_raw_config(context, "configured_mvbox_folder");
             if let Some(dest_folder) = dest_folder {
                 let mut dest_uid = 0;
                 if ImapResult::RetryLater

--- a/src/job_thread.rs
+++ b/src/job_thread.rs
@@ -116,14 +116,14 @@ impl JobThread {
         if ret_connected {
             if context
                 .sql
-                .get_config_int(context, "folders_configured")
+                .get_raw_config_int(context, "folders_configured")
                 .unwrap_or_default()
                 < 3
             {
                 self.imap.configure_folders(context, 0x1);
             }
 
-            if let Some(mvbox_name) = context.sql.get_config(context, self.folder_config_name) {
+            if let Some(mvbox_name) = context.sql.get_raw_config(context, self.folder_config_name) {
                 self.imap.set_watch_folder(mvbox_name);
             } else {
                 self.imap.disconnect(context);

--- a/src/location.rs
+++ b/src/location.rs
@@ -3,6 +3,7 @@ use quick_xml;
 use quick_xml::events::{BytesEnd, BytesStart, BytesText};
 
 use crate::chat;
+use crate::config::Config;
 use crate::constants::*;
 use crate::context::*;
 use crate::dc_tools::*;
@@ -375,8 +376,7 @@ pub fn get_kml(context: &Context, chat_id: u32) -> Result<(String, u32), Error> 
     let mut last_added_location_id = 0;
 
     let self_addr = context
-        .sql
-        .get_config(context, "configured_addr")
+        .get_config(Config::ConfiguredAddr)
         .unwrap_or_default();
 
     let (locations_send_begin, locations_send_until, locations_last_sent) = context.sql.query_row(

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -51,53 +51,53 @@ impl LoginParam {
 
         let key = format!("{}addr", prefix);
         let addr = sql
-            .get_config(context, key)
+            .get_raw_config(context, key)
             .unwrap_or_default()
             .trim()
             .to_string();
 
         let key = format!("{}mail_server", prefix);
-        let mail_server = sql.get_config(context, key).unwrap_or_default();
+        let mail_server = sql.get_raw_config(context, key).unwrap_or_default();
 
         let key = format!("{}mail_port", prefix);
-        let mail_port = sql.get_config_int(context, key).unwrap_or_default();
+        let mail_port = sql.get_raw_config_int(context, key).unwrap_or_default();
 
         let key = format!("{}mail_user", prefix);
-        let mail_user = sql.get_config(context, key).unwrap_or_default();
+        let mail_user = sql.get_raw_config(context, key).unwrap_or_default();
 
         let key = format!("{}mail_pw", prefix);
-        let mail_pw = sql.get_config(context, key).unwrap_or_default();
+        let mail_pw = sql.get_raw_config(context, key).unwrap_or_default();
 
         let key = format!("{}imap_certificate_checks", prefix);
         let imap_certificate_checks =
-            if let Some(certificate_checks) = sql.get_config_int(context, key) {
+            if let Some(certificate_checks) = sql.get_raw_config_int(context, key) {
                 num_traits::FromPrimitive::from_i32(certificate_checks).unwrap_or_default()
             } else {
                 Default::default()
             };
 
         let key = format!("{}send_server", prefix);
-        let send_server = sql.get_config(context, key).unwrap_or_default();
+        let send_server = sql.get_raw_config(context, key).unwrap_or_default();
 
         let key = format!("{}send_port", prefix);
-        let send_port = sql.get_config_int(context, key).unwrap_or_default();
+        let send_port = sql.get_raw_config_int(context, key).unwrap_or_default();
 
         let key = format!("{}send_user", prefix);
-        let send_user = sql.get_config(context, key).unwrap_or_default();
+        let send_user = sql.get_raw_config(context, key).unwrap_or_default();
 
         let key = format!("{}send_pw", prefix);
-        let send_pw = sql.get_config(context, key).unwrap_or_default();
+        let send_pw = sql.get_raw_config(context, key).unwrap_or_default();
 
         let key = format!("{}smtp_certificate_checks", prefix);
         let smtp_certificate_checks =
-            if let Some(certificate_checks) = sql.get_config_int(context, key) {
+            if let Some(certificate_checks) = sql.get_raw_config_int(context, key) {
                 num_traits::FromPrimitive::from_i32(certificate_checks).unwrap_or_default()
             } else {
                 Default::default()
             };
 
         let key = format!("{}server_flags", prefix);
-        let server_flags = sql.get_config_int(context, key).unwrap_or_default();
+        let server_flags = sql.get_raw_config_int(context, key).unwrap_or_default();
 
         LoginParam {
             addr: addr.to_string(),

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -60,11 +60,13 @@ pub struct MimeFactory<'a> {
 
 impl<'a> MimeFactory<'a> {
     fn new(context: &'a Context, msg: Message) -> Self {
-        let cget = |context: &Context, name: &str| context.sql.get_config(context, name);
         MimeFactory {
-            from_addr: cget(&context, "configured_addr").unwrap_or_default(),
-            from_displayname: cget(&context, "displayname").unwrap_or_default(),
-            selfstatus: cget(&context, "selfstatus")
+            from_addr: context
+                .get_config(Config::ConfiguredAddr)
+                .unwrap_or_default(),
+            from_displayname: context.get_config(Config::Displayname).unwrap_or_default(),
+            selfstatus: context
+                .get_config(Config::Selfstatus)
                 .unwrap_or_else(|| context.stock_str(StockMessage::StatusLine).to_string()),
             recipients_names: Vec::with_capacity(5),
             recipients_addr: Vec::with_capacity(5),
@@ -703,8 +705,7 @@ impl<'a> MimeFactory<'a> {
                 let email_to_remove = msg.param.get(Param::Arg).unwrap_or_default();
 
                 let self_addr = context
-                    .sql
-                    .get_config(context, "configured_addr")
+                    .get_config(Config::ConfiguredAddr)
                     .unwrap_or_default();
 
                 if !email_to_remove.is_empty() && email_to_remove != self_addr {

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -82,17 +82,17 @@ pub fn dc_get_oauth2_access_token(
 
         // read generated token
         if !regenerate && !is_expired(context) {
-            let access_token = context.sql.get_config(context, "oauth2_access_token");
+            let access_token = context.sql.get_raw_config(context, "oauth2_access_token");
             if access_token.is_some() {
                 // success
                 return access_token;
             }
         }
 
-        let refresh_token = context.sql.get_config(context, "oauth2_refresh_token");
+        let refresh_token = context.sql.get_raw_config(context, "oauth2_refresh_token");
         let refresh_token_for = context
             .sql
-            .get_config(context, "oauth2_refresh_token_for")
+            .get_raw_config(context, "oauth2_refresh_token_for")
             .unwrap_or_else(|| "unset".into());
 
         let (redirect_uri, token_url, update_redirect_uri_on_success) =
@@ -101,7 +101,7 @@ pub fn dc_get_oauth2_access_token(
                 (
                     context
                         .sql
-                        .get_config(context, "oauth2_pending_redirect_uri")
+                        .get_raw_config(context, "oauth2_pending_redirect_uri")
                         .unwrap_or_else(|| "unset".into()),
                     oauth2.init_token,
                     true,
@@ -114,7 +114,7 @@ pub fn dc_get_oauth2_access_token(
                 (
                     context
                         .sql
-                        .get_config(context, "oauth2_redirect_uri")
+                        .get_raw_config(context, "oauth2_redirect_uri")
                         .unwrap_or_else(|| "unset".into()),
                     oauth2.refresh_token,
                     false,
@@ -293,7 +293,7 @@ impl Oauth2 {
 fn is_expired(context: &Context) -> bool {
     let expire_timestamp = context
         .sql
-        .get_config_int64(context, "oauth2_timestamp_expires")
+        .get_raw_config_int64(context, "oauth2_timestamp_expires")
         .unwrap_or_default();
 
     if expire_timestamp <= 0 {

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -82,10 +82,7 @@ pub fn dc_get_securejoin_qr(context: &Context, group_chat_id: u32) -> Option<Str
         }
     };
 
-    let self_name = context
-        .sql
-        .get_config(context, "displayname")
-        .unwrap_or_default();
+    let self_name = context.get_config(Config::Displayname).unwrap_or_default();
 
     fingerprint = match get_self_fingerprint(context) {
         Some(fp) => fp,

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -241,7 +241,7 @@ impl Sql {
     }
 
     /// Get configuration options from the database.
-    pub fn get_config(&self, context: &Context, key: impl AsRef<str>) -> Option<String> {
+    pub fn get_raw_config(&self, context: &Context, key: impl AsRef<str>) -> Option<String> {
         if !self.is_open() || key.as_ref().is_empty() {
             return None;
         }
@@ -261,14 +261,14 @@ impl Sql {
         self.set_config(context, key, Some(&format!("{}", value)))
     }
 
-    pub fn get_config_int(&self, context: &Context, key: impl AsRef<str>) -> Option<i32> {
-        self.get_config(context, key).and_then(|s| s.parse().ok())
+    pub fn get_raw_config_int(&self, context: &Context, key: impl AsRef<str>) -> Option<i32> {
+        self.get_raw_config(context, key).and_then(|s| s.parse().ok())
     }
 
-    pub fn get_config_bool(&self, context: &Context, key: impl AsRef<str>) -> bool {
+    pub fn get_raw_config_bool(&self, context: &Context, key: impl AsRef<str>) -> bool {
         // Not the most obvious way to encode bool as string, but it is matter
         // of backward compatibility.
-        self.get_config_int(context, key).unwrap_or_default() > 0
+        self.get_raw_config_int(context, key).unwrap_or_default() > 0
     }
 
     pub fn set_config_bool<T>(&self, context: &Context, key: T, value: bool) -> Result<()>
@@ -288,8 +288,8 @@ impl Sql {
         self.set_config(context, key, Some(&format!("{}", value)))
     }
 
-    pub fn get_config_int64(&self, context: &Context, key: impl AsRef<str>) -> Option<i64> {
-        self.get_config(context, key).and_then(|r| r.parse().ok())
+    pub fn get_raw_config_int64(&self, context: &Context, key: impl AsRef<str>) -> Option<i64> {
+        self.get_raw_config(context, key).and_then(|r| r.parse().ok())
     }
 
     fn start_stmt(&self, stmt: impl AsRef<str>) {
@@ -481,7 +481,7 @@ fn open(
             }
         } else {
             exists_before_update = 1;
-            dbversion_before_update = sql.get_config_int(context, "dbversion").unwrap_or_default();
+            dbversion_before_update = sql.get_raw_config_int(context, "dbversion").unwrap_or_default();
         }
 
         // (1) update low-level database structure.
@@ -818,7 +818,7 @@ fn open(
             // this snippet converts older databases and can be removed after some time.
             info!(context, "[migration] update file paths");
             let repl_from = sql
-                .get_config(context, "backup_for")
+                .get_raw_config(context, "backup_for")
                 .unwrap_or_else(|| context.get_blobdir().to_string_lossy().into());
 
             let repl_from = dc_ensure_no_slash_safe(&repl_from);

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -262,7 +262,8 @@ impl Sql {
     }
 
     pub fn get_raw_config_int(&self, context: &Context, key: impl AsRef<str>) -> Option<i32> {
-        self.get_raw_config(context, key).and_then(|s| s.parse().ok())
+        self.get_raw_config(context, key)
+            .and_then(|s| s.parse().ok())
     }
 
     pub fn get_raw_config_bool(&self, context: &Context, key: impl AsRef<str>) -> bool {
@@ -289,7 +290,8 @@ impl Sql {
     }
 
     pub fn get_raw_config_int64(&self, context: &Context, key: impl AsRef<str>) -> Option<i64> {
-        self.get_raw_config(context, key).and_then(|r| r.parse().ok())
+        self.get_raw_config(context, key)
+            .and_then(|r| r.parse().ok())
     }
 
     fn start_stmt(&self, stmt: impl AsRef<str>) {
@@ -481,7 +483,9 @@ fn open(
             }
         } else {
             exists_before_update = 1;
-            dbversion_before_update = sql.get_raw_config_int(context, "dbversion").unwrap_or_default();
+            dbversion_before_update = sql
+                .get_raw_config_int(context, "dbversion")
+                .unwrap_or_default();
         }
 
         // (1) update low-level database structure.


### PR DESCRIPTION
- prefer context.get_config() over context.sql.get_config()
- do not panic on context.get_config_int(), fixes #669 
- rename raw config-getters to sql.get_raw_config*() to make more obvious that these function do no handle defaults and to make inadvertent use more obvious in the future