### PR TITLE
prefer get_config_bool() where appropriate

### DIFF
--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -477,8 +477,8 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context) {
                     }
                     16 => {
                         progress!(context, 900);
-                        let flags: libc::c_int = if 0 != context.get_config_int(Config::MvboxWatch)
-                            || 0 != context.get_config_int(Config::MvboxMove)
+                        let flags: libc::c_int = if context.get_config_bool(Config::MvboxWatch)
+                            || context.get_config_bool(Config::MvboxMove)
                         {
                             DC_CREATE_MVBOX as i32
                         } else {
@@ -602,12 +602,7 @@ pub fn dc_connect_to_configured_imap(context: &Context, imap: &Imap) -> libc::c_
 
     if imap.is_connected() {
         ret_connected = 1
-    } else if context
-        .sql
-        .get_raw_config_int(context, "configured")
-        .unwrap_or_default()
-        == 0
-    {
+    } else if !context.sql.get_raw_config_bool(context, "configured") {
         warn!(context, "Not configured, cannot connect.",);
     } else {
         let param = LoginParam::from_database(context, "configured_");

--- a/src/context.rs
+++ b/src/context.rs
@@ -393,7 +393,7 @@ impl Context {
     }
 
     pub fn do_heuristics_moves(&self, folder: &str, msg_id: u32) {
-        if self.get_config_int(Config::MvboxMove) == 0 {
+        if !self.get_config_bool(Config::MvboxMove) {
             return;
         }
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -852,9 +852,7 @@ unsafe fn handle_reports(
                 let mut param = Params::new();
                 param.set(Param::ServerFolder, server_folder.as_ref());
                 param.set_int(Param::ServerUid, server_uid as i32);
-                if mime_parser.is_send_by_messenger
-                    && 0 != context.get_config_int(Config::MvboxMove)
-                {
+                if mime_parser.is_send_by_messenger && context.get_config_bool(Config::MvboxMove) {
                     param.set_int(Param::AlsoMove, 1);
                 }
                 job_add(context, Action::MarkseenMdnOnImap, 0, param, 0);

--- a/src/job.rs
+++ b/src/job.rs
@@ -368,7 +368,7 @@ pub fn perform_imap_fetch(context: &Context) {
     if 0 == connect_to_inbox(context, &inbox) {
         return;
     }
-    if context.get_config_int(Config::InboxWatch) == 0 {
+    if !context.get_config_bool(Config::InboxWatch) {
         info!(context, "INBOX-watch disabled.",);
         return;
     }
@@ -403,23 +403,23 @@ pub fn perform_imap_idle(context: &Context) {
 }
 
 pub fn perform_mvbox_fetch(context: &Context) {
-    let use_network = context.get_config_int(Config::MvboxWatch);
+    let use_network = context.get_config_bool(Config::MvboxWatch);
 
     context
         .mvbox_thread
         .write()
         .unwrap()
-        .fetch(context, use_network == 1);
+        .fetch(context, use_network);
 }
 
 pub fn perform_mvbox_idle(context: &Context) {
-    let use_network = context.get_config_int(Config::MvboxWatch);
+    let use_network = context.get_config_bool(Config::MvboxWatch);
 
     context
         .mvbox_thread
         .read()
         .unwrap()
-        .idle(context, use_network == 1);
+        .idle(context, use_network);
 }
 
 pub fn interrupt_mvbox_idle(context: &Context) {
@@ -427,23 +427,23 @@ pub fn interrupt_mvbox_idle(context: &Context) {
 }
 
 pub fn perform_sentbox_fetch(context: &Context) {
-    let use_network = context.get_config_int(Config::SentboxWatch);
+    let use_network = context.get_config_bool(Config::SentboxWatch);
 
     context
         .sentbox_thread
         .write()
         .unwrap()
-        .fetch(context, use_network == 1);
+        .fetch(context, use_network);
 }
 
 pub fn perform_sentbox_idle(context: &Context) {
-    let use_network = context.get_config_int(Config::SentboxWatch);
+    let use_network = context.get_config_bool(Config::SentboxWatch);
 
     context
         .sentbox_thread
         .read()
         .unwrap()
-        .idle(context, use_network == 1);
+        .idle(context, use_network);
 }
 
 pub fn interrupt_sentbox_idle(context: &Context) {


### PR DESCRIPTION
for db input/output, we still use get_config_int() to convert to/from 0/1.
also for info() we prefer get_config_int() to show the real value.

successor of #670