### PR TITLE
rename sql-config-setters to set_raw_config*()

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -122,7 +122,7 @@ fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int {
         real_spec = to_string(spec);
         context
             .sql
-            .set_config(context, "import_spec", Some(&real_spec))
+            .set_raw_config(context, "import_spec", Some(&real_spec))
             .unwrap();
     } else {
         let rs = context.sql.get_raw_config(context, "import_spec");

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,20 +115,20 @@ impl Context {
             Config::Selfavatar if value.is_some() => {
                 let rel_path = std::fs::canonicalize(value.unwrap())?;
                 self.sql
-                    .set_config(self, key, Some(&rel_path.to_string_lossy()))
+                    .set_raw_config(self, key, Some(&rel_path.to_string_lossy()))
             }
             Config::InboxWatch => {
-                let ret = self.sql.set_config(self, key, value);
+                let ret = self.sql.set_raw_config(self, key, value);
                 interrupt_imap_idle(self);
                 ret
             }
             Config::SentboxWatch => {
-                let ret = self.sql.set_config(self, key, value);
+                let ret = self.sql.set_raw_config(self, key, value);
                 interrupt_sentbox_idle(self);
                 ret
             }
             Config::MvboxWatch => {
-                let ret = self.sql.set_config(self, key, value);
+                let ret = self.sql.set_raw_config(self, key, value);
                 interrupt_mvbox_idle(self);
                 ret
             }
@@ -140,9 +140,9 @@ impl Context {
                     value
                 };
 
-                self.sql.set_config(self, key, val)
+                self.sql.set_raw_config(self, key, val)
             }
-            _ => self.sql.set_config(self, key, value),
+            _ => self.sql.set_raw_config(self, key, value),
         }
     }
 }

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -114,7 +114,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context) {
                                 param.addr = oauth2_addr;
                                 context
                                     .sql
-                                    .set_config(context, "addr", Some(param.addr.as_str()))
+                                    .set_raw_config(context, "addr", Some(param.addr.as_str()))
                                     .ok();
                             }
                             progress!(context, 20);
@@ -501,7 +501,7 @@ pub unsafe fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context) {
                             )
                             .ok();
 
-                        context.sql.set_config_bool(context, "configured", true);
+                        context.sql.set_raw_config_bool(context, "configured", true);
                         true
                     }
                     18 => {

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -884,7 +884,7 @@ impl Imap {
         let key = format!("imap.mailbox.{}", folder.as_ref());
         let val = format!("{}:{}", uidvalidity, lastseenuid);
 
-        context.sql.set_config(context, &key, Some(&val)).ok();
+        context.sql.set_raw_config(context, &key, Some(&val)).ok();
     }
 
     fn fetch_single_msg<S: AsRef<str>>(
@@ -1396,18 +1396,18 @@ impl Imap {
 
         context
             .sql
-            .set_config_int(context, "folders_configured", 3)
+            .set_raw_config_int(context, "folders_configured", 3)
             .ok();
         if let Some(ref mvbox_folder) = mvbox_folder {
             context
                 .sql
-                .set_config(context, "configured_mvbox_folder", Some(mvbox_folder))
+                .set_raw_config(context, "configured_mvbox_folder", Some(mvbox_folder))
                 .ok();
         }
         if let Some(ref sentbox_folder) = sentbox_folder {
             context
                 .sql
-                .set_config(
+                .set_raw_config(
                     context,
                     "configured_sentbox_folder",
                     Some(sentbox_folder.name()),

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -313,7 +313,7 @@ fn set_self_key(
             };
             context
                 .sql
-                .set_config_int(context, "e2ee_enabled", e2ee_enabled)?;
+                .set_raw_config_int(context, "e2ee_enabled", e2ee_enabled)?;
         }
         None => {
             if prefer_encrypt_required {
@@ -695,7 +695,7 @@ fn export_backup(context: &Context, dir: impl AsRef<Path>) -> Result<()> {
                 }
                 if ok_to_continue {
                     if sql
-                        .set_config_int(context, "backup_time", now as i32)
+                        .set_raw_config_int(context, "backup_time", now as i32)
                         .is_ok()
                     {
                         context.call_cb(Event::ImexFileWritten(dest_path_filename.clone()));

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -129,40 +129,40 @@ impl LoginParam {
         let sql = &context.sql;
 
         let key = format!("{}addr", prefix);
-        sql.set_config(context, key, Some(&self.addr))?;
+        sql.set_raw_config(context, key, Some(&self.addr))?;
 
         let key = format!("{}mail_server", prefix);
-        sql.set_config(context, key, Some(&self.mail_server))?;
+        sql.set_raw_config(context, key, Some(&self.mail_server))?;
 
         let key = format!("{}mail_port", prefix);
-        sql.set_config_int(context, key, self.mail_port)?;
+        sql.set_raw_config_int(context, key, self.mail_port)?;
 
         let key = format!("{}mail_user", prefix);
-        sql.set_config(context, key, Some(&self.mail_user))?;
+        sql.set_raw_config(context, key, Some(&self.mail_user))?;
 
         let key = format!("{}mail_pw", prefix);
-        sql.set_config(context, key, Some(&self.mail_pw))?;
+        sql.set_raw_config(context, key, Some(&self.mail_pw))?;
 
         let key = format!("{}imap_certificate_checks", prefix);
-        sql.set_config_int(context, key, self.imap_certificate_checks as i32)?;
+        sql.set_raw_config_int(context, key, self.imap_certificate_checks as i32)?;
 
         let key = format!("{}send_server", prefix);
-        sql.set_config(context, key, Some(&self.send_server))?;
+        sql.set_raw_config(context, key, Some(&self.send_server))?;
 
         let key = format!("{}send_port", prefix);
-        sql.set_config_int(context, key, self.send_port)?;
+        sql.set_raw_config_int(context, key, self.send_port)?;
 
         let key = format!("{}send_user", prefix);
-        sql.set_config(context, key, Some(&self.send_user))?;
+        sql.set_raw_config(context, key, Some(&self.send_user))?;
 
         let key = format!("{}send_pw", prefix);
-        sql.set_config(context, key, Some(&self.send_pw))?;
+        sql.set_raw_config(context, key, Some(&self.send_pw))?;
 
         let key = format!("{}smtp_certificate_checks", prefix);
-        sql.set_config_int(context, key, self.smtp_certificate_checks as i32)?;
+        sql.set_raw_config_int(context, key, self.smtp_certificate_checks as i32)?;
 
         let key = format!("{}server_flags", prefix);
-        sql.set_config_int(context, key, self.server_flags)?;
+        sql.set_raw_config_int(context, key, self.server_flags)?;
 
         Ok(())
     }

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -50,7 +50,7 @@ pub fn dc_get_oauth2_url(
     if let Some(oauth2) = Oauth2::from_address(addr) {
         if context
             .sql
-            .set_config(
+            .set_raw_config(
                 context,
                 "oauth2_pending_redirect_uri",
                 Some(redirect_uri.as_ref()),
@@ -159,11 +159,11 @@ pub fn dc_get_oauth2_access_token(
         if let Some(ref token) = response.refresh_token {
             context
                 .sql
-                .set_config(context, "oauth2_refresh_token", Some(token))
+                .set_raw_config(context, "oauth2_refresh_token", Some(token))
                 .ok();
             context
                 .sql
-                .set_config(context, "oauth2_refresh_token_for", Some(code.as_ref()))
+                .set_raw_config(context, "oauth2_refresh_token_for", Some(code.as_ref()))
                 .ok();
         }
 
@@ -172,7 +172,7 @@ pub fn dc_get_oauth2_access_token(
         if let Some(ref token) = response.access_token {
             context
                 .sql
-                .set_config(context, "oauth2_access_token", Some(token))
+                .set_raw_config(context, "oauth2_access_token", Some(token))
                 .ok();
             let expires_in = response
                 .expires_in
@@ -181,13 +181,13 @@ pub fn dc_get_oauth2_access_token(
                 .unwrap_or_else(|| 0);
             context
                 .sql
-                .set_config_int64(context, "oauth2_timestamp_expires", expires_in)
+                .set_raw_config_int64(context, "oauth2_timestamp_expires", expires_in)
                 .ok();
 
             if update_redirect_uri_on_success {
                 context
                     .sql
-                    .set_config(context, "oauth2_redirect_uri", Some(redirect_uri.as_ref()))
+                    .set_raw_config(context, "oauth2_redirect_uri", Some(redirect_uri.as_ref()))
                     .ok();
             }
         } else {

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -193,14 +193,14 @@ impl Sql {
     ///
     /// Setting `None` deletes the value.  On failure an error message
     /// will already have been logged.
-    pub fn set_config(
+    pub fn set_raw_config(
         &self,
         context: &Context,
         key: impl AsRef<str>,
         value: Option<&str>,
     ) -> Result<()> {
         if !self.is_open() {
-            error!(context, "set_config(): Database not ready.");
+            error!(context, "set_raw_config(): Database not ready.");
             return Err(Error::SqlNoConnection);
         }
 
@@ -234,7 +234,7 @@ impl Sql {
         match res {
             Ok(_) => Ok(()),
             Err(err) => {
-                error!(context, "set_config(): Cannot change value. {:?}", &err);
+                error!(context, "set_raw_config(): Cannot change value. {:?}", &err);
                 Err(err)
             }
         }
@@ -252,13 +252,13 @@ impl Sql {
         )
     }
 
-    pub fn set_config_int(
+    pub fn set_raw_config_int(
         &self,
         context: &Context,
         key: impl AsRef<str>,
         value: i32,
     ) -> Result<()> {
-        self.set_config(context, key, Some(&format!("{}", value)))
+        self.set_raw_config(context, key, Some(&format!("{}", value)))
     }
 
     pub fn get_raw_config_int(&self, context: &Context, key: impl AsRef<str>) -> Option<i32> {
@@ -272,21 +272,21 @@ impl Sql {
         self.get_raw_config_int(context, key).unwrap_or_default() > 0
     }
 
-    pub fn set_config_bool<T>(&self, context: &Context, key: T, value: bool) -> Result<()>
+    pub fn set_raw_config_bool<T>(&self, context: &Context, key: T, value: bool) -> Result<()>
     where
         T: AsRef<str>,
     {
         let value = if value { Some("1") } else { None };
-        self.set_config(context, key, value)
+        self.set_raw_config(context, key, value)
     }
 
-    pub fn set_config_int64(
+    pub fn set_raw_config_int64(
         &self,
         context: &Context,
         key: impl AsRef<str>,
         value: i64,
     ) -> Result<()> {
-        self.set_config(context, key, Some(&format!("{}", value)))
+        self.set_raw_config(context, key, Some(&format!("{}", value)))
     }
 
     pub fn get_raw_config_int64(&self, context: &Context, key: impl AsRef<str>) -> Option<i64> {
@@ -479,7 +479,7 @@ fn open(
                 // cannot create the tables - maybe we cannot write?
                 return Err(Error::SqlFailedToOpen);
             } else {
-                sql.set_config_int(context, "dbversion", 0)?;
+                sql.set_raw_config_int(context, "dbversion", 0)?;
             }
         } else {
             exists_before_update = 1;
@@ -507,7 +507,7 @@ fn open(
                 params![],
             )?;
             dbversion = 1;
-            sql.set_config_int(context, "dbversion", 1)?;
+            sql.set_raw_config_int(context, "dbversion", 1)?;
         }
         if dbversion < 2 {
             info!(context, "[migration] v2");
@@ -516,7 +516,7 @@ fn open(
                 params![],
             )?;
             dbversion = 2;
-            sql.set_config_int(context, "dbversion", 2)?;
+            sql.set_raw_config_int(context, "dbversion", 2)?;
         }
         if dbversion < 7 {
             info!(context, "[migration] v7");
@@ -531,7 +531,7 @@ fn open(
                 params![],
             )?;
             dbversion = 7;
-            sql.set_config_int(context, "dbversion", 7)?;
+            sql.set_raw_config_int(context, "dbversion", 7)?;
         }
         if dbversion < 10 {
             info!(context, "[migration] v10");
@@ -550,7 +550,7 @@ fn open(
                 params![],
             )?;
             dbversion = 10;
-            sql.set_config_int(context, "dbversion", 10)?;
+            sql.set_raw_config_int(context, "dbversion", 10)?;
         }
         if dbversion < 12 {
             info!(context, "[migration] v12");
@@ -563,7 +563,7 @@ fn open(
                 params![],
             )?;
             dbversion = 12;
-            sql.set_config_int(context, "dbversion", 12)?;
+            sql.set_raw_config_int(context, "dbversion", 12)?;
         }
         if dbversion < 17 {
             info!(context, "[migration] v17");
@@ -578,7 +578,7 @@ fn open(
             )?;
             sql.execute("CREATE INDEX msgs_index5 ON msgs (starred);", params![])?;
             dbversion = 17;
-            sql.set_config_int(context, "dbversion", 17)?;
+            sql.set_raw_config_int(context, "dbversion", 17)?;
         }
         if dbversion < 18 {
             info!(context, "[migration] v18");
@@ -588,7 +588,7 @@ fn open(
             )?;
             sql.execute("ALTER TABLE acpeerstates ADD COLUMN gossip_key;", params![])?;
             dbversion = 18;
-            sql.set_config_int(context, "dbversion", 18)?;
+            sql.set_raw_config_int(context, "dbversion", 18)?;
         }
         if dbversion < 27 {
             info!(context, "[migration] v27");
@@ -606,7 +606,7 @@ fn open(
                 params![],
             )?;
             dbversion = 27;
-            sql.set_config_int(context, "dbversion", 27)?;
+            sql.set_raw_config_int(context, "dbversion", 27)?;
         }
         if dbversion < 34 {
             info!(context, "[migration] v34");
@@ -636,7 +636,7 @@ fn open(
             )?;
             recalc_fingerprints = 1;
             dbversion = 34;
-            sql.set_config_int(context, "dbversion", 34)?;
+            sql.set_raw_config_int(context, "dbversion", 34)?;
         }
         if dbversion < 39 {
             info!(context, "[migration] v39");
@@ -667,7 +667,7 @@ fn open(
                 )?;
             }
             dbversion = 39;
-            sql.set_config_int(context, "dbversion", 39)?;
+            sql.set_raw_config_int(context, "dbversion", 39)?;
         }
         if dbversion < 40 {
             info!(context, "[migration] v40");
@@ -676,25 +676,25 @@ fn open(
                 params![],
             )?;
             dbversion = 40;
-            sql.set_config_int(context, "dbversion", 40)?;
+            sql.set_raw_config_int(context, "dbversion", 40)?;
         }
         if dbversion < 41 {
             info!(context, "[migration] v41");
             update_file_paths = 1;
             dbversion = 41;
-            sql.set_config_int(context, "dbversion", 41)?;
+            sql.set_raw_config_int(context, "dbversion", 41)?;
         }
         if dbversion < 42 {
             info!(context, "[migration] v42");
             sql.execute("UPDATE msgs SET txt='' WHERE type!=10", params![])?;
             dbversion = 42;
-            sql.set_config_int(context, "dbversion", 42)?;
+            sql.set_raw_config_int(context, "dbversion", 42)?;
         }
         if dbversion < 44 {
             info!(context, "[migration] v44");
             sql.execute("ALTER TABLE msgs ADD COLUMN mime_headers TEXT;", params![])?;
             dbversion = 44;
-            sql.set_config_int(context, "dbversion", 44)?;
+            sql.set_raw_config_int(context, "dbversion", 44)?;
         }
         if dbversion < 46 {
             info!(context, "[migration] v46");
@@ -707,7 +707,7 @@ fn open(
                 params![],
             )?;
             dbversion = 46;
-            sql.set_config_int(context, "dbversion", 46)?;
+            sql.set_raw_config_int(context, "dbversion", 46)?;
         }
         if dbversion < 47 {
             info!(context, "[migration] v47");
@@ -716,7 +716,7 @@ fn open(
                 params![],
             )?;
             dbversion = 47;
-            sql.set_config_int(context, "dbversion", 47)?;
+            sql.set_raw_config_int(context, "dbversion", 47)?;
         }
         if dbversion < 48 {
             info!(context, "[migration] v48");
@@ -726,7 +726,7 @@ fn open(
             )?;
 
             dbversion = 48;
-            sql.set_config_int(context, "dbversion", 48)?;
+            sql.set_raw_config_int(context, "dbversion", 48)?;
         }
         if dbversion < 49 {
             info!(context, "[migration] v49");
@@ -735,15 +735,15 @@ fn open(
                 params![],
             )?;
             dbversion = 49;
-            sql.set_config_int(context, "dbversion", 49)?;
+            sql.set_raw_config_int(context, "dbversion", 49)?;
         }
         if dbversion < 50 {
             info!(context, "[migration] v50");
             if 0 != exists_before_update {
-                sql.set_config_int(context, "show_emails", 2)?;
+                sql.set_raw_config_int(context, "show_emails", 2)?;
             }
             dbversion = 50;
-            sql.set_config_int(context, "dbversion", 50)?;
+            sql.set_raw_config_int(context, "dbversion", 50)?;
         }
         if dbversion < 53 {
             info!(context, "[migration] v53");
@@ -776,7 +776,7 @@ fn open(
                 params![],
             )?;
             dbversion = 53;
-            sql.set_config_int(context, "dbversion", 53)?;
+            sql.set_raw_config_int(context, "dbversion", 53)?;
         }
         if dbversion < 54 {
             info!(context, "[migration] v54");
@@ -786,7 +786,7 @@ fn open(
             )?;
             sql.execute("CREATE INDEX msgs_index6 ON msgs (location_id);", params![])?;
             dbversion = 54;
-            sql.set_config_int(context, "dbversion", 54)?;
+            sql.set_raw_config_int(context, "dbversion", 54)?;
         }
         if dbversion < 55 {
             info!(context, "[migration] v55");
@@ -795,7 +795,7 @@ fn open(
                 params![],
             )?;
 
-            sql.set_config_int(context, "dbversion", 55)?;
+            sql.set_raw_config_int(context, "dbversion", 55)?;
         }
 
         if 0 != recalc_fingerprints {
@@ -842,7 +842,7 @@ fn open(
                 NO_PARAMS,
             )?;
 
-            sql.set_config(context, "backup_for", None)?;
+            sql.set_raw_config(context, "backup_for", None)?;
         }
     }
 


### PR DESCRIPTION
the rename is reasonable as the getter is called get_raw_config*()
and to make the functional difference to context.set|get_config() clearer.

successor of #670 and #671