### PR TITLE
always expect bad c-strings

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -24,9 +24,7 @@ use num_traits::{FromPrimitive, ToPrimitive};
 
 use deltachat::contact::Contact;
 use deltachat::context::Context;
-use deltachat::dc_tools::{
-    as_path, as_str, dc_strdup, to_string_lossy, OsStrExt, StrExt,
-};
+use deltachat::dc_tools::{as_path, as_str, dc_strdup, to_string_lossy, OsStrExt, StrExt};
 use deltachat::*;
 
 // as C lacks a good and portable error handling,

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -25,7 +25,7 @@ use num_traits::{FromPrimitive, ToPrimitive};
 use deltachat::contact::Contact;
 use deltachat::context::Context;
 use deltachat::dc_tools::{
-    as_path, as_str, dc_strdup, to_string, to_string_lossy, OsStrExt, StrExt,
+    as_path, as_str, dc_strdup, to_string_lossy, OsStrExt, StrExt,
 };
 use deltachat::*;
 
@@ -381,8 +381,8 @@ pub unsafe extern "C" fn dc_get_oauth2_url(
         return ptr::null_mut(); // NULL explicitly defined as "unknown"
     }
     let ffi_context = &*context;
-    let addr = to_string(addr);
-    let redirect = to_string(redirect);
+    let addr = to_string_lossy(addr);
+    let redirect = to_string_lossy(redirect);
     ffi_context
         .with_inner(|ctx| match oauth2::dc_get_oauth2_url(ctx, addr, redirect) {
             Some(res) => res.strdup(),

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -119,7 +119,7 @@ fn poke_spec(context: &Context, spec: *const libc::c_char) -> libc::c_int {
 
     /* if `spec` is given, remember it for later usage; if it is not given, try to use the last one */
     if !spec.is_null() {
-        real_spec = to_string(spec);
+        real_spec = to_string_lossy(spec);
         context
             .sql
             .set_raw_config(context, "import_spec", Some(&real_spec))

--- a/src/configure/auto_outlook.rs
+++ b/src/configure/auto_outlook.rs
@@ -164,7 +164,7 @@ unsafe fn outlk_autodiscover_endtag_cb(event: &BytesEnd, outlk_ad: &mut outlk_au
             ) == 0
                 && outlk_ad.out_imap_set == 0
             {
-                outlk_ad.out.mail_server = to_string(outlk_ad.config[2]);
+                outlk_ad.out.mail_server = to_string_lossy(outlk_ad.config[2]);
                 outlk_ad.out.mail_port = port;
                 if 0 != ssl_on {
                     outlk_ad.out.server_flags |= DC_LP_IMAP_SOCKET_SSL as i32
@@ -178,7 +178,7 @@ unsafe fn outlk_autodiscover_endtag_cb(event: &BytesEnd, outlk_ad: &mut outlk_au
             ) == 0
                 && outlk_ad.out_smtp_set == 0
             {
-                outlk_ad.out.send_server = to_string(outlk_ad.config[2]);
+                outlk_ad.out.send_server = to_string_lossy(outlk_ad.config[2]);
                 outlk_ad.out.send_port = port;
                 if 0 != ssl_on {
                     outlk_ad.out.server_flags |= DC_LP_SMTP_SOCKET_SSL as i32

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -890,7 +890,7 @@ impl<'a> MimeParser<'a> {
             unsafe {
                 let fld_message_id = (*field).fld_data.fld_message_id;
                 if !fld_message_id.is_null() {
-                    return Some(to_string((*fld_message_id).mid_value));
+                    return Some(to_string_lossy((*fld_message_id).mid_value));
                 }
             }
         }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -688,8 +688,8 @@ unsafe fn add_parts(
                         } else {
                             None
                         },
-                        to_string(mime_in_reply_to),
-                        to_string(mime_references),
+                        to_string_lossy(mime_in_reply_to),
+                        to_string_lossy(mime_references),
                     ])?;
 
                     txt_raw = None;
@@ -1026,7 +1026,7 @@ unsafe fn create_or_lookup_group(
             {
                 let fld_in_reply_to = (*field).fld_data.fld_in_reply_to;
                 if !fld_in_reply_to.is_null() {
-                    grpid = to_string(dc_extract_grpid_from_rfc724_mid_list(
+                    grpid = to_string_lossy(dc_extract_grpid_from_rfc724_mid_list(
                         (*fld_in_reply_to).mid_list,
                     ));
                 }
@@ -1037,7 +1037,7 @@ unsafe fn create_or_lookup_group(
                 {
                     let fld_references = (*field).fld_data.fld_references;
                     if !fld_references.is_null() {
-                        grpid = to_string(dc_extract_grpid_from_rfc724_mid_list(
+                        grpid = to_string_lossy(dc_extract_grpid_from_rfc724_mid_list(
                             (*fld_references).mid_list,
                         ));
                     }

--- a/src/dc_strencode.rs
+++ b/src/dc_strencode.rs
@@ -86,7 +86,7 @@ pub(crate) fn dc_decode_header_words(input: &str) -> String {
         if r as u32 != MAILIMF_NO_ERROR || out.is_null() {
             input.to_string()
         } else {
-            let res = to_string(out);
+            let res = to_string_lossy(out);
             free(out.cast());
             res
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -355,7 +355,7 @@ impl Message {
                     ) && buf_headerline == "-----BEGIN PGP MESSAGE-----"
                         && !buf_setupcodebegin.is_null()
                     {
-                        return Some(to_string(buf_setupcodebegin));
+                        return Some(to_string_lossy(buf_setupcodebegin));
                     }
                 }
             }

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -133,7 +133,7 @@ impl Context {
         if ptr.is_null() {
             Cow::Borrowed(id.fallback())
         } else {
-            let ret = to_string(ptr);
+            let ret = to_string_lossy(ptr);
             unsafe { libc::free(ptr as *mut libc::c_void) };
             Cow::Owned(ret)
         }

--- a/src/wrapmime.rs
+++ b/src/wrapmime.rs
@@ -42,7 +42,7 @@ pub fn get_ct_subtype(mime: *mut Mailmime) -> Option<String> {
         let ct: *mut mailmime_content = (*mime).mm_content_type;
 
         if !ct.is_null() && !(*ct).ct_subtype.is_null() {
-            Some(to_string((*ct).ct_subtype))
+            Some(to_string_lossy((*ct).ct_subtype))
         } else {
             None
         }


### PR DESCRIPTION
always use to_string_lossy() for converting c-strings to String

the function to_string() is removed;
c-strings may always be badly formatted and this should never lead to a panic.

nb: also scanned over the remaining .to_string() member functions, seems as if  .to_string_lossy() is already called where it is needed, eg. for Path or OsString objects.