### PR TITLE
use .to_string_lossy() member of Path, CStr etc.

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2136,7 +2136,7 @@ pub unsafe extern "C" fn dc_chat_get_profile_image(chat: *mut dc_chat_t) -> *mut
     let ffi_context = &*ffi_chat.context;
     ffi_context
         .with_inner(|ctx| match ffi_chat.chat.get_profile_image(ctx) {
-            Some(p) => p.to_str().unwrap_or_default().to_string().strdup(),
+            Some(p) => p.to_string_lossy().strdup(),
             None => ptr::null_mut(),
         })
         .unwrap_or_else(|_| ptr::null_mut())
@@ -2773,7 +2773,7 @@ pub unsafe extern "C" fn dc_contact_get_profile_image(
             ffi_contact
                 .contact
                 .get_profile_image(ctx)
-                .map(|p| p.to_str().unwrap_or_default().to_string().strdup())
+                .map(|p| p.to_string_lossy().strdup())
                 .unwrap_or_else(|| std::ptr::null_mut())
         })
         .unwrap_or_else(|_| ptr::null_mut())

--- a/mmime/src/charconv.rs
+++ b/mmime/src/charconv.rs
@@ -16,12 +16,9 @@ pub unsafe fn charconv(
 ) -> libc::c_int {
     assert!(!fromcode.is_null(), "invalid fromcode");
     assert!(!s.is_null(), "invalid input string");
-    if let Some(encoding) = charset::Charset::for_label(
-        CStr::from_ptr(fromcode)
-            .to_str()
-            .unwrap_or_default()
-            .as_bytes(),
-    ) {
+    if let Some(encoding) =
+        charset::Charset::for_label(CStr::from_ptr(fromcode).to_string_lossy().as_bytes())
+    {
         let data = std::slice::from_raw_parts(s as *const u8, strlen(s));
 
         let (res, _, _) = encoding.decode(data);

--- a/mmime/src/mailmime/write_generic.rs
+++ b/mmime/src/mailmime/write_generic.rs
@@ -1515,8 +1515,8 @@ pub unsafe fn mailmime_data_write_driver(
         }
         1 => {
             let filename = CStr::from_ptr((*mime_data).dt_data.dt_filename)
-                .to_str()
-                .unwrap_or_default();
+                .to_string_lossy()
+                .into_owned();
             if let Ok(file) = std::fs::File::open(filename) {
                 if let Ok(mut text) = memmap::MmapOptions::new().map_copy(&file) {
                     if 0 != (*mime_data).dt_encoded {

--- a/src/aheader.rs
+++ b/src/aheader.rs
@@ -79,19 +79,13 @@ impl Aheader {
                 let optional_field = unsafe { (*field).fld_data.fld_optional_field };
                 if !optional_field.is_null()
                     && unsafe { !(*optional_field).fld_name.is_null() }
-                    && unsafe {
-                        CStr::from_ptr((*optional_field).fld_name)
-                            .to_str()
-                            .unwrap_or_default()
-                    } == "Autocrypt"
+                    && unsafe { CStr::from_ptr((*optional_field).fld_name).to_string_lossy() }
+                        == "Autocrypt"
                 {
-                    let value = unsafe {
-                        CStr::from_ptr((*optional_field).fld_value)
-                            .to_str()
-                            .unwrap_or_default()
-                    };
+                    let value =
+                        unsafe { CStr::from_ptr((*optional_field).fld_value).to_string_lossy() };
 
-                    if let Ok(test) = Self::from_str(value) {
+                    if let Ok(test) = Self::from_str(&value) {
                         if addr_cmp(&test.addr, wanted_from) {
                             if fine_header.is_none() {
                                 fine_header = Some(test);

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -620,12 +620,9 @@ impl<'a> MimeParser<'a> {
                     && strcmp(charset, b"utf-8\x00" as *const u8 as *const libc::c_char) != 0i32
                     && strcmp(charset, b"UTF-8\x00" as *const u8 as *const libc::c_char) != 0i32
                 {
-                    if let Some(encoding) = Charset::for_label(
-                        CStr::from_ptr(charset)
-                            .to_str()
-                            .unwrap_or_default()
-                            .as_bytes(),
-                    ) {
+                    if let Some(encoding) =
+                        Charset::for_label(CStr::from_ptr(charset).to_string_lossy().as_bytes())
+                    {
                         let (res, _, _) = encoding.decode(&decoded_data);
                         if res.is_empty() {
                             /* no error - but nothing to add */


### PR DESCRIPTION
use .to_string_lossy() member of Path, CStr etc. instead of calling to_str().unwrap_or_default().

this partly reverts and improves the unwrap_or_default() calls introduced in #673