### PR TITLE
bubble up

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -436,7 +436,7 @@ unsafe fn add_parts(
                 to_ids,
                 chat_id,
                 &mut chat_id_blocked,
-            );
+            )?;
             if 0 != *chat_id && Blocked::Not != chat_id_blocked && create_blocked == Blocked::Not {
                 chat::unblock(context, *chat_id);
                 chat_id_blocked = Blocked::Not;
@@ -521,7 +521,7 @@ unsafe fn add_parts(
                     to_ids,
                     chat_id,
                     &mut chat_id_blocked,
-                );
+                )?;
                 if 0 != *chat_id && Blocked::Not != chat_id_blocked {
                     chat::unblock(context, *chat_id);
                     chat_id_blocked = Blocked::Not;
@@ -968,7 +968,7 @@ unsafe fn create_or_lookup_group(
     to_ids: &mut Vec<u32>,
     ret_chat_id: *mut u32,
     ret_chat_id_blocked: &mut Blocked,
-) {
+) -> Result<()> {
     let group_explicitly_left: bool;
     let mut chat_id = 0;
     let mut chat_id_blocked = Blocked::Not;
@@ -1055,7 +1055,7 @@ unsafe fn create_or_lookup_group(
                         &mut chat_id_blocked,
                     );
                     cleanup(ret_chat_id, ret_chat_id_blocked, chat_id, chat_id_blocked);
-                    return;
+                    return Ok(());
                 }
             }
         }
@@ -1180,7 +1180,7 @@ unsafe fn create_or_lookup_group(
         }
         if 0 == allow_creation {
             cleanup(ret_chat_id, ret_chat_id_blocked, chat_id, chat_id_blocked);
-            return;
+            return Ok(());
         }
         chat_id = create_group_record(
             context,
@@ -1211,7 +1211,7 @@ unsafe fn create_or_lookup_group(
             );
         }
         cleanup(ret_chat_id, ret_chat_id_blocked, chat_id, chat_id_blocked);
-        return;
+        return Ok(());
     }
 
     // execute group commands
@@ -1264,7 +1264,7 @@ unsafe fn create_or_lookup_group(
                 } else {
                     chat.param.set(Param::ProfileImage, grpimage);
                 }
-                chat.update_param(context).unwrap_or_default();
+                chat.update_param(context)?;
                 send_EVENT_CHAT_MODIFIED = 1;
             }
         }
@@ -1333,6 +1333,7 @@ unsafe fn create_or_lookup_group(
     }
 
     cleanup(ret_chat_id, ret_chat_id_blocked, chat_id, chat_id_blocked);
+    return Ok(())
 }
 
 /// Handle groups for received messages

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -291,6 +291,7 @@ pub unsafe fn dc_receive_imf(
         &rr_event_to_send,
     );
 }
+
 unsafe fn add_parts(
     context: &Context,
     mut mime_parser: &mut MimeParser,
@@ -1443,7 +1444,7 @@ unsafe fn create_or_lookup_adhoc_group(
     context.call_cb(Event::ChatModified(chat_id));
 
     cleanup(ret_chat_id, ret_chat_id_blocked, chat_id, chat_id_blocked);
-    return Ok(())
+    return Ok(());
 }
 
 fn create_group_record(

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -694,8 +694,7 @@ impl<'a> MimeFactory<'a> {
                         }
                         Ok(())
                     },
-                )
-                .unwrap_or_default();
+                )?;
 
             let command = factory.msg.param.get_cmd();
             let msg = &factory.msg;
@@ -898,9 +897,7 @@ fn build_body_file(
         wrapmime::append_ct_param(content, "name", &filename_encoded)?;
 
         let mime_sub = mailmime_new_empty(content, mime_fields);
-        let abs_path = dc_get_abs_path(context, path_filename)
-            .to_c_string()
-            .unwrap_or_default();
+        let abs_path = dc_get_abs_path(context, path_filename).to_c_string()?;
         mailmime_set_body_file(mime_sub, dc_strdup(abs_path.as_ptr()));
         Ok((mime_sub, filename_to_send))
     }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -671,30 +671,28 @@ impl<'a> MimeFactory<'a> {
                 .push(factory.from_displayname.to_string());
             factory.recipients_addr.push(factory.from_addr.to_string());
         } else {
-            context
-                .sql
-                .query_map(
-                    "SELECT c.authname, c.addr  \
-                     FROM chats_contacts cc  \
-                     LEFT JOIN contacts c ON cc.contact_id=c.id  \
-                     WHERE cc.chat_id=? AND cc.contact_id>9;",
-                    params![factory.msg.chat_id as i32],
-                    |row| {
-                        let authname: String = row.get(0)?;
-                        let addr: String = row.get(1)?;
-                        Ok((authname, addr))
-                    },
-                    |rows| {
-                        for row in rows {
-                            let (authname, addr) = row?;
-                            if !vec_contains_lowercase(&factory.recipients_addr, &addr) {
-                                factory.recipients_addr.push(addr);
-                                factory.recipients_names.push(authname);
-                            }
+            context.sql.query_map(
+                "SELECT c.authname, c.addr  \
+                 FROM chats_contacts cc  \
+                 LEFT JOIN contacts c ON cc.contact_id=c.id  \
+                 WHERE cc.chat_id=? AND cc.contact_id>9;",
+                params![factory.msg.chat_id as i32],
+                |row| {
+                    let authname: String = row.get(0)?;
+                    let addr: String = row.get(1)?;
+                    Ok((authname, addr))
+                },
+                |rows| {
+                    for row in rows {
+                        let (authname, addr) = row?;
+                        if !vec_contains_lowercase(&factory.recipients_addr, &addr) {
+                            factory.recipients_addr.push(addr);
+                            factory.recipients_names.push(authname);
                         }
-                        Ok(())
-                    },
-                )?;
+                    }
+                    Ok(())
+                },
+            )?;
 
             let command = factory.msg.param.get_cmd();
             let msg = &factory.msg;


### PR DESCRIPTION
this pr targets potential logic errors introduced by #673 - when unwrap_and_default() instead of unwrap() is used to just ignore a return value, this will avoid panics but may introduce logical errors.

this bubbles up the errors instead of panicing or just continuing.

it is a bit ugly wrt to some cleanup-functions in receive_imf as they will not be called, however, i think, the overall situation is improved anyway.