### PR TITLE
xml-parsing errors of autoconfig are no user-visible error

### DIFF
--- a/src/configure/auto_mozilla.rs
+++ b/src/configure/auto_mozilla.rs
@@ -72,7 +72,7 @@ pub fn moz_autoconfigure(
                 moz_autoconfigure_text_cb(e, &mut moz_ac, &reader)
             }
             Err(e) => {
-                error!(
+                warn!(
                     context,
                     "Configure xml: Error at position {}: {:?}",
                     reader.buffer_position(),


### PR DESCRIPTION
address https://github.com/deltachat/deltachat-ios/issues/328 
dont escalate xml-parsing errors to users through error! macro, just use warning. 