### PR TITLE
len-check in strncasecmp()

### DIFF
--- a/mmime/src/other.rs
+++ b/mmime/src/other.rs
@@ -42,11 +42,11 @@ pub(crate) unsafe fn strncasecmp(
 
     let s1_slice = std::slice::from_raw_parts(
         s1 as *const u8,
-        std::cmp::min(n, strnlen(s1 as *const i8, n)),
+        strnlen(s1 as *const i8, n),
     );
     let s2_slice = std::slice::from_raw_parts(
         s2 as *const u8,
-        std::cmp::min(n, strnlen(s2 as *const i8, n)),
+        strnlen(s2 as *const i8, n),
     );
 
     let s1 = std::ffi::CStr::from_bytes_with_nul_unchecked(s1_slice)

--- a/mmime/src/other.rs
+++ b/mmime/src/other.rs
@@ -8,7 +8,7 @@ use crate::mailmime::types_helper::*;
 
 pub(crate) use libc::{
     calloc, close, free, isalpha, isdigit, malloc, memcmp, memcpy, memmove, memset, realloc,
-    strcpy, strlen, strncmp, strncpy,
+    strcpy, strlen, strncmp, strncpy, strnlen,
 };
 
 pub(crate) unsafe fn strcasecmp(s1: *const libc::c_char, s2: *const libc::c_char) -> libc::c_int {
@@ -40,8 +40,14 @@ pub(crate) unsafe fn strncasecmp(
 
     // s1 and s2 might not be null terminated.
 
-    let s1_slice = std::slice::from_raw_parts(s1 as *const u8, n);
-    let s2_slice = std::slice::from_raw_parts(s2 as *const u8, n);
+    let s1_slice = std::slice::from_raw_parts(
+        s1 as *const u8,
+        std::cmp::min(n, strnlen(s1 as *const i8, n)),
+    );
+    let s2_slice = std::slice::from_raw_parts(
+        s2 as *const u8,
+        std::cmp::min(n, strnlen(s2 as *const i8, n)),
+    );
 
     let s1 = std::ffi::CStr::from_bytes_with_nul_unchecked(s1_slice)
         .to_string_lossy()
@@ -1691,6 +1697,14 @@ mod tests {
                 CString::new("helloworld").unwrap().as_ptr(),
                 CString::new("Helloward").unwrap().as_ptr(),
                 4,
+            )
+        });
+
+        assert_eq!(0, unsafe {
+            strncasecmp(
+                CString::new("hell").unwrap().as_ptr(),
+                CString::new("Hell").unwrap().as_ptr(),
+                100_000_000,
             )
         });
     }

--- a/mmime/src/other.rs
+++ b/mmime/src/other.rs
@@ -40,14 +40,8 @@ pub(crate) unsafe fn strncasecmp(
 
     // s1 and s2 might not be null terminated.
 
-    let s1_slice = std::slice::from_raw_parts(
-        s1 as *const u8,
-        strnlen(s1 as *const i8, n),
-    );
-    let s2_slice = std::slice::from_raw_parts(
-        s2 as *const u8,
-        strnlen(s2 as *const i8, n),
-    );
+    let s1_slice = std::slice::from_raw_parts(s1 as *const u8, strnlen(s1 as *const i8, n));
+    let s2_slice = std::slice::from_raw_parts(s2 as *const u8, strnlen(s2 as *const i8, n));
 
     let s1 = std::ffi::CStr::from_bytes_with_nul_unchecked(s1_slice)
         .to_string_lossy()


### PR DESCRIPTION
strncasecmp() compares the given number of characters but not after a 0-byte.

this targets the open question from https://github.com/deltachat/deltachat-core-rust/pull/703#issuecomment-539998040 by not reading beyond the first 0-byte

(the different descriptions of strnlen() are not totally clear on that point, however, they guarantee to not read beyond N, so that they cannot call just strlen(). eg. the glibc-implementation stops on the first 0-byte: https://github.com/lattera/glibc/blob/master/string/strnlen.c and i assume this is also true for others)

@dignifiedquire would be cool if you can check if things still work for you :)