### PR TITLE
Don't use hard-coded email addresses in tests

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -150,6 +150,11 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig):
             lib.dc_set_config(ac._dc_context, b"configured", b"1")
             return ac
 
+        def peek_online_config(self):
+            if not session_liveconfig:
+                pytest.skip("specify DCC_PY_LIVECONFIG or --liveconfig")
+            return session_liveconfig.get(self.live_count)
+
         def get_online_config(self):
             if not session_liveconfig:
                 pytest.skip("specify DCC_PY_LIVECONFIG or --liveconfig")

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -389,7 +389,8 @@ class TestOnlineAccount:
 
     def test_one_account_send_bcc_setting(self, acfactory, lp):
         ac1 = acfactory.get_online_configuring_account()
-        c2 = ac1.create_contact(email="notexists@testrun.org")
+        ac2_config = acfactory.peek_online_config()
+        c2 = ac1.create_contact(email=ac2_config["addr"])
         chat = ac1.create_chat_by_contact(c2)
         assert chat.id > const.DC_CHAT_ID_LAST_SPECIAL
         wait_successful_IMAP_SMTP_connection(ac1)


### PR DESCRIPTION
Fixes #718

The new function `AccountMaker.peek_online_config()` returns the next configuration map from the list of live accounts, without creating an account or starting configuration. Multiple calls will return the same configuration. The next call to `get_online_*()` will use that configuration to actually create the account.