### PR TITLE
make oauth2 POST successfully

### DIFF
--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -7,6 +7,7 @@ use crate::context::Context;
 use crate::dc_tools::*;
 
 const OAUTH2_GMAIL: Oauth2 = Oauth2 {
+    // see https://developers.google.com/identity/protocols/OAuth2InstalledApp
     client_id: "959970109878-4mvtgf6feshskf7695nfln6002mom908.apps.googleusercontent.com",
     get_code: "https://accounts.google.com/o/oauth2/auth?client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&response_type=code&scope=https%3A%2F%2Fmail.google.com%2F%20email&access_type=offline",
     init_token: "https://accounts.google.com/o/oauth2/token?client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&code=$CODE&grant_type=authorization_code",
@@ -15,6 +16,7 @@ const OAUTH2_GMAIL: Oauth2 = Oauth2 {
 };
 
 const OAUTH2_YANDEX: Oauth2 = Oauth2 {
+    // see https://tech.yandex.com/oauth/doc/dg/reference/auto-code-client-docpage/
     client_id: "c4d0b6735fc8420a816d7e1303469341",
     get_code: "https://oauth.yandex.com/authorize?client_id=$CLIENT_ID&response_type=code&scope=mail%3Aimap_full%20mail%3Asmtp&force_confirm=true",
     init_token: "https://oauth.yandex.com/token?grant_type=authorization_code&code=$CODE&client_id=$CLIENT_ID&client_secret=58b8c6e94cf44fbe952da8511955dacf",
@@ -89,6 +91,7 @@ pub fn dc_get_oauth2_access_token(
             }
         }
 
+        // generate new token: build & call auth url
         let refresh_token = context.sql.get_raw_config(context, "oauth2_refresh_token");
         let refresh_token_for = context
             .sql
@@ -146,6 +149,7 @@ pub fn dc_get_oauth2_access_token(
             return None;
         }
 
+        // generate new token: parse returned json
         let parsed: reqwest::Result<Response> = response.json();
         if parsed.is_err() {
             warn!(
@@ -155,6 +159,8 @@ pub fn dc_get_oauth2_access_token(
             return None;
         }
         println!("response: {:?}", &parsed);
+
+        // update refresh_token if given, typically on the first round, but we update it later as well.
         let response = parsed.unwrap();
         if let Some(ref token) = response.refresh_token {
             context

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -142,7 +142,7 @@ pub fn dc_get_oauth2_access_token(
         if !response.status().is_success() {
             warn!(
                 context,
-                "Error calling OAuth2 at {}: {:?}",
+                "Unsuccessful response when calling OAuth2 at {}: {:?}",
                 token_url,
                 response.status()
             );


### PR DESCRIPTION
this or does a correct POST call to get the oauth2 access tokens.

it does _not fix_ #119, there seems still to be the same hang as always in [`client.authenticate("XOAUTH2", &auth)`](https://github.com/deltachat/deltachat-core-rust/blob/master/src/imap.rs#L428), however,  this or is  necessary step for fixing that finally.