### PR TITLE
make oauth2.get_addr work

### DIFF
--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -112,6 +112,7 @@ pub fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context) {
                         dc_get_oauth2_addr(context, &param.addr, &param.mail_pw)
                             .and_then(|e| e.parse().ok())
                     {
+                        info!(context, "Authorized address is {}", oauth2_addr);
                         param.addr = oauth2_addr;
                         context
                             .sql

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -297,7 +297,7 @@ impl Oauth2 {
             return None;
         }
 
-        let parsed: reqwest::Result<HashMap<String, String>> = response.json();
+        let parsed: reqwest::Result<HashMap<String, serde_json::Value>> = response.json();
         if parsed.is_err() {
             warn!(
                 context,
@@ -306,11 +306,13 @@ impl Oauth2 {
             return None;
         }
         if let Ok(response) = parsed {
+            // serde_json::Value.as_str() removes the quotes of json-strings
             let addr = response.get("email");
             if addr.is_none() {
                 warn!(context, "E-mail missing in userinfo.");
+                return None;
             }
-
+            let addr = addr.unwrap().as_str();
             addr.map(|addr| addr.to_string())
         } else {
             warn!(context, "Failed to parse userinfo.");


### PR DESCRIPTION
oauth2.get_addr is used for gmail-oauth2
to retrieve the address really authorized in the oauth2 process.

this pr fixes parsing the json by allowing any json-type, not only strings for the different fields (we are not interested in any stuff beside email anyway).

fixes #721