### PR TITLE
Fix forwarding

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -192,7 +192,7 @@ unsafe fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
     let msgtext = msg.get_text();
     info!(
         context,
-        "{}#{}{}{}: {} (Contact#{}): {} {}{}{}{} [{}]",
+        "{}#{}{}{}: {} (Contact#{}): {} {}{}{}{}{} [{}]",
         prefix.as_ref(),
         msg.get_id() as libc::c_int,
         if msg.get_showpadlock() { "🔒" } else { "" },
@@ -211,6 +211,11 @@ unsafe fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
             "[FRESH]"
         },
         if msg.is_info() { "[INFO]" } else { "" },
+        if msg.is_forwarded() {
+            "[FORWARDED]"
+        } else {
+            ""
+        },
         statestr,
         &temp2,
     );


### PR DESCRIPTION
this pr removes the mostly useless re-usage of the Simplifier object, it was don in c for $reasons, but i think there is no worth in rust.

this already fixes #724 - which is great, however, not sure why before this pr [`if simplifier.unwrap().is_forwarded` was always false](https://github.com/deltachat/deltachat-core-rust/blob/master/src/dc_mimeparser.rs#L661) although [`is_forwarded` is set to true in simplify.rs](https://github.com/deltachat/deltachat-core-rust/blob/master/src/dc_simplify.rs#L73)

apart from that, this pr also fixes a potential issue as is_forwarding was never set to false - beside in the constructor but not on re-use as done before this pr.