### PR TITLE
do not panic on bad utf-8 received from ffi

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -24,7 +24,9 @@ use num_traits::{FromPrimitive, ToPrimitive};
 
 use deltachat::contact::Contact;
 use deltachat::context::Context;
-use deltachat::dc_tools::{as_path, as_str, dc_strdup, to_string_lossy, OsStrExt, StrExt};
+use deltachat::dc_tools::{
+    as_opt_str, as_path, as_str, dc_strdup, to_string_lossy, OsStrExt, StrExt,
+};
 use deltachat::stock::StockMessage;
 use deltachat::*;
 
@@ -2918,14 +2920,6 @@ pub unsafe extern "C" fn dc_lot_get_timestamp(lot: *mut dc_lot_t) -> i64 {
 #[no_mangle]
 pub unsafe extern "C" fn dc_str_unref(s: *mut libc::c_char) {
     libc::free(s as *mut _)
-}
-
-fn as_opt_str<'a>(s: *const libc::c_char) -> Option<&'a str> {
-    if s.is_null() {
-        return None;
-    }
-
-    Some(as_str(s))
 }
 
 pub mod providers;

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -735,6 +735,14 @@ pub fn to_string_lossy(s: *const libc::c_char) -> String {
     cstr.to_string_lossy().to_string()
 }
 
+pub fn to_opt_string_lossy(s: *const libc::c_char) -> Option<String> {
+    if s.is_null() {
+        return None;
+    }
+
+    Some(to_string_lossy(s))
+}
+
 pub fn as_str<'a>(s: *const libc::c_char) -> &'a str {
     as_str_safe(s).unwrap_or_else(|err| panic!("{}", err))
 }


### PR DESCRIPTION
prefer to_string_lossy() for converting c-strings to String
c-strings may always be badly formatted and this should never lead to a panic.

fixes https://github.com/deltachat/deltachat-android/issues/1065

see also https://github.com/deltachat/deltachat-core-rust/pull/674 https://github.com/deltachat/deltachat-core-rust/pull/679 that already does the conversion on other places.