### PR TITLE
Typed blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -519,6 +519,7 @@ dependencies = [
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusqlite 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustyline 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sanitize-filename 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2030,6 +2031,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sanitize-filename"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3010,6 +3020,7 @@ dependencies = [
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
 "checksum safemem 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b08423011dae9a5ca23f07cf57dac3857f5c885d352b76f6d95f4aea9434d0"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
+"checksum sanitize-filename 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23fd0fec94ec480abfd86bb8f4f6c57e0efb36dac5c852add176ea7b04c74801"
 "checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
 "checksum scheduled-thread-pool 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bd07742e081ff6c077f5f6b283f12f32b9e7cc765b316160d66289b74546fbb3"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ escaper = "0.1.0"
 bitflags = "1.1.0"
 jetscii = "0.4.4"
 debug_stub_derive = "0.3.0"
+sanitize-filename = "0.2.1"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/run-integration-tests.sh
+++ b/run-integration-tests.sh
@@ -23,7 +23,7 @@ if [ $? != 0 ]; then
 fi
 
 pushd python
-if [ -e "./liveconfig" && -z "$DCC_PY_LIVECONFIG" ]; then
+if [ -e "./liveconfig" -a -z "$DCC_PY_LIVECONFIG" ]; then
     export DCC_PY_LIVECONFIG=liveconfig
 fi
 tox "$@"

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,0 +1,604 @@
+use std::fmt;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::context::Context;
+use crate::events::Event;
+
+/// Represents a file in the blob directory.
+///
+/// The object has a name, which will always be valid UTF-8.  Having a
+/// blob object does not imply the respective file exists, however
+/// when using one of the `create*()` methods a unique file is
+/// created.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlobObject<'a> {
+    blobdir: &'a Path,
+    name: String,
+}
+
+impl<'a> BlobObject<'a> {
+    /// Creates a new blob object with a unique name.
+    ///
+    /// Creates a new file in the blob directory.  The name will be
+    /// derived from the platform-agnostic basename of the suggested
+    /// name, followed by a random number and followed by a possible
+    /// extension.  The `data` will be written into the file.
+    ///
+    /// # Errors
+    ///
+    /// [BlobErrorKind::CreateFailure] is used when the file could not
+    /// be created.  You can expect [BlobError.cause] to contain an
+    /// underlying error.
+    ///
+    /// [BlobErrorKind::WriteFailure] is used when the file could not
+    /// be written to.  You can expect [BlobError.cause] to contain an
+    /// underlying error.
+    pub fn create(
+        context: &'a Context,
+        suggested_name: impl AsRef<str>,
+        data: &[u8],
+    ) -> std::result::Result<BlobObject<'a>, BlobError> {
+        let blobdir = context.get_blobdir();
+        let (stem, ext) = BlobObject::sanitise_name(suggested_name.as_ref().to_string());
+        let mut name = format!("{}{}", stem, ext);
+        let max_attempt = 15;
+        for attempt in 0..max_attempt {
+            let path = blobdir.join(&name);
+            match fs::OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(&path)
+            {
+                Ok(mut file) => {
+                    file.write_all(data)
+                        .map_err(|err| BlobError::new_write_failure(blobdir, &name, err))?;
+                    let blob = BlobObject {
+                        blobdir,
+                        name: format!("$BLOBDIR/{}", name),
+                    };
+                    context.call_cb(Event::NewBlobFile(blob.as_name().to_string()));
+                    return Ok(blob);
+                }
+                Err(err) => {
+                    if attempt == max_attempt {
+                        return Err(BlobError::new_create_failure(blobdir, &name, err));
+                    } else {
+                        name = format!("{}-{}{}", stem, rand::random::<u32>(), ext);
+                    }
+                }
+            }
+        }
+        Err(BlobError::new_create_failure(
+            blobdir,
+            &name,
+            format_err!("Unreachable code - supposedly"),
+        ))
+    }
+
+    /// Creates a new blob object with unique name by copying an existing file.
+    ///
+    /// This creates a new blob as described in [BlobObject::create]
+    /// but also copies an existing file into it.
+    ///
+    /// # Errors
+    ///
+    /// In addition to the errors in [BlobObject::create] the
+    /// [BlobErrorKind::CopyFailure] is used when the data can not be
+    /// copied.
+    pub fn create_and_copy(
+        context: &'a Context,
+        src: impl AsRef<Path>,
+    ) -> std::result::Result<BlobObject<'a>, BlobError> {
+        let blob = BlobObject::create(context, src.as_ref().to_string_lossy(), b"")?;
+        fs::copy(src.as_ref(), blob.to_abs_path()).map_err(|err| {
+            fs::remove_file(blob.to_abs_path()).ok();
+            BlobError::new_copy_failure(blob.blobdir, &blob.name, src.as_ref(), err)
+        })?;
+        Ok(blob)
+    }
+
+    /// Creates a blob from a file, possibly copying it to the blobdir.
+    ///
+    /// If the source file is not a path to into the blob directory
+    /// the file will be copied into the blob directory first.  If the
+    /// source file is already in the blobdir it will not be copied
+    /// and only be created if it is a valid blobname, that is no
+    /// subdirectory is used and [BlobObject::sanitise_name] does not
+    /// modify the filename.
+    ///
+    /// # Errors
+    ///
+    /// This merely delegates to the [BlobObject::create_and_copy] and
+    /// the [BlobObject::from_path] methods.  See those for possible
+    /// errors.
+    pub fn create_from_path(
+        context: &Context,
+        src: impl AsRef<Path>,
+    ) -> std::result::Result<BlobObject, BlobError> {
+        match src.as_ref().starts_with(context.get_blobdir()) {
+            true => BlobObject::from_path(context, src),
+            false => BlobObject::create_and_copy(context, src),
+        }
+    }
+
+    /// Returns a [BlobObject] for an existing blob from a path.
+    ///
+    /// The path must designate a file directly in the blobdir and
+    /// must use a valid blob name.  That is after sanitisation the
+    /// name must still be the same, that means it must be valid UTF-8
+    /// and not have any special characters in it.
+    ///
+    /// # Errors
+    ///
+    /// [BlobErrorKind::WrongBlobdir] is used if the path is not in
+    /// the blob directory.
+    ///
+    /// [BlobErrorKind::WrongName] is used if the file name does not
+    /// remain identical after sanitisation.
+    pub fn from_path(
+        context: &Context,
+        path: impl AsRef<Path>,
+    ) -> std::result::Result<BlobObject, BlobError> {
+        let rel_path = path
+            .as_ref()
+            .strip_prefix(context.get_blobdir())
+            .map_err(|_| BlobError::new_wrong_blobdir(context.get_blobdir(), path.as_ref()))?;
+        let name = rel_path
+            .to_str()
+            .ok_or_else(|| BlobError::new_wrong_name(path.as_ref()))?;
+        BlobObject::from_name(context, name.to_string())
+    }
+
+    /// Returns a [BlobObject] for an existing blob.
+    ///
+    /// The `name` may optionally be prefixed with the `$BLOBDIR/`
+    /// prefixed, as returned by [BlobObject::as_name].  This is how
+    /// you want to create a [BlobObject] for a filename read from the
+    /// database.
+    ///
+    /// # Errors
+    ///
+    /// [BlobErrorKind::WrongName] is used if the name is not a valid
+    /// blobname, i.e. if [BlobObject::sanitise_name] does modify the
+    /// provided name.
+    pub fn from_name(
+        context: &'a Context,
+        name: String,
+    ) -> std::result::Result<BlobObject<'a>, BlobError> {
+        let name: String = match name.starts_with("$BLOBDIR/") {
+            true => name.splitn(2, '/').last().unwrap().to_string(),
+            false => name,
+        };
+        let (stem, ext) = BlobObject::sanitise_name(name.clone());
+        if format!("{}{}", stem, ext) != name.as_ref() {
+            return Err(BlobError::new_wrong_name(name));
+        }
+        Ok(BlobObject {
+            blobdir: context.get_blobdir(),
+            name: format!("$BLOBDIR/{}", name),
+        })
+    }
+
+    /// Returns the absolute path to the blob in the filesystem.
+    pub fn to_abs_path(&self) -> PathBuf {
+        let fname = Path::new(&self.name).strip_prefix("$BLOBDIR/").unwrap();
+        self.blobdir.join(fname)
+    }
+
+    /// Returns the blob name, as stored in the database.
+    ///
+    /// This returns the blob in the `$BLOBDIR/<name>` format used in
+    /// the database.  Do not use this unless you're about to store
+    /// this string in the database or [Params].  Eventually even
+    /// those conversions should be handled by the type system.
+    pub fn as_name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the filename of the blob.
+    pub fn as_file_name(&self) -> &str {
+        self.name.rsplitn(2, '/').next().unwrap()
+    }
+
+    /// The path relative in the blob directory.
+    pub fn as_rel_path(&self) -> &Path {
+        Path::new(self.as_file_name())
+    }
+
+    /// Returns the extension of the blob.
+    ///
+    /// If a blob's filename has an extension, it is always guaranteed
+    /// to be lowercase.
+    pub fn suffix(&self) -> Option<&str> {
+        let ext = self.name.rsplitn(2, '.').next();
+        if ext == Some(&self.name) {
+            None
+        } else {
+            ext
+        }
+    }
+
+    /// Create a safe name based on a messy input string.
+    ///
+    /// The safe name will be a valid filename on Unix and Windows and
+    /// not contain any path separators.  The input can contain path
+    /// segments separated by either Unix or Windows path separators,
+    /// the rightmost non-empty segment will be used as name,
+    /// sanitised for special characters.
+    ///
+    /// The resulting name is returned as a tuple, the first part
+    /// being the stem or basename and the second being an extension,
+    /// including the dot.  E.g. "foo.txt" is returned as `("foo",
+    /// ".txt")` while "bar" is returned as `("bar", "")`.
+    ///
+    /// The extension part will always be lowercased.
+    fn sanitise_name(mut name: String) -> (String, String) {
+        for part in name.rsplit('/') {
+            if part.len() > 0 {
+                name = part.to_string();
+                break;
+            }
+        }
+        for part in name.rsplit('\\') {
+            if part.len() > 0 {
+                name = part.to_string();
+                break;
+            }
+        }
+        let opts = sanitize_filename::Options {
+            truncate: true,
+            windows: true,
+            replacement: "",
+        };
+        let clean = sanitize_filename::sanitize_with_options(name, opts);
+        let mut iter = clean.rsplitn(2, '.');
+        let mut ext = iter.next().unwrap_or_default().to_string();
+        let mut stem = iter.next().unwrap_or_default().to_string();
+        ext.truncate(32);
+        stem.truncate(32);
+        match stem.len() {
+            0 => (ext, "".to_string()),
+            _ => (stem, format!(".{}", ext).to_lowercase()),
+        }
+    }
+}
+
+impl<'a> fmt::Display for BlobObject<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "$BLOBDIR/{}", self.name)
+    }
+}
+
+/// Errors for the [BlobObject].
+///
+/// To keep the return type small and thus the happy path fast this
+/// stores everything on the heap.
+#[derive(Debug)]
+pub struct BlobError {
+    inner: Box<BlobErrorInner>,
+}
+
+#[derive(Debug)]
+struct BlobErrorInner {
+    kind: BlobErrorKind,
+    data: BlobErrorData,
+    backtrace: failure::Backtrace,
+}
+
+/// Error kind for [BlobError].
+///
+/// Each error kind has associated data in the [BlobErrorData].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlobErrorKind {
+    /// Failed to create the blob.
+    CreateFailure,
+    /// Failed to write data to blob.
+    WriteFailure,
+    /// Failed to copy data to blob.
+    CopyFailure,
+    /// Blob is not in the blobdir.
+    WrongBlobdir,
+    /// Blob has a bad name.
+    ///
+    /// E.g. the name is not sanitised correctly or contains a
+    /// sub-directory.
+    WrongName,
+}
+
+/// Associated data for each [BlobError] error kind.
+///
+/// This is not stored directly on the [BlobErrorKind] so that the
+/// kind can stay trivially Copy and Eq.  It is however possible to
+/// create a [BlobError] with mismatching [BlobErrorKind] and
+/// [BlobErrorData], don't do that.
+///
+/// Any blobname stored here is the bare name, without the `$BLOBDIR`
+/// prefix.  All data is owned so that errors do not need to be tied
+/// to any lifetimes.
+#[derive(Debug)]
+enum BlobErrorData {
+    CreateFailure {
+        blobdir: PathBuf,
+        blobname: String,
+        cause: failure::Error,
+    },
+    WriteFailure {
+        blobdir: PathBuf,
+        blobname: String,
+        cause: failure::Error,
+    },
+    CopyFailure {
+        blobdir: PathBuf,
+        blobname: String,
+        src: PathBuf,
+        cause: failure::Error,
+    },
+    WrongBlobdir {
+        blobdir: PathBuf,
+        src: PathBuf,
+    },
+    WrongName {
+        blobname: PathBuf,
+    },
+}
+
+impl BlobError {
+    pub fn kind(&self) -> BlobErrorKind {
+        self.inner.kind
+    }
+
+    fn new_create_failure(
+        blobdir: impl Into<PathBuf>,
+        blobname: impl Into<String>,
+        cause: impl Into<failure::Error>,
+    ) -> BlobError {
+        BlobError {
+            inner: Box::new(BlobErrorInner {
+                kind: BlobErrorKind::CreateFailure,
+                data: BlobErrorData::CreateFailure {
+                    blobdir: blobdir.into(),
+                    blobname: blobname.into(),
+                    cause: cause.into(),
+                },
+                backtrace: failure::Backtrace::new(),
+            }),
+        }
+    }
+
+    fn new_write_failure(
+        blobdir: impl Into<PathBuf>,
+        blobname: impl Into<String>,
+        cause: impl Into<failure::Error>,
+    ) -> BlobError {
+        BlobError {
+            inner: Box::new(BlobErrorInner {
+                kind: BlobErrorKind::WriteFailure,
+                data: BlobErrorData::WriteFailure {
+                    blobdir: blobdir.into(),
+                    blobname: blobname.into(),
+                    cause: cause.into(),
+                },
+                backtrace: failure::Backtrace::new(),
+            }),
+        }
+    }
+
+    fn new_copy_failure(
+        blobdir: impl Into<PathBuf>,
+        blobname: impl Into<String>,
+        src: impl Into<PathBuf>,
+        cause: impl Into<failure::Error>,
+    ) -> BlobError {
+        BlobError {
+            inner: Box::new(BlobErrorInner {
+                kind: BlobErrorKind::CopyFailure,
+                data: BlobErrorData::CopyFailure {
+                    blobdir: blobdir.into(),
+                    blobname: blobname.into(),
+                    src: src.into(),
+                    cause: cause.into(),
+                },
+                backtrace: failure::Backtrace::new(),
+            }),
+        }
+    }
+
+    fn new_wrong_blobdir(blobdir: impl Into<PathBuf>, src: impl Into<PathBuf>) -> BlobError {
+        BlobError {
+            inner: Box::new(BlobErrorInner {
+                kind: BlobErrorKind::WrongBlobdir,
+                data: BlobErrorData::WrongBlobdir {
+                    blobdir: blobdir.into(),
+                    src: src.into(),
+                },
+                backtrace: failure::Backtrace::new(),
+            }),
+        }
+    }
+
+    fn new_wrong_name(blobname: impl Into<PathBuf>) -> BlobError {
+        BlobError {
+            inner: Box::new(BlobErrorInner {
+                kind: BlobErrorKind::WrongName,
+                data: BlobErrorData::WrongName {
+                    blobname: blobname.into(),
+                },
+                backtrace: failure::Backtrace::new(),
+            }),
+        }
+    }
+}
+
+impl fmt::Display for BlobError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // Match on the data rather than kind, they are equivalent for
+        // identifying purposes but contain the actual data we need.
+        match &self.inner.data {
+            BlobErrorData::CreateFailure {
+                blobdir, blobname, ..
+            } => write!(
+                f,
+                "Failed to create blob {} in {}",
+                blobname,
+                blobdir.display()
+            ),
+            BlobErrorData::WriteFailure {
+                blobdir, blobname, ..
+            } => write!(
+                f,
+                "Failed to write data to blob {} in {}",
+                blobname,
+                blobdir.display()
+            ),
+            BlobErrorData::CopyFailure {
+                blobdir,
+                blobname,
+                src,
+                ..
+            } => write!(
+                f,
+                "Failed to copy data from {} to blob {} in {}",
+                src.display(),
+                blobname,
+                blobdir.display(),
+            ),
+            BlobErrorData::WrongBlobdir { blobdir, src } => write!(
+                f,
+                "File path {} is not in blobdir {}",
+                src.display(),
+                blobdir.display(),
+            ),
+            BlobErrorData::WrongName { blobname } => {
+                write!(f, "Blob has a bad name: {}", blobname.display(),)
+            }
+        }
+    }
+}
+
+impl failure::Fail for BlobError {
+    fn cause(&self) -> Option<&dyn failure::Fail> {
+        match &self.inner.data {
+            BlobErrorData::CreateFailure { cause, .. }
+            | BlobErrorData::WriteFailure { cause, .. }
+            | BlobErrorData::CopyFailure { cause, .. } => Some(cause.as_fail()),
+            _ => None,
+        }
+    }
+
+    fn backtrace(&self) -> Option<&failure::Backtrace> {
+        Some(&self.inner.backtrace)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::test_utils::*;
+
+    #[test]
+    fn test_create() {
+        let t = dummy_context();
+        let blob = BlobObject::create(&t.ctx, "foo", b"hello").unwrap();
+        let fname = t.ctx.get_blobdir().join("foo");
+        let data = fs::read(fname).unwrap();
+        assert_eq!(data, b"hello");
+        assert_eq!(blob.as_name(), "$BLOBDIR/foo");
+        assert_eq!(blob.to_abs_path(), t.ctx.get_blobdir().join("foo"));
+    }
+
+    #[test]
+    fn test_lowercase_ext() {
+        let t = dummy_context();
+        let blob = BlobObject::create(&t.ctx, "foo.TXT", b"hello").unwrap();
+        assert_eq!(blob.as_name(), "$BLOBDIR/foo.txt");
+    }
+
+    #[test]
+    fn test_as_file_name() {
+        let t = dummy_context();
+        let blob = BlobObject::create(&t.ctx, "foo.txt", b"hello").unwrap();
+        assert_eq!(blob.as_file_name(), "foo.txt");
+    }
+
+    #[test]
+    fn test_as_rel_path() {
+        let t = dummy_context();
+        let blob = BlobObject::create(&t.ctx, "foo.txt", b"hello").unwrap();
+        assert_eq!(blob.as_rel_path(), Path::new("foo.txt"));
+    }
+
+    #[test]
+    fn test_suffix() {
+        let t = dummy_context();
+        let foo = BlobObject::create(&t.ctx, "foo.txt", b"hello").unwrap();
+        assert_eq!(foo.suffix(), Some("txt"));
+        let bar = BlobObject::create(&t.ctx, "bar", b"world").unwrap();
+        assert_eq!(bar.suffix(), None);
+    }
+
+    #[test]
+    fn test_create_dup() {
+        let t = dummy_context();
+        BlobObject::create(&t.ctx, "foo.txt", b"hello").unwrap();
+        let foo = t.ctx.get_blobdir().join("foo.txt");
+        assert!(foo.exists());
+        BlobObject::create(&t.ctx, "foo.txt", b"world").unwrap();
+        for dirent in fs::read_dir(t.ctx.get_blobdir()).unwrap() {
+            let fname = dirent.unwrap().file_name();
+            if fname == foo.file_name().unwrap() {
+                assert_eq!(fs::read(&foo).unwrap(), b"hello");
+            } else {
+                let name = fname.to_str().unwrap();
+                assert!(name.starts_with("foo"));
+                assert!(name.ends_with(".txt"));
+            }
+        }
+    }
+
+    #[test]
+    fn test_create_long_names() {
+        let t = dummy_context();
+        let s = "12312312039182039182039812039810293810293810293810293801293801293123123";
+        let blob = BlobObject::create(&t.ctx, s, b"data").unwrap();
+        let blobname = blob.as_name().split('/').last().unwrap();
+        assert!(s.len() > blobname.len());
+    }
+
+    #[test]
+    fn test_create_and_copy() {
+        let t = dummy_context();
+        let src = t.dir.path().join("src");
+        fs::write(&src, b"boo").unwrap();
+        let blob = BlobObject::create_and_copy(&t.ctx, &src).unwrap();
+        assert_eq!(blob.as_name(), "$BLOBDIR/src");
+        let data = fs::read(blob.to_abs_path()).unwrap();
+        assert_eq!(data, b"boo");
+
+        let whoops = t.dir.path().join("whoops");
+        assert!(BlobObject::create_and_copy(&t.ctx, &whoops).is_err());
+        let whoops = t.ctx.get_blobdir().join("whoops");
+        assert!(!whoops.exists());
+    }
+
+    #[test]
+    fn test_create_from_path() {
+        let t = dummy_context();
+
+        let src_ext = t.dir.path().join("external");
+        fs::write(&src_ext, b"boo").unwrap();
+        let blob = BlobObject::create_from_path(&t.ctx, &src_ext).unwrap();
+        assert_eq!(blob.as_name(), "$BLOBDIR/external");
+        let data = fs::read(blob.to_abs_path()).unwrap();
+        assert_eq!(data, b"boo");
+
+        let src_int = t.ctx.get_blobdir().join("internal");
+        fs::write(&src_int, b"boo").unwrap();
+        let blob = BlobObject::create_from_path(&t.ctx, &src_int).unwrap();
+        assert_eq!(blob.as_name(), "$BLOBDIR/internal");
+        let data = fs::read(blob.to_abs_path()).unwrap();
+        assert_eq!(data, b"boo");
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 use std::ffi::OsString;
-use std::fs;
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Condvar, Mutex, RwLock};
 
@@ -11,7 +9,6 @@ use crate::chat::*;
 use crate::config::Config;
 use crate::constants::*;
 use crate::contact::*;
-use crate::dc_tools::{dc_copy_file, dc_derive_safe_stem_ext};
 use crate::error::*;
 use crate::events::Event;
 use crate::imap::*;
@@ -24,7 +21,6 @@ use crate::message::{self, Message};
 use crate::param::Params;
 use crate::smtp::*;
 use crate::sql::Sql;
-use rand::{thread_rng, Rng};
 
 /// Callback function type for [Context]
 ///
@@ -163,59 +159,6 @@ impl Context {
 
     pub fn get_blobdir(&self) -> &Path {
         self.blobdir.as_path()
-    }
-
-    pub fn copy_to_blobdir(&self, orig_filename: impl AsRef<str>) -> Result<String> {
-        // return a $BLOBDIR/<filename> with the content of orig_filename
-        // copied into it. The <filename> will be safely derived from
-        // orig_filename, and will not clash with existing filenames.
-        let dest = self.new_blob_file(&orig_filename, b"")?;
-        if dc_copy_file(
-            &self,
-            PathBuf::from(orig_filename.as_ref()),
-            PathBuf::from(&dest),
-        ) {
-            Ok(dest)
-        } else {
-            bail!("could not copy {} to {}", orig_filename.as_ref(), dest);
-        }
-    }
-
-    pub fn new_blob_file(&self, orig_filename: impl AsRef<str>, data: &[u8]) -> Result<String> {
-        // return a $BLOBDIR/<FILENAME> string which corresponds to the
-        // respective file in the blobdir, and which contains the data.
-        // FILENAME is computed by looking and possibly mangling the
-        // basename of orig_filename. The resulting filenames are meant
-        // to be human-readable.
-        let (stem, ext) = dc_derive_safe_stem_ext(orig_filename.as_ref());
-
-        // ext starts with "." or is empty string, so we can always resconstruct
-
-        for i in 0..3 {
-            let candidate_basename = match i {
-                // first a try to just use the (possibly mangled) original basename
-                0 => format!("{}{}", stem, ext),
-
-                // otherwise extend stem with random numbers
-                _ => {
-                    let mut rng = thread_rng();
-                    let random_id: u32 = rng.gen();
-                    format!("{}-{}{}", stem, random_id, ext)
-                }
-            };
-            let path = self.get_blobdir().join(&candidate_basename);
-            if let Ok(mut file) = fs::OpenOptions::new()
-                .create_new(true)
-                .write(true)
-                .open(&path)
-            {
-                file.write_all(data)?;
-                let db_entry = format!("$BLOBDIR/{}", candidate_basename);
-                self.call_cb(Event::NewBlobFile(db_entry.clone()));
-                return Ok(db_entry);
-            }
-        }
-        bail!("out of luck to create new blob file");
     }
 
     pub fn call_cb(&self, event: Event) -> uintptr_t {
@@ -536,7 +479,6 @@ pub fn get_version_str() -> &'static str {
 mod tests {
     use super::*;
 
-    use crate::dc_tools::*;
     use crate::test_utils::*;
 
     #[test]
@@ -572,51 +514,6 @@ mod tests {
         std::fs::write(&blobdir, b"123").unwrap();
         let res = Context::new(Box::new(|_, _| 0), "FakeOS".into(), dbfile);
         assert!(res.is_err());
-    }
-
-    #[test]
-    fn test_new_blob_file() {
-        let t = dummy_context();
-        let context = t.ctx;
-        let x = &context.new_blob_file("hello", b"data").unwrap();
-        assert!(dc_file_exist(&context, x));
-        assert!(x.starts_with("$BLOBDIR"));
-        assert!(dc_read_file(&context, x).unwrap() == b"data");
-
-        let y = &context.new_blob_file("hello", b"data").unwrap();
-        assert!(dc_file_exist(&context, y));
-        assert!(y.starts_with("$BLOBDIR/hello-"));
-
-        let x = &context.new_blob_file("xyz/hello.png", b"data").unwrap();
-        assert!(dc_file_exist(&context, x));
-        assert_eq!(x, "$BLOBDIR/hello.png");
-
-        let y = &context.new_blob_file("hello\\world.png", b"data").unwrap();
-        assert!(dc_file_exist(&context, y));
-        assert_eq!(y, "$BLOBDIR/world.png");
-    }
-
-    #[test]
-    fn test_new_blob_file_long_names() {
-        let t = dummy_context();
-        let context = t.ctx;
-        let s = "12312312039182039182039812039810293810293810293810293801293801293123123";
-        let x = &context.new_blob_file(s, b"data").unwrap();
-        println!("blobfilename '{}'", x);
-        println!("xxxxfilename '{}'", s);
-        assert!(x.len() < s.len());
-        assert!(dc_file_exist(&context, x));
-        assert!(x.starts_with("$BLOBDIR"));
-    }
-
-    #[test]
-    fn test_new_blob_file_unicode() {
-        let t = dummy_context();
-        let context = t.ctx;
-        let s = "helloäworld.qwe";
-        let x = &context.new_blob_file(s, b"data").unwrap();
-        assert_eq!(x, "$BLOBDIR/hello-world.qwe");
-        assert_eq!(dc_read_file(&context, x).unwrap(), b"data");
     }
 
     #[test]

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1228,14 +1228,8 @@ unsafe fn create_or_lookup_group(
                 if part.typ == Viewtype::Image {
                     grpimage = part
                         .param
-                        .get(Param::File)
-                        .and_then(|param| ParamsFile::from_param(context, param).ok())
-                        .and_then(|file| match file {
-                            ParamsFile::FsPath(path) => {
-                                BlobObject::create_from_path(context, path).ok()
-                            }
-                            ParamsFile::Blob(blob) => Some(blob),
-                        });
+                        .get_blob(Param::File, context, true)
+                        .unwrap_or(None);
                     info!(context, "found image {:?}", grpimage);
                     changed = true;
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,8 @@ pub enum Error {
     Base64Decode(base64::DecodeError),
     #[fail(display = "{:?}", _0)]
     FromUtf8(std::string::FromUtf8Error),
+    #[fail(display = "{}", _0)]
+    BlobError(#[cause] crate::blob::BlobError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -91,6 +93,12 @@ impl From<pgp::errors::Error> for Error {
 impl From<std::string::FromUtf8Error> for Error {
     fn from(err: std::string::FromUtf8Error) -> Error {
         Error::FromUtf8(err)
+    }
+}
+
+impl From<crate::blob::BlobError> for Error {
+    fn from(err: crate::blob::BlobError) -> Error {
+        Error::BlobError(err)
     }
 }
 

--- a/src/job.rs
+++ b/src/job.rs
@@ -139,15 +139,7 @@ impl Job {
             }
         }
 
-        if let Some(filename) = self
-            .param
-            .get(Param::File)
-            .and_then(|param| ParamsFile::from_param(context, param).ok())
-            .map(|file| match file {
-                ParamsFile::FsPath(path) => path,
-                ParamsFile::Blob(blob) => blob.to_abs_path(),
-            })
-        {
+        if let Some(filename) = self.param.get_path(Param::File, context).unwrap_or(None) {
             if let Ok(body) = dc_read_file(context, &filename) {
                 if let Some(recipients) = self.param.get(Param::Recipients) {
                     let recipients_list = recipients
@@ -573,15 +565,7 @@ pub fn job_send_msg(context: &Context, msg_id: u32) -> Result<(), Error> {
     let mut mimefactory = MimeFactory::load_msg(context, msg_id)?;
 
     if chat::msgtype_has_file(mimefactory.msg.type_0) {
-        let file_param = mimefactory
-            .msg
-            .param
-            .get(Param::File)
-            .and_then(|param| ParamsFile::from_param(context, param).ok())
-            .map(|file| match file {
-                ParamsFile::FsPath(path) => path,
-                ParamsFile::Blob(blob) => blob.to_abs_path(),
-            });
+        let file_param = mimefactory.msg.param.get_path(Param::File, context)?;
         if let Some(pathNfilename) = file_param {
             if (mimefactory.msg.type_0 == Viewtype::Image
                 || mimefactory.msg.type_0 == Viewtype::Gif)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub(crate) mod events;
 pub use events::*;
 
 mod aheader;
+pub mod blob;
 pub mod chat;
 pub mod chatlist;
 pub mod config;


### PR DESCRIPTION
I never knew what kind of stuff was in one of those strings referring to blobs, so I thought fixing it with types would be a good thing.  Turns out that was more involved than hoped for.

Anyway, this tries to be strict about blobs by creating a `BlobObject`.  This object should also make it easier to in the future not store all blobs into one directory or even into an sqlite store.  Furthermore since blobs get passed through the params system a lot, the `ParamsFile` was added, basically any filename read from params should be parsable into that enum, allowing you to know if you're dealing with a pathname or already with a blob.

This doesn't always make things less verbose on call sites, I apologise for that.  In the future some of this could improve by making the storage more explicit, e.g. Params could have FromParams/ToParams traits.  OTOH maybe Params should be moved to columns in the db directly, anyway I'm not making any calls on those things yet.  The upshot of this is that you need to manually remember to parse a filename retrieved from params with ParamsFile for now.

Some places still exists where filenames are retrieved from Params without the ParamsFile bit.  They don't have access to a context object and after checking them they already are safe and I felt like adding the complexities of pushing context into those APIs was not a good idea.  Again I believe later improvements might end up bypassing some of this, or maybe they wont.

Lastly I must admit I experimented with errors here.  I wanted a bespoke error object and wanted to have the cause carried along so you can see where errors come from as well as have backtraces.  Again, currently nothing uses the causes and kinds because everything gets dumped in the global Error type.  But I think in the future more things could have custom errors and causes and backtraces, I expect this will become especially nice once the core has it's own log it can write.

Finally, (phew, you're still reading), I realise this is bending the "freeze for a release" a bit.  But than it's not the only improvement which hasn't been directly related to a bug before.  And it's been semi-frozen for ages...

Thanks for reviewing!
The diff is a lot larger than I'd like so here some **review pointers**: `BlobObject` in **context.rs** is important.  If you don't care about error handling much skip all the BlobError/BlobErrorKind/BlobErrorData stuff, you can see how it's used which is what matters.  Secondly `ParamsFile` in **params.rs** is important.
After that the rest is mostly applying this stuff to current call sites, sometimes care must be taken not to change the logic.