### PR TITLE
A MsgId newtype

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -22,11 +22,13 @@ use std::sync::RwLock;
 use libc::uintptr_t;
 use num_traits::{FromPrimitive, ToPrimitive};
 
+use deltachat::constants::DC_MSG_ID_LAST_SPECIAL;
 use deltachat::contact::Contact;
 use deltachat::context::Context;
 use deltachat::dc_tools::{
     as_path, dc_strdup, to_opt_string_lossy, to_string_lossy, OsStrExt, StrExt,
 };
+use deltachat::message::MsgId;
 use deltachat::stock::StockMessage;
 use deltachat::*;
 
@@ -141,9 +143,12 @@ impl ContextWrapper {
                     | Event::IncomingMsg { chat_id, msg_id }
                     | Event::MsgDelivered { chat_id, msg_id }
                     | Event::MsgFailed { chat_id, msg_id }
-                    | Event::MsgRead { chat_id, msg_id } => {
-                        ffi_cb(self, event_id, chat_id as uintptr_t, msg_id as uintptr_t)
-                    }
+                    | Event::MsgRead { chat_id, msg_id } => ffi_cb(
+                        self,
+                        event_id,
+                        chat_id as uintptr_t,
+                        msg_id.to_u32() as uintptr_t,
+                    ),
                     Event::ChatModified(chat_id) => ffi_cb(self, event_id, chat_id as uintptr_t, 0),
                     Event::ContactsChanged(id) | Event::LocationChanged(id) => {
                         let id = id.unwrap_or_default();
@@ -681,7 +686,8 @@ pub unsafe extern "C" fn dc_create_chat_by_msg_id(context: *mut dc_context_t, ms
     let ffi_context = &*context;
     ffi_context
         .with_inner(|ctx| {
-            chat::create_by_msg_id(ctx, msg_id).unwrap_or_log_default(ctx, "Failed to create chat")
+            chat::create_by_msg_id(ctx, MsgId::new(msg_id))
+                .unwrap_or_log_default(ctx, "Failed to create chat")
         })
         .unwrap_or(0)
 }
@@ -739,6 +745,7 @@ pub unsafe extern "C" fn dc_prepare_msg(
             chat::prepare_msg(ctx, chat_id, &mut ffi_msg.message)
                 .unwrap_or_log_default(ctx, "Failed to prepare message")
         })
+        .map(|msg_id| msg_id.to_u32())
         .unwrap_or(0)
 }
 
@@ -759,6 +766,7 @@ pub unsafe extern "C" fn dc_send_msg(
             chat::send_msg(ctx, chat_id, &mut ffi_msg.message)
                 .unwrap_or_log_default(ctx, "Failed to send message")
         })
+        .map(|msg_id| msg_id.to_u32())
         .unwrap_or(0)
 }
 
@@ -777,6 +785,7 @@ pub unsafe extern "C" fn dc_send_text_msg(
     ffi_context
         .with_inner(|ctx| {
             chat::send_text_msg(ctx, chat_id, text_to_send)
+                .map(|msg_id| msg_id.to_u32())
                 .unwrap_or_log_default(ctx, "Failed to send text message")
         })
         .unwrap_or(0)
@@ -841,9 +850,19 @@ pub unsafe extern "C" fn dc_get_chat_msgs(
         return ptr::null_mut();
     }
     let ffi_context = &*context;
+    let marker_flag = if marker1before <= DC_MSG_ID_LAST_SPECIAL {
+        None
+    } else {
+        Some(MsgId::new(marker1before))
+    };
     ffi_context
         .with_inner(|ctx| {
-            let arr = dc_array_t::from(chat::get_chat_msgs(ctx, chat_id, flags, marker1before));
+            let arr = dc_array_t::from(
+                chat::get_chat_msgs(ctx, chat_id, flags, marker_flag)
+                    .iter()
+                    .map(|msg_id| msg_id.to_u32())
+                    .collect::<Vec<u32>>(),
+            );
             Box::into_raw(Box::new(arr))
         })
         .unwrap_or_else(|_| ptr::null_mut())
@@ -887,7 +906,12 @@ pub unsafe extern "C" fn dc_get_fresh_msgs(
     let ffi_context = &*context;
     ffi_context
         .with_inner(|ctx| {
-            let arr = dc_array_t::from(ctx.get_fresh_msgs());
+            let arr = dc_array_t::from(
+                ctx.get_fresh_msgs()
+                    .iter()
+                    .map(|msg_id| msg_id.to_u32())
+                    .collect::<Vec<u32>>(),
+            );
             Box::into_raw(Box::new(arr))
         })
         .unwrap_or_else(|_| ptr::null_mut())
@@ -949,13 +973,12 @@ pub unsafe extern "C" fn dc_get_chat_media(
         from_prim(or_msg_type3).expect(&format!("incorrect or_msg_type3 = {}", or_msg_type3));
     ffi_context
         .with_inner(|ctx| {
-            let arr = dc_array_t::from(chat::get_chat_media(
-                ctx,
-                chat_id,
-                msg_type,
-                or_msg_type2,
-                or_msg_type3,
-            ));
+            let arr = dc_array_t::from(
+                chat::get_chat_media(ctx, chat_id, msg_type, or_msg_type2, or_msg_type3)
+                    .iter()
+                    .map(|msg_id| msg_id.to_u32())
+                    .collect::<Vec<u32>>(),
+            );
             Box::into_raw(Box::new(arr))
         })
         .unwrap_or_else(|_| ptr::null_mut())
@@ -988,7 +1011,16 @@ pub unsafe extern "C" fn dc_get_next_media(
         from_prim(or_msg_type3).expect(&format!("incorrect or_msg_type3 = {}", or_msg_type3));
     ffi_context
         .with_inner(|ctx| {
-            chat::get_next_media(ctx, msg_id, direction, msg_type, or_msg_type2, or_msg_type3)
+            chat::get_next_media(
+                ctx,
+                MsgId::new(msg_id),
+                direction,
+                msg_type,
+                or_msg_type2,
+                or_msg_type3,
+            )
+            .map(|msg_id| msg_id.to_u32())
+            .unwrap_or(0)
         })
         .unwrap_or(0)
 }
@@ -1059,7 +1091,12 @@ pub unsafe extern "C" fn dc_search_msgs(
     let ffi_context = &*context;
     ffi_context
         .with_inner(|ctx| {
-            let arr = dc_array_t::from(ctx.search_msgs(chat_id, to_string_lossy(query)));
+            let arr = dc_array_t::from(
+                ctx.search_msgs(chat_id, to_string_lossy(query))
+                    .iter()
+                    .map(|msg_id| msg_id.to_u32())
+                    .collect::<Vec<u32>>(),
+            );
             Box::into_raw(Box::new(arr))
         })
         .unwrap_or_else(|_| ptr::null_mut())
@@ -1211,7 +1248,7 @@ pub unsafe extern "C" fn dc_get_msg_info(
     }
     let ffi_context = &*context;
     ffi_context
-        .with_inner(|ctx| message::get_msg_info(ctx, msg_id).strdup())
+        .with_inner(|ctx| message::get_msg_info(ctx, MsgId::new(msg_id)).strdup())
         .unwrap_or_else(|_| ptr::null_mut())
 }
 
@@ -1227,7 +1264,7 @@ pub unsafe extern "C" fn dc_get_mime_headers(
     let ffi_context = &*context;
     ffi_context
         .with_inner(|ctx| {
-            message::get_mime_headers(ctx, msg_id)
+            message::get_mime_headers(ctx, MsgId::new(msg_id))
                 .map(|s| s.strdup())
                 .unwrap_or_else(|| ptr::null_mut())
         })
@@ -1245,11 +1282,10 @@ pub unsafe extern "C" fn dc_delete_msgs(
         return;
     }
     let ffi_context = &*context;
-
     let ids = std::slice::from_raw_parts(msg_ids, msg_cnt as usize);
-
+    let msg_ids: Vec<MsgId> = ids.iter().map(|id| MsgId::new(*id)).collect();
     ffi_context
-        .with_inner(|ctx| message::delete_msgs(ctx, ids))
+        .with_inner(|ctx| message::delete_msgs(ctx, &msg_ids[..]))
         .unwrap_or(())
 }
 
@@ -1269,11 +1305,11 @@ pub unsafe extern "C" fn dc_forward_msgs(
         return;
     }
     let ids = std::slice::from_raw_parts(msg_ids, msg_cnt as usize);
-
+    let msg_ids: Vec<MsgId> = ids.iter().map(|id| MsgId::new(*id)).collect();
     let ffi_context = &*context;
     ffi_context
         .with_inner(|ctx| {
-            chat::forward_msgs(ctx, ids, chat_id)
+            chat::forward_msgs(ctx, &msg_ids[..], chat_id)
                 .unwrap_or_log_default(ctx, "Failed to forward message")
         })
         .unwrap_or_default()
@@ -1302,10 +1338,14 @@ pub unsafe extern "C" fn dc_markseen_msgs(
         return;
     }
     let ids = std::slice::from_raw_parts(msg_ids, msg_cnt as usize);
-
+    let msg_ids: Vec<MsgId> = ids
+        .iter()
+        .filter(|id| **id > DC_MSG_ID_LAST_SPECIAL)
+        .map(|id| MsgId::new(*id))
+        .collect();
     let ffi_context = &*context;
     ffi_context
-        .with_inner(|ctx| message::markseen_msgs(ctx, ids))
+        .with_inner(|ctx| message::markseen_msgs(ctx, &msg_ids[..]))
         .ok();
 }
 
@@ -1320,12 +1360,11 @@ pub unsafe extern "C" fn dc_star_msgs(
         eprintln!("ignoring careless call to dc_star_msgs()");
         return;
     }
-
     let ids = std::slice::from_raw_parts(msg_ids, msg_cnt as usize);
-
+    let msg_ids: Vec<MsgId> = ids.iter().map(|id| MsgId::new(*id)).collect();
     let ffi_context = &*context;
     ffi_context
-        .with_inner(|ctx| message::star_msgs(ctx, ids, star == 1))
+        .with_inner(|ctx| message::star_msgs(ctx, &msg_ids[..], star == 1))
         .ok();
 }
 
@@ -1338,7 +1377,7 @@ pub unsafe extern "C" fn dc_get_msg(context: *mut dc_context_t, msg_id: u32) -> 
     let ffi_context = &*context;
     ffi_context
         .with_inner(|ctx| {
-            let message = match message::Message::load_from_db(ctx, msg_id) {
+            let message = match message::Message::load_from_db(ctx, MsgId::new(msg_id)) {
                 Ok(msg) => msg,
                 Err(e) => {
                     error!(ctx, "Error getting msg #{}: {}", msg_id, e);
@@ -1625,7 +1664,8 @@ pub unsafe extern "C" fn dc_continue_key_transfer(
     let ffi_context = &*context;
     ffi_context
         .with_inner(|ctx| {
-            match imex::continue_key_transfer(ctx, msg_id, &to_string_lossy(setup_code)) {
+            match imex::continue_key_transfer(ctx, MsgId::new(msg_id), &to_string_lossy(setup_code))
+            {
                 Ok(()) => 1,
                 Err(err) => {
                     error!(ctx, "dc_continue_key_transfer: {}", err);
@@ -2036,7 +2076,11 @@ pub unsafe extern "C" fn dc_chatlist_get_msg_id(
         return 0;
     }
     let ffi_list = &*chatlist;
-    ffi_list.list.get_msg_id(index as usize)
+    ffi_list
+        .list
+        .get_msg_id(index as usize)
+        .map(|msg_id| msg_id.to_u32())
+        .unwrap_or(0)
 }
 
 #[no_mangle]
@@ -2278,7 +2322,7 @@ pub unsafe extern "C" fn dc_msg_get_id(msg: *mut dc_msg_t) -> u32 {
         return 0;
     }
     let ffi_msg = &*msg;
-    ffi_msg.message.get_id()
+    ffi_msg.message.get_id().to_u32()
 }
 
 #[no_mangle]

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -193,6 +193,8 @@ impl<'a> BlobObject<'a> {
     /// the database.  Do not use this unless you're about to store
     /// this string in the database or [Params].  Eventually even
     /// those conversions should be handled by the type system.
+    ///
+    /// [Params]: crate::param::Params
     pub fn as_name(&self) -> &str {
         &self.name
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -68,7 +68,7 @@ pub const DC_GCL_ARCHIVED_ONLY: usize = 0x01;
 pub const DC_GCL_NO_SPECIALS: usize = 0x02;
 pub const DC_GCL_ADD_ALLDONE_HINT: usize = 0x04;
 
-const DC_GCM_ADDDAYMARKER: usize = 0x01;
+pub const DC_GCM_ADDDAYMARKER: u32 = 0x01;
 
 pub const DC_GCL_VERIFIED_ONLY: usize = 0x01;
 pub const DC_GCL_ADD_SELF: usize = 0x02;
@@ -120,7 +120,7 @@ impl Default for Chattype {
 }
 
 pub const DC_MSG_ID_MARKER1: u32 = 1;
-const DC_MSG_ID_DAYMARKER: u32 = 9;
+pub const DC_MSG_ID_DAYMARKER: u32 = 9;
 pub const DC_MSG_ID_LAST_SPECIAL: u32 = 9;
 
 /// approx. max. length returned by dc_msg_get_text()

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -14,7 +14,7 @@ use crate::error::Result;
 use crate::events::Event;
 use crate::key::*;
 use crate::login_param::LoginParam;
-use crate::message::MessageState;
+use crate::message::{MessageState, MsgId};
 use crate::peerstate::*;
 use crate::sql;
 use crate::stock::StockMessage;
@@ -243,7 +243,7 @@ impl Contact {
         {
             context.call_cb(Event::MsgsChanged {
                 chat_id: 0,
-                msg_id: 0,
+                msg_id: MsgId::new(0),
             });
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,8 @@ pub enum Error {
     FromUtf8(std::string::FromUtf8Error),
     #[fail(display = "{}", _0)]
     BlobError(#[cause] crate::blob::BlobError),
+    #[fail(display = "Invalid Message ID.")]
+    InvalidMsgId,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -99,6 +101,12 @@ impl From<std::string::FromUtf8Error> for Error {
 impl From<crate::blob::BlobError> for Error {
     fn from(err: crate::blob::BlobError) -> Error {
         Error::BlobError(err)
+    }
+}
+
+impl From<crate::message::InvalidMsgId> for Error {
+    fn from(_err: crate::message::InvalidMsgId) -> Error {
+        Error::InvalidMsgId
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use strum::EnumProperty;
 
+use crate::message::MsgId;
+
 impl Event {
     /// Returns the corresponding Event id.
     pub fn as_id(&self) -> i32 {
@@ -125,7 +127,7 @@ pub enum Event {
     ///
     /// @return 0
     #[strum(props(id = "2000"))]
-    MsgsChanged { chat_id: u32, msg_id: u32 },
+    MsgsChanged { chat_id: u32, msg_id: MsgId },
 
     /// There is a fresh message. Typically, the user will show an notification
     /// when receiving this message.
@@ -134,28 +136,28 @@ pub enum Event {
     ///
     /// @return 0
     #[strum(props(id = "2005"))]
-    IncomingMsg { chat_id: u32, msg_id: u32 },
+    IncomingMsg { chat_id: u32, msg_id: MsgId },
 
     /// A single message is sent successfully. State changed from  DC_STATE_OUT_PENDING to
     /// DC_STATE_OUT_DELIVERED, see dc_msg_get_state().
     ///
     /// @return 0
     #[strum(props(id = "2010"))]
-    MsgDelivered { chat_id: u32, msg_id: u32 },
+    MsgDelivered { chat_id: u32, msg_id: MsgId },
 
     /// A single message could not be sent. State changed from DC_STATE_OUT_PENDING or DC_STATE_OUT_DELIVERED to
     /// DC_STATE_OUT_FAILED, see dc_msg_get_state().
     ///
     /// @return 0
     #[strum(props(id = "2012"))]
-    MsgFailed { chat_id: u32, msg_id: u32 },
+    MsgFailed { chat_id: u32, msg_id: MsgId },
 
     /// A single message is read by the receiver. State changed from DC_STATE_OUT_DELIVERED to
     /// DC_STATE_OUT_MDN_RCVD, see dc_msg_get_state().
     ///
     /// @return 0
     #[strum(props(id = "2015"))]
-    MsgRead { chat_id: u32, msg_id: u32 },
+    MsgRead { chat_id: u32, msg_id: MsgId },
 
     /// Chat changed.  The name or the image of a chat group was changed or members were added or removed.
     /// Or the verify state of a chat has changed.

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1509,7 +1509,7 @@ fn precheck_imf(context: &Context, rfc724_mid: &str, server_folder: &str, server
             job_add(
                 context,
                 Action::MarkseenMsgOnImap,
-                msg_id as libc::c_int,
+                msg_id.to_u32() as i32,
                 Params::new(),
                 0,
             );

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -16,7 +16,7 @@ use crate::error::*;
 use crate::events::Event;
 use crate::job::*;
 use crate::key::*;
-use crate::message::Message;
+use crate::message::{Message, MsgId};
 use crate::param::*;
 use crate::pgp;
 use crate::sql::{self, Sql};
@@ -227,8 +227,8 @@ pub fn create_setup_code(_context: &Context) -> String {
     ret
 }
 
-pub fn continue_key_transfer(context: &Context, msg_id: u32, setup_code: &str) -> Result<()> {
-    ensure!(msg_id > DC_MSG_ID_LAST_SPECIAL, "wrong id");
+pub fn continue_key_transfer(context: &Context, msg_id: MsgId, setup_code: &str) -> Result<()> {
+    ensure!(!msg_id.is_special(), "wrong id");
 
     let msg = Message::load_from_db(context, msg_id);
     if msg.is_err() {

--- a/src/location.rs
+++ b/src/location.rs
@@ -10,7 +10,7 @@ use crate::dc_tools::*;
 use crate::error::Error;
 use crate::events::Event;
 use crate::job::*;
-use crate::message::Message;
+use crate::message::{Message, MsgId};
 use crate::param::*;
 use crate::sql;
 use crate::stock::StockMessage;
@@ -476,12 +476,16 @@ pub fn set_kml_sent_timestamp(
     Ok(())
 }
 
-pub fn set_msg_location_id(context: &Context, msg_id: u32, location_id: u32) -> Result<(), Error> {
+pub fn set_msg_location_id(
+    context: &Context,
+    msg_id: MsgId,
+    location_id: u32,
+) -> Result<(), Error> {
     sql::execute(
         context,
         &context.sql,
         "UPDATE msgs SET location_id=? WHERE id=?;",
-        params![location_id, msg_id as i32],
+        params![location_id, msg_id],
     )?;
 
     Ok(())

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use deltachat_derive::{FromSql, ToSql};
+use failure::Fail;
 
 use crate::chat::{self, Chat};
 use crate::constants::*;
@@ -17,8 +18,133 @@ use crate::pgp::*;
 use crate::sql;
 use crate::stock::StockMessage;
 
-/// In practice, the user additionally cuts the string himself pixel-accurate.
+// In practice, the user additionally cuts the string themselves
+// pixel-accurate.
 const SUMMARY_CHARACTERS: usize = 160;
+
+/// Message ID, including reserved IDs.
+///
+/// Some message IDs are reserved to identify special message types.
+/// This type can represent both the special as well as normal
+/// messages.
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+pub struct MsgId(u32);
+
+impl MsgId {
+    /// Create a new [MsgId].
+    pub fn new(id: u32) -> MsgId {
+        MsgId(id)
+    }
+
+    /// Create a new unset [MsgId].
+    pub fn new_unset() -> MsgId {
+        MsgId(0)
+    }
+
+    /// Whether the message ID signifies a special message.
+    ///
+    /// This kind of message ID can not be used for real messages.
+    pub fn is_special(&self) -> bool {
+        match self.0 {
+            0..=DC_MSG_ID_LAST_SPECIAL => true,
+            _ => false,
+        }
+    }
+
+    /// Whether the message ID is unset.
+    ///
+    /// When a message is created it initially has a ID of `0`, which
+    /// is filled in by a real message ID once the message is saved in
+    /// the database.  This returns true while the message has not
+    /// been saved and thus not yet been given an actual message ID.
+    ///
+    /// When this is `true`, [MsgId::is_special] will also always be
+    /// `true`.
+    pub fn is_unset(&self) -> bool {
+        self.0 == 0
+    }
+
+    /// Whether the message ID is the special marker1 marker.
+    ///
+    /// See the docs of the `dc_get_chat_msgs` C API for details.
+    pub fn is_marker1(&self) -> bool {
+        self.0 == DC_MSG_ID_MARKER1
+    }
+
+    /// Whether the message ID is the special day marker.
+    ///
+    /// See the docs of the `dc_get_chat_msgs` C API for details.
+    pub fn is_daymarker(&self) -> bool {
+        self.0 == DC_MSG_ID_DAYMARKER
+    }
+
+    /// Bad evil escape hatch.
+    ///
+    /// Avoid using this, eventually types should be cleaned up enough
+    /// that it is no longer necessary.
+    pub fn to_u32(&self) -> u32 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for MsgId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Would be nice if we could use match here, but no computed values in ranges.
+        if self.0 == DC_MSG_ID_MARKER1 {
+            write!(f, "Msg#Marker1")
+        } else if self.0 == DC_MSG_ID_DAYMARKER {
+            write!(f, "Msg#DayMarker")
+        } else if self.0 <= DC_MSG_ID_LAST_SPECIAL {
+            write!(f, "Msg#UnknownSpecial")
+        } else {
+            write!(f, "Msg#{}", self.0)
+        }
+    }
+}
+
+/// Allow converting [MsgId] to an SQLite type.
+///
+/// This allows you to directly store [MsgId] into the database.
+///
+/// # Errors
+///
+/// This **does** ensure that no special message IDs are written into
+/// the database and the conversion will fail if this is not the case.
+impl rusqlite::types::ToSql for MsgId {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput> {
+        if self.0 <= DC_MSG_ID_LAST_SPECIAL {
+            return Err(rusqlite::Error::ToSqlConversionFailure(Box::new(
+                InvalidMsgId.compat(),
+            )));
+        }
+        let val = rusqlite::types::Value::Integer(self.0 as i64);
+        let out = rusqlite::types::ToSqlOutput::Owned(val);
+        Ok(out)
+    }
+}
+
+/// Allow converting an SQLite integer directly into [MsgId].
+impl rusqlite::types::FromSql for MsgId {
+    fn column_result(value: rusqlite::types::ValueRef) -> rusqlite::types::FromSqlResult<Self> {
+        // Would be nice if we could use match here, but alas.
+        i64::column_result(value).and_then(|val| {
+            if 0 <= val && val <= std::u32::MAX as i64 {
+                Ok(MsgId::new(val as u32))
+            } else {
+                Err(rusqlite::types::FromSqlError::OutOfRange(val))
+            }
+        })
+    }
+}
+
+/// Message ID was invalid.
+///
+/// This usually occurs when trying to use a message ID of
+/// [DC_MSG_ID_LAST_SPECIAL] or below in a situation where this is not
+/// possible.
+#[derive(Debug, Fail)]
+#[fail(display = "Invalid Message ID.")]
+pub struct InvalidMsgId;
 
 /// An object representing a single message in memory.
 /// The message object is not updated.
@@ -29,7 +155,7 @@ const SUMMARY_CHARACTERS: usize = 160;
 /// approx. max. length returned by dc_get_msg_info()
 #[derive(Debug, Clone, Default)]
 pub struct Message {
-    pub(crate) id: u32,
+    pub(crate) id: MsgId,
     pub(crate) from_id: u32,
     pub(crate) to_id: u32,
     pub(crate) chat_id: u32,
@@ -61,70 +187,105 @@ impl Message {
         msg
     }
 
-    pub fn load_from_db(context: &Context, id: u32) -> Result<Message, Error> {
+    pub fn load_from_db(context: &Context, id: MsgId) -> Result<Message, Error> {
+        ensure!(
+            !id.is_special(),
+            "Can not load special message IDs from DB."
+        );
         context.sql.query_row(
-        "SELECT  \
-         m.id,rfc724_mid,m.mime_in_reply_to,m.server_folder,m.server_uid,m.move_state,m.chat_id,  \
-         m.from_id,m.to_id,m.timestamp,m.timestamp_sent,m.timestamp_rcvd, m.type,m.state,m.msgrmsg,m.txt,  \
-         m.param,m.starred,m.hidden,m.location_id, c.blocked  \
-         FROM msgs m \
-         LEFT JOIN chats c ON c.id=m.chat_id WHERE m.id=?;",
-        params![id as i32],
-        |row| {
-            let mut msg = Message::default();
-            msg.id = row.get::<_, i32>(0)? as u32;
-            msg.rfc724_mid = row.get::<_, String>(1)?;
-            msg.in_reply_to = row.get::<_, Option<String>>(2)?;
-            msg.server_folder = row.get::<_, Option<String>>(3)?;
-            msg.server_uid = row.get(4)?;
-            msg.move_state = row.get(5)?;
-            msg.chat_id = row.get(6)?;
-            msg.from_id = row.get(7)?;
-            msg.to_id = row.get(8)?;
-            msg.timestamp_sort = row.get(9)?;
-            msg.timestamp_sent = row.get(10)?;
-            msg.timestamp_rcvd = row.get(11)?;
-            msg.type_0 = row.get(12)?;
-            msg.state = row.get(13)?;
-            msg.is_dc_message = row.get(14)?;
+            concat!(
+                "SELECT",
+                "    m.id AS id,",
+                "    rfc724_mid AS rfc724mid,",
+                "    m.mime_in_reply_to AS mime_in_reply_to,",
+                "    m.server_folder AS server_folder,",
+                "    m.server_uid AS server_uid,",
+                "    m.move_state as move_state,",
+                "    m.chat_id AS chat_id,",
+                "    m.from_id AS from_id,",
+                "    m.to_id AS to_id,",
+                "    m.timestamp AS timestamp,",
+                "    m.timestamp_sent AS timestamp_sent,",
+                "    m.timestamp_rcvd AS timestamp_rcvd,",
+                "    m.type AS type,",
+                "    m.state AS state,",
+                "    m.msgrmsg AS msgrmsg,",
+                "    m.txt AS txt,",
+                "    m.param AS param,",
+                "    m.starred AS starred,",
+                "    m.hidden AS hidden,",
+                "    m.location_id AS location,",
+                "    c.blocked AS blocked",
+                " FROM msgs m LEFT JOIN chats c ON c.id=m.chat_id",
+                " WHERE m.id=?;"
+            ),
+            params![id],
+            |row| {
+                let mut msg = Message::default();
+                // msg.id = row.get::<_, AnyMsgId>("id")?;
+                msg.id = row.get("id")?;
+                msg.rfc724_mid = row.get::<_, String>("rfc724mid")?;
+                msg.in_reply_to = row.get::<_, Option<String>>("mime_in_reply_to")?;
+                msg.server_folder = row.get::<_, Option<String>>("server_folder")?;
+                msg.server_uid = row.get("server_uid")?;
+                msg.move_state = row.get("move_state")?;
+                msg.chat_id = row.get("chat_id")?;
+                msg.from_id = row.get("from_id")?;
+                msg.to_id = row.get("to_id")?;
+                msg.timestamp_sort = row.get("timestamp")?;
+                msg.timestamp_sent = row.get("timestamp_sent")?;
+                msg.timestamp_rcvd = row.get("timestamp_rcvd")?;
+                msg.type_0 = row.get("type")?;
+                msg.state = row.get("state")?;
+                msg.is_dc_message = row.get("msgrmsg")?;
 
-            let text;
-            if let rusqlite::types::ValueRef::Text(buf) = row.get_raw(15) {
-                if let Ok(t) = String::from_utf8(buf.to_vec()) {
-                    text = t;
+                let text;
+                if let rusqlite::types::ValueRef::Text(buf) = row.get_raw("txt") {
+                    if let Ok(t) = String::from_utf8(buf.to_vec()) {
+                        text = t;
+                    } else {
+                        warn!(
+                            context,
+                            concat!(
+                                "dc_msg_load_from_db: could not get ",
+                                "text column as non-lossy utf8 id {}"
+                            ),
+                            id
+                        );
+                        text = String::from_utf8_lossy(buf).into_owned();
+                    }
                 } else {
-                    warn!(context, "dc_msg_load_from_db: could not get text column as non-lossy utf8 id {}", id);
-                    text = String::from_utf8_lossy(buf).into_owned();
+                    text = "".to_string();
                 }
-            } else {
-                text = "".to_string();
-            }
-            msg.text = Some(text);
+                msg.text = Some(text);
 
-            msg.param = row.get::<_, String>(16)?.parse().unwrap_or_default();
-            msg.starred = row.get(17)?;
-            msg.hidden = row.get(18)?;
-            msg.location_id = row.get(19)?;
-            msg.chat_blocked = row.get::<_, Option<Blocked>>(20)?.unwrap_or_default();
+                msg.param = row.get::<_, String>("param")?.parse().unwrap_or_default();
+                msg.starred = row.get("starred")?;
+                msg.hidden = row.get("hidden")?;
+                msg.location_id = row.get("location")?;
+                msg.chat_blocked = row
+                    .get::<_, Option<Blocked>>("blocked")?
+                    .unwrap_or_default();
 
-            Ok(msg)
-        })
+                Ok(msg)
+            },
+        )
     }
 
-    pub fn delete_from_db(context: &Context, msg_id: u32) {
+    pub fn delete_from_db(context: &Context, msg_id: MsgId) {
         if let Ok(msg) = Message::load_from_db(context, msg_id) {
             sql::execute(
                 context,
                 &context.sql,
                 "DELETE FROM msgs WHERE id=?;",
-                params![msg.id as i32],
+                params![msg.id],
             )
             .ok();
             sql::execute(
                 context,
                 &context.sql,
                 "DELETE FROM msgs_mdns WHERE msg_id=?;",
-                params![msg.id as i32],
+                params![msg.id],
             )
             .ok();
         }
@@ -188,7 +349,7 @@ impl Message {
         }
     }
 
-    pub fn get_id(&self) -> u32 {
+    pub fn get_id(&self) -> MsgId {
         self.id
     }
 
@@ -400,7 +561,7 @@ impl Message {
             context,
             &context.sql,
             "UPDATE msgs SET param=? WHERE id=?;",
-            params![self.param.to_string(), self.id as i32],
+            params![self.param.to_string(), self.id],
         )
         .is_ok()
     }
@@ -510,7 +671,7 @@ impl Lot {
     }
 }
 
-pub fn get_msg_info(context: &Context, msg_id: u32) -> String {
+pub fn get_msg_info(context: &Context, msg_id: MsgId) -> String {
     let mut ret = String::new();
 
     let msg = Message::load_from_db(context, msg_id);
@@ -523,11 +684,11 @@ pub fn get_msg_info(context: &Context, msg_id: u32) -> String {
     let rawtxt: Option<String> = context.sql.query_get_value(
         context,
         "SELECT txt_raw FROM msgs WHERE id=?;",
-        params![msg_id as i32],
+        params![msg_id],
     );
 
     if rawtxt.is_none() {
-        ret += &format!("Cannot load message #{}.", msg_id as usize);
+        ret += &format!("Cannot load message {}.", msg_id);
         return ret;
     }
     let rawtxt = rawtxt.unwrap_or_default();
@@ -560,7 +721,7 @@ pub fn get_msg_info(context: &Context, msg_id: u32) -> String {
 
     if let Ok(rows) = context.sql.query_map(
         "SELECT contact_id, timestamp_sent FROM msgs_mdns WHERE msg_id=?;",
-        params![msg_id as i32],
+        params![msg_id],
         |row| {
             let contact_id: i32 = row.get(0)?;
             let ts: i64 = row.get(1)?;
@@ -670,21 +831,21 @@ pub fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)> {
     Some(info)
 }
 
-pub fn get_mime_headers(context: &Context, msg_id: u32) -> Option<String> {
+pub fn get_mime_headers(context: &Context, msg_id: MsgId) -> Option<String> {
     context.sql.query_get_value(
         context,
         "SELECT mime_headers FROM msgs WHERE id=?;",
-        params![msg_id as i32],
+        params![msg_id],
     )
 }
 
-pub fn delete_msgs(context: &Context, msg_ids: &[u32]) {
+pub fn delete_msgs(context: &Context, msg_ids: &[MsgId]) {
     for msg_id in msg_ids.iter() {
         update_msg_chat_id(context, *msg_id, DC_CHAT_ID_TRASH);
         job_add(
             context,
             Action::DeleteMsgOnImap,
-            *msg_id as libc::c_int,
+            msg_id.to_u32() as i32,
             Params::new(),
             0,
         );
@@ -693,35 +854,45 @@ pub fn delete_msgs(context: &Context, msg_ids: &[u32]) {
     if !msg_ids.is_empty() {
         context.call_cb(Event::MsgsChanged {
             chat_id: 0,
-            msg_id: 0,
+            msg_id: MsgId::new(0),
         });
         job_kill_action(context, Action::Housekeeping);
         job_add(context, Action::Housekeeping, 0, Params::new(), 10);
     };
 }
 
-fn update_msg_chat_id(context: &Context, msg_id: u32, chat_id: u32) -> bool {
+fn update_msg_chat_id(context: &Context, msg_id: MsgId, chat_id: u32) -> bool {
     sql::execute(
         context,
         &context.sql,
         "UPDATE msgs SET chat_id=? WHERE id=?;",
-        params![chat_id as i32, msg_id as i32],
+        params![chat_id as i32, msg_id],
     )
     .is_ok()
 }
 
-pub fn markseen_msgs(context: &Context, msg_ids: &[u32]) -> bool {
+pub fn markseen_msgs(context: &Context, msg_ids: &[MsgId]) -> bool {
     if msg_ids.is_empty() {
         return false;
     }
 
     let msgs = context.sql.prepare(
-        "SELECT m.state, c.blocked  FROM msgs m  LEFT JOIN chats c ON c.id=m.chat_id  WHERE m.id=? AND m.chat_id>9",
+        concat!(
+            "SELECT",
+            "    m.state AS state,",
+            "    c.blocked AS blocked",
+            " FROM msgs m LEFT JOIN chats c ON c.id=m.chat_id",
+            " WHERE m.id=? AND m.chat_id>9"
+        ),
         |mut stmt, _| {
             let mut res = Vec::with_capacity(msg_ids.len());
             for id in msg_ids.iter() {
-                let query_res = stmt.query_row(params![*id as i32], |row| {
-                    Ok((row.get::<_, MessageState>(0)?, row.get::<_, Option<Blocked>>(1)?.unwrap_or_default()))
+                let query_res = stmt.query_row(params![*id], |row| {
+                    Ok((
+                        row.get::<_, MessageState>("state")?,
+                        row.get::<_, Option<Blocked>>("blocked")?
+                            .unwrap_or_default(),
+                    ))
                 });
                 if let Err(rusqlite::Error::QueryReturnedNoRows) = query_res {
                     continue;
@@ -731,7 +902,7 @@ pub fn markseen_msgs(context: &Context, msg_ids: &[u32]) -> bool {
             }
 
             Ok(res)
-        }
+        },
     );
 
     if msgs.is_err() {
@@ -745,12 +916,12 @@ pub fn markseen_msgs(context: &Context, msg_ids: &[u32]) -> bool {
         if curr_blocked == Blocked::Not {
             if curr_state == MessageState::InFresh || curr_state == MessageState::InNoticed {
                 update_msg_state(context, *id, MessageState::InSeen);
-                info!(context, "Seen message #{}.", id);
+                info!(context, "Seen message {}.", id);
 
                 job_add(
                     context,
                     Action::MarkseenMsgOnImap,
-                    *id as i32,
+                    id.to_u32() as i32,
                     Params::new(),
                     0,
                 );
@@ -765,24 +936,24 @@ pub fn markseen_msgs(context: &Context, msg_ids: &[u32]) -> bool {
     if send_event {
         context.call_cb(Event::MsgsChanged {
             chat_id: 0,
-            msg_id: 0,
+            msg_id: MsgId::new(0),
         });
     }
 
     true
 }
 
-pub fn update_msg_state(context: &Context, msg_id: u32, state: MessageState) -> bool {
+pub fn update_msg_state(context: &Context, msg_id: MsgId, state: MessageState) -> bool {
     sql::execute(
         context,
         &context.sql,
         "UPDATE msgs SET state=? WHERE id=?;",
-        params![state, msg_id as i32],
+        params![state, msg_id],
     )
     .is_ok()
 }
 
-pub fn star_msgs(context: &Context, msg_ids: &[u32], star: bool) -> bool {
+pub fn star_msgs(context: &Context, msg_ids: &[MsgId], star: bool) -> bool {
     if msg_ids.is_empty() {
         return false;
     }
@@ -790,7 +961,7 @@ pub fn star_msgs(context: &Context, msg_ids: &[u32], star: bool) -> bool {
         .sql
         .prepare("UPDATE msgs SET starred=? WHERE id=?;", |mut stmt, _| {
             for msg_id in msg_ids.iter() {
-                stmt.execute(params![star as i32, *msg_id as i32])?;
+                stmt.execute(params![star as i32, *msg_id])?;
             }
             Ok(())
         })
@@ -868,8 +1039,8 @@ pub fn get_summarytext_by_raw(
 
 // Context functions to work with messages
 
-pub fn exists(context: &Context, msg_id: u32) -> bool {
-    if msg_id <= DC_CHAT_ID_LAST_SPECIAL {
+pub fn exists(context: &Context, msg_id: MsgId) -> bool {
+    if msg_id.is_special() {
         return false;
     }
 
@@ -898,7 +1069,7 @@ pub fn update_msg_move_state(context: &Context, rfc724_mid: &str, state: MoveSta
     .is_ok()
 }
 
-pub fn set_msg_failed(context: &Context, msg_id: u32, error: Option<impl AsRef<str>>) {
+pub fn set_msg_failed(context: &Context, msg_id: MsgId, error: Option<impl AsRef<str>>) {
     if let Ok(mut msg) = Message::load_from_db(context, msg_id) {
         if msg.state.can_fail() {
             msg.state = MessageState::OutFailed;
@@ -912,7 +1083,7 @@ pub fn set_msg_failed(context: &Context, msg_id: u32, error: Option<impl AsRef<s
             context,
             &context.sql,
             "UPDATE msgs SET state=?, param=? WHERE id=?;",
-            params![msg.state, msg.param.to_string(), msg_id as i32],
+            params![msg.state, msg.param.to_string(), msg_id],
         )
         .is_ok()
         {
@@ -924,38 +1095,39 @@ pub fn set_msg_failed(context: &Context, msg_id: u32, error: Option<impl AsRef<s
     }
 }
 
-/// returns true if an event should be send
+/// returns Some if an event should be send
 pub fn mdn_from_ext(
     context: &Context,
     from_id: u32,
     rfc724_mid: &str,
     timestamp_sent: i64,
-    ret_chat_id: &mut u32,
-    ret_msg_id: &mut u32,
-) -> bool {
-    if from_id <= 9 || rfc724_mid.is_empty() || *ret_chat_id != 0 || *ret_msg_id != 0 {
-        return false;
+) -> Option<(u32, MsgId)> {
+    if from_id <= 9 || rfc724_mid.is_empty() {
+        return None;
     }
 
-    let mut read_by_all = false;
-
     if let Ok((msg_id, chat_id, chat_type, msg_state)) = context.sql.query_row(
-        "SELECT m.id, c.id, c.type, m.state FROM msgs m  \
-         LEFT JOIN chats c ON m.chat_id=c.id  \
-         WHERE rfc724_mid=? AND from_id=1  \
-         ORDER BY m.id;",
+        concat!(
+            "SELECT",
+            "    m.id AS msg_id,",
+            "    c.id AS chat_id,",
+            "    c.type AS type,",
+            "    m.state AS state",
+            " FROM msgs m LEFT JOIN chats c ON m.chat_id=c.id",
+            " WHERE rfc724_mid=? AND from_id=1",
+            " ORDER BY m.id;"
+        ),
         params![rfc724_mid],
         |row| {
             Ok((
-                row.get::<_, i32>(0)?,
-                row.get::<_, i32>(1)?,
-                row.get::<_, Chattype>(2)?,
-                row.get::<_, MessageState>(3)?,
+                row.get::<_, MsgId>("msg_id")?,
+                row.get::<_, u32>("chat_id")?,
+                row.get::<_, Chattype>("type")?,
+                row.get::<_, MessageState>("state")?,
             ))
         },
     ) {
-        *ret_msg_id = msg_id as u32;
-        *ret_chat_id = chat_id as u32;
+        let mut read_by_all = false;
 
         // if already marked as MDNS_RCVD msgstate_can_fail() returns false.
         // however, it is important, that ret_msg_id is set above as this
@@ -965,20 +1137,20 @@ pub fn mdn_from_ext(
                 .sql
                 .exists(
                     "SELECT contact_id FROM msgs_mdns WHERE msg_id=? AND contact_id=?;",
-                    params![*ret_msg_id as i32, from_id as i32,],
+                    params![msg_id, from_id as i32,],
                 )
                 .unwrap_or_default();
 
             if !mdn_already_in_table {
                 context.sql.execute(
                     "INSERT INTO msgs_mdns (msg_id, contact_id, timestamp_sent) VALUES (?, ?, ?);",
-                    params![*ret_msg_id as i32, from_id as i32, timestamp_sent],
+                    params![msg_id, from_id as i32, timestamp_sent],
                 ).unwrap_or_default(); // TODO: better error handling
             }
 
             // Normal chat? that's quite easy.
             if chat_type == Chattype::Single {
-                update_msg_state(context, *ret_msg_id, MessageState::OutMdnRcvd);
+                update_msg_state(context, msg_id, MessageState::OutMdnRcvd);
                 read_by_all = true;
             } else {
                 // send event about new state
@@ -987,7 +1159,7 @@ pub fn mdn_from_ext(
                     .query_get_value::<_, isize>(
                         context,
                         "SELECT COUNT(*) FROM msgs_mdns WHERE msg_id=?;",
-                        params![*ret_msg_id as i32],
+                        params![msg_id],
                     )
                     .unwrap_or_default() as usize;
                 /*
@@ -1003,16 +1175,19 @@ pub fn mdn_from_ext(
                 (S=Sender, R=Recipient)
                  */
                 // for rounding, SELF is already included!
-                let soll_cnt = (chat::get_chat_contact_cnt(context, *ret_chat_id) + 1) / 2;
+                let soll_cnt = (chat::get_chat_contact_cnt(context, chat_id) + 1) / 2;
                 if ist_cnt >= soll_cnt {
-                    update_msg_state(context, *ret_msg_id, MessageState::OutMdnRcvd);
+                    update_msg_state(context, msg_id, MessageState::OutMdnRcvd);
                     read_by_all = true;
                 } // else wait for more receipts
             }
         }
+        return match read_by_all {
+            true => Some((chat_id, msg_id)),
+            false => None,
+        };
     }
-
-    read_by_all
+    None
 }
 
 /// The number of messages assigned to real chat (!=deaddrop, !=trash)
@@ -1066,7 +1241,7 @@ pub fn rfc724_mid_cnt(context: &Context, rfc724_mid: &str) -> libc::c_int {
 pub(crate) fn rfc724_mid_exists(
     context: &Context,
     rfc724_mid: &str,
-) -> Result<(String, u32, u32), Error> {
+) -> Result<(String, u32, MsgId), Error> {
     ensure!(!rfc724_mid.is_empty(), "empty rfc724_mid");
 
     context.sql.query_row(
@@ -1075,7 +1250,7 @@ pub(crate) fn rfc724_mid_exists(
         |row| {
             let server_folder = row.get::<_, Option<String>>(0)?.unwrap_or_default();
             let server_uid = row.get(1)?;
-            let msg_id = row.get(2)?;
+            let msg_id: MsgId = row.get(2)?;
 
             Ok((server_folder, server_uid, msg_id))
         },

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -22,6 +22,7 @@ use crate::dc_tools::*;
 use crate::e2ee::*;
 use crate::error::Error;
 use crate::location;
+use crate::message::MsgId;
 use crate::message::{self, Message};
 use crate::param::*;
 use crate::stock::StockMessage;
@@ -107,7 +108,7 @@ impl<'a> MimeFactory<'a> {
         Ok(())
     }
 
-    pub fn load_mdn(context: &'a Context, msg_id: u32) -> Result<MimeFactory, Error> {
+    pub fn load_mdn(context: &'a Context, msg_id: MsgId) -> Result<MimeFactory, Error> {
         if !context.get_config_bool(Config::MdnsEnabled) {
             // MDNs not enabled - check this is late, in the job. the
             // user may have changed its choice while offline ...
@@ -653,8 +654,8 @@ impl<'a> MimeFactory<'a> {
         Ok(())
     }
 
-    pub fn load_msg(context: &Context, msg_id: u32) -> Result<MimeFactory, Error> {
-        ensure!(msg_id > DC_CHAT_ID_LAST_SPECIAL, "Invalid chat id");
+    pub fn load_msg(context: &Context, msg_id: MsgId) -> Result<MimeFactory, Error> {
+        ensure!(!msg_id.is_special(), "Invalid chat id");
 
         let msg = Message::load_from_db(context, msg_id)?;
         let chat = Chat::load_from_db(context, msg.chat_id)?;
@@ -720,7 +721,7 @@ impl<'a> MimeFactory<'a> {
         }
         let row = context.sql.query_row(
             "SELECT mime_in_reply_to, mime_references FROM msgs WHERE id=?",
-            params![factory.msg.id as i32],
+            params![factory.msg.id],
             |row| {
                 let in_reply_to: String = row.get(0)?;
                 let references: String = row.get(1)?;

--- a/src/param.rs
+++ b/src/param.rs
@@ -49,6 +49,14 @@ pub enum Param {
     /// For Messages
     Error = b'L',
     /// For Messages: space-separated list of messaged IDs of forwarded copies.
+    ///
+    /// This is used when a [Message] is in the
+    /// [MessageState::OutPending] state but is already forwarded.
+    /// In this case the forwarded messages are written to the
+    /// database and their message IDs are added to this parameter of
+    /// the original message, which is also saved in the database.
+    /// When the original message is then finally sent this parameter
+    /// is used to also send all the forwarded messages.
     PrepForwards = b'P',
     /// For Jobs
     SetLatitude = b'l',


### PR DESCRIPTION
This more strongly types the ubiquitous message id type by no longer
making it an integer.  It keeps the actual ID opaque.  Only for the
generic job API the number keeps being used.  Some locations also need
to create it from an integer and call MsgId::new().

Initially I wanted to split this into two types, the normal MsgId which would not be allowed to contain any of the special message IDs.  However due to the way `Message` is created it lives for a fair amount of time before it gets to the database and thus gets a message id.  That would require a builder pattern to make the message and that was all just too much for one PR.  Instead this switch is a little simpler.  Still looks verbose though, there simply are so many places where message id is used.