### PR TITLE
Decrypt messages in memory

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3712,20 +3712,12 @@ int64_t          dc_lot_get_timestamp     (const dc_lot_t* lot);
  * Decrypt a message in memory and return the selected decrypted message part as a string.
  *
  * @param context The context object.
- * @param content_type The content type.
- * @param content The message content.
- * @param sender_addr The sender address of the message.
+ * @param mime_msg The multi-part mime message.
  * @param extract_part The part to extract. Counting starts with 0.
  * @param out_total_number_of_parts Returns the total number of parts of this message.
  * @return The decrypted message part or NULL in case of error.
  */
-char*           dc_decrypt_message_in_memory(
-    dc_context_t* context,
-    const char *content_type,
-    const char *content,
-    const char *sender_addr,
-    int extract_part,
-    int *out_total_number_of_parts);
+char*           dc_decrypt_message_in_memory(dc_context_t* context, const char *mime_msg, int extract_part, int *out_total_number_of_parts);
 
 
 /**

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3709,6 +3709,26 @@ int64_t          dc_lot_get_timestamp     (const dc_lot_t* lot);
 
 
 /**
+ * Decrypt a message in memory and return the selected decrypted message part as a string.
+ *
+ * @param context The context object.
+ * @param content_type The content type.
+ * @param content The message content.
+ * @param sender_addr The sender address of the message.
+ * @param extract_part The part to extract. Counting starts with 0.
+ * @param out_total_number_of_parts Returns the total number of parts of this message.
+ * @return The decrypted message part or NULL in case of error.
+ */
+char*           dc_decrypt_message_in_memory(
+    dc_context_t* context,
+    const char *content_type,
+    const char *content,
+    const char *sender_addr,
+    int extract_part,
+    int *out_total_number_of_parts);
+
+
+/**
  * @defgroup DC_MSG DC_MSG
  *
  * With these constants the type of a message is defined.

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -426,14 +426,10 @@ pub unsafe extern "C" fn dc_get_version_str() -> *mut libc::c_char {
 #[no_mangle]
 pub unsafe extern "C" fn dc_decrypt_message_in_memory(
     context: *mut dc_context_t,
-    content_type: *const libc::c_char,
-    content: *const libc::c_char,
-    sender_addr: *const libc::c_char,
+    mime_msg: *const libc::c_char,
     extract_part: libc::c_int,
     out_total_number_of_parts: *mut libc::c_int,
 ) -> *mut libc::c_char {
-    use deltachat::dc_tools::as_str;
-
     if context.is_null() {
         eprintln!("ignoring careless call to dc_decrypt_msg_in_memory()");
         return ptr::null_mut();
@@ -443,9 +439,7 @@ pub unsafe extern "C" fn dc_decrypt_message_in_memory(
     if let Ok(Ok(msg_parts)) = ffi_context.with_inner(|ctx| {
         e2ee::decrypt_message_in_memory(
             ctx,
-            as_str(content_type),
-            as_str(content),
-            as_str(sender_addr),
+            &to_string_lossy(mime_msg),
         )
     }) {
         if out_total_number_of_parts.is_null() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub mod configure;
 pub mod constants;
 pub mod contact;
 pub mod context;
-mod e2ee;
+pub mod e2ee;
 mod imap;
 pub mod imex;
 pub mod job;

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -27,14 +27,14 @@ use crate::param::*;
 use crate::stock::StockMessage;
 use crate::wrapmime;
 
-#[derive(Clone, Copy, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Loaded {
     Nothing,
     Message,
     MDN, // TODO: invent more descriptive name
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct MimeFactory<'a> {
     pub from_addr: String,
     pub from_displayname: String,


### PR DESCRIPTION
We need that function to decrypt messages that arrive via Webpush.

Open for suggestions. IMHO, it would be better to pass the raw mime message to ```dc_decrypt_message_in_memory()``` instead of splitting it into content and content_type and adding "To" and "From" headers. Also, the function could return an allocated array so that there is no need to call the function multiple times.