### PR TITLE
show all contact-requests in chatlist if show_emails=ALL

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -45,7 +45,7 @@ pub enum Config {
     MvboxWatch,
     #[strum(props(default = "1"))]
     MvboxMove,
-    #[strum(props(default = "0"))]
+    #[strum(props(default = "0"))] // also change ShowEmails.default() on changes
     ShowEmails,
     SaveMimeHeaders,
     ConfiguredAddr,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -54,7 +54,7 @@ pub enum ShowEmails {
 
 impl Default for ShowEmails {
     fn default() -> Self {
-        ShowEmails::Off
+        ShowEmails::Off // also change Config.ShowEmails props(default) on changes
     }
 }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -44,6 +44,20 @@ impl Default for Blocked {
     }
 }
 
+#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive, FromSql, ToSql)]
+#[repr(u8)]
+pub enum ShowEmails {
+    Off = 0,
+    AcceptedContacts = 1,
+    All = 2,
+}
+
+impl Default for ShowEmails {
+    fn default() -> Self {
+        ShowEmails::Off
+    }
+}
+
 pub const DC_IMAP_SEEN: u32 = 0x1;
 
 pub const DC_HANDSHAKE_CONTINUE_NORMAL_PROCESSING: i32 = 0x01;
@@ -250,11 +264,6 @@ const DC_EVENT_IS_OFFLINE: usize = 2081; // deprecated;
 const DC_ERROR_SEE_STRING: usize = 0; // deprecated;
 const DC_ERROR_SELF_NOT_IN_GROUP: usize = 1; // deprecated;
 const DC_STR_SELFNOTINGRP: usize = 21; // deprecated;
-
-/// Values for dc_get|set_config("show_emails")
-const DC_SHOW_EMAILS_OFF: usize = 0;
-const DC_SHOW_EMAILS_ACCEPTED_CONTACTS: usize = 1;
-const DC_SHOW_EMAILS_ALL: usize = 2;
 
 // TODO: Strings need some doumentation about used placeholders.
 // These constants are used to set stock translation strings

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -369,9 +369,10 @@ unsafe fn add_parts(
     // incoming non-chat messages may be discarded;
     // maybe this can be optimized later, by checking the state before the message body is downloaded
     let mut allow_creation = 1;
+    let show_emails =
+        ShowEmails::from_i32(context.get_config_int(Config::ShowEmails)).unwrap_or_default();
     if mime_parser.is_system_message != SystemMessage::AutocryptSetupMessage && msgrmsg == 0 {
-        let show_emails =
-            ShowEmails::from_i32(context.get_config_int(Config::ShowEmails)).unwrap_or_default();
+        // this message is a classic email not a chat-message nor a reply to one
         if show_emails == ShowEmails::Off {
             *chat_id = DC_CHAT_ID_TRASH;
             allow_creation = 0
@@ -490,12 +491,13 @@ unsafe fn add_parts(
         }
 
         // if the chat_id is blocked,
-        // for unknown senders and non-delta messages set the state to NOTICED
-        // to not result in a contact request (this would require the state FRESH)
+        // for unknown senders and non-delta-messages set the state to NOTICED
+        // to not result in a chatlist-contact-request (this would require the state FRESH)
         if Blocked::Not != chat_id_blocked
             && state == MessageState::InFresh
             && !incoming_origin.is_verified()
             && msgrmsg == 0
+            && show_emails != ShowEmails::All
         {
             state = MessageState::InNoticed;
         }


### PR DESCRIPTION
this pr targets several requests of users (eg. [here](https://support.delta.chat/t/show-classic-emails-for-all-advanced-settings-does-not-work/452) or [here](https://support.delta.chat/t/no-contact-request-is-poping-up/318/5)) that want to see "email contact requests" directly in the chatlist when show_emails set to ALL.

before, no contact-requests are shown in the chatlist even if show_emails is set to ALL; users who want to use delta as their only email-client have to manually open the contat-requests activity to not miss a mail.

i think this pr makes things a bit more obvious.