### PR TITLE
Fix imap hang / survive disconnects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "slice-deque 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -495,7 +495,7 @@ dependencies = [
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "image-meta 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "imap 1.0.2 (git+https://github.com/jonhoo/rust-imap)",
+ "imap 1.0.2 (git+https://github.com/deltachat/rust-imap?branch=fix-imap-hang1)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jetscii 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "imap"
 version = "1.0.2"
-source = "git+https://github.com/jonhoo/rust-imap#465481de88ff128b3c1403a056e56f6ead8a3a0e"
+source = "git+https://github.com/deltachat/rust-imap?branch=fix-imap-hang1#b4c4a799860d8b98ee1d480933b007b4d863ff53"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2018,7 +2018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "safemem"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2914,7 +2914,7 @@ dependencies = [
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum image-meta 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b00861cbbb254a627d8acc0cec786b484297d896ab8f20fdc8e28536a3e918ef"
-"checksum imap 1.0.2 (git+https://github.com/jonhoo/rust-imap)" = "<none>"
+"checksum imap 1.0.2 (git+https://github.com/deltachat/rust-imap?branch=fix-imap-hang1)" = "<none>"
 "checksum imap-proto 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b92ca529b24c5f80a950abe993d3883df6fe6791d4a46b1fda1eb339796c589"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
@@ -3017,7 +3017,7 @@ dependencies = [
 "checksum rusty-fork 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3dd93264e10c577503e926bd1430193eeb5d21b059148910082245309b424fae"
 "checksum rustyline 4.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0f47ea1ceb347d2deae482d655dc8eef4bd82363d3329baffa3818bd76fea48b"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
-"checksum safemem 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d2b08423011dae9a5ca23f07cf57dac3857f5c885d352b76f6d95f4aea9434d0"
+"checksum safemem 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum sanitize-filename 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23fd0fec94ec480abfd86bb8f4f6c57e0efb36dac5c852add176ea7b04c74801"
 "checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "imap"
 version = "1.0.2"
-source = "git+https://github.com/deltachat/rust-imap?branch=fix-imap-hang1#5b1f48cb97ad5e424704e035959c1a4b3bbe7916"
+source = "git+https://github.com/deltachat/rust-imap?branch=fix-imap-hang1#2f7a7415d32b3ad71b92b9ef26036c34640501c9"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "imap"
 version = "1.0.2"
-source = "git+https://github.com/deltachat/rust-imap?branch=fix-imap-hang1#b4c4a799860d8b98ee1d480933b007b4d863ff53"
+source = "git+https://github.com/deltachat/rust-imap?branch=fix-imap-hang1#5b1f48cb97ad5e424704e035959c1a4b3bbe7916"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "imap"
 version = "1.0.2"
-source = "git+https://github.com/deltachat/rust-imap?branch=fix-imap-hang1#0fb44133bebcc037205472fe9904794c7827356e"
+source = "git+https://github.com/deltachat/rust-imap?branch=fix-imap-hang1#b69901986d4a61614be5d79c75b543d8230a4668"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,7 +1005,7 @@ dependencies = [
 [[package]]
 name = "imap"
 version = "1.0.2"
-source = "git+https://github.com/deltachat/rust-imap?branch=fix-imap-hang1#2f7a7415d32b3ad71b92b9ef26036c34640501c9"
+source = "git+https://github.com/deltachat/rust-imap?branch=fix-imap-hang1#0fb44133bebcc037205472fe9904794c7827356e"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bufstream 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ num-derive = "0.2.5"
 num-traits = "0.2.6"
 native-tls = "0.2.3"
 lettre = { git = "https://github.com/deltachat/lettre", branch = "master" }
-imap = { git = "https://github.com/jonhoo/rust-imap", branch = "master" }
+imap = { git = "https://github.com/deltachat/rust-imap", branch = "fix-imap-hang1" }
 base64 = "0.10"
 charset = "0.1"
 percent-encoding = "2.0"

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1014,18 +1014,15 @@ impl Imap {
                         };
                         match res {
                             Ok(true) => {
-                                // println!("wait_keepalive returned data, idle-finished");
                                 let _ = sender.send(Ok(()));
                                 break;
                             }
-                            Ok(false) => {
-                                // println!("wait_keepalive returned no data, let's re-enter idle");
-                            }
-                            Err(_err) => {
-                                // eprintln!("wait_keepalive returned error {} -- SHUTTING DOWN", _err);
-                                let _ = sender.send(Err(imap::error::Error::Bad(
-                                    "wait_keepalive failed".to_string(),
-                                )));
+                            Ok(false) => {} // continue loop
+                            Err(err) => {
+                                let _ = sender.send(Err(imap::error::Error::Bad(format!(
+                                    "wait_keepalive failed {}",
+                                    err
+                                ))));
                                 break;
                             }
                         }
@@ -1108,7 +1105,6 @@ impl Imap {
             let mut watch = lock.lock().unwrap();
 
             loop {
-                println!("wait_timeout");
                 let res = cvar.wait_timeout(watch, seconds_to_wait).unwrap();
                 watch = res.0;
                 if *watch {
@@ -1118,7 +1114,6 @@ impl Imap {
                     break;
                 }
             }
-            println!("wait_timeout ended");
 
             *watch = false;
 
@@ -1149,7 +1144,6 @@ impl Imap {
                     do_fake_idle = false;
                 }
             }
-            println!("do_fake_idle={}", do_fake_idle);
         }
     }
 


### PR DESCRIPTION
With this PR Delta Chat Desktop (and probably all other apps) survive network-disconnects better.  After re-connecting-to-network imap-idle will resume, messages will be fetched etc.  Before it used to hang. 

It can take up to a minute or so to detect if network is there unless dc_interrupt_idle() is called from the UI (Android and iOS do this IIRC).   If the disconnect happens during a running idle call, and network is back before the idle-timeout kicks in (23 minutes) then messages should be retrieved immediately. 

note that this draws in a somewhat experimental refactoring of rust-imap's idle-handling, currently forked at [deltachat/rust-imap](https://github.com/deltachat/rust-imap). 


