### PR TITLE
let dc_get_chat_id_by_contact_id() returns 0 if no chat is found

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -715,10 +715,7 @@ pub unsafe extern "C" fn dc_get_chat_id_by_contact_id(
     }
     let ffi_context = &*context;
     ffi_context
-        .with_inner(|ctx| {
-            chat::get_by_contact_id(ctx, contact_id)
-                .unwrap_or(0)
-        })
+        .with_inner(|ctx| chat::get_by_contact_id(ctx, contact_id).unwrap_or(0))
         .unwrap_or(0)
 }
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -717,7 +717,7 @@ pub unsafe extern "C" fn dc_get_chat_id_by_contact_id(
     ffi_context
         .with_inner(|ctx| {
             chat::get_by_contact_id(ctx, contact_id)
-                .unwrap_or_log_default(ctx, "Failed to get chat")
+                .unwrap_or(0)
         })
         .unwrap_or(0)
 }


### PR DESCRIPTION
if dc_get_chat_id_by_contact_id() does not find a chat, this is no error.

in fact, the function is used to probe if there is a chat with a given contact at several places eg. in the android-ui.

this is also the behavior of core-c.

fixes https://github.com/deltachat/deltachat-android/issues/1085