### PR TITLE
Message id / FFI cleanups 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog 
 
+## 1.0.0-beta5
+
+- fix dc_get_msg() to return empty messages when asked for special ones 
+
 ## 1.0.0-beta4
 
 - fix more than one sending of autocrypt setup message

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1386,8 +1386,7 @@ pub unsafe extern "C" fn dc_get_msg(context: *mut dc_context_t, msg_id: u32) -> 
                         // C-core API returns empty messages, do the same
                         warn!(
                             ctx,
-                            "dc_get_msg called with special msg_id={}, returning empty msg",
-                            msg_id
+                            "dc_get_msg called with special msg_id={}, returning empty msg", msg_id
                         );
                         message::Message::default()
                     } else {
@@ -3035,4 +3034,3 @@ fn convert_and_prune_message_ids(msg_ids: *const u32, msg_cnt: libc::c_int) -> V
 
     msg_ids
 }
-

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -95,6 +95,13 @@ def test_markseen_invalid_message_ids(acfactory):
     ac1._evlogger.ensure_event_not_queued("DC_EVENT_WARNING|DC_EVENT_ERROR")
 
 
+def test_get_special_message_id_returns_empty_message(acfactory):
+    ac1 = acfactory.get_configured_offline_account()
+    for i in range(1, 10):
+        msg = ac1.get_message_by_id(i)
+        assert msg.id == 0
+
+
 def test_provider_info():
     provider = lib.dc_provider_new_from_email(cutil.as_dc_charpointer("ex@example.com"))
     assert cutil.from_dc_charpointer(

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -294,18 +294,14 @@ impl Chatlist {
         let lastmsg_id = self.ids[index].1;
         let mut lastcontact = None;
 
-        let lastmsg = if !lastmsg_id.is_special() {
-            if let Ok(lastmsg) = Message::load_from_db(context, lastmsg_id) {
-                if lastmsg.from_id != 1
-                    && (chat.typ == Chattype::Group || chat.typ == Chattype::VerifiedGroup)
-                {
-                    lastcontact = Contact::load_from_db(context, lastmsg.from_id).ok();
-                }
-
-                Some(lastmsg)
-            } else {
-                None
+        let lastmsg = if let Ok(lastmsg) = Message::load_from_db(context, lastmsg_id) {
+            if lastmsg.from_id != 1
+                && (chat.typ == Chattype::Group || chat.typ == Chattype::VerifiedGroup)
+            {
+                lastcontact = Contact::load_from_db(context, lastmsg.from_id).ok();
             }
+
+            Some(lastmsg)
         } else {
             None
         };

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -231,11 +231,7 @@ pub fn create_setup_code(_context: &Context) -> String {
 pub fn continue_key_transfer(context: &Context, msg_id: MsgId, setup_code: &str) -> Result<()> {
     ensure!(!msg_id.is_special(), "wrong id");
 
-    let msg = Message::load_from_db(context, msg_id);
-    if msg.is_err() {
-        bail!("Message is no Autocrypt Setup Message.");
-    }
-    let msg = msg.unwrap_or_default();
+    let msg = Message::load_from_db(context, msg_id)?;
     ensure!(
         msg.is_setupmessage(),
         "Message is no Autocrypt Setup Message."

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -655,8 +655,6 @@ impl<'a> MimeFactory<'a> {
     }
 
     pub fn load_msg(context: &Context, msg_id: MsgId) -> Result<MimeFactory, Error> {
-        ensure!(!msg_id.is_special(), "Invalid chat id");
-
         let msg = Message::load_from_db(context, msg_id)?;
         let chat = Chat::load_from_db(context, msg.chat_id)?;
         let mut factory = MimeFactory::new(context, msg);


### PR DESCRIPTION
- make dc_get_msg() return empty messages for special ids. this fixes https://github.com/deltachat/deltachat-desktop/issues/1091
- some simplifications around Message::load_from_db