### PR TITLE
fix boolean error in chatlist::get_msg_id()

### DIFF
--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -251,7 +251,7 @@ impl Chatlist {
     ///
     /// To get the message object from the message ID, use dc_get_msg().
     pub fn get_msg_id(&self, index: usize) -> Result<MsgId> {
-        ensure!(index >= self.ids.len(), "Chatlist index out of range");
+        ensure!(index < self.ids.len(), "Chatlist index out of range");
         Ok(self.ids[index].1)
     }
 


### PR DESCRIPTION
the error led to unusable contact requests,
at least on android and ios (probably also desktop)
because msg_id=dc_chatlist_get_msg_id() always returns 0
and create_chat_by_msg_id(msg_id)
or dc_marknoticed_contact(<get sender from msg_id>)
failed therefore.

fixes https://github.com/deltachat/deltachat-ios/issues/375 and fixes https://github.com/deltachat/deltachat-android/issues/1097 and probably a similar issue on desktop.

the issue was not reproducibly in the repl tools as there all ids are typically shown and used directly, dc_chatlist_get_msg_id() is not used there.