### PR TITLE
do not panic on bad utf-8 received from mime (and some other places) 

### DIFF
--- a/deltachat-ffi/src/providers.rs
+++ b/deltachat-ffi/src/providers.rs
@@ -2,7 +2,7 @@ extern crate deltachat_provider_database;
 
 use std::ptr;
 
-use deltachat::dc_tools::{as_str, StrExt};
+use deltachat::dc_tools::{to_string_lossy, StrExt};
 use deltachat_provider_database::StatusState;
 
 #[no_mangle]
@@ -12,7 +12,7 @@ pub type dc_provider_t = deltachat_provider_database::Provider;
 pub unsafe extern "C" fn dc_provider_new_from_domain(
     domain: *const libc::c_char,
 ) -> *const dc_provider_t {
-    match deltachat_provider_database::get_provider_info(as_str(domain)) {
+    match deltachat_provider_database::get_provider_info(&to_string_lossy(domain)) {
         Some(provider) => provider,
         None => ptr::null(),
     }
@@ -22,7 +22,8 @@ pub unsafe extern "C" fn dc_provider_new_from_domain(
 pub unsafe extern "C" fn dc_provider_new_from_email(
     email: *const libc::c_char,
 ) -> *const dc_provider_t {
-    let domain = deltachat_provider_database::get_domain_from_email(as_str(email));
+    let email = to_string_lossy(email);
+    let domain = deltachat_provider_database::get_domain_from_email(&email);
     match deltachat_provider_database::get_provider_info(domain) {
         Some(provider) => provider,
         None => ptr::null(),

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -127,12 +127,7 @@ impl<'a> MimeParser<'a> {
             if let Some(field) = self.lookup_field("Subject") {
                 if (*field).fld_type == MAILIMF_FIELD_SUBJECT as libc::c_int {
                     let subj = (*(*field).fld_data.fld_subject).sbj_value;
-                    let subj = to_opt_string_lossy(subj);
-                    self.subject = if subj.is_some() {
-                        Some(dc_decode_header_words(&subj.unwrap()))
-                    } else {
-                        None
-                    };
+                    self.subject = to_opt_string_lossy(subj).map(|x| dc_decode_header_words(&x));
                 }
             }
 

--- a/src/dc_mimeparser.rs
+++ b/src/dc_mimeparser.rs
@@ -630,7 +630,7 @@ impl<'a> MimeParser<'a> {
                             self.context,
                             "Cannot convert {} bytes from \"{}\" to \"utf-8\".",
                             decoded_data.len(),
-                            as_str(charset),
+                            to_string_lossy(charset),
                         );
                     }
                 }
@@ -729,8 +729,10 @@ impl<'a> MimeParser<'a> {
                     if !(*mime).mm_content_type.is_null()
                         && !(*(*mime).mm_content_type).ct_subtype.is_null()
                     {
-                        desired_filename =
-                            format!("file.{}", as_str((*(*mime).mm_content_type).ct_subtype));
+                        desired_filename = format!(
+                            "file.{}",
+                            to_string_lossy((*(*mime).mm_content_type).ct_subtype)
+                        );
                     } else {
                         return false;
                     }
@@ -850,7 +852,8 @@ impl<'a> MimeParser<'a> {
             }) as *mut mailimf_mailbox;
 
             if !mb.is_null() {
-                let from_addr_norm = addr_normalize(as_str((*mb).mb_addr_spec));
+                let from_addr = to_string_lossy((*mb).mb_addr_spec);
+                let from_addr_norm = addr_normalize(&from_addr);
                 let recipients = wrapmime::mailimf_get_recipients(self.header_root);
                 if recipients.len() == 1 && recipients.contains(from_addr_norm) {
                     sender_equals_recipient = true;

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -82,7 +82,7 @@ pub(crate) fn dc_str_from_clist(list: *const clist, delimiter: &str) -> String {
             if !res.is_empty() {
                 res += delimiter;
             }
-            res += as_str(rfc724_mid as *const libc::c_char);
+            res += &to_string_lossy(rfc724_mid as *const libc::c_char);
         }
     }
     res
@@ -303,9 +303,9 @@ pub(crate) fn dc_extract_grpid_from_rfc724_mid_list(list: *const clist) -> *mut 
     if !list.is_null() {
         unsafe {
             for cur in (*list).into_iter() {
-                let mid = as_str(cur as *const libc::c_char);
+                let mid = to_string_lossy(cur as *const libc::c_char);
 
-                if let Some(grpid) = dc_extract_grpid_from_rfc724_mid(mid) {
+                if let Some(grpid) = dc_extract_grpid_from_rfc724_mid(&mid) {
                     return grpid.strdup();
                 }
             }

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -708,14 +708,6 @@ pub fn as_str<'a>(s: *const libc::c_char) -> &'a str {
     as_str_safe(s).unwrap_or_else(|err| panic!("{}", err))
 }
 
-/// Converts a C string to either a Rust `&str` or `None` if  it is a null pointer.
-pub fn as_opt_str<'a>(s: *const libc::c_char) -> Option<&'a str> {
-    if s.is_null() {
-        return None;
-    }
-    Some(as_str(s))
-}
-
 fn as_str_safe<'a>(s: *const libc::c_char) -> Result<&'a str, Error> {
     assert!(!s.is_null(), "cannot be used on null pointers");
 

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -704,19 +704,6 @@ pub fn to_opt_string_lossy(s: *const libc::c_char) -> Option<String> {
     Some(to_string_lossy(s))
 }
 
-pub fn as_str<'a>(s: *const libc::c_char) -> &'a str {
-    as_str_safe(s).unwrap_or_else(|err| panic!("{}", err))
-}
-
-fn as_str_safe<'a>(s: *const libc::c_char) -> Result<&'a str, Error> {
-    assert!(!s.is_null(), "cannot be used on null pointers");
-
-    let cstr = unsafe { CStr::from_ptr(s) };
-
-    cstr.to_str()
-        .map_err(|err| format_err!("Non utf8 string: '{:?}' ({:?})", cstr.to_bytes(), err))
-}
-
 /// Convert a C `*char` pointer to a [std::path::Path] slice.
 ///
 /// This converts a `*libc::c_char` pointer to a [Path] slice.  This
@@ -753,7 +740,11 @@ pub fn as_path<'a>(s: *const libc::c_char) -> &'a std::path::Path {
 #[allow(dead_code)]
 fn as_path_unicode<'a>(s: *const libc::c_char) -> &'a std::path::Path {
     assert!(!s.is_null(), "cannot be used on null pointers");
-    std::path::Path::new(as_str(s))
+
+    let cstr = unsafe { CStr::from_ptr(s) };
+    let str = cstr.to_str().unwrap_or_else(|err| panic!("{}", err));
+
+    std::path::Path::new(str)
 }
 
 pub(crate) fn time() -> i64 {

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -449,7 +449,7 @@ fn update_gossip_peerstates(
 
             let optional_field = unsafe { *optional_field };
             if !optional_field.fld_name.is_null()
-                && as_str(optional_field.fld_name) == "Autocrypt-Gossip"
+                && to_string_lossy(optional_field.fld_name) == "Autocrypt-Gossip"
             {
                 let value = to_string_lossy(optional_field.fld_value);
                 let gossip_header = Aheader::from_str(&value);
@@ -655,7 +655,7 @@ fn contains_report(mime: *mut Mailmime) -> bool {
 
         if tp_type == MAILMIME_TYPE_COMPOSITE_TYPE as libc::c_int
             && ct_type == MAILMIME_COMPOSITE_TYPE_MULTIPART as libc::c_int
-            && as_str(unsafe { (*mime.mm_content_type).ct_subtype }) == "report"
+            && to_string_lossy(unsafe { (*mime.mm_content_type).ct_subtype }) == "report"
         {
             return true;
         }


### PR DESCRIPTION
prefer to_string_lossy() for converting c-strings to String
c-strings may always be badly formatted and this should never lead to a panic.
eg. passing the utf-8-sequence ed a0 bd ed b8 80 to the subject would cause a crash.

in fact, looking at the crash reports of eg. ios, this might be the reason for some crashes. 

this pr makes the functions as_str(), as_opt_str() and as_str_safe() superfluous; instead to_string_lossy() and to_opt_string_lossy() is now used everywhere.

as_path() may still panic, however, this is only used for creating the context - so if things are bad there, this might be a reasonable approach.

this is a successor of https://github.com/deltachat/deltachat-core-rust/pull/728 that did similar changes for string coming from ffi.