### PR TITLE
avoid usage of get_subtitle() in repl-tool

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2610,8 +2610,6 @@ int             dc_chat_get_type             (const dc_chat_t* chat);
  *
  * To change the name, use dc_set_chat_name()
  *
- * See also: dc_chat_get_subtitle()
- *
  * @memberof dc_chat_t
  * @param chat The chat object.
  * @return Chat name as a string. Must be released using dc_str_unref() after usage. Never NULL.
@@ -2619,13 +2617,13 @@ int             dc_chat_get_type             (const dc_chat_t* chat);
 char*           dc_chat_get_name             (const dc_chat_t* chat);
 
 
-/**
+/*
  * Get a subtitle for a chat.  The subtitle is eg. the email-address or the
  * number of group members.
  *
- * See also: dc_chat_get_name()
+ * Deprecated function. Subtitles should be created in the ui
+ * where plural forms and other specials can be handled more gracefully.
  *
- * @memberof dc_chat_t
  * @param chat The chat object to calulate the subtitle for.
  * @return Subtitle as a string. Must be released using dc_str_unref() after usage. Never NULL.
  */

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -517,15 +517,13 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
 
                 for i in (0..cnt).rev() {
                     let chat = Chat::load_from_db(context, chatlist.get_chat_id(i))?;
-                    let temp_subtitle = chat.get_subtitle(context);
                     let temp_name = chat.get_name();
                     info!(
                         context,
-                        "{}#{}: {} [{}] [{} fresh]",
+                        "{}#{}: {} [{} fresh]",
                         chat_prefix(&chat),
                         chat.get_id(),
                         temp_name,
-                        temp_subtitle,
                         chat::get_fresh_msg_cnt(context, chat.get_id()),
                     );
                     let lot = chatlist.get_summary(context, i, Some(&chat));
@@ -583,7 +581,13 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             let sel_chat = sel_chat.as_ref().unwrap();
 
             let msglist = chat::get_chat_msgs(context, sel_chat.get_id(), 0x1, None);
-            let temp2 = sel_chat.get_subtitle(context);
+            let members = chat::get_chat_contacts(context, sel_chat.id);
+            let temp2 = if sel_chat.get_type() == Chattype::Single && members.len() >= 1 {
+                let contact = Contact::get_by_id(context, members[0])?;
+                contact.get_addr().to_string()
+            } else {
+                format!("{} member(s)", members.len())
+            };
             let temp_name = sel_chat.get_name();
             info!(
                 context,


### PR DESCRIPTION
once it is removed in node, see https://github.com/deltachat/deltachat-node/issues/387 , we can drop the function completely and also clean up a handful of then unused strings.