### PR TITLE
fix conversion from nanoseconds to milliseconds

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -403,7 +403,7 @@ pub fn perform_imap_fetch(context: &Context) {
     info!(
         context,
         "INBOX-fetch done in {:.4} ms.",
-        start.elapsed().as_nanos() as f64 / 1000.0,
+        start.elapsed().as_nanos() as f64 / 1_000_000.0,
     );
 }
 


### PR DESCRIPTION
1_000_000 nanosecond = 1 millisecond