### PR TITLE
fix cannot export issue and test 

### DIFF
--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -153,6 +153,14 @@ class Account(object):
         self.check_is_configured()
         return from_dc_charpointer(lib.dc_get_info(self._dc_context))
 
+    def get_latest_backupfile(self, backupdir):
+        """ return the latest backup file in a given directory.
+        """
+        res = lib.dc_imex_has_backup(self._dc_context, as_dc_charpointer(backupdir))
+        if res == ffi.NULL:
+            return None
+        return from_dc_charpointer(res)
+
     def get_blobdir(self):
         """ return the directory for files.
 
@@ -477,8 +485,9 @@ class Account(object):
 
     def stop_threads(self, wait=True):
         """ stop IMAP/SMTP threads. """
-        self.stop_ongoing()
-        self._threads.stop(wait=wait)
+        if self._threads.is_started():
+            self.stop_ongoing()
+            self._threads.stop(wait=wait)
 
     def shutdown(self, wait=True):
         """ stop threads and close and remove underlying dc_context and callbacks. """

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -75,7 +75,7 @@ pub fn imex(context: &Context, what: ImexMode, param1: Option<impl AsRef<Path>>)
     job_add(context, Action::ImexImap, 0, param, 0);
 }
 
-/// Returns the filename of the backup if found, nullptr otherwise.
+/// Returns the filename of the backup found (otherwise an error) 
 pub fn has_backup(context: &Context, dir_name: impl AsRef<Path>) -> Result<String> {
     let dir_name = dir_name.as_ref();
     let dir_iter = std::fs::read_dir(dir_name)?;
@@ -105,7 +105,7 @@ pub fn has_backup(context: &Context, dir_name: impl AsRef<Path>) -> Result<Strin
     }
     match newest_backup_path {
         Some(path) => Ok(path.to_string_lossy().into_owned()),
-        None => bail!("no backup found"),
+        None => bail!("no backup found in {}", dir_name.display()),
     }
 }
 


### PR DESCRIPTION
this is mainly for better debugging and for fixing #760 -- for export the db is copied "by hand" (opening source in read, destination in write mode, then use `io::copy`), both to provide better error logging, but it already seems to fix a real android issue (@cyberta verified #760 goes away for him).

Note that this PR does not fix an other issue https://github.com/deltachat/deltachat-ios/issues/322 but there is a python test for that which is currently marking a test for #322 as "expected to fail".   This remaining issue probably also relates to #804 which is also not fixed here. 

It still makes sense to merge this PR here as it at least fixes the "cannot export at all" issue on some Android platforms (#760).   