### PR TITLE
add dc_msg_is_truncated and dc_msg_get_full_text

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2951,6 +2951,32 @@ int64_t          dc_msg_get_sort_timestamp     (const dc_msg_t* msg);
  */
 char*           dc_msg_get_text               (const dc_msg_t* msg);
 
+/**
+ * Get the text of the message.
+ * If there is no text associated with the message, an empty string is returned.
+ * NULL is never returned.
+ *
+ * Same as dc_msg_get_text, but isn't truncated
+ *
+ * To get information about the message and more/raw text, use dc_get_msg_info().
+ *
+ * @memberof dc_msg_t
+ * @param msg The message object.
+ * @return Message text. The result must be released using dc_str_unref(). Never returns NULL.
+ */
+char*           dc_msg_get_full_text          (const dc_msg_t* msg);
+
+
+/**
+ * Check if a message is truncated.
+ *
+ * @memberof dc_msg_t
+ * @param msg The message object.
+ * @return 1=message is truncated, 0=message not truncated.
+ */
+int             dc_msg_is_truncated            (const dc_msg_t* msg);
+
+// define DC_MSG_TRUNCATE_THRESHOLD
 
 /**
  * Find out full path, file name and extension of the file associated with a

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2420,7 +2420,26 @@ pub unsafe extern "C" fn dc_msg_get_text(msg: *mut dc_msg_t) -> *mut libc::c_cha
         return dc_strdup(ptr::null());
     }
     let ffi_msg = &*msg;
-    ffi_msg.message.get_text().unwrap_or_default().strdup()
+    ffi_msg.message.get_text(false).unwrap_or_default().strdup()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dc_msg_get_full_text(msg: *mut dc_msg_t) -> *mut libc::c_char {
+    if msg.is_null() {
+        eprintln!("ignoring careless call to dc_msg_get_full_text()");
+        return dc_strdup(ptr::null());
+    }
+    let ffi_msg = &*msg;
+    ffi_msg.message.get_text(true).unwrap_or_default().strdup()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn is_truncated(msg: *mut dc_msg_t) -> libc::c_int {
+    if msg.is_null() {
+        return 0
+    }
+    let ffi_msg = &*msg;
+    ffi_msg.message.is_truncated().into()
 }
 
 #[no_mangle]

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -189,7 +189,7 @@ unsafe fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
         _ => "",
     };
     let temp2 = dc_timestamp_to_str(msg.get_timestamp());
-    let msgtext = msg.get_text();
+    let msgtext = msg.get_text(false);
     info!(
         context,
         "{}#{}{}{}: {} (Contact#{}): {} {}{}{}{}{} [{}]",

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -249,6 +249,8 @@ impl Default for Viewtype {
     }
 }
 
+pub const DC_MSG_TRUNCATE_THRESHOLD:usize = 30000;
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/message.rs
+++ b/src/message.rs
@@ -381,10 +381,23 @@ impl Message {
         self.timestamp_sort
     }
 
-    pub fn get_text(&self) -> Option<String> {
-        self.text
+    pub fn is_truncated(&self) -> bool {
+        if let Some(text) = &self.text {
+            return text.chars().count() > DC_MSG_TRUNCATE_THRESHOLD
+        }
+        false
+    }
+
+    pub fn get_text(&self, full_message: bool) -> Option<String> {
+        if full_message {
+            self.text
             .as_ref()
-            .map(|text| dc_truncate(text, 30000, false).to_string())
+            .map(|text| text.to_string())
+        } else {
+            self.text
+                .as_ref()
+                .map(|text| dc_truncate(text, DC_MSG_TRUNCATE_THRESHOLD, false).to_string())
+        }
     }
 
     pub fn get_filename(&self) -> Option<String> {


### PR DESCRIPTION
would fix #745, but this needs to be discussed first, maybe the ui should do the whole truncating and the core just returns the whole text.
**But we'll postpone this draft pr and discussion to after the 1.0 release**

todo until a mergeable state:
- [X] rust functions
- [ ] deltachat.h and ffi
- [ ] python bindings