### PR TITLE
Add logging to the core

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 environment:
+  RUST_BACKTRACE: full
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
 

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -366,11 +366,12 @@ fn main_0(args: Vec<String>) -> Result<(), failure::Error> {
         println!("Error: Bad arguments, expected [db-name].");
         return Err(format_err!("No db-name specified"));
     }
-    let context = Context::new(
+    let context = ContextBuilder::new(
         Box::new(receive_event),
         "CLI".into(),
         Path::new(&args[1]).to_path_buf(),
-    )?;
+    )
+    .create()?;
 
     println!("Delta Chat Core is awaiting your commands.");
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -39,8 +39,9 @@ fn main() {
     let dir = tempdir().unwrap();
     let dbfile = dir.path().join("db.sqlite");
     println!("creating database {:?}", dbfile);
-    let ctx =
-        Context::new(Box::new(cb), "FakeOs".into(), dbfile).expect("Failed to create context");
+    let ctx = ContextBuilder::new(Box::new(cb), "FakeOs".into(), dbfile)
+        .create()
+        .expect("Failed to create context");
     let running = Arc::new(RwLock::new(true));
     let info = ctx.get_info();
     let duration = time::Duration::from_millis(4000);

--- a/src/context.rs
+++ b/src/context.rs
@@ -15,6 +15,7 @@ use crate::imap::*;
 use crate::job::*;
 use crate::job_thread::JobThread;
 use crate::key::*;
+use crate::log;
 use crate::login_param::LoginParam;
 use crate::lot::Lot;
 use crate::message::{self, Message, MsgId};
@@ -62,6 +63,7 @@ pub struct Context {
     /// Mutex to avoid generating the key for the user more than once.
     pub generating_key_mutex: Mutex<()>,
     pub translated_stockstrings: RwLock<HashMap<usize, String>>,
+    pub logger: RwLock<log::Logger>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -212,6 +214,7 @@ impl Context {
             perform_inbox_jobs_needed: Arc::new(RwLock::new(false)),
             generating_key_mutex: Mutex::new(()),
             translated_stockstrings: RwLock::new(HashMap::new()),
+            logger: RwLock::new(log::Logger::new(logdir)?),
         };
 
         ensure!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ extern crate jetscii;
 extern crate debug_stub_derive;
 
 #[macro_use]
-mod log;
+pub mod log;
 #[macro_use]
 pub mod error;
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -153,6 +153,9 @@ macro_rules! info {
     };
     ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
+        if let Ok(mut logger) = $ctx.logger.write() {
+            logger.log($crate::log::LogLevel::Info, callsite!(), &formatted).ok();
+        }
         emit_event!($ctx, $crate::Event::Info(formatted));
     }};
 }
@@ -164,6 +167,9 @@ macro_rules! warn {
     };
     ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
+        if let Ok(mut logger) = $ctx.logger.write() {
+            logger.log($crate::log::LogLevel::Warning, callsite!(), &formatted).ok();
+        }
         emit_event!($ctx, $crate::Event::Warning(formatted));
     }};
 }
@@ -175,6 +181,9 @@ macro_rules! error {
     };
     ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
+        if let Ok(mut logger) = $ctx.logger.write() {
+            logger.log($crate::log::LogLevel::Error, callsite!(), &formatted).ok();
+        }
         emit_event!($ctx, $crate::Event::Error(formatted));
     }};
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,4 +1,89 @@
-//! # Logging macros
+//! # Logging support
+
+use std::fmt;
+use std::io::prelude::*;
+use std::path::PathBuf;
+
+/// A logger for a [Context].
+#[derive(Debug)]
+pub struct Logger {
+    logdir: PathBuf,
+    logfile: std::ffi::OsString,
+    file_handle: std::fs::File,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LogLevel {
+    Info,
+    Warning,
+    Error,
+}
+
+impl fmt::Display for LogLevel {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LogLevel::Info => write!(f, "I"),
+            LogLevel::Warning => write!(f, "W"),
+            LogLevel::Error => write!(f, "E"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Callsite<'a> {
+    pub module: &'a str,
+    pub file: &'a str,
+    pub line: u32,
+}
+
+impl fmt::Display for Callsite<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}:{} in {}", self.file, self.line, self.module)
+    }
+}
+
+impl Logger {
+    pub fn new(logdir: PathBuf) -> Result<Logger, std::io::Error> {
+        let fname = format!(
+            "{}.log",
+            chrono::offset::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+        );
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(logdir.join(&fname))?;
+        Ok(Logger {
+            logdir,
+            logfile: fname.into(),
+            file_handle: file,
+        })
+    }
+
+    pub fn log(
+        &mut self,
+        level: LogLevel,
+        callsite: Callsite,
+        msg: &str,
+    ) -> Result<(), std::io::Error> {
+        write!(&mut self.file_handle, "{} [{}]: {}\n", level, callsite, msg)
+    }
+
+    pub fn flush(&mut self) -> Result<(), std::io::Error> {
+        self.file_handle.flush()
+    }
+}
+
+#[macro_export]
+macro_rules! callsite {
+    () => {
+        $crate::log::Callsite {
+            module: module_path!(),
+            file: file!(),
+            line: line!(),
+        }
+    };
+}
 
 #[macro_export]
 macro_rules! info {
@@ -38,4 +123,38 @@ macro_rules! emit_event {
     ($ctx:expr, $event:expr) => {
         $ctx.call_cb($event);
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_logging() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path();
+        let mut logger = Logger::new(dir.to_path_buf()).unwrap();
+        logger.log(LogLevel::Info, callsite!(), "foo").unwrap();
+        logger.log(LogLevel::Warning, callsite!(), "bar").unwrap();
+        logger.log(LogLevel::Error, callsite!(), "baz").unwrap();
+        logger.flush();
+        let log = std::fs::read_to_string(logger.logdir.join(logger.logfile)).unwrap();
+        println!("{}", log);
+        let lines: Vec<&str> = log.lines().collect();
+
+        assert!(lines[0].starts_with("I"));
+        assert!(lines[0].contains("src/log.rs"));
+        assert!(lines[0].contains("deltachat::log::tests"));
+        assert!(lines[0].contains("foo"));
+
+        assert!(lines[1].starts_with("W"));
+        assert!(lines[1].contains("src/log.rs"));
+        assert!(lines[1].contains("deltachat::log::tests"));
+        assert!(lines[1].contains("bar"));
+
+        assert!(lines[2].starts_with("E"));
+        assert!(lines[2].contains("src/log.rs"));
+        assert!(lines[2].contains("deltachat::log::tests"));
+        assert!(lines[2].contains("baz"));
+    }
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -70,7 +70,14 @@ impl Logger {
     fn open(logdir: &Path) -> Result<(String, fs::File), io::Error> {
         let basename =
             chrono::offset::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
-        let mut fname = sanitize_filename::sanitize(format!("{}.log", &basename));
+        let mut fname = sanitize_filename::sanitize_with_options(
+            format!("{}.log", &basename),
+            sanitize_filename::Options {
+                truncate: true,
+                windows: true,
+                replacement: ".",
+            },
+        );
         let mut counter = 0;
         loop {
             match std::fs::OpenOptions::new()

--- a/src/log.rs
+++ b/src/log.rs
@@ -36,14 +36,13 @@ impl fmt::Display for LogLevel {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Callsite<'a> {
-    pub module: &'a str,
     pub file: &'a str,
     pub line: u32,
 }
 
 impl fmt::Display for Callsite<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{} in {}", self.file, self.line, self.module)
+        write!(f, "{}:{}", self.file, self.line)
     }
 }
 
@@ -148,7 +147,6 @@ impl Logger {
 macro_rules! callsite {
     () => {
         $crate::log::Callsite {
-            module: module_path!(),
             file: file!(),
             line: line!(),
         }
@@ -226,7 +224,6 @@ mod tests {
         assert!(lines[0]
             .contains(format!("{}", std::thread::current().name().unwrap_or("unnamed")).as_str()));
         assert!(lines[0].contains(&format!("src{}log.rs", std::path::MAIN_SEPARATOR)));
-        assert!(lines[0].contains("deltachat::log::tests"));
         assert!(lines[0].contains("foo"));
 
         assert!(lines[1].starts_with("W"));
@@ -234,7 +231,6 @@ mod tests {
         assert!(lines[1]
             .contains(format!("{}", std::thread::current().name().unwrap_or("unnamed")).as_str()));
         assert!(lines[1].contains(&format!("src{}log.rs", std::path::MAIN_SEPARATOR)));
-        assert!(lines[1].contains("deltachat::log::tests"));
         assert!(lines[1].contains("bar"));
 
         assert!(lines[2].starts_with("E"));
@@ -242,7 +238,6 @@ mod tests {
         assert!(lines[2]
             .contains(format!("{}", std::thread::current().name().unwrap_or("unnamed")).as_str()));
         assert!(lines[2].contains(&format!("src{}log.rs", std::path::MAIN_SEPARATOR)));
-        assert!(lines[2].contains("deltachat::log::tests"));
         assert!(lines[2].contains("baz"));
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -7,7 +7,7 @@ use tempfile::{tempdir, TempDir};
 
 use crate::config::Config;
 use crate::constants::KeyType;
-use crate::context::{Context, ContextCallback};
+use crate::context::{Context, ContextBuilder, ContextCallback};
 use crate::events::Event;
 use crate::key;
 
@@ -33,7 +33,9 @@ pub fn test_context(callback: Option<Box<ContextCallback>>) -> TestContext {
         Some(cb) => cb,
         None => Box::new(|_, _| 0),
     };
-    let ctx = Context::new(cb, "FakeOs".into(), dbfile).unwrap();
+    let ctx = ContextBuilder::new(cb, "FakeOs".into(), dbfile)
+        .create()
+        .unwrap();
     TestContext { ctx: ctx, dir: dir }
 }
 

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -219,7 +219,9 @@ struct TestContext {
 fn create_test_context() -> TestContext {
     let dir = tempdir().unwrap();
     let dbfile = dir.path().join("db.sqlite");
-    let ctx = Context::new(Box::new(cb), "FakeOs".into(), dbfile).unwrap();
+    let ctx = ContextBuilder::new(Box::new(cb), "FakeOs".into(), dbfile)
+        .create()
+        .unwrap();
     TestContext { ctx, dir }
 }
 


### PR DESCRIPTION
Currently this has a mutex around a the logging, writes to a ${dbfile}-logs directory using timestamped files. Each file grows up to about 4Mb and 5 files are kept. The log directory is customisable, these numbers are not. Log output looks like:

$ cat foo.db-logs/2019-11-23T15:19:21Z.log
I ThreadId(1)/main [src/sql.rs:359 in deltachat::sql]: First time init: creating tables in "/tmp/sandbox/foo.db".
I ThreadId(1)/main [src/sql.rs:502 in deltachat::sql]: [migration] v1
I ThreadId(1)/main [src/sql.rs:515 in deltachat::sql]: [migration] v2

In the future it might be worth to migrate to a dedicated thread doing the logging without a mutex and receiving log events via an mpsc channel. I don't think in the current situation it's trivial to add an mpsc transmitter to the Context so I think this will become nicer/more realistic as the threading behaviour gets cleaned up.