### PR TITLE
restore config-param if configure() fails

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -501,15 +501,9 @@ char*           dc_get_oauth2_url            (dc_context_t* context, const char*
  * To interrupt a configuration prematurely, use dc_stop_ongoing_process();
  * this is not needed if #DC_EVENT_CONFIGURE_PROGRESS reports success.
  *
- * On a successfull configuration,
- * the core makes a copy of the parameters mentioned above:
- * the original parameters as are never modified by the core.
- *
- * UI-implementors should keep this in mind -
- * eg. if the UI wants to prefill a configure-edit-dialog with these parameters,
- * the UI should reset them if the user cancels the dialog
- * after a configure-attempts has failed.
- * Otherwise the parameters may not reflect the current configuation.
+ * If #DC_EVENT_CONFIGURE_PROGRESS reports failure,
+ * the core continues to use the last working configuration
+ * and parameters as `addr`, `mail_pw` etc. are set to that.
  *
  * @memberof dc_context_t
  * @param context The context object as created by dc_context_new().

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -421,6 +421,16 @@ pub fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context) {
         );
     }
     */
+
+    // remember the entered parameters on success
+    // and restore to last-entered on failure.
+    // this way, the parameters visible to the ui are always in-sync with the current configuration.
+    if success {
+        LoginParam::from_database(context, "").save_to_database(context, "configured_raw_");
+    } else {
+        LoginParam::from_database(context, "configured_raw_").save_to_database(context, "");
+    }
+
     context.free_ongoing();
     progress!(context, if success { 1000 } else { 0 });
 }


### PR DESCRIPTION
this pr restores the ui-visible parameter-set to the actually used one if configuration fails.

before that, it was "decided" in https://github.com/deltachat/deltachat-core/issues/246 that this should be done by the ui, however, in practise this never happened.

while being a bug all the time, its becoming worse with the new certificate-check settings.

so, the easiest attempt to fix that seems to be in the core.

closes https://github.com/deltachat/deltachat-android/issues/1106 and probably similar issues in other uis.