### PR TITLE
fix time

### DIFF
--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -159,8 +159,10 @@ pub fn dc_timestamp_to_str(wanted: i64) -> String {
 }
 
 pub(crate) fn dc_gm2local_offset() -> i64 {
+    /* returns the offset that must be _added_ to an UTC/GMT-time to create the localtime.
+    the function may return negative values. */
     let lt = Local::now();
-    ((lt.offset().local_minus_utc() / (60 * 60)) * 100) as i64
+    lt.offset().local_minus_utc() as i64
 }
 
 /* timesmearing */

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -154,7 +154,7 @@ pub(crate) fn dc_timestamp_from_date(date_time: *mut mailimf_date_time) -> i64 {
  ******************************************************************************/
 
 pub fn dc_timestamp_to_str(wanted: i64) -> String {
-    let ts = chrono::Utc.timestamp(wanted, 0);
+    let ts = Local.timestamp(wanted, 0);
     ts.format("%Y.%m.%d %H:%M:%S").to_string()
 }
 


### PR DESCRIPTION
with this pr, [daymarkers](https://c.delta.chat/classdc__context__t.html#a51353ff6b85fa9278d2ec476c3c95eda) will be shown at the correct positions.

moreover, this pr let [dc_get_msg_info()](https://c.delta.chat/classdc__context__t.html#a9752923b64ca8288045e999a11ccf7f4) and the repl tool show local timestamps, this fixes eg. https://support.delta.chat/t/dc-0-950-0-bugs/671

i think, at some point, we'll let dc_get_msg_info() return more structured information; then we'll probably return UTC-timestamps as on other places. but this is out of scope currently.