### PR TITLE
add missing DC_STR_DEVICE_MESSAGES

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4467,7 +4467,8 @@ void            dc_array_add_id              (dc_array_t*, uint32_t); // depreca
 #define DC_STR_MSGLOCATIONDISABLED        65
 #define DC_STR_LOCATION                   66
 #define DC_STR_STICKER                    67
-#define DC_STR_COUNT                      67
+#define DC_STR_DEVICE_MESSAGES            68
+#define DC_STR_COUNT                      68
 
 /*
  * @}


### PR DESCRIPTION
this constant was missing on introducing the new string - mainly because searching for an existing string and amending all tables with its occurrences becomes harder and is no longer sufficient due to different writings, CamelCase and UPPER_SNAKE_CASE.