### PR TITLE
disable bcc_self by default

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use itertools::Itertools;
+use num_traits::FromPrimitive;
 
 use crate::blob::{BlobErrorKind, BlobObject};
 use crate::chatlist::*;
@@ -1012,7 +1013,8 @@ pub fn get_chat_msgs(
         Ok(ret)
     };
     let success = if chat_id == DC_CHAT_ID_DEADDROP {
-        let show_emails = context.get_config_int(Config::ShowEmails);
+        let show_emails =
+            ShowEmails::from_i32(context.get_config_int(Config::ShowEmails)).unwrap_or_default();
         context.sql.query_map(
             concat!(
                 "SELECT m.id AS id, m.timestamp AS timestamp",
@@ -1029,7 +1031,7 @@ pub fn get_chat_msgs(
                 "   AND m.msgrmsg>=?",
                 " ORDER BY m.timestamp,m.id;"
             ),
-            params![if show_emails == 2 { 0 } else { 1 }],
+            params![if show_emails == ShowEmails::All { 0 } else { 1 }],
             process_row,
             process_rows,
         )

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,7 @@ pub enum Config {
     Displayname,
     Selfstatus,
     Selfavatar,
-    #[strum(props(default = "1"))]
+    #[strum(props(default = "0"))]
     BccSelf,
     #[strum(props(default = "1"))]
     E2eeEnabled,

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use rusqlite::{Connection, OpenFlags, Statement, NO_PARAMS};
 use thread_local_object::ThreadLocal;
 
+use crate::constants::ShowEmails;
 use crate::context::Context;
 use crate::dc_tools::*;
 use crate::error::{Error, Result};
@@ -736,7 +737,7 @@ fn open(
         if dbversion < 50 {
             info!(context, "[migration] v50");
             if exists_before_update {
-                sql.set_raw_config_int(context, "show_emails", 2)?;
+                sql.set_raw_config_int(context, "show_emails", ShowEmails::All as i32)?;
             }
             dbversion = 50;
             sql.set_raw_config_int(context, "dbversion", 50)?;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -804,8 +804,14 @@ fn open(
                 "ALTER TABLE locations ADD COLUMN independent INTEGER DEFAULT 0;",
                 params![],
             )?;
-
             sql.set_raw_config_int(context, "dbversion", 55)?;
+        }
+        if dbversion < 56 {
+            info!(context, "[migration] v56");
+            if exists_before_update && sql.get_raw_config_int(context, "bcc_self").is_none() {
+                sql.set_raw_config_int(context, "bcc_self", 1)?;
+            }
+            sql.set_raw_config_int(context, "dbversion", 56)?;
         }
 
         // (2) updates that require high-level objects

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -348,7 +348,7 @@ fn open(
     }
 
     if !readonly {
-        let mut exists_before_update = 0;
+        let mut exists_before_update = false;
         let mut dbversion_before_update = 0;
         /* Init tables to dbversion=0 */
         if !sql.table_exists("config") {
@@ -478,7 +478,7 @@ fn open(
                 sql.set_raw_config_int(context, "dbversion", 0)?;
             }
         } else {
-            exists_before_update = 1;
+            exists_before_update = true;
             dbversion_before_update = sql
                 .get_raw_config_int(context, "dbversion")
                 .unwrap_or_default();
@@ -735,7 +735,7 @@ fn open(
         }
         if dbversion < 50 {
             info!(context, "[migration] v50");
-            if 0 != exists_before_update {
+            if exists_before_update {
                 sql.set_raw_config_int(context, "show_emails", 2)?;
             }
             dbversion = 50;


### PR DESCRIPTION
this pr changes the default value for bcc_self to _disabled_ for new installations. for existing existing installations, the value is not changed.

moreover, this pr adds a device-message when an autocrypt-setup-messages was decrypted successfully and bcc_self is disabled. the device-message informs the user about the bcc_self then. this is done in maybe_add_bcc_self_device_msg()

we may also call maybe_add_bcc_self_device_msg() when we see an incoming message that is not moved by us; this would also detect changes done on key transfers. but afaik, these parts are subject to change anyway, so maybe we can postpone that a bit.