### PR TITLE
reimlpement certchecks for imap and smtp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,6 +684,7 @@ dependencies = [
  "strum_macros 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread-local-object 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "webpki 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "webpki-roots 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ sanitize-filename = "0.2.1"
 stop-token = { version = "0.1.1", features = ["unstable"] }
 rustls = "0.16.0"
 webpki-roots = "0.18.0"
+webpki = "0.21.0"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/imap_client.rs
+++ b/src/imap_client.rs
@@ -8,7 +8,7 @@ use async_std::net::{self, TcpStream};
 use async_std::prelude::*;
 use async_tls::client::TlsStream;
 
-use crate::login_param::CertificateChecks;
+use crate::login_param::{dc_build_tls, CertificateChecks};
 
 const DCC_IMAP_DEBUG: &str = "DCC_IMAP_DEBUG";
 
@@ -34,11 +34,10 @@ impl Client {
     pub async fn connect_secure<A: net::ToSocketAddrs, S: AsRef<str>>(
         addr: A,
         domain: S,
-        _certificate_checks: CertificateChecks,
+        certificate_checks: CertificateChecks,
     ) -> ImapResult<Self> {
         let stream = TcpStream::connect(addr).await?;
-        let tls = async_tls::TlsConnector::new();
-
+        let tls = dc_build_tls(certificate_checks);
         let tls_stream = tls.connect(domain.as_ref(), stream)?.await?;
 
         let mut client = ImapClient::new(tls_stream);

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -4,7 +4,6 @@ use std::fmt;
 use crate::context::Context;
 use crate::error::Error;
 use async_std::sync::Arc;
-use async_tls;
 use rustls;
 use webpki;
 
@@ -269,7 +268,7 @@ impl rustls::ServerCertVerifier for NoCertificateVerification {
     }
 }
 
-pub fn dc_build_tls(certificate_checks: CertificateChecks) -> async_tls::TlsConnector {
+pub fn dc_build_tls_config(certificate_checks: CertificateChecks) -> rustls::ClientConfig {
     let mut config = rustls::ClientConfig::new();
     match certificate_checks {
         CertificateChecks::Strict => {}
@@ -293,7 +292,7 @@ pub fn dc_build_tls(certificate_checks: CertificateChecks) -> async_tls::TlsConn
                 .set_certificate_verifier(Arc::new(NoCertificateVerification {}));
         }
     }
-    Arc::new(config).into()
+    config
 }
 
 #[cfg(test)]

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -5,7 +5,7 @@ use crate::constants::*;
 use crate::context::Context;
 use crate::error::Error;
 use crate::events::Event;
-use crate::login_param::LoginParam;
+use crate::login_param::{dc_build_tls_config, LoginParam};
 use crate::oauth2::*;
 
 #[derive(DebugStub)]
@@ -65,10 +65,7 @@ impl Smtp {
         let domain = &lp.send_server;
         let port = lp.send_port as u16;
 
-        let mut tls_config = rustls::ClientConfig::new();
-        tls_config
-            .root_store
-            .add_server_trust_anchors(&webpki_roots::TLS_SERVER_ROOTS);
+        let tls_config = dc_build_tls_config(lp.smtp_certificate_checks);
         let tls_parameters = ClientTlsParameters::new(domain.to_string(), tls_config);
 
         let (creds, mechanism) = if 0 != lp.server_flags & (DC_LP_AUTH_OAUTH2 as i32) {


### PR DESCRIPTION
Only "Strict" and "Automatic" are implemented for CertChecks.  The other ones (invalidcert/invalidhostname) are equivalent to Automatic which allows invalid certs or even clear. 