### PR TITLE
test and tweak bcc-self

### DIFF
--- a/src/imex.rs
+++ b/src/imex.rs
@@ -160,7 +160,6 @@ fn do_initiate_key_transfer(context: &Context) -> Result<String> {
     // it would be too much noise to have two things popping up at the same time.
     // maybe_add_bcc_self_device_msg() is called on the other device
     // once the transfer is completed.
-    maybe_add_bcc_self_device_msg(context)?;
     Ok(setup_code)
 }
 


### PR DESCRIPTION
this pr adds some tests for device-messages, avoids a random label where no label is needed and removes an accidental call.