### PR TITLE
[wip] experimental new get json api for chat info

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2568,6 +2568,25 @@ dc_context_t*    dc_chatlist_get_context     (dc_chatlist_t* chatlist);
 
 
 /**
+ * Get info summary for a chat, in json format. 
+ *
+ * The returned json string has the following key/values: 
+ *
+ * id: chat id 
+ * name: chat/group name 
+ * color: color of this chat 
+ * last-message-from: who sent the last message 
+ * last-message-text: message (truncated) 
+ * last-message-state: DC_STATE* constant
+ * last-message-date: 
+ * avatar-path: path-to-blobfile 
+ * is_verified: yes/no
+
+ * @return a utf8-encoded json string containing all requested info. Must be freed using dc_lot_unref().  NULL is never returned.
+ */
+char*            dc_chat_get_info_json(dc_context_t* context, size_t chat_id)
+
+/**
  * @class dc_chat_t
  *
  * An object representing a single chat in memory.

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2584,7 +2584,7 @@ dc_context_t*    dc_chatlist_get_context     (dc_chatlist_t* chatlist);
 
  * @return a utf8-encoded json string containing all requested info. Must be freed using dc_lot_unref().  NULL is never returned.
  */
-char*            dc_chat_get_info_json(dc_context_t* context, size_t chat_id)
+char*            dc_chat_get_info_json       (dc_context_t* context, size_t chat_id);
 
 /**
  * @class dc_chat_t

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2342,6 +2342,27 @@ pub unsafe extern "C" fn dc_chat_is_sending_locations(chat: *mut dc_chat_t) -> l
     ffi_chat.chat.is_sending_locations() as libc::c_int
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn dc_chat_get_info_json(
+    context: *mut dc_context_t,
+    chat_id: u32,
+) -> *mut libc::c_char {
+    if context.is_null() {
+        eprintln!("ignoring careless call to dc_get_oauth2_url()");
+        return ptr::null_mut(); // NULL explicitly defined as "unknown"
+    }
+    let ffi_context = &*context;
+    ffi_context
+        .with_inner(|ctx| match chat::get_info_json(ctx, chat_id) {
+            Ok(s) => s.strdup(),
+            Err(err) => {
+                error!(ctx, "get_info_json({}) returned: {}", chat_id, err);
+                "".strdup()
+            }
+        })
+        .unwrap_or_else(|_| ptr::null_mut())
+}
+
 // dc_msg_t
 
 /// FFI struct for [dc_msg_t]

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -2,6 +2,7 @@
 
 import mimetypes
 import calendar
+import json
 from datetime import datetime
 import os
 from .cutil import as_dc_charpointer, from_dc_charpointer, iter_array
@@ -241,6 +242,12 @@ class Chat(object):
         Noticed messages are no longer fresh.
         """
         return lib.dc_marknoticed_chat(self._dc_context, self.id)
+
+    def get_summary(self):
+        """ return dictionary with summary information. """
+        dc_res = lib.dc_chat_get_info_json(self._dc_context, self.id)
+        s = from_dc_charpointer(dc_res)
+        return json.loads(s)
 
     # ------  group management API ------------------------------
 

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -155,6 +155,9 @@ class TestOfflineChat:
         chat.set_name("title2")
         assert chat.get_name() == "title2"
 
+        d = chat.get_summary()
+        assert d["chat_id"] == chat.id
+
     def test_group_chat_creation_with_translation(self, ac1):
         ac1.set_stock_translation(const.DC_STR_NEWGROUPDRAFT, "xyz %1$s")
         ac1._evlogger.consume_events()

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1885,7 +1885,67 @@ pub fn forward_msgs(context: &Context, msg_ids: &[MsgId], chat_id: u32) -> Resul
 }
 
 pub fn get_info_json(context: &Context, chat_id: u32) -> Result<String, Error> {
-    let s = format!("{{\n {:?}: {:?}\n}}", "chat_id", chat_id);
+    let chat = Chat::load_from_db(context, chat_id).unwrap();
+
+    // ToDo: 
+    // - [x] id
+    // - [x] type
+    // - [x] name
+    // - [x] archived
+    // - [x] color
+    // - [x] profileImage
+    // - [x] subtitle
+    // - [x] draft,
+    // - [ ] deaddrop,
+    // - [ ] summary,
+    // - [ ] lastUpdated,
+    // - [ ] freshMessageCounter,
+    // - [ ] email
+
+    let profile_image = match chat.get_profile_image(context) {
+        Some(path) => path.into_os_string().into_string().unwrap(),
+        None => "".to_string()
+    };
+
+    let draft = match get_draft(context, chat_id) {
+        Ok(message) => {
+            match message {
+              Some(m) => m.text.unwrap_or("".to_string())   ,
+              None => "".to_string()
+            } 
+        },
+        Err(_) => "".to_string()
+    };
+      
+    let s = format!("{{\
+                    \"id\": {:?},\
+                    \"type\": {:?},\
+                    \"name\": {:?},\
+                    \"archived\": {:?},\
+                    \"grpid\": {:?},\
+                    \"blocked\": {:?},\
+                    \"param\": {:?},\
+                    \"gossiped_timestamp\": {:?},\
+                    \"is_sending_locations\": {:?},\
+                    \"color\": {:?},\
+                    \"profile_image\": {:?},\
+                    \"subtitle\": {:?},\
+                    \"draft\": {:?}\
+                    }}",
+                    chat.id,
+                    chat.typ as u32,
+                    chat.name,
+                    chat.archived,
+                    chat.grpid,
+                    chat.blocked as u32,
+                    chat.param.to_string(),
+                    chat.gossiped_timestamp,
+                    chat.is_sending_locations,
+                    chat.get_color(context),
+                    profile_image,
+                    chat.get_subtitle(context),
+                    draft);
+                    
     Ok(s)
 }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1884,6 +1884,11 @@ pub fn forward_msgs(context: &Context, msg_ids: &[MsgId], chat_id: u32) -> Resul
     Ok(())
 }
 
+pub fn get_info_json(context: &Context, chat_id: u32) -> Result<String, Error> {
+    let s = format!("{{\n {:?}: {:?}\n}}", "chat_id", chat_id);
+    Ok(s)
+}
+
 pub fn get_chat_contact_cnt(context: &Context, chat_id: u32) -> usize {
     context
         .sql


### PR DESCRIPTION
did ths in a little hacking session with @jikstra -- aiming to fix #555 by exposing a `dc_*_json(context, ...)` FFI which returns an utf8-encoded json string with rich information.  Current idea is to just write a json string with `format!` but if you have leightweight suggestions on how to produce json (serde-json and serializing structs?) then please shoot.  
