### PR TITLE
Do not use wildcard match in msgtype_has_file

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -690,6 +690,8 @@ pub fn prepare_msg<'a>(
 
 pub fn msgtype_has_file(msgtype: Viewtype) -> bool {
     match msgtype {
+        Viewtype::Unknown => false,
+        Viewtype::Text => false,
         Viewtype::Image => true,
         Viewtype::Gif => true,
         Viewtype::Sticker => true,
@@ -697,7 +699,6 @@ pub fn msgtype_has_file(msgtype: Viewtype) -> bool {
         Viewtype::Voice => true,
         Viewtype::Video => true,
         Viewtype::File => true,
-        _ => false,
     }
 }
 


### PR DESCRIPTION
This way there will be a compiler error notifying that the function needs to be updated when a new message type is added.