### PR TITLE
[wip] test sql-string literals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -496,6 +496,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "image-meta 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "imap 1.0.2 (git+https://github.com/deltachat/rust-imap)",
+ "indoc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "jetscii 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1031,6 +1032,27 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "indoc"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "indoc-impl 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "indoc-impl"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unindent 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1579,6 +1601,16 @@ dependencies = [
  "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2590,6 +2622,11 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unindent"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unsafe-any"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,6 +2954,8 @@ dependencies = [
 "checksum imap 1.0.2 (git+https://github.com/deltachat/rust-imap)" = "<none>"
 "checksum imap-proto 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1b92ca529b24c5f80a950abe993d3883df6fe6791d4a46b1fda1eb339796c589"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
+"checksum indoc 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3f9553c1e16c114b8b77ebeb329e5f2876eed62a8d51178c8bc6bff0d65f98f8"
+"checksum indoc-impl 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b714fc08d0961716390977cdff1536234415ac37b509e34e5a983def8340fb75"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum itertools 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "87fa75c9dea7b07be3138c49abbb83fd4bea199b5cdc76f9804458edc5da0d6e"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
@@ -2974,6 +3013,7 @@ dependencies = [
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "717ee476b1690853d222af4634056d830b5197ffd747726a9a1eee6da9f49074"
+"checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum proptest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cf147e022eacf0c8a054ab864914a7602618adba841d800a9a9868a5237a529f"
@@ -3083,6 +3123,7 @@ dependencies = [
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum unindent 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "63f18aa3b0e35fed5a0048f029558b1518095ffe2a0a31fb87c93dece93a4993"
 "checksum unsafe-any 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f30360d7979f5e9c6e6cea48af192ea8fab4afb3cf72597154b8f08935bc9c7f"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ bitflags = "1.1.0"
 jetscii = "0.4.4"
 debug_stub_derive = "0.3.0"
 sanitize-filename = "0.2.1"
+indoc = "0.3"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1172,6 +1172,29 @@ fn maybe_add_from_param(
 #[cfg(test)]
 mod test {
     use super::*;
+    use indoc::indoc;
+
+    #[test]
+    fn test_literals() {
+        // sql formatted with the rust-multiline-literal will easily fail.
+        let a = "SELECT a\
+                 FROM b";
+        assert_eq!(a, "SELECT aFROM b");
+
+        // sql formatted with the concat-macro with also easily fail.
+        // also you cannot convince `cargo fmt` to align the statements.
+        let a = concat!("SELECT a", "FROM b");
+        assert_eq!(a, "SELECT aFROM b");
+
+        // the indoc-macro keeps lineends so that spaces are not needed.
+        // sqlite treats the lineends as normal whitespace so things are fine.
+        // also `cargo fmt` does not destroy the layout and there is less boilerplate.
+        let a = indoc!(
+            "SELECT a
+             FROM b"
+        );
+        assert_eq!(a, "SELECT a\nFROM b");
+    }
 
     #[test]
     fn test_maybe_add_file() {

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1176,17 +1176,22 @@ mod test {
 
     #[test]
     fn test_literals() {
-        // sql formatted with the rust-multiline-literal will easily fail.
+        // (a) sql formatted with the rust-multiline-literal will easily fail.
         let a = "SELECT a\
                  FROM b";
         assert_eq!(a, "SELECT aFROM b");
 
-        // sql formatted with the concat-macro with also easily fail.
+        // (b) if used without the trailing backspace, things are fine.
+        let a = "SELECT a
+                 FROM b";
+        assert_eq!(a, "SELECT a\n                 FROM b");
+
+        // (c) sql formatted with the concat-macro with also easily fail.
         // also you cannot convince `cargo fmt` to align the statements.
         let a = concat!("SELECT a", "FROM b");
         assert_eq!(a, "SELECT aFROM b");
 
-        // the indoc-macro keeps lineends so that spaces are not needed.
+        // (d) the indoc-macro keeps lineends so that spaces are not needed.
         // sqlite treats the lineends as normal whitespace so things are fine.
         // also `cargo fmt` does not destroy the layout and there is less boilerplate.
         let a = indoc!(
@@ -1194,6 +1199,13 @@ mod test {
              FROM b"
         );
         assert_eq!(a, "SELECT a\nFROM b");
+
+        // (e) when adding a trailing backslash, things will fail, though.
+        let a = indoc!(
+            "SELECT a\
+             FROM b"
+        );
+        assert_eq!(a, "SELECT aFROM b");
     }
 
     #[test]


### PR DESCRIPTION
this pr picks up the multi-line-discussion started at https://github.com/deltachat/deltachat-core-rust/pull/848#pullrequestreview-317966093

i wrote a small test that tests (a) rust-literals with backslash, (b) rust-literals without backslash, (c) concat-macro, (d) indoc-macro without backslash and (e) with backslash.

indoc allows free formatting and does not require spaces to be added.
the disadvantage ist some overhead (not sure, if the macro does sth. runtime, however) and an additional dependency.

~~if we decide to use indoc, maybe we can merge this pr to make sure, the dependency does not decide to do things slightly different. it's also nice for some documentation.~~

EDIT: when using indoc with a backslash, things are also bad here. so maybe just use the normal rust-literal without the backslash ((b) in the example) as @flub suggested at https://github.com/deltachat/deltachat-core-rust/pull/848#discussion_r347088237