### PR TITLE
tweak device messages

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1112,8 +1112,10 @@ void            dc_set_draft                 (dc_context_t* context, uint32_t ch
  *     If you pass NULL here, the message is added unconditionally.
  * @param msg Message to be added to the device-chat.
  *     The message appears to the user as an incoming message.
- * @return The ID of the added message,
- *     if the message was already added or skipped before or on errors, 0 is returned.
+ *     If you pass NULL here, only the given label will be added
+ *     and block adding messages with that label in the future.
+ * @return The ID of the just added message,
+ *     if the message was already added or no message to add is given, 0 is returned.
  *
  * Example:
  * ~~~
@@ -1126,7 +1128,7 @@ void            dc_set_draft                 (dc_context_t* context, uint32_t ch
  * if (dc_add_device_msg(context, "welcome", welcome_msg)) {
  *     // do not add the changelog on a new installations -
  *     // not now and not when this code is executed again
- *     dc_skip_device_msg(context, "update-123");
+ *     dc_add_device_msg(context, "update-123", NULL);
  * } else {
  *     // welcome message was not added now, this is an oder installation,
  *     // add a changelog
@@ -1138,35 +1140,14 @@ uint32_t        dc_add_device_msg            (dc_context_t* context, const char*
 
 
 /**
- * Skip a device-message permanently.
- * Subsequent calls to dc_add_device_msg() with the same label
- * won't add the device-message then.
- * This might be handy if you want to add
- * eg. different messages for first-install and updates.
- *
- * @memberof dc_context_t
- * @param context The context as created by dc_context_new().
- * @param label A unique name for the message to skip.
- *     The label is typically not displayed to the user and
- *     must be created from the characters `A-Z`, `a-z`, `0-9`, `_` or `-`.
- *     If a message with that label already exist,
- *     nothing happens.
- * @return None.
- */
-void            dc_skip_device_msg           (dc_context_t* context, const char* label);
-
-
-
-/**
- * Check if a device-message was ever added or skipped.
- * Device-messages can be added or skipped
- * using dc_add_device_msg() or dc_skip_device_msg().
+ * Check if a device-message with a given label was ever added.
+ * Device-messages can be added dc_add_device_msg().
  *
  * @memberof dc_context_t
  * @param context The context as created by dc_context_new().
  * @param label Label of the message to check.
- * @return 1=A message with this label was added or skipped at some point,
- *     0=A message with this label was never added nor skipped.
+ * @return 1=A message with this label was added at some point,
+ *     0=A message with this label was never added.
  */
 int             dc_has_device_msg            (dc_context_t* context, const char* label);
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1171,6 +1171,21 @@ uint32_t        dc_add_device_msg_unlabelled(dc_context_t* context, dc_msg_t* ms
 void            dc_skip_device_msg           (dc_context_t* context, const char* label);
 
 
+
+/**
+ * Check if a device-message was ever added or skipped.
+ * Device-messages can be added or skipped
+ * using dc_add_device_msg_once() or dc_skip_device_msg().
+ *
+ * @memberof dc_context_t
+ * @param context The context as created by dc_context_new().
+ * @param label Label of the message to check.
+ * @return 1=A message with this label was added or skipped at some point,
+ *     0=A message with this label was never added nor skipped.
+ */
+int             dc_has_device_msg            (dc_context_t* context, const char* label);
+
+
 /**
  * Get draft for a chat, if any.
  * See dc_set_draft() for more details about drafts.

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1117,7 +1117,7 @@ uint32_t        dc_add_device_msg            (dc_context_t* context, dc_msg_t* m
  * Add a message only one time to the device-chat.
  * The device-message is defined by a name.
  * If a message with the same name was added before,
- * the message is not added again.
+ * the message is not added again, even if the message was deleted in between.
  * Use dc_add_device_msg() to add device-messages unconditionally.
  *
  * Sends the event #DC_EVENT_MSGS_CHANGED on success.
@@ -1130,7 +1130,7 @@ uint32_t        dc_add_device_msg            (dc_context_t* context, dc_msg_t* m
  * @param msg Message to be added to the device-chat.
  *     The message appears to the user as an incoming message.
  * @return The ID of the added message,
- *     this might be the id of an older message with the same name.
+ *     if the message was already added before or on errors, 0 is returned.
  */
 uint32_t        dc_add_device_msg_once       (dc_context_t* context, const char* label, dc_msg_t* msg);
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1096,8 +1096,8 @@ void            dc_set_draft                 (dc_context_t* context, uint32_t ch
  * Add a message to the device-chat.
  * Device-messages usually contain update information
  * and some hints that are added during the program runs, multi-device etc.
- * The device-message is defined by a label;
- * If a message with the same label was added or skipped before,
+ * The device-message may be defined by a label;
+ * if a message with the same label was added or skipped before,
  * the message is not added again, even if the message was deleted in between.
  * If needed, the device-chat is created before.
  *
@@ -1109,6 +1109,7 @@ void            dc_set_draft                 (dc_context_t* context, uint32_t ch
  * @param label A unique name for the message to add.
  *     The label is typically not displayed to the user and
  *     must be created from the characters `A-Z`, `a-z`, `0-9`, `_` or `-`.
+ *     If you pass NULL here, the message is added unconditionally.
  * @param msg Message to be added to the device-chat.
  *     The message appears to the user as an incoming message.
  * @return The ID of the added message,
@@ -1122,39 +1123,23 @@ void            dc_set_draft                 (dc_context_t* context, uint32_t ch
  * dc_msg_t* changelog_msg = dc_msg_new(DC_MSG_TEXT);
  * dc_msg_set_text(changelog_msg, "we have added 3 new emojis :)");
  *
- * if (dc_add_device_msg_once(context, "welcome", welcome_msg)) {
+ * if (dc_add_device_msg(context, "welcome", welcome_msg)) {
  *     // do not add the changelog on a new installations -
  *     // not now and not when this code is executed again
  *     dc_skip_device_msg(context, "update-123");
  * } else {
  *     // welcome message was not added now, this is an oder installation,
  *     // add a changelog
- *     dc_add_device_msg_once(context, "update-123", changelog_msg);
+ *     dc_add_device_msg(context, "update-123", changelog_msg);
  * }
  * ~~~
  */
-uint32_t        dc_add_device_msg_once       (dc_context_t* context, const char* label, dc_msg_t* msg);
-
-
-/**
- * Add a message to the device-chat unconditionally.
- * As this skips the test if the message was added before,
- * normally, you should prefer dc_add_device_msg_once() over this function
- *
- * Sends the event #DC_EVENT_MSGS_CHANGED on success.
- *
- * @memberof dc_context_t
- * @param context The context as created by dc_context_new().
- * @param msg Message to be added to the device-chat.
- *     The message appears to the user as an incoming message.
- * @return The ID of the added message.
- */
-uint32_t        dc_add_device_msg_unlabelled(dc_context_t* context, dc_msg_t* msg);
+uint32_t        dc_add_device_msg            (dc_context_t* context, const char* label, dc_msg_t* msg);
 
 
 /**
  * Skip a device-message permanently.
- * Subsequent calls to dc_add_device_msg_once() with the same label
+ * Subsequent calls to dc_add_device_msg() with the same label
  * won't add the device-message then.
  * This might be handy if you want to add
  * eg. different messages for first-install and updates.
@@ -1175,7 +1160,7 @@ void            dc_skip_device_msg           (dc_context_t* context, const char*
 /**
  * Check if a device-message was ever added or skipped.
  * Device-messages can be added or skipped
- * using dc_add_device_msg_once() or dc_skip_device_msg().
+ * using dc_add_device_msg() or dc_skip_device_msg().
  *
  * @memberof dc_context_t
  * @param context The context as created by dc_context_new().
@@ -2811,7 +2796,7 @@ int             dc_chat_is_self_talk         (const dc_chat_t* chat);
  * From the ui view, device-talks are not very special,
  * the user can delete and forward messages, archive the chat, set notifications etc.
  *
- * Messages can be added to the device-talk using dc_add_device_msg_once()
+ * Messages can be added to the device-talk using dc_add_device_msg()
  *
  * @memberof dc_chat_t
  * @param chat The chat object.

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1149,7 +1149,7 @@ uint32_t        dc_add_device_msg            (dc_context_t* context, const char*
  * @return 1=A message with this label was added at some point,
  *     0=A message with this label was never added.
  */
-int             dc_has_device_msg            (dc_context_t* context, const char* label);
+int             dc_was_device_msg_ever_added (dc_context_t* context, const char* label);
 
 
 /**

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1096,31 +1096,13 @@ void            dc_set_draft                 (dc_context_t* context, uint32_t ch
  * Add a message to the device-chat.
  * Device-messages usually contain update information
  * and some hints that are added during the program runs, multi-device etc.
- *
- * Device-messages may be added from the core,
- * however, with this function, this can be done from the ui as well.
+ * The device-message is defined by a label;
+ * If a message with the same label was added or skipped before,
+ * the message is not added again, even if the message was deleted in between.
  * If needed, the device-chat is created before.
  *
  * Sends the event #DC_EVENT_MSGS_CHANGED on success.
  * To check, if a given chat is a device-chat, see dc_chat_is_device_talk()
- *
- * @memberof dc_context_t
- * @param context The context as created by dc_context_new().
- * @param msg Message to be added to the device-chat.
- *     The message appears to the user as an incoming message.
- * @return The ID of the added message.
- */
-uint32_t        dc_add_device_msg            (dc_context_t* context, dc_msg_t* msg);
-
-
-/**
- * Add a message only one time to the device-chat.
- * The device-message is defined by a name.
- * If a message with the same name was added before,
- * the message is not added again, even if the message was deleted in between.
- * Use dc_add_device_msg() to add device-messages unconditionally.
- *
- * Sends the event #DC_EVENT_MSGS_CHANGED on success.
  *
  * @memberof dc_context_t
  * @param context The context as created by dc_context_new().
@@ -1130,26 +1112,7 @@ uint32_t        dc_add_device_msg            (dc_context_t* context, dc_msg_t* m
  * @param msg Message to be added to the device-chat.
  *     The message appears to the user as an incoming message.
  * @return The ID of the added message,
- *     if the message was already added before or on errors, 0 is returned.
- */
-uint32_t        dc_add_device_msg_once       (dc_context_t* context, const char* label, dc_msg_t* msg);
-
-
-/**
- * Skip a device-message permanently.
- * Subsequent calls to dc_add_device_msg_once() with the same label
- * won't add the device-message then.
- * This might be handy if you want to add
- * eg. different messages for first-install and updates.
- *
- * @memberof dc_context_t
- * @param context The context as created by dc_context_new().
- * @param label A unique name for the message to skip.
- *     The label is typically not displayed to the user and
- *     must be created from the characters `A-Z`, `a-z`, `0-9`, `_` or `-`.
- *     If a message with that label already exist,
- *     nothing happens.
- * @return None.
+ *     if the message was already added or skipped before or on errors, 0 is returned.
  *
  * Example:
  * ~~~
@@ -1169,6 +1132,41 @@ uint32_t        dc_add_device_msg_once       (dc_context_t* context, const char*
  *     dc_add_device_msg_once(context, "update-123", changelog_msg);
  * }
  * ~~~
+ */
+uint32_t        dc_add_device_msg_once       (dc_context_t* context, const char* label, dc_msg_t* msg);
+
+
+/**
+ * Add a message to the device-chat unconditionally.
+ * As this skips the test if the message was added before,
+ * normally, you should prefer dc_add_device_msg_once() over this function
+ *
+ * Sends the event #DC_EVENT_MSGS_CHANGED on success.
+ *
+ * @memberof dc_context_t
+ * @param context The context as created by dc_context_new().
+ * @param msg Message to be added to the device-chat.
+ *     The message appears to the user as an incoming message.
+ * @return The ID of the added message.
+ */
+uint32_t        dc_add_device_msg_unlabelled(dc_context_t* context, dc_msg_t* msg);
+
+
+/**
+ * Skip a device-message permanently.
+ * Subsequent calls to dc_add_device_msg_once() with the same label
+ * won't add the device-message then.
+ * This might be handy if you want to add
+ * eg. different messages for first-install and updates.
+ *
+ * @memberof dc_context_t
+ * @param context The context as created by dc_context_new().
+ * @param label A unique name for the message to skip.
+ *     The label is typically not displayed to the user and
+ *     must be created from the characters `A-Z`, `a-z`, `0-9`, `_` or `-`.
+ *     If a message with that label already exist,
+ *     nothing happens.
+ * @return None.
  */
 void            dc_skip_device_msg           (dc_context_t* context, const char* label);
 
@@ -2798,9 +2796,7 @@ int             dc_chat_is_self_talk         (const dc_chat_t* chat);
  * From the ui view, device-talks are not very special,
  * the user can delete and forward messages, archive the chat, set notifications etc.
  *
- * Messages may be added from the core to the device chat,
- * so the chat just pops up as usual.
- * However, if needed the ui can also add messages using dc_add_device_msg()
+ * Messages can be added to the device-talk using dc_add_device_msg_once()
  *
  * @memberof dc_chat_t
  * @param chat The chat object.

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1136,6 +1136,44 @@ uint32_t        dc_add_device_msg_once       (dc_context_t* context, const char*
 
 
 /**
+ * Skip a device-message permanently.
+ * Subsequent calls to dc_add_device_msg_once() with the same label
+ * won't add the device-message then.
+ * This might be handy if you want to add
+ * eg. different messages for first-install and updates.
+ *
+ * @memberof dc_context_t
+ * @param context The context as created by dc_context_new().
+ * @param label A unique name for the message to skip.
+ *     The label is typically not displayed to the user and
+ *     must be created from the characters `A-Z`, `a-z`, `0-9`, `_` or `-`.
+ *     If a message with that label already exist,
+ *     nothing happens.
+ * @return None.
+ *
+ * Example:
+ * ~~~
+ * dc_msg_t* welcome_msg = dc_msg_new(DC_MSG_TEXT);
+ * dc_msg_set_text(welcome_msg, "great that you give this app a try!");
+ *
+ * dc_msg_t* changelog_msg = dc_msg_new(DC_MSG_TEXT);
+ * dc_msg_set_text(changelog_msg, "we have added 3 new emojis :)");
+ *
+ * if (dc_add_device_msg_once(context, "welcome", welcome_msg)) {
+ *     // do not add the changelog on a new installations -
+ *     // not now and not when this code is executed again
+ *     dc_skip_device_msg(context, "update-123");
+ * } else {
+ *     // welcome message was not added now, this is an oder installation,
+ *     // add a changelog
+ *     dc_add_device_msg_once(context, "update-123", changelog_msg);
+ * }
+ * ~~~
+ */
+void            dc_skip_device_msg           (dc_context_t* context, const char* label);
+
+
+/**
  * Get draft for a chat, if any.
  * See dc_set_draft() for more details about drafts.
  *

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -871,6 +871,23 @@ pub unsafe extern "C" fn dc_skip_device_msg(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_has_device_msg(
+    context: *mut dc_context_t,
+    label: *const libc::c_char,
+) -> libc::c_int {
+    if context.is_null() || label.is_null() {
+        eprintln!("ignoring careless call to dc_has_device_msg()");
+        return 0;
+    }
+    let ffi_context = &mut *context;
+    ffi_context
+        .with_inner(|ctx| {
+            chat::has_device_msg(ctx, &to_string_lossy(label)).unwrap_or(false) as libc::c_int
+        })
+        .unwrap_or(0)
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_get_draft(context: *mut dc_context_t, chat_id: u32) -> *mut dc_msg_t {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_draft()");

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -812,41 +812,25 @@ pub unsafe extern "C" fn dc_set_draft(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_add_device_msg_unlabelled(
-    context: *mut dc_context_t,
-    msg: *mut dc_msg_t,
-) -> u32 {
-    if context.is_null() || msg.is_null() {
-        eprintln!("ignoring careless call to dc_add_device_msg_unlabelled()");
-        return 0;
-    }
-    let ffi_context = &mut *context;
-    let ffi_msg = &mut *msg;
-    ffi_context
-        .with_inner(|ctx| {
-            chat::add_device_msg_unlabelled(ctx, &mut ffi_msg.message)
-                .unwrap_or_log_default(ctx, "Failed to add device message")
-        })
-        .map(|msg_id| msg_id.to_u32())
-        .unwrap_or(0)
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn dc_add_device_msg_once(
+pub unsafe extern "C" fn dc_add_device_msg(
     context: *mut dc_context_t,
     label: *const libc::c_char,
     msg: *mut dc_msg_t,
 ) -> u32 {
     if context.is_null() || label.is_null() || msg.is_null() {
-        eprintln!("ignoring careless call to dc_add_device_msg_once()");
+        eprintln!("ignoring careless call to dc_add_device_msg()");
         return 0;
     }
     let ffi_context = &mut *context;
     let ffi_msg = &mut *msg;
     ffi_context
         .with_inner(|ctx| {
-            chat::add_device_msg_once(ctx, &to_string_lossy(label), &mut ffi_msg.message)
-                .unwrap_or_log_default(ctx, "Failed to add device message once")
+            chat::add_device_msg(
+                ctx,
+                to_opt_string_lossy(label).as_ref().map(|x| x.as_str()),
+                &mut ffi_msg.message,
+            )
+            .unwrap_or_log_default(ctx, "Failed to add device message")
         })
         .map(|msg_id| msg_id.to_u32())
         .unwrap_or(0)

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -812,16 +812,19 @@ pub unsafe extern "C" fn dc_set_draft(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_add_device_msg(context: *mut dc_context_t, msg: *mut dc_msg_t) -> u32 {
+pub unsafe extern "C" fn dc_add_device_msg_unlabelled(
+    context: *mut dc_context_t,
+    msg: *mut dc_msg_t,
+) -> u32 {
     if context.is_null() || msg.is_null() {
-        eprintln!("ignoring careless call to dc_add_device_msg()");
+        eprintln!("ignoring careless call to dc_add_device_msg_unlabelled()");
         return 0;
     }
     let ffi_context = &mut *context;
     let ffi_msg = &mut *msg;
     ffi_context
         .with_inner(|ctx| {
-            chat::add_device_msg(ctx, &mut ffi_msg.message)
+            chat::add_device_msg_unlabelled(ctx, &mut ffi_msg.message)
                 .unwrap_or_log_default(ctx, "Failed to add device message")
         })
         .map(|msg_id| msg_id.to_u32())

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -842,18 +842,19 @@ pub unsafe extern "C" fn dc_add_device_msg(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_has_device_msg(
+pub unsafe extern "C" fn dc_was_device_msg_ever_added(
     context: *mut dc_context_t,
     label: *const libc::c_char,
 ) -> libc::c_int {
     if context.is_null() || label.is_null() {
-        eprintln!("ignoring careless call to dc_has_device_msg()");
+        eprintln!("ignoring careless call to dc_was_device_msg_ever_added()");
         return 0;
     }
     let ffi_context = &mut *context;
     ffi_context
         .with_inner(|ctx| {
-            chat::has_device_msg(ctx, &to_string_lossy(label)).unwrap_or(false) as libc::c_int
+            chat::was_device_msg_ever_added(ctx, &to_string_lossy(label)).unwrap_or(false)
+                as libc::c_int
         })
         .unwrap_or(0)
 }

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -850,6 +850,24 @@ pub unsafe extern "C" fn dc_add_device_msg_once(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_skip_device_msg(
+    context: *mut dc_context_t,
+    label: *const libc::c_char,
+) {
+    if context.is_null() || label.is_null() {
+        eprintln!("ignoring careless call to dc_skip_device_msg()");
+        return;
+    }
+    let ffi_context = &mut *context;
+    ffi_context
+        .with_inner(|ctx| {
+            chat::skip_device_msg(ctx, &to_string_lossy(label))
+                .unwrap_or_log_default(ctx, "Failed to skip device message")
+        })
+        .unwrap_or(())
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_get_draft(context: *mut dc_context_t, chat_id: u32) -> *mut dc_msg_t {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_draft()");

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -837,7 +837,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             );
             let mut msg = Message::new(Viewtype::Text);
             msg.set_text(Some(arg1.to_string()));
-            chat::add_device_msg(context, None, &mut msg)?;
+            chat::add_device_msg(context, None, Some(&mut msg))?;
         }
         "listmedia" => {
             ensure!(sel_chat.is_some(), "No chat selected.");

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -837,7 +837,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             );
             let mut msg = Message::new(Viewtype::Text);
             msg.set_text(Some(arg1.to_string()));
-            chat::add_device_msg_unlabelled(context, &mut msg)?;
+            chat::add_device_msg(context, None, &mut msg)?;
         }
         "listmedia" => {
             ensure!(sel_chat.is_some(), "No chat selected.");

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -837,7 +837,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             );
             let mut msg = Message::new(Viewtype::Text);
             msg.set_text(Some(arg1.to_string()));
-            chat::add_device_msg(context, &mut msg)?;
+            chat::add_device_msg_unlabelled(context, &mut msg)?;
         }
         "listmedia" => {
             ensure!(sel_chat.is_some(), "No chat selected.");

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1952,7 +1952,7 @@ pub fn get_chat_id_by_grpid(context: &Context, grpid: impl AsRef<str>) -> (u32, 
         .unwrap_or((0, false, Blocked::Not))
 }
 
-pub fn add_device_msg(context: &Context, msg: &mut Message) -> Result<MsgId, Error> {
+pub fn add_device_msg_unlabelled(context: &Context, msg: &mut Message) -> Result<MsgId, Error> {
     add_device_msg_maybe_labelled(context, None, msg)
 }
 
@@ -2147,18 +2147,18 @@ mod tests {
     }
 
     #[test]
-    fn test_add_device_msg() {
+    fn test_add_device_msg_unlabelled() {
         let t = test_context(Some(Box::new(logging_cb)));
 
         // add two device-messages
         let mut msg1 = Message::new(Viewtype::Text);
         msg1.text = Some("first message".to_string());
-        let msg1_id = add_device_msg(&t.ctx, &mut msg1);
+        let msg1_id = add_device_msg_unlabelled(&t.ctx, &mut msg1);
         assert!(msg1_id.is_ok());
 
         let mut msg2 = Message::new(Viewtype::Text);
         msg2.text = Some("second message".to_string());
-        let msg2_id = add_device_msg(&t.ctx, &mut msg2);
+        let msg2_id = add_device_msg_unlabelled(&t.ctx, &mut msg2);
         assert!(msg2_id.is_ok());
         assert_ne!(msg1_id.as_ref().unwrap(), msg2_id.as_ref().unwrap());
 
@@ -2263,7 +2263,7 @@ mod tests {
         let t = dummy_context();
         let mut msg = Message::new(Viewtype::Text);
         msg.text = Some("foo".to_string());
-        let msg_id = add_device_msg(&t.ctx, &mut msg).unwrap();
+        let msg_id = add_device_msg_unlabelled(&t.ctx, &mut msg).unwrap();
         let chat_id1 = message::Message::load_from_db(&t.ctx, msg_id)
             .unwrap()
             .chat_id;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1962,12 +1962,7 @@ pub fn add_device_msg(
 
     // if the device message is labeled and was ever added, do nothing
     if let Some(label) = label {
-        ensure!(!label.is_empty(), "cannot add empty label");
-        if let Ok(()) = context.sql.query_row(
-            "SELECT label FROM devmsglabels WHERE label=?",
-            params![label],
-            |_| Ok(()),
-        ) {
+        if has_device_msg(context, label)? {
             info!(context, "device-message {} already added", label);
             return Ok(MsgId::new_unset());
         }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1966,7 +1966,7 @@ pub fn add_device_msg(
     let mut msg_id = MsgId::new_unset();
 
     if let Some(label) = label {
-        if has_device_msg(context, label)? {
+        if was_device_msg_ever_added(context, label)? {
             info!(context, "device-message {} already added", label);
             return Ok(msg_id);
         }
@@ -2011,7 +2011,7 @@ pub fn add_device_msg(
     Ok(msg_id)
 }
 
-pub fn has_device_msg(context: &Context, label: &str) -> Result<bool, Error> {
+pub fn was_device_msg_ever_added(context: &Context, label: &str) -> Result<bool, Error> {
     ensure!(!label.is_empty(), "empty label");
     if let Ok(()) = context.sql.query_row(
         "SELECT label FROM devmsglabels WHERE label=?",
@@ -2237,19 +2237,19 @@ mod tests {
     }
 
     #[test]
-    fn test_has_device_msg() {
+    fn test_was_device_msg_ever_added() {
         let t = test_context(Some(Box::new(logging_cb)));
         add_device_msg(&t.ctx, Some("some-label"), None).ok();
-        assert!(has_device_msg(&t.ctx, "some-label").unwrap());
+        assert!(was_device_msg_ever_added(&t.ctx, "some-label").unwrap());
 
         let mut msg = Message::new(Viewtype::Text);
         msg.text = Some("message text".to_string());
         add_device_msg(&t.ctx, Some("another-label"), Some(&mut msg)).ok();
-        assert!(has_device_msg(&t.ctx, "another-label").unwrap());
+        assert!(was_device_msg_ever_added(&t.ctx, "another-label").unwrap());
 
-        assert!(!has_device_msg(&t.ctx, "unused-label").unwrap());
+        assert!(!was_device_msg_ever_added(&t.ctx, "unused-label").unwrap());
 
-        assert!(has_device_msg(&t.ctx, "").is_err());
+        assert!(was_device_msg_ever_added(&t.ctx, "").is_err());
     }
 
     fn chatlist_len(ctx: &Context, listflags: usize) -> usize {

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -247,7 +247,7 @@ fn maybe_add_bcc_self_device_msg(context: &Context) -> Result<()> {
              go to the settings and enable \"Send copy to self\"."
                 .to_string(),
         );
-        chat::add_device_msg_once(context, "bcc-self-hint", &mut msg)?;
+        chat::add_device_msg(context, Some("bcc-self-hint"), &mut msg)?;
     }
     Ok(())
 }

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -247,7 +247,7 @@ fn maybe_add_bcc_self_device_msg(context: &Context) -> Result<()> {
              go to the settings and enable \"Send copy to self\"."
                 .to_string(),
         );
-        chat::add_device_msg(context, Some("bcc-self-hint"), &mut msg)?;
+        chat::add_device_msg(context, Some("bcc-self-hint"), Some(&mut msg))?;
     }
     Ok(())
 }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -815,7 +815,7 @@ fn open(
             // records in the devmsglabels are kept when the message is deleted.
             // so, msg_id may or may not exist.
             sql.execute(
-                "CREATE TABLE devmsglabels (id INTEGER PRIMARY KEY AUTOINCREMENT, label TEXT, msg_id INTEGER);",
+                "CREATE TABLE devmsglabels (id INTEGER PRIMARY KEY AUTOINCREMENT, label TEXT, msg_id INTEGER DEFAULT 0);",
                 NO_PARAMS,
             )?;
             sql.execute(

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -810,24 +810,23 @@ fn open(
             )?;
             sql.set_raw_config_int(context, "dbversion", 55)?;
         }
-        if dbversion < 57 {
-            info!(context, "[migration] v57");
-            // label is a unique name and is currently used for device-messages only.
-            // in contrast to rfc724_mid and other fields, the label is generated on the device
-            // and allows reliable identifications this way.
+        if dbversion < 59 {
+            info!(context, "[migration] v59");
+            // records in the devmsglabels are kept when the message is deleted.
+            // so, msg_id may or may not exist.
             sql.execute(
-                "ALTER TABLE msgs ADD COLUMN label TEXT DEFAULT '';",
-                params![],
+                "CREATE TABLE devmsglabels (id INTEGER PRIMARY KEY AUTOINCREMENT, label TEXT, msg_id INTEGER);",
+                NO_PARAMS,
+            )?;
+            sql.execute(
+                "CREATE INDEX devmsglabels_index1 ON devmsglabels (label);",
+                NO_PARAMS,
             )?;
             if exists_before_update && sql.get_raw_config_int(context, "bcc_self").is_none() {
                 sql.set_raw_config_int(context, "bcc_self", 1)?;
             }
-            sql.set_raw_config_int(context, "dbversion", 57)?;
-        }
-        if dbversion < 58 {
-            info!(context, "[migration] v58");
             update_icons = true;
-            sql.set_raw_config_int(context, "dbversion", 58)?;
+            sql.set_raw_config_int(context, "dbversion", 59)?;
         }
 
         // (2) updates that require high-level objects


### PR DESCRIPTION
this pr is about to make device messages more usable, needed eg. by https://github.com/deltachat/deltachat-android/pull/1121:

- messages deleted by the user manually must not be added again with dc_add_device_msg_once() (i've overseen this issue on the first implementation)
- for allowing different messages on new-install and updates, it would be nice to have an option to "skip" a device message
- also, a function to check if a given device-message was ever added (even if deleted by the user) is useful for the ui