### PR TITLE
resultify imap connect/fetch/idle and simplify connection handling

### DIFF
--- a/ci_scripts/remote_tests_python.sh
+++ b/ci_scripts/remote_tests_python.sh
@@ -35,8 +35,12 @@ ssh $SSHTARGET <<_HERE
     #rm -rf virtualenv venv
     #virtualenv -q -p python3.7 venv 
     #source venv/bin/activate
-    set -x
-
     #pip install -q tox virtualenv
+
+    set -x
+    which python
+    source \$HOME/venv/bin/activate
+    which python
+
     bash ci_scripts/run-python-test.sh 
 _HERE

--- a/ci_scripts/remote_tests_python.sh
+++ b/ci_scripts/remote_tests_python.sh
@@ -31,11 +31,12 @@ ssh $SSHTARGET <<_HERE
     export TARGET=release
     export DCC_PY_LIVECONFIG=$DCC_PY_LIVECONFIG
 
-    rm -rf virtualenv venv
-    virtualenv -q -p python3.7 venv 
-    source venv/bin/activate
+    #we rely on tox/virtualenv being available in the host
+    #rm -rf virtualenv venv
+    #virtualenv -q -p python3.7 venv 
+    #source venv/bin/activate
     set -x
 
-    pip install -q tox virtualenv
+    #pip install -q tox virtualenv
     bash ci_scripts/run-python-test.sh 
 _HERE

--- a/ci_scripts/run-python-test.sh
+++ b/ci_scripts/run-python-test.sh
@@ -19,5 +19,6 @@ rm -rf src/deltachat/__pycache__
 export PYTHONDONTWRITEBYTECODE=1
 
 # run python tests (tox invokes pytest to run tests in python/tests)
-TOX_PARALLEL_NO_SPINNER=1 tox -p2 -e lint,doc
-tox -e py37
+#TOX_PARALLEL_NO_SPINNER=1 tox -e lint,doc
+tox -e lint
+tox -e doc,py37

--- a/ci_scripts/run-python-test.sh
+++ b/ci_scripts/run-python-test.sh
@@ -19,4 +19,5 @@ rm -rf src/deltachat/__pycache__
 export PYTHONDONTWRITEBYTECODE=1
 
 # run python tests (tox invokes pytest to run tests in python/tests)
-tox -e lintdoc,py37 
+TOX_PARALLEL_NO_SPINNER=1 tox -p2 -e lint,doc
+tox -e py37

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -461,7 +461,7 @@ pub unsafe extern "C" fn dc_perform_imap_jobs(context: *mut dc_context_t) {
     }
     let ffi_context = &*context;
     ffi_context
-        .with_inner(|ctx| job::perform_imap_jobs(ctx))
+        .with_inner(|ctx| job::perform_inbox_jobs(ctx))
         .unwrap_or(())
 }
 
@@ -473,19 +473,20 @@ pub unsafe extern "C" fn dc_perform_imap_fetch(context: *mut dc_context_t) {
     }
     let ffi_context = &*context;
     ffi_context
-        .with_inner(|ctx| job::perform_imap_fetch(ctx))
+        .with_inner(|ctx| job::perform_inbox_fetch(ctx))
         .unwrap_or(())
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn dc_perform_imap_idle(context: *mut dc_context_t) {
+    // TODO rename function in co-ordination with UIs
     if context.is_null() {
         eprintln!("ignoring careless call to dc_perform_imap_idle()");
         return;
     }
     let ffi_context = &*context;
     ffi_context
-        .with_inner(|ctx| job::perform_imap_idle(ctx))
+        .with_inner(|ctx| job::perform_inbox_idle(ctx))
         .unwrap_or(())
 }
 
@@ -497,7 +498,7 @@ pub unsafe extern "C" fn dc_interrupt_imap_idle(context: *mut dc_context_t) {
     }
     let ffi_context = &*context;
     ffi_context
-        .with_inner(|ctx| job::interrupt_imap_idle(ctx))
+        .with_inner(|ctx| job::interrupt_inbox_idle(ctx, true))
         .unwrap_or(())
 }
 

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -496,7 +496,7 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             println!("{:#?}", context.get_info());
         }
         "interrupt" => {
-            interrupt_imap_idle(context);
+            interrupt_inbox_idle(context, true);
         }
         "maybenetwork" => {
             maybe_network(context);

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -150,11 +150,11 @@ fn start_threads(c: Arc<RwLock<Context>>) {
     let ctx = c.clone();
     let handle_imap = std::thread::spawn(move || loop {
         while_running!({
-            perform_imap_jobs(&ctx.read().unwrap());
-            perform_imap_fetch(&ctx.read().unwrap());
+            perform_inbox_jobs(&ctx.read().unwrap());
+            perform_inbox_fetch(&ctx.read().unwrap());
             while_running!({
                 let context = ctx.read().unwrap();
-                perform_imap_idle(&context);
+                perform_inbox_idle(&context);
             });
         });
     });
@@ -202,7 +202,7 @@ fn stop_threads(context: &Context) {
         println!("Stopping threads");
         IS_RUNNING.store(false, Ordering::Relaxed);
 
-        interrupt_imap_idle(context);
+        interrupt_inbox_idle(context, true);
         interrupt_mvbox_idle(context);
         interrupt_sentbox_idle(context);
         interrupt_smtp_idle(context);
@@ -455,9 +455,9 @@ unsafe fn handle_cmd(line: &str, ctx: Arc<RwLock<Context>>) -> Result<ExitResult
         }
         "imap-jobs" => {
             if HANDLE.clone().lock().unwrap().is_some() {
-                println!("imap-jobs are already running in a thread.");
+                println!("inbox-jobs are already running in a thread.");
             } else {
-                perform_imap_jobs(&ctx.read().unwrap());
+                perform_inbox_jobs(&ctx.read().unwrap());
             }
         }
         "configure" => {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -11,7 +11,8 @@ use deltachat::configure::*;
 use deltachat::contact::*;
 use deltachat::context::*;
 use deltachat::job::{
-    perform_imap_fetch, perform_imap_idle, perform_imap_jobs, perform_smtp_idle, perform_smtp_jobs,
+    perform_inbox_fetch, perform_inbox_idle, perform_inbox_jobs, perform_smtp_idle,
+    perform_smtp_jobs,
 };
 use deltachat::Event;
 
@@ -50,12 +51,12 @@ fn main() {
     let r1 = running.clone();
     let t1 = thread::spawn(move || {
         while *r1.read().unwrap() {
-            perform_imap_jobs(&ctx1);
+            perform_inbox_jobs(&ctx1);
             if *r1.read().unwrap() {
-                perform_imap_fetch(&ctx1);
+                perform_inbox_fetch(&ctx1);
 
                 if *r1.read().unwrap() {
-                    perform_imap_idle(&ctx1);
+                    perform_inbox_idle(&ctx1);
                 }
             }
         }
@@ -113,7 +114,7 @@ fn main() {
     println!("stopping threads");
 
     *running.clone().write().unwrap() = false;
-    deltachat::job::interrupt_imap_idle(&ctx);
+    deltachat::job::interrupt_inbox_idle(&ctx, true);
     deltachat::job::interrupt_smtp_idle(&ctx);
 
     println!("joining");

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -573,8 +573,10 @@ class IOThreads:
         self._log_event("py-bindings-info", 0, "INBOX THREAD START")
         while not self._thread_quitflag:
             lib.dc_perform_imap_jobs(self._dc_context)
-            lib.dc_perform_imap_fetch(self._dc_context)
-            lib.dc_perform_imap_idle(self._dc_context)
+            if not self._thread_quitflag:
+                lib.dc_perform_imap_fetch(self._dc_context)
+            if not self._thread_quitflag:
+                lib.dc_perform_imap_idle(self._dc_context)
         self._log_event("py-bindings-info", 0, "INBOX THREAD FINISHED")
 
     def mvbox_thread_run(self):

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -431,7 +431,7 @@ class TestOnlineAccount:
         ev = ac1._evlogger.get_matching("DC_EVENT_DELETED_BLOB_FILE")
 
     def test_mvbox_sentbox_threads(self, acfactory, lp):
-        lp.sec("ac1: start with mvbox/sentbox threads")
+        lp.sec("ac1: start with mvbox thread")
         ac1 = acfactory.get_online_configuring_account(mvbox=True, sentbox=True)
 
         lp.sec("ac2: start without mvbox/sentbox threads")

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -41,7 +41,7 @@ def test_dc_close_events(tmpdir):
             else:
                 print("skipping event", *ev)
 
-    find("disconnecting INBOX-watch")
+    find("disconnecting inbox-thread")
     find("disconnecting sentbox-thread")
     find("disconnecting mvbox-thread")
     find("disconnecting SMTP")

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -48,13 +48,12 @@ commands =
     rst-lint --encoding 'utf-8' README.rst
 
 [testenv:doc]
-skipsdist = True
-usedevelop = True
+changedir=doc
 deps =
     sphinx==2.2.0
     breathe
 commands =
-    sphinx-build -w toxdoc-warnings.log -b html doc doc/_build/html
+    sphinx-build -w toxdoc-warnings.log -b html . _build/html
 
 
 [testenv:lintdoc]

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,7 +121,7 @@ impl Context {
             }
             Config::InboxWatch => {
                 let ret = self.sql.set_raw_config(self, key, value);
-                interrupt_imap_idle(self);
+                interrupt_inbox_idle(self, true);
                 ret
             }
             Config::SentboxWatch => {

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -65,7 +65,12 @@ pub fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context) {
 
     let mut param_autoconfig: Option<LoginParam> = None;
 
-    context.inbox.read().unwrap().disconnect(context);
+    context
+        .inbox_thread
+        .read()
+        .unwrap()
+        .imap
+        .disconnect(context);
     context
         .sentbox_thread
         .read()
@@ -359,9 +364,10 @@ pub fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context) {
                     0
                 };
                 context
-                    .inbox
+                    .inbox_thread
                     .read()
                     .unwrap()
+                    .imap
                     .configure_folders(context, flags);
                 true
             }
@@ -401,7 +407,12 @@ pub fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context) {
         }
     }
     if imap_connected_here {
-        context.inbox.read().unwrap().disconnect(context);
+        context
+            .inbox_thread
+            .read()
+            .unwrap()
+            .imap
+            .disconnect(context);
     }
     if smtp_connected_here {
         context.smtp.clone().lock().unwrap().disconnect();
@@ -497,7 +508,13 @@ fn try_imap_one_param(context: &Context, param: &LoginParam) -> Option<bool> {
         param.mail_user, param.mail_server, param.mail_port, param.server_flags
     );
     info!(context, "Trying: {}", inf);
-    if context.inbox.read().unwrap().connect(context, &param) {
+    if context
+        .inbox_thread
+        .read()
+        .unwrap()
+        .imap
+        .connect(context, &param)
+    {
         info!(context, "success: {}", inf);
         return Some(true);
     }

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -7,8 +7,6 @@ use crate::constants::*;
 use crate::context::Context;
 use crate::dc_tools::*;
 use crate::e2ee;
-use crate::error::*;
-use crate::imap::*;
 use crate::job::*;
 use crate::login_param::LoginParam;
 use crate::oauth2::*;
@@ -581,26 +579,6 @@ fn try_smtp_one_param(context: &Context, param: &LoginParam) -> Option<bool> {
             }
         }
     }
-}
-
-/// Connects to the configured account
-pub fn dc_connect_to_configured_imap(context: &Context, imap: &Imap) -> Result<()> {
-    if async_std::task::block_on(async move { imap.is_connected().await }) {
-        return Ok(());
-    }
-    if !context.sql.get_raw_config_bool(context, "configured") {
-        return Err(Error::ConnectWithoutConfigure);
-    }
-
-    let param = LoginParam::from_database(context, "configured_");
-    // the trailing underscore is correct
-
-    if imap.connect(context, &param) {
-        return Ok(());
-    }
-    return Err(Error::ImapConnectionFailed(
-        format!("{}", param).to_string(),
-    ));
 }
 
 /*******************************************************************************

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,10 @@ pub enum Error {
     WatchFolderNotFound(String),
     #[fail(display = "Connection Failed params: {}", _0)]
     ImapConnectionFailed(String),
+    #[fail(display = "Could not get OAUTH token")]
+    ImapOauthError,
+    #[fail(display = "Could not login as {}", _0)]
+    ImapLoginFailed(String),
     #[fail(display = "Cannot idle")]
     ImapMissesIdle,
     #[fail(display = "Imap IDLE protocol failed to init/complete")]
@@ -48,6 +52,8 @@ pub enum Error {
     ConnectWithoutConfigure,
     #[fail(display = "imap operation attempted while imap is torn down")]
     ImapInTeardown,
+    #[fail(display = "No IMAP Connection established")]
+    ImapNoConnection,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,8 +42,12 @@ pub enum Error {
     ImapMissesIdle,
     #[fail(display = "Imap IDLE protocol failed to init/complete")]
     ImapIdleProtocolFailed(String),
+    #[fail(display = "Imap IDLE failed to select folder {:?}", _0)]
+    ImapSelectFailed(String),
     #[fail(display = "Connect without configured params")]
     ConnectWithoutConfigure,
+    #[fail(display = "imap operation attempted while imap is torn down")]
+    ImapInTeardown,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,6 +34,16 @@ pub enum Error {
     BlobError(#[cause] crate::blob::BlobError),
     #[fail(display = "Invalid Message ID.")]
     InvalidMsgId,
+    #[fail(display = "Watch folder not found {:?}", _0)]
+    WatchFolderNotFound(String),
+    #[fail(display = "Connection Failed params: {}", _0)]
+    ImapConnectionFailed(String),
+    #[fail(display = "Cannot idle")]
+    ImapMissesIdle,
+    #[fail(display = "Imap IDLE protocol failed to init/complete")]
+    ImapIdleProtocolFailed(String),
+    #[fail(display = "Connect without configured params")]
+    ConnectWithoutConfigure,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -219,12 +219,12 @@ impl Imap {
                         context.stock_string_repl_str2(
                             StockMessage::ServerResponse,
                             format!("{}:{}", imap_server, imap_port),
-                            format!("{}", err),
+                            err.to_string(),
                         )
                     };
                     // IMAP connection failures are reported to users
                     emit_event!(context, Event::ErrorNetwork(message));
-                    return Err(Error::ImapConnectionFailed(format!("{}", err)));
+                    return Err(Error::ImapConnectionFailed(err.to_string()));
                 }
             };
 
@@ -779,7 +779,7 @@ impl Imap {
                     // typically also need to change the Insecure branch.
                     IdleHandle::Secure(mut handle) => {
                         if let Err(err) = handle.init().await {
-                            return Err(Error::ImapIdleProtocolFailed(format!("{}", err)));
+                            return Err(Error::ImapIdleProtocolFailed(err.to_string()));
                         }
 
                         let (idle_wait, interrupt) = handle.wait_with_timeout(timeout);
@@ -817,13 +817,13 @@ impl Imap {
                                 // means that we waited long (with idle_wait)
                                 // but the network went away/changed
                                 self.trigger_reconnect();
-                                return Err(Error::ImapIdleProtocolFailed(format!("{}", err)));
+                                return Err(Error::ImapIdleProtocolFailed(err.to_string()));
                             }
                         }
                     }
                     IdleHandle::Insecure(mut handle) => {
                         if let Err(err) = handle.init().await {
-                            return Err(Error::ImapIdleProtocolFailed(format!("{}", err)));
+                            return Err(Error::ImapIdleProtocolFailed(err.to_string()));
                         }
 
                         let (idle_wait, interrupt) = handle.wait_with_timeout(timeout);
@@ -861,7 +861,7 @@ impl Imap {
                                 // means that we waited long (with idle_wait)
                                 // but the network went away/changed
                                 self.trigger_reconnect();
-                                return Err(Error::ImapIdleProtocolFailed(format!("{}", err)));
+                                return Err(Error::ImapIdleProtocolFailed(err.to_string()));
                             }
                         }
                     }

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -866,7 +866,8 @@ impl Imap {
     }
 
     pub(crate) fn fake_idle(&self, context: &Context, watch_folder: Option<String>) {
-        // Idle using polling.
+        // Idle using polling. This is also needed if we're not yet configured -
+        // in this case, we're waiting for a configure job (and an interrupt).
         task::block_on(async move {
             let fake_idle_start_time = SystemTime::now();
 
@@ -1072,7 +1073,8 @@ impl Imap {
         task::block_on(async move {
             if uid == 0 {
                 return Some(ImapActionResult::Failed);
-            } else if !self.is_connected().await {
+            }
+            if !self.is_connected().await {
                 // currently jobs are only performed on the INBOX thread
                 // TODO: make INBOX/SENT/MVBOX perform the jobs on their
                 // respective folders to avoid select_folder network traffic

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1,3 +1,8 @@
+//! # Imap handling module
+//!
+//! uses [async-email/async-imap](https://github.com/async-email/async-imap)
+//! to implement connect, fetch, delete functionality with standard IMAP servers.
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime};
 
@@ -280,7 +285,7 @@ impl Imap {
         cfg.has_xlist = false;
     }
 
-    /// Connects to configured account
+    /// Connects to imap account using already-configured parameters.
     pub fn connect_configured(&self, context: &Context) -> Result<()> {
         if async_std::task::block_on(async move {
             self.is_connected().await && !self.should_reconnect()
@@ -310,6 +315,8 @@ impl Imap {
         ));
     }
 
+    /// tries connecting to imap account using the specific login
+    /// parameters
     pub fn connect(&self, context: &Context, lp: &LoginParam) -> bool {
         task::block_on(async move {
             if lp.mail_server.is_empty() || lp.mail_user.is_empty() || lp.mail_pw.is_empty() {

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -51,7 +51,7 @@ pub enum ImexMode {
 
 /// Import/export things.
 /// For this purpose, the function creates a job that is executed in the IMAP-thread then;
-/// this requires to call dc_perform_imap_jobs() regularly.
+/// this requires to call dc_perform_inbox_jobs() regularly.
 ///
 /// What to do is defined by the _what_ parameter.
 ///

--- a/src/job.rs
+++ b/src/job.rs
@@ -219,7 +219,7 @@ impl Job {
 
     #[allow(non_snake_case)]
     fn do_DC_JOB_MOVE_MSG(&mut self, context: &Context) {
-        let inbox = context.inbox.read().unwrap();
+        let imap_inbox = &context.inbox_thread.read().unwrap().imap;
 
         if let Ok(msg) = Message::load_from_db(context, MsgId::new(self.foreign_id)) {
             if context
@@ -228,7 +228,7 @@ impl Job {
                 .unwrap_or_default()
                 < 3
             {
-                inbox.configure_folders(context, 0x1i32);
+                imap_inbox.configure_folders(context, 0x1i32);
             }
             let dest_folder = context
                 .sql
@@ -238,7 +238,7 @@ impl Job {
                 let server_folder = msg.server_folder.as_ref().unwrap();
                 let mut dest_uid = 0;
 
-                match inbox.mv(
+                match imap_inbox.mv(
                     context,
                     server_folder,
                     msg.server_uid,
@@ -264,7 +264,7 @@ impl Job {
 
     #[allow(non_snake_case)]
     fn do_DC_JOB_DELETE_MSG_ON_IMAP(&mut self, context: &Context) {
-        let inbox = context.inbox.read().unwrap();
+        let imap_inbox = &context.inbox_thread.read().unwrap().imap;
 
         if let Ok(mut msg) = Message::load_from_db(context, MsgId::new(self.foreign_id)) {
             if !msg.rfc724_mid.is_empty() {
@@ -279,7 +279,8 @@ impl Job {
                     we delete the message from the server */
                     let mid = msg.rfc724_mid;
                     let server_folder = msg.server_folder.as_ref().unwrap();
-                    let res = inbox.delete_msg(context, &mid, server_folder, &mut msg.server_uid);
+                    let res =
+                        imap_inbox.delete_msg(context, &mid, server_folder, &mut msg.server_uid);
                     if res == ImapActionResult::RetryLater {
                         self.try_again_later(-1i32, None);
                         return;
@@ -292,27 +293,27 @@ impl Job {
 
     #[allow(non_snake_case)]
     fn do_DC_JOB_EMPTY_SERVER(&mut self, context: &Context) {
-        let inbox = context.inbox.read().unwrap();
+        let imap_inbox = &context.inbox_thread.read().unwrap().imap;
         if self.foreign_id & DC_EMPTY_MVBOX > 0 {
             if let Some(mvbox_folder) = context
                 .sql
                 .get_raw_config(context, "configured_mvbox_folder")
             {
-                inbox.empty_folder(context, &mvbox_folder);
+                imap_inbox.empty_folder(context, &mvbox_folder);
             }
         }
         if self.foreign_id & DC_EMPTY_INBOX > 0 {
-            inbox.empty_folder(context, "INBOX");
+            imap_inbox.empty_folder(context, "INBOX");
         }
     }
 
     #[allow(non_snake_case)]
     fn do_DC_JOB_MARKSEEN_MSG_ON_IMAP(&mut self, context: &Context) {
-        let inbox = context.inbox.read().unwrap();
+        let imap_inbox = &context.inbox_thread.read().unwrap().imap;
 
         if let Ok(msg) = Message::load_from_db(context, MsgId::new(self.foreign_id)) {
             let folder = msg.server_folder.as_ref().unwrap();
-            match inbox.set_seen(context, folder, msg.server_uid) {
+            match imap_inbox.set_seen(context, folder, msg.server_uid) {
                 ImapActionResult::RetryLater => {
                     self.try_again_later(3i32, None);
                 }
@@ -342,8 +343,8 @@ impl Job {
             .unwrap_or_default()
             .to_string();
         let uid = self.param.get_int(Param::ServerUid).unwrap_or_default() as u32;
-        let inbox = context.inbox.read().unwrap();
-        if inbox.set_seen(context, &folder, uid) == ImapActionResult::RetryLater {
+        let imap_inbox = &context.inbox_thread.read().unwrap().imap;
+        if imap_inbox.set_seen(context, &folder, uid) == ImapActionResult::RetryLater {
             self.try_again_later(3i32, None);
             return;
         }
@@ -354,7 +355,7 @@ impl Job {
                 .unwrap_or_default()
                 < 3
             {
-                inbox.configure_folders(context, 0x1i32);
+                imap_inbox.configure_folders(context, 0x1i32);
             }
             let dest_folder = context
                 .sql
@@ -362,7 +363,7 @@ impl Job {
             if let Some(dest_folder) = dest_folder {
                 let mut dest_uid = 0;
                 if ImapActionResult::RetryLater
-                    == inbox.mv(context, &folder, uid, &dest_folder, &mut dest_uid)
+                    == imap_inbox.mv(context, &folder, uid, &dest_folder, &mut dest_uid)
                 {
                     self.try_again_later(3, None);
                 }
@@ -382,81 +383,14 @@ pub fn job_kill_action(context: &Context, action: Action) -> bool {
     .is_ok()
 }
 
-pub fn perform_imap_fetch(context: &Context) {
-    if !context.get_config_bool(Config::InboxWatch) {
-        info!(context, "INBOX-fetch skipped: INBOX-watch is disabled.");
-        return;
-    }
-    let inbox = context.inbox.read().unwrap();
-    let start = std::time::Instant::now();
+pub fn perform_inbox_fetch(context: &Context) {
+    let use_network = context.get_config_bool(Config::InboxWatch);
 
-    if let Err(err) = connect_to_inbox(context, &inbox) {
-        warn!(context, "could not connect to inbox: {:?}", err);
-        return;
-    }
-    info!(context, "INBOX-fetch started...",);
-    inbox.fetch(context);
-    if inbox.should_reconnect() {
-        info!(context, "INBOX-fetch aborted, starting over...",);
-        inbox.fetch(context);
-    }
-    info!(
-        context,
-        "INBOX-fetch done in {:.4} ms.",
-        start.elapsed().as_nanos() as f64 / 1_000_000.0,
-    );
-}
-
-pub fn perform_imap_idle(context: &Context) {
-    if *context.perform_inbox_jobs_needed.clone().read().unwrap() {
-        info!(
-            context,
-            "INBOX-IDLE will not be started because of waiting jobs."
-        );
-        return;
-    }
-    let inbox = context.inbox.read().unwrap();
-    let poll_mode = if !context.get_config_bool(Config::InboxWatch) {
-        Some(IdlePollMode::Never)
-    } else {
-        match connect_to_inbox(context, &inbox) {
-            Err(Error::ImapConnectionFailed(param)) => {
-                warn!(context, "perform_imap_idle could not connect {:?}", param);
-                Some(IdlePollMode::Often)
-            }
-            Err(err) => {
-                warn!(context, "perform_imap_idle error: {}", err);
-                // anything else than a plain connection error
-                // hints at configuration issues.
-                Some(IdlePollMode::Never)
-            }
-
-            Ok(()) => {
-                info!(context, "INBOX-IDLE starting...");
-                let res = inbox.idle(context);
-                info!(context, "INBOX-IDLE ended.");
-
-                match res {
-                    Ok(()) => None,
-                    Err(Error::ImapConnectionFailed(param)) => {
-                        warn!(
-                            context,
-                            "perform_imap_idle IDLE could not connect {:?}", param
-                        );
-                        Some(IdlePollMode::Often)
-                    }
-                    Err(err) => {
-                        warn!(context, "perform_imap_idle IDLE error: {}", err);
-                        Some(IdlePollMode::Never)
-                    }
-                }
-            }
-        }
-    };
-
-    if let Some(poll_mode) = poll_mode {
-        inbox.fake_idle(context, poll_mode);
-    }
+    context
+        .inbox_thread
+        .write()
+        .unwrap()
+        .fetch(context, use_network);
 }
 
 pub fn perform_mvbox_fetch(context: &Context) {
@@ -469,20 +403,6 @@ pub fn perform_mvbox_fetch(context: &Context) {
         .fetch(context, use_network);
 }
 
-pub fn perform_mvbox_idle(context: &Context) {
-    let use_network = context.get_config_bool(Config::MvboxWatch);
-
-    context
-        .mvbox_thread
-        .read()
-        .unwrap()
-        .idle(context, use_network);
-}
-
-pub fn interrupt_mvbox_idle(context: &Context) {
-    context.mvbox_thread.read().unwrap().interrupt_idle(context);
-}
-
 pub fn perform_sentbox_fetch(context: &Context) {
     let use_network = context.get_config_bool(Config::SentboxWatch);
 
@@ -493,6 +413,33 @@ pub fn perform_sentbox_fetch(context: &Context) {
         .fetch(context, use_network);
 }
 
+pub fn perform_inbox_idle(context: &Context) {
+    if *context.perform_inbox_jobs_needed.clone().read().unwrap() {
+        info!(
+            context,
+            "INBOX-IDLE will not be started because of waiting jobs."
+        );
+        return;
+    }
+    let use_network = context.get_config_bool(Config::InboxWatch);
+
+    context
+        .inbox_thread
+        .read()
+        .unwrap()
+        .idle(context, use_network);
+}
+
+pub fn perform_mvbox_idle(context: &Context) {
+    let use_network = context.get_config_bool(Config::MvboxWatch);
+
+    context
+        .mvbox_thread
+        .read()
+        .unwrap()
+        .idle(context, use_network);
+}
+
 pub fn perform_sentbox_idle(context: &Context) {
     let use_network = context.get_config_bool(Config::SentboxWatch);
 
@@ -501,6 +448,27 @@ pub fn perform_sentbox_idle(context: &Context) {
         .read()
         .unwrap()
         .idle(context, use_network);
+}
+
+pub fn interrupt_inbox_idle(context: &Context, block: bool) {
+    info!(context, "interrupt_inbox_idle called blocking={}", block);
+    if block {
+        context.inbox_thread.read().unwrap().interrupt_idle(context);
+    } else {
+        match context.inbox_thread.try_read() {
+            Ok(inbox_thread) => {
+                inbox_thread.interrupt_idle(context);
+            }
+            Err(err) => {
+                *context.perform_inbox_jobs_needed.write().unwrap() = true;
+                warn!(context, "could not interrupt idle: {}", err);
+            }
+        }
+    }
+}
+
+pub fn interrupt_mvbox_idle(context: &Context) {
+    context.mvbox_thread.read().unwrap().interrupt_idle(context);
 }
 
 pub fn interrupt_sentbox_idle(context: &Context) {
@@ -603,7 +571,7 @@ pub fn maybe_network(context: &Context) {
     }
 
     interrupt_smtp_idle(context);
-    interrupt_imap_idle(context);
+    interrupt_inbox_idle(context, true);
     interrupt_mvbox_idle(context);
     interrupt_sentbox_idle(context);
 }
@@ -717,15 +685,15 @@ pub fn job_send_msg(context: &Context, msg_id: MsgId) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn perform_imap_jobs(context: &Context) {
-    info!(context, "dc_perform_imap_jobs starting.",);
+pub fn perform_inbox_jobs(context: &Context) {
+    info!(context, "dc_perform_inbox_jobs starting.",);
 
     let probe_imap_network = *context.probe_imap_network.clone().read().unwrap();
     *context.probe_imap_network.write().unwrap() = false;
     *context.perform_inbox_jobs_needed.write().unwrap() = false;
 
     job_perform(context, Thread::Imap, probe_imap_network);
-    info!(context, "dc_perform_imap_jobs ended.",);
+    info!(context, "dc_perform_inbox_jobs ended.",);
 }
 
 pub fn perform_mvbox_jobs(context: &Context) {
@@ -961,12 +929,6 @@ fn suspend_smtp_thread(context: &Context, suspend: bool) {
     }
 }
 
-pub fn connect_to_inbox(context: &Context, imap: &Imap) -> Result<(), Error> {
-    dc_connect_to_configured_imap(context, imap)?;
-    imap.set_watch_folder("INBOX".into());
-    Ok(())
-}
-
 fn send_mdn(context: &Context, msg_id: MsgId) -> Result<(), Error> {
     let mut mimefactory = MimeFactory::load_mdn(context, msg_id)?;
     unsafe { mimefactory.render()? };
@@ -1037,7 +999,7 @@ pub fn job_add(
     ).ok();
 
     match thread {
-        Thread::Imap => interrupt_imap_idle(context),
+        Thread::Imap => interrupt_inbox_idle(context, false),
         Thread::Smtp => interrupt_smtp_idle(context),
         Thread::Unknown => {}
     }
@@ -1052,12 +1014,4 @@ pub fn interrupt_smtp_idle(context: &Context) {
     state.perform_jobs_needed = 1;
     state.idle = true;
     cvar.notify_one();
-}
-
-pub fn interrupt_imap_idle(context: &Context) {
-    info!(context, "Interrupting INBOX-IDLE...",);
-
-    *context.perform_inbox_jobs_needed.write().unwrap() = true;
-
-    context.inbox.read().unwrap().interrupt_idle();
 }

--- a/src/job_thread.rs
+++ b/src/job_thread.rs
@@ -123,9 +123,14 @@ impl JobThread {
         let watch_folder_name = match context.sql.get_raw_config(context, self.folder_config_name) {
             Some(name) => name,
             None => {
-                return Err(Error::WatchFolderNotFound(
-                    self.folder_config_name.to_string(),
-                ));
+                if self.folder_config_name == "configured_inbox_folder" {
+                    // operating on an old database?
+                    "INBOX".to_string()
+                } else {
+                    return Err(Error::WatchFolderNotFound(
+                        self.folder_config_name.to_string(),
+                    ));
+                }
             }
         };
 


### PR DESCRIPTION
presumably fixes #842 and probably some other issues. 

- resultify all connect, idle and fetch commands for better and more precise error logging 
- introduce several specific Imap related Errors to ease debugging and to e able to better react from the caller side (maybe this was a bit overdone, but i guess it cannot hurt to have specific error feedback in the log) 
- unify imap thread handling (context.inbox -> context.inbox_thread) 
  
