### PR TITLE
adding git gc to cargo-induced git checkouts. 

### DIFF
--- a/ci_scripts/remote_tests_python.sh
+++ b/ci_scripts/remote_tests_python.sh
@@ -25,6 +25,8 @@ echo "--- Running $CIRCLE_JOB remotely"
 ssh $SSHTARGET <<_HERE
     set +x -e
     cd $BUILDDIR
+    # make sure git checkouts are clean (no dangling revspcs)
+    cargo cache --gc
     # let's share the target dir with our last run on this branch/job-type
     # cargo will make sure to block/unblock us properly 
     export CARGO_TARGET_DIR=\`pwd\`/../target

--- a/ci_scripts/remote_tests_rust.sh
+++ b/ci_scripts/remote_tests_rust.sh
@@ -21,6 +21,8 @@ echo "--- Running $CIRCLE_JOB remotely"
 ssh $SSHTARGET <<_HERE
     set +x -e
     cd $BUILDDIR
+    # make sure git checkouts are clean (no dangling revspecs)
+    cargo cache --gc
     # let's share the target dir with our last run on this branch/job-type
     # cargo will make sure to block/unblock us properly 
     export CARGO_TARGET_DIR=\`pwd\`/../target


### PR DESCRIPTION
This avoids problems with dangling commits that can give false positives to CI runs because objects still exist there which are not present on the remote repo. 