### PR TITLE
safer interruptability of fake-idle 

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -887,37 +887,43 @@ impl Imap {
             let interval = async_std::stream::interval(Duration::from_secs(60));
             let mut interrupt_interval = interrupt.stop_token().stop_stream(interval);
             *self.interrupt.lock().await = Some(interrupt);
+            if self.skip_next_idle_wait.load(Ordering::SeqCst) {
+                // interrupt_idle has happened before we
+                // provided self.interrupt
+                self.skip_next_idle_wait.store(false, Ordering::SeqCst);
+                info!(context, "fake-idle wait was skipped");
+            } else {
+                // loop until we are interrupted or if we fetched something
+                while let Some(_) = interrupt_interval.next().await {
+                    // try to connect with proper login params
+                    // (setup_handle_if_needed might not know about them if we
+                    // never successfully connected)
+                    if let Err(err) = self.connect_configured(context) {
+                        warn!(context, "fake_idle: could not connect: {}", err);
+                        continue;
+                    }
+                    if self.config.read().await.can_idle {
+                        // we only fake-idled because network was gone during IDLE, probably
+                        break;
+                    }
+                    info!(context, "fake_idle is connected");
+                    // we are connected, let's see if fetching messages results
+                    // in anything.  If so, we behave as if IDLE had data but
+                    // will have already fetched the messages so perform_*_fetch
+                    // will not find any new.
 
-            // loop until we are interrupted or if we fetched something
-            while let Some(_) = interrupt_interval.next().await {
-                // try to connect with proper login params
-                // (setup_handle_if_needed might not know about them if we
-                // never successfully connected)
-                if let Err(err) = self.connect_configured(context) {
-                    warn!(context, "fake_idle: could not connect: {}", err);
-                    continue;
-                }
-                if self.config.read().await.can_idle {
-                    // we only fake-idled because network was gone during IDLE, probably
-                    break;
-                }
-                info!(context, "fake_idle is connected");
-                // we are connected, let's see if fetching messages results
-                // in anything.  If so, we behave as if IDLE had data but
-                // will have already fetched the messages so perform_*_fetch
-                // will not find any new.
-
-                if let Some(ref watch_folder) = watch_folder {
-                    match self.fetch_from_single_folder(context, watch_folder).await {
-                        Ok(res) => {
-                            info!(context, "fetch_from_single_folder returned {:?}", res);
-                            if res {
-                                break;
+                    if let Some(ref watch_folder) = watch_folder {
+                        match self.fetch_from_single_folder(context, watch_folder).await {
+                            Ok(res) => {
+                                info!(context, "fetch_from_single_folder returned {:?}", res);
+                                if res {
+                                    break;
+                                }
                             }
-                        }
-                        Err(err) => {
-                            error!(context, "could not fetch from folder: {}", err);
-                            self.trigger_reconnect()
+                            Err(err) => {
+                                error!(context, "could not fetch from folder: {}", err);
+                                self.trigger_reconnect()
+                            }
                         }
                     }
                 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -1016,4 +1016,5 @@ pub fn interrupt_smtp_idle(context: &Context) {
     state.perform_jobs_needed = 1;
     state.idle = true;
     cvar.notify_one();
+    info!(context, "Interrupting SMTP-idle... ended",);
 }

--- a/src/job_thread.rs
+++ b/src/job_thread.rs
@@ -70,6 +70,7 @@ impl JobThread {
 
         state.idle = true;
         cvar.notify_one();
+        info!(context, "Interrupting {}-IDLE... finished", self.name);
     }
 
     pub fn fetch(&mut self, context: &Context, use_network: bool) {


### PR DESCRIPTION
reusing the same skip_next_idle pattern as with idle