### PR TITLE
remove thread-suspend

### DIFF
--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -69,18 +69,6 @@ pub fn dc_job_do_DC_JOB_CONFIGURE_IMAP(context: &Context) {
         .unwrap()
         .imap
         .disconnect(context);
-    context
-        .sentbox_thread
-        .read()
-        .unwrap()
-        .imap
-        .disconnect(context);
-    context
-        .mvbox_thread
-        .read()
-        .unwrap()
-        .imap
-        .disconnect(context);
     context.smtp.clone().lock().unwrap().disconnect();
     info!(context, "Configure ...",);
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -498,8 +498,6 @@ pub struct BobStatus {
 #[derive(Default, Debug)]
 pub struct SmtpState {
     pub idle: bool,
-    pub suspended: bool,
-    pub doing_jobs: bool,
     pub perform_jobs_needed: i32,
     pub probe_network: bool,
 }


### PR DESCRIPTION
remove maybe unneeded thread-suspension.

EDIT: i try to summarize the assumptions, from the meeting yesterday:

- for initial configure(), this suspend is always be superfluous, threads are in fake-idle anyway
- for subsequent configure(), imap-part: configure() uses the inbox-handle disconnects, and is called from the inbox-thread. sentbox_thread and mvbox_thread may or may not work during configure(), however, once configure() succeeds, they should go from fake-idle to normal-idle - but i think an interrupt would be needed for that.
- for subsequent configure(), smtp-part: this would require using an independent smtp-handle as currently it may happen that the smtp-thread tries to connect at the same time as configure-thread tries

so, in general, the following things are **missing**:
- using independent handle for smtp, probably also makes sense for imap as we have the idea to move dc_configure() out of the job
- calling interrupt for all threads on successful configure
- think about export/import