### PR TITLE
move self-sent-messages

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -461,6 +461,20 @@ class TestOnlineAccount:
         assert ev[2] > const.DC_CHAT_ID_LAST_SPECIAL
         ev = ac2._evlogger.get_matching("DC_EVENT_IMAP_MESSAGE_MOVED")
 
+    def test_move_works_on_self_sent(self, acfactory):
+        ac1 = acfactory.get_online_configuring_account(mvbox=True)
+        ac1.set_config("bcc_self", "1")
+        ac2 = acfactory.get_online_configuring_account()
+        wait_configuration_progress(ac2, 1000)
+        wait_configuration_progress(ac1, 1000)
+        chat = self.get_chat(ac1, ac2)
+        chat.send_text("message1")
+        chat.send_text("message2")
+        chat.send_text("message3")
+        ac1._evlogger.get_matching("DC_EVENT_IMAP_MESSAGE_MOVED")
+        ac1._evlogger.get_matching("DC_EVENT_IMAP_MESSAGE_MOVED")
+        ac1._evlogger.get_matching("DC_EVENT_IMAP_MESSAGE_MOVED")
+
     def test_forward_messages(self, acfactory):
         ac1, ac2 = acfactory.get_two_online_accounts()
         chat = self.get_chat(ac1, ac2)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -8,21 +8,6 @@ lazy_static! {
     pub static ref DC_VERSION_STR: String = env!("CARGO_PKG_VERSION").to_string();
 }
 
-#[repr(u8)]
-#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive, ToSql, FromSql)]
-pub enum MoveState {
-    Undefined = 0,
-    Pending = 1,
-    Stay = 2,
-    Moving = 3,
-}
-
-impl Default for MoveState {
-    fn default() -> Self {
-        MoveState::Undefined
-    }
-}
-
 // some defaults
 const DC_E2EE_DEFAULT_ENABLED: i32 = 1;
 const DC_INBOX_WATCH_DEFAULT: i32 = 1;

--- a/src/context.rs
+++ b/src/context.rs
@@ -435,19 +435,14 @@ impl Context {
             return;
         }
 
-        if !self.is_inbox(folder) && !self.is_sentbox(folder) {
+        if self.is_mvbox(folder) {
             return;
         }
-
         if let Ok(msg) = Message::load_from_db(self, msg_id) {
             if msg.is_setupmessage() {
                 // do not move setup messages;
                 // there may be a non-delta device that wants to handle it
                 return;
-            }
-
-            if self.is_mvbox(folder) {
-                message::update_msg_move_state(self, &msg.rfc724_mid, MoveState::Stay);
             }
 
             // 1 = dc message, 2 = reply to dc message
@@ -459,7 +454,6 @@ impl Context {
                     Params::new(),
                     0,
                 );
-                message::update_msg_move_state(self, &msg.rfc724_mid, MoveState::Moving);
             }
         }
     }

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -23,7 +23,7 @@ use crate::events::Event;
 use crate::imap_client::*;
 use crate::job::{job_add, Action};
 use crate::login_param::{CertificateChecks, LoginParam};
-use crate::message::{self, update_msg_move_state, update_server_uid};
+use crate::message::{self, update_server_uid};
 use crate::oauth2::dc_get_oauth2_access_token;
 use crate::param::Params;
 use crate::stock::StockMessage;
@@ -1423,7 +1423,6 @@ fn precheck_imf(context: &Context, rfc724_mid: &str, server_folder: &str, server
             );
         } else if old_server_folder != server_folder {
             info!(context, "[move] detected moved message {}", rfc724_mid,);
-            update_msg_move_state(context, &rfc724_mid, MoveState::Stay);
         }
 
         if old_server_folder != server_folder || old_server_uid != server_uid {

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1413,6 +1413,7 @@ fn precheck_imf(context: &Context, rfc724_mid: &str, server_folder: &str, server
     {
         if old_server_folder.is_empty() && old_server_uid == 0 {
             info!(context, "[move] detected bbc-self {}", rfc724_mid,);
+            context.do_heuristics_moves(server_folder.as_ref(), msg_id);
             job_add(
                 context,
                 Action::MarkseenMsgOnImap,

--- a/src/message.rs
+++ b/src/message.rs
@@ -159,7 +159,6 @@ pub struct Message {
     pub(crate) from_id: u32,
     pub(crate) to_id: u32,
     pub(crate) chat_id: u32,
-    pub(crate) move_state: MoveState,
     pub(crate) type_0: Viewtype,
     pub(crate) state: MessageState,
     pub(crate) hidden: bool,
@@ -200,7 +199,6 @@ impl Message {
                 "    m.mime_in_reply_to AS mime_in_reply_to,",
                 "    m.server_folder AS server_folder,",
                 "    m.server_uid AS server_uid,",
-                "    m.move_state as move_state,",
                 "    m.chat_id AS chat_id,",
                 "    m.from_id AS from_id,",
                 "    m.to_id AS to_id,",
@@ -228,7 +226,6 @@ impl Message {
                 msg.in_reply_to = row.get::<_, Option<String>>("mime_in_reply_to")?;
                 msg.server_folder = row.get::<_, Option<String>>("server_folder")?;
                 msg.server_uid = row.get("server_uid")?;
-                msg.move_state = row.get("move_state")?;
                 msg.chat_id = row.get("chat_id")?;
                 msg.from_id = row.get("from_id")?;
                 msg.to_id = row.get("to_id")?;
@@ -1072,18 +1069,6 @@ pub fn exists(context: &Context, msg_id: MsgId) -> bool {
     } else {
         false
     }
-}
-
-pub fn update_msg_move_state(context: &Context, rfc724_mid: &str, state: MoveState) -> bool {
-    // we update the move_state for all messages belonging to a given Message-ID
-    // so that the state stay intact when parts are deleted
-    sql::execute(
-        context,
-        &context.sql,
-        "UPDATE msgs SET move_state=? WHERE rfc724_mid=?;",
-        params![state as i32, rfc724_mid],
-    )
-    .is_ok()
 }
 
 pub fn set_msg_failed(context: &Context, msg_id: MsgId, error: Option<impl AsRef<str>>) {

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -729,6 +729,7 @@ fn open(
         }
         if dbversion < 48 {
             info!(context, "[migration] v48");
+            // NOTE: move_state is not used anymore
             sql.execute(
                 "ALTER TABLE msgs ADD COLUMN move_state INTEGER DEFAULT 1;",
                 params![],


### PR DESCRIPTION
also move messages sent to ourselves via bcc_self to the DeltaChat folder (other messages are moved in receive_imf())

closes #896 