### PR TITLE
Cmp addr case insensitive

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1486,7 +1486,7 @@ pub(crate) fn add_contact_to_chat_ex(
     let self_addr = context
         .get_config(Config::ConfiguredAddr)
         .unwrap_or_default();
-    if contact.get_addr() == &self_addr {
+    if addr_cmp(contact.get_addr(), &self_addr) {
         // ourself is added using DC_CONTACT_ID_SELF, do not add this address explicitly.
         // if SELF is not in the group, members cannot be added at all.
         warn!(

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1087,6 +1087,10 @@ mod tests {
     fn test_normalize_addr() {
         assert_eq!(addr_normalize("mailto:john@doe.com"), "john@doe.com");
         assert_eq!(addr_normalize("  hello@world.com   "), "hello@world.com");
+
+        // normalisation preserves case to allow user-defined spelling.
+        // however, case is ignored on addr_cmp()
+        assert_ne!(addr_normalize("John@Doe.com"), "john@doe.com");
     }
 
     #[test]
@@ -1207,5 +1211,12 @@ mod tests {
         assert_eq!(contact.get_name(), t.ctx.stock_str(StockMessage::SelfMsg));
         assert_eq!(contact.get_addr(), ""); // we're not configured
         assert!(!contact.is_blocked());
+    }
+
+    #[test]
+    fn test_addr_cmp() {
+        assert!(addr_cmp("AA@AA.ORG", "aa@aa.ORG"));
+        assert!(addr_cmp(" aa@aa.ORG ", "AA@AA.ORG"));
+        assert!(addr_cmp(" mailto:AA@AA.ORG", "Aa@Aa.orG"));
     }
 }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -272,7 +272,7 @@ impl Contact {
             .get_config(Config::ConfiguredAddr)
             .unwrap_or_default();
 
-        if addr_normalized == addr_self {
+        if addr_cmp(addr_normalized, addr_self) {
             return DC_CONTACT_ID_SELF;
         }
 
@@ -309,7 +309,7 @@ impl Contact {
             .get_config(Config::ConfiguredAddr)
             .unwrap_or_default();
 
-        if addr == addr_self {
+        if addr_cmp(addr, addr_self) {
             return Ok((DC_CONTACT_ID_SELF, sth_modified));
         }
 

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1026,17 +1026,16 @@ fn cat_fingerprint(
 }
 
 pub fn addr_cmp(addr1: impl AsRef<str>, addr2: impl AsRef<str>) -> bool {
-    let norm1 = addr_normalize(addr1.as_ref());
-    let norm2 = addr_normalize(addr2.as_ref());
+    let norm1 = addr_normalize(addr1.as_ref()).to_lowercase();
+    let norm2 = addr_normalize(addr2.as_ref()).to_lowercase();
 
     norm1 == norm2
 }
 
 pub fn addr_equals_self(context: &Context, addr: impl AsRef<str>) -> bool {
     if !addr.as_ref().is_empty() {
-        let normalized_addr = addr_normalize(addr.as_ref());
         if let Some(self_addr) = context.get_config(Config::ConfiguredAddr) {
-            return normalized_addr == self_addr;
+            return addr_cmp(addr, self_addr);
         }
     }
     false

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -707,7 +707,7 @@ impl<'a> MimeFactory<'a> {
                     .get_config(Config::ConfiguredAddr)
                     .unwrap_or_default();
 
-                if !email_to_remove.is_empty() && email_to_remove != self_addr {
+                if !email_to_remove.is_empty() && !addr_cmp(email_to_remove, self_addr) {
                     if !vec_contains_lowercase(&factory.recipients_addr, &email_to_remove) {
                         factory.recipients_names.push("".to_string());
                         factory.recipients_addr.push(email_to_remove.to_string());


### PR DESCRIPTION
this pr makes the email-address-comparison in addr_cmp() case-insensitive (as it was in core-c).

moreover, this pr changes places where normal-string-comparison is used for comparing email-addresses to use addr_cmp().

closes https://github.com/deltachat/deltachat-core-rust/issues/899