### PR TITLE
Skip bad jobs in the database

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -5,10 +5,10 @@ macro_rules! info {
     ($ctx:expr,  $msg:expr) => {
         info!($ctx, $msg,)
     };
-    ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {
+    ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
         emit_event!($ctx, $crate::Event::Info(formatted));
-    };
+    }};
 }
 
 #[macro_export]
@@ -16,10 +16,10 @@ macro_rules! warn {
     ($ctx:expr, $msg:expr) => {
         warn!($ctx, $msg,)
     };
-    ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {
+    ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
         emit_event!($ctx, $crate::Event::Warning(formatted));
-    };
+    }};
 }
 
 #[macro_export]
@@ -27,10 +27,10 @@ macro_rules! error {
     ($ctx:expr, $msg:expr) => {
         error!($ctx, $msg,)
     };
-    ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {
+    ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
         emit_event!($ctx, $crate::Event::Error(formatted));
-    };
+    }};
 }
 
 #[macro_export]


### PR DESCRIPTION
Be more defensive: if somehow we got corrupt jobs in the database skip
over them rather than fail to do anything.

This only modifies the query_map() call, the rest is only split off
into it's own function to make it testable.  Smaller functions are
good anyway.