### PR TITLE
sort newly created chats atop of chatlist

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -637,7 +637,7 @@ pub fn create_or_lookup_by_contact_id(
         context,
         &context.sql,
         format!(
-            "INSERT INTO chats (type, name, param, blocked, grpid) VALUES({}, '{}', '{}', {}, '{}')",
+            "INSERT INTO chats (type, name, param, blocked, grpid, created_timestamp) VALUES({}, '{}', '{}', {}, '{}', {})",
             100,
             chat_name,
             match contact_id {
@@ -650,6 +650,7 @@ pub fn create_or_lookup_by_contact_id(
             },
             create_blocked as u8,
             contact.get_addr(),
+            dc_create_smeared_timestamp(context),
         ),
         params![],
     )?;
@@ -1388,7 +1389,7 @@ pub fn create_group_chat(
     sql::execute(
         context,
         &context.sql,
-        "INSERT INTO chats (type, name, grpid, param) VALUES(?, ?, ?, \'U=1\');",
+        "INSERT INTO chats (type, name, grpid, param, created_timestamp) VALUES(?, ?, ?, \'U=1\', ?);",
         params![
             if verified != VerifiedStatus::Unverified {
                 Chattype::VerifiedGroup
@@ -1396,7 +1397,8 @@ pub fn create_group_chat(
                 Chattype::Group
             },
             chat_name.as_ref(),
-            grpid
+            grpid,
+            dc_create_smeared_timestamp(context),
         ],
     )?;
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -650,7 +650,7 @@ pub fn create_or_lookup_by_contact_id(
             },
             create_blocked as u8,
             contact.get_addr(),
-            dc_create_smeared_timestamp(context),
+            time(),
         ),
         params![],
     )?;
@@ -1398,7 +1398,7 @@ pub fn create_group_chat(
             },
             chat_name.as_ref(),
             grpid,
-            dc_create_smeared_timestamp(context),
+            time(),
         ],
     )?;
 

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -119,22 +119,20 @@ impl Chatlist {
         let mut ids = if let Some(query_contact_id) = query_contact_id {
             // show chats shared with a given contact
             context.sql.query_map(
-                concat!(
-                    "SELECT c.id, m.id",
-                    " FROM chats c",
-                    " LEFT JOIN msgs m",
-                    "        ON c.id=m.chat_id",
-                    "       AND m.timestamp=(",
-                    "               SELECT MAX(timestamp)",
-                    "                 FROM msgs",
-                    "                WHERE chat_id=c.id",
-                    "                  AND hidden=0)",
-                    " WHERE c.id>9",
-                    "   AND c.blocked=0",
-                    "   AND c.id IN(SELECT chat_id FROM chats_contacts WHERE contact_id=?)",
-                    " GROUP BY c.id",
-                    " ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;"
-                ),
+                "SELECT c.id, m.id
+                 FROM chats c
+                 LEFT JOIN msgs m
+                        ON c.id=m.chat_id
+                       AND m.timestamp=(
+                               SELECT MAX(timestamp)
+                                 FROM msgs
+                                WHERE chat_id=c.id
+                                  AND hidden=0)
+                 WHERE c.id>9
+                   AND c.blocked=0
+                   AND c.id IN(SELECT chat_id FROM chats_contacts WHERE contact_id=?)
+                 GROUP BY c.id
+                 ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;",
                 params![query_contact_id as i32],
                 process_row,
                 process_rows,
@@ -142,22 +140,20 @@ impl Chatlist {
         } else if 0 != listflags & DC_GCL_ARCHIVED_ONLY {
             // show archived chats
             context.sql.query_map(
-                concat!(
-                    "SELECT c.id, m.id",
-                    " FROM chats c",
-                    " LEFT JOIN msgs m",
-                    "        ON c.id=m.chat_id",
-                    "       AND m.timestamp=(",
-                    "               SELECT MAX(timestamp)",
-                    "                 FROM msgs",
-                    "                WHERE chat_id=c.id",
-                    "                  AND hidden=0)",
-                    " WHERE c.id>9",
-                    "   AND c.blocked=0",
-                    "   AND c.archived=1",
-                    " GROUP BY c.id",
-                    " ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;"
-                ),
+                "SELECT c.id, m.id
+                 FROM chats c
+                 LEFT JOIN msgs m
+                        ON c.id=m.chat_id
+                       AND m.timestamp=(
+                               SELECT MAX(timestamp)
+                                 FROM msgs
+                                WHERE chat_id=c.id
+                                  AND hidden=0)
+                 WHERE c.id>9
+                   AND c.blocked=0
+                   AND c.archived=1
+                 GROUP BY c.id
+                 ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;",
                 params![],
                 process_row,
                 process_rows,
@@ -168,22 +164,20 @@ impl Chatlist {
 
             let str_like_cmd = format!("%{}%", query);
             context.sql.query_map(
-                concat!(
-                    "SELECT c.id, m.id",
-                    " FROM chats c",
-                    " LEFT JOIN msgs m",
-                    "        ON c.id=m.chat_id",
-                    "       AND m.timestamp=(",
-                    "               SELECT MAX(timestamp)",
-                    "                 FROM msgs",
-                    "                WHERE chat_id=c.id",
-                    "                  AND hidden=0)",
-                    " WHERE c.id>9",
-                    "   AND c.blocked=0",
-                    "   AND c.name LIKE ?",
-                    " GROUP BY c.id",
-                    " ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;"
-                ),
+                "SELECT c.id, m.id
+                 FROM chats c
+                 LEFT JOIN msgs m
+                        ON c.id=m.chat_id
+                       AND m.timestamp=(
+                               SELECT MAX(timestamp)
+                                 FROM msgs
+                                WHERE chat_id=c.id
+                                  AND hidden=0)
+                 WHERE c.id>9
+                   AND c.blocked=0
+                   AND c.name LIKE ?
+                 GROUP BY c.id
+                 ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;",
                 params![str_like_cmd],
                 process_row,
                 process_rows,
@@ -191,22 +185,20 @@ impl Chatlist {
         } else {
             //  show normal chatlist
             let mut ids = context.sql.query_map(
-                concat!(
-                    "SELECT c.id, m.id",
-                    " FROM chats c",
-                    " LEFT JOIN msgs m",
-                    "        ON c.id=m.chat_id",
-                    "       AND m.timestamp=(",
-                    "               SELECT MAX(timestamp)",
-                    "                 FROM msgs",
-                    "                WHERE chat_id=c.id",
-                    "                  AND hidden=0)",
-                    " WHERE c.id>9",
-                    "   AND c.blocked=0",
-                    "   AND c.archived=0",
-                    " GROUP BY c.id",
-                    " ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;"
-                ),
+                "SELECT c.id, m.id
+                 FROM chats c
+                 LEFT JOIN msgs m
+                        ON c.id=m.chat_id
+                       AND m.timestamp=(
+                               SELECT MAX(timestamp)
+                                 FROM msgs
+                                WHERE chat_id=c.id
+                                  AND hidden=0)
+                 WHERE c.id>9
+                   AND c.blocked=0
+                   AND c.archived=0
+                 GROUP BY c.id
+                 ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;",
                 params![],
                 process_row,
                 process_rows,

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -132,7 +132,7 @@ impl Chatlist {
                    AND c.blocked=0
                    AND c.id IN(SELECT chat_id FROM chats_contacts WHERE contact_id=?)
                  GROUP BY c.id
-                 ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;",
+                 ORDER BY IFNULL(m.timestamp,c.created_timestamp) DESC, m.id DESC;",
                 params![query_contact_id as i32],
                 process_row,
                 process_rows,
@@ -153,7 +153,7 @@ impl Chatlist {
                    AND c.blocked=0
                    AND c.archived=1
                  GROUP BY c.id
-                 ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;",
+                 ORDER BY IFNULL(m.timestamp,c.created_timestamp) DESC, m.id DESC;",
                 params![],
                 process_row,
                 process_rows,
@@ -177,7 +177,7 @@ impl Chatlist {
                    AND c.blocked=0
                    AND c.name LIKE ?
                  GROUP BY c.id
-                 ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;",
+                 ORDER BY IFNULL(m.timestamp,c.created_timestamp) DESC, m.id DESC;",
                 params![str_like_cmd],
                 process_row,
                 process_rows,
@@ -198,7 +198,7 @@ impl Chatlist {
                    AND c.blocked=0
                    AND c.archived=0
                  GROUP BY c.id
-                 ORDER BY IFNULL(m.timestamp,0) DESC, m.id DESC;",
+                 ORDER BY IFNULL(m.timestamp,c.created_timestamp) DESC, m.id DESC;",
                 params![],
                 process_row,
                 process_rows,

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1449,7 +1449,7 @@ fn create_group_record(
             grpname.as_ref(),
             grpid.as_ref(),
             create_blocked,
-            dc_create_smeared_timestamp(context),
+            time(),
         ],
     )
     .is_err()

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1439,7 +1439,7 @@ fn create_group_record(
     if sql::execute(
         context,
         &context.sql,
-        "INSERT INTO chats (type, name, grpid, blocked) VALUES(?, ?, ?, ?);",
+        "INSERT INTO chats (type, name, grpid, blocked, created_timestamp) VALUES(?, ?, ?, ?, ?);",
         params![
             if VerifiedStatus::Unverified != create_verified {
                 Chattype::VerifiedGroup
@@ -1449,6 +1449,7 @@ fn create_group_record(
             grpname.as_ref(),
             grpid.as_ref(),
             create_blocked,
+            dc_create_smeared_timestamp(context),
         ],
     )
     .is_err()

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -829,6 +829,14 @@ fn open(
             update_icons = true;
             sql.set_raw_config_int(context, "dbversion", 59)?;
         }
+        if dbversion < 60 {
+            info!(context, "[migration] v60");
+            sql.execute(
+                "ALTER TABLE chats ADD COLUMN created_timestamp INTEGER DEFAULT 0;",
+                NO_PARAMS,
+            )?;
+            sql.set_raw_config_int(context, "dbversion", 60)?;
+        }
 
         // (2) updates that require high-level objects
         // (the structure is complete now and all objects are usable)


### PR DESCRIPTION
this pr sorts the chatlist so that empty chats are sorted atop of the chatlist (as long as there are not chats with messages that are even newer)

as a nice side-effect, this way also new created one-to-one-chats are shown atop even if no messages was sent yet.

closes #909