### PR TITLE
Resultify select error and fix uid_validity flakyness

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -794,6 +794,7 @@ class TestOnlineAccount:
         chat2 = ac2.qr_join_chat(qr)
         assert chat2.id >= 10
         wait_securejoin_inviter_progress(ac1, 1000)
+        ac1._evlogger.get_matching("DC_EVENT_SECUREJOIN_MEMBER_ADDED")
 
         lp.sec("ac2: read member added message")
         msg = ac2.wait_next_incoming_message()

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -355,13 +355,14 @@ pub fn JobConfigureImap(context: &Context) {
                 progress!(context, 900);
                 let create_mvbox = context.get_config_bool(Config::MvboxWatch)
                     || context.get_config_bool(Config::MvboxMove);
-                context
-                    .inbox_thread
-                    .read()
-                    .unwrap()
-                    .imap
-                    .configure_folders(context, create_mvbox);
-                true
+                let imap = &context.inbox_thread.read().unwrap().imap;
+                if let Err(err) = imap.ensure_configured_folders(context, create_mvbox) {
+                    error!(context, "configuring folders failed: {:?}", err);
+                    false
+                } else {
+                    // XXX call fetch_from_single_folder to set last_seen_uid 
+                    true
+                }
             }
             17 => {
                 progress!(context, 910);

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -360,8 +360,13 @@ pub fn JobConfigureImap(context: &Context) {
                     error!(context, "configuring folders failed: {:?}", err);
                     false
                 } else {
-                    // XXX call fetch_from_single_folder to set last_seen_uid 
-                    true
+                    let res = imap.select_with_uidvalidity(context, "INBOX");
+                    if let Err(err) = res {
+                        error!(context, "could not read INBOX status: {:?}", err);
+                        false
+                    } else {
+                        true
+                    }
                 }
             }
             17 => {

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -383,11 +383,10 @@ pub fn JobConfigureImap(context: &Context) {
                 // (~30 seconds on a Moto G4 play) and might looks as if message sending is always that slow.
                 e2ee::ensure_secret_key_exists(context);
                 success = true;
-                info!(context, "Configure completed.");
+                info!(context, "key generation completed");
                 progress!(context, 940);
                 break; // We are done here
             }
-
             _ => {
                 error!(context, "Internal error: step counter out of bound",);
                 break;
@@ -409,24 +408,6 @@ pub fn JobConfigureImap(context: &Context) {
     if smtp_connected_here {
         context.smtp.clone().lock().unwrap().disconnect();
     }
-
-    /*
-    if !success {
-        // disconnect if configure did not succeed
-        if imap_connected_here {
-            // context.inbox.read().unwrap().disconnect(context);
-        }
-        if smtp_connected_here {
-            // context.smtp.clone().lock().unwrap().disconnect();
-        }
-    } else {
-        assert!(imap_connected_here && smtp_connected_here);
-        info!(
-            context,
-            0, "Keeping IMAP/SMTP connections open after successful configuration"
-        );
-    }
-    */
 
     // remember the entered parameters on success
     // and restore to last-entered on failure.

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,12 +54,6 @@ pub enum Error {
     ImapInTeardown,
     #[fail(display = "No IMAP Connection established")]
     ImapNoConnection,
-    /*
-    #[fail(display = "IMAP Connection lost: {:?}", _0)]
-    ImapConnectionLost(String),
-    #[fail(display = "Failed to obtain Imap Session")]
-    CouldNotObtainImapSession,
-    */
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -54,6 +54,12 @@ pub enum Error {
     ImapInTeardown,
     #[fail(display = "No IMAP Connection established")]
     ImapNoConnection,
+    /*
+    #[fail(display = "IMAP Connection lost: {:?}", _0)]
+    ImapConnectionLost(String),
+    #[fail(display = "Failed to obtain Imap Session")]
+    CouldNotObtainImapSession,
+    */
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -115,7 +115,7 @@ impl Default for ImapConfig {
     }
 }
 
-#[derive(Debug, Fail, Clone, Eq, PartialEq)]
+#[derive(Debug, Fail)]
 enum SelectError {
     #[fail(display = "Could not obtain imap-session object.")]
     NoSession,
@@ -124,7 +124,7 @@ enum SelectError {
     ConnectionLost,
 
     #[fail(display = "imap-close (to expunge messages) failed: {}", _0)]
-    CloseExpungeFailed(String),
+    CloseExpungeFailed(#[cause] async_imap::error::Error),
 
     #[fail(display = "Folder name invalid: {:?}", _0)]
     BadFolderName(String),
@@ -462,7 +462,7 @@ impl Imap {
                             info!(context, "close/expunge succeeded");
                         }
                         Err(err) => {
-                            return Err(SelectError::CloseExpungeFailed(err.to_string()));
+                            return Err(SelectError::CloseExpungeFailed(err));
                         }
                     }
                 } else {

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -40,7 +40,7 @@ pub enum ImapActionResult {
 }
 
 const PREFETCH_FLAGS: &str = "(UID ENVELOPE)";
-const JUST_UID : &str = "(UID)";
+const JUST_UID: &str = "(UID)";
 const BODY_FLAGS: &str = "(FLAGS BODY.PEEK[])";
 const SELECT_ALL: &str = "1:*";
 
@@ -577,16 +577,23 @@ impl Imap {
                 return Ok(false);
             }
 
-            // uid_validity has changed or is being set the first time. 
-            // find the last seen uid within the new uid_validity scope. 
+            // uid_validity has changed or is being set the first time.
+            // find the last seen uid within the new uid_validity scope.
 
             let new_last_seen_uid = if mailbox.uid_next.is_none() {
-                warn!(context, "IMAP folder did not report uid_next, falling back to fetching");
+                warn!(
+                    context,
+                    "IMAP folder did not report uid_next, falling back to fetching"
+                );
                 if let Some(ref mut session) = &mut *self.session.lock().await {
                     // `FETCH <message sequence number> (UID)`
                     let set = format!("{}:*", mailbox.exists);
                     match session.fetch(set, JUST_UID).await {
-                        Ok(list) => list.iter().last().and_then(|res| res.uid).unwrap_or_default(),
+                        Ok(list) => list
+                            .iter()
+                            .last()
+                            .and_then(|res| res.uid)
+                            .unwrap_or_default(),
                         Err(err) => {
                             bail!("fetch failed: {:?}", err);
                         }
@@ -597,7 +604,7 @@ impl Imap {
             } else {
                 mailbox.uid_next.unwrap() - 1
             };
-           
+
             self.set_config_last_seen_uid(context, &folder, new_uid_validity, new_last_seen_uid);
             info!(
                 context,


### PR DESCRIPTION
with considerable help from @flub this refactors imap.select_folder() to return specific errors, and refactors the callsites to handle them properly.  While refactoring the call sites another flakyness issue occured which is also fixed with this PR: the determination of "last seen uid" is now done using imap-provided information ("uid_next") and better/leaner fetch operation to determine the maximum uid the imap server currently knows, thanks also @dignifiedquire for thinking along. 