### PR TITLE
Convert BlobError into an enum

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use itertools::Itertools;
 use num_traits::FromPrimitive;
 
-use crate::blob::{BlobErrorKind, BlobObject};
+use crate::blob::{BlobError, BlobObject};
 use crate::chatlist::*;
 use crate::config::*;
 use crate::constants::*;
@@ -1797,8 +1797,8 @@ pub fn set_chat_profile_image(
         ));
     } else {
         let image_blob = BlobObject::from_path(context, Path::new(new_image.as_ref())).or_else(
-            |err| match err.kind() {
-                BlobErrorKind::WrongBlobdir => {
+            |err| match err {
+                BlobError::WrongBlobdir { .. } => {
                     BlobObject::create_and_copy(context, Path::new(new_image.as_ref()))
                 }
                 _ => Err(err),

--- a/src/param.rs
+++ b/src/param.rs
@@ -321,7 +321,6 @@ mod tests {
     use std::fs;
     use std::path::Path;
 
-    use crate::blob::BlobErrorKind;
     use crate::test_utils::*;
 
     #[test]
@@ -404,7 +403,10 @@ mod tests {
 
         // Blob does not exist yet, expect BlobError.
         let err = p.get_blob(Param::File, &t.ctx, false).unwrap_err();
-        assert_eq!(err.kind(), BlobErrorKind::WrongBlobdir);
+        match err {
+            BlobError::WrongBlobdir { .. } => (),
+            _ => panic!("wrong error type/variant: {:?}", err),
+        }
 
         fs::write(fname, b"boo").unwrap();
         let blob = p.get_blob(Param::File, &t.ctx, true).unwrap().unwrap();


### PR DESCRIPTION
This deletes a lot of code and complexity.  Though comes at some cost:

- The type no longer fits in a register and will always be on the
  stack.

- Constructing the errors is more verbose, no more auto Into casting.