### PR TITLE
do not create device-chat on skipped messages

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1962,8 +1962,7 @@ pub fn add_device_msg(
         label.is_some() || msg.is_some(),
         "device-messages need label, msg or both"
     );
-    let (chat_id, _blocked) =
-        create_or_lookup_by_contact_id(context, DC_CONTACT_ID_DEVICE, Blocked::Not)?;
+    let mut chat_id = 0;
     let mut msg_id = MsgId::new_unset();
 
     if let Some(label) = label {
@@ -1974,6 +1973,8 @@ pub fn add_device_msg(
     }
 
     if let Some(msg) = msg {
+        chat_id = create_or_lookup_by_contact_id(context, DC_CONTACT_ID_DEVICE, Blocked::Not)?.0;
+
         let rfc724_mid = dc_create_outgoing_rfc724_mid(None, "@device");
         prepare_msg_blob(context, msg)?;
         unarchive(context, chat_id)?;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2253,6 +2253,22 @@ mod tests {
         assert!(was_device_msg_ever_added(&t.ctx, "").is_err());
     }
 
+    #[test]
+    fn test_delete_device_chat() {
+        let t = test_context(Some(Box::new(logging_cb)));
+
+        let mut msg = Message::new(Viewtype::Text);
+        msg.text = Some("message text".to_string());
+        add_device_msg(&t.ctx, Some("some-label"), Some(&mut msg)).ok();
+        let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
+        assert_eq!(chats.len(), 1);
+
+        // after the device-chat and all messages are deleted, a re-adding should do nothing
+        delete(&t.ctx, chats.get_chat_id(0)).ok();
+        add_device_msg(&t.ctx, Some("some-label"), Some(&mut msg)).ok();
+        assert_eq!(chatlist_len(&t.ctx, 0), 0)
+    }
+
     fn chatlist_len(ctx: &Context, listflags: usize) -> usize {
         Chatlist::try_load(ctx, listflags, None, None)
             .unwrap()


### PR DESCRIPTION
if the user has deleted the device chat created eg. with add_device_message('welcome', ...) it must not be recreated when trying to add the same labeled message again.

this pr makes sure, we create the device chat only if the message will really be added to that.

closes #927