### PR TITLE
Resultify configure module

### DIFF
--- a/src/configure/auto_mozilla.rs
+++ b/src/configure/auto_mozilla.rs
@@ -10,7 +10,7 @@ use crate::constants::*;
 use crate::context::Context;
 use crate::login_param::LoginParam;
 
-use super::read_autoconf_file;
+use super::read_url::read_url;
 
 #[derive(Debug, Fail)]
 pub enum Error {
@@ -119,7 +119,7 @@ pub fn moz_autoconfigure(
     url: &str,
     param_in: &LoginParam,
 ) -> Option<LoginParam> {
-    let xml_raw = read_autoconf_file(context, url)?;
+    let xml_raw = read_url(context, url).ok()?;
 
     match parse_xml(&param_in.addr, &xml_raw) {
         Err(err) => {

--- a/src/configure/auto_mozilla.rs
+++ b/src/configure/auto_mozilla.rs
@@ -58,7 +58,7 @@ enum MozConfigTag {
     Username,
 }
 
-pub fn parse_xml(in_emailaddr: &str, xml_raw: &str) -> Result<LoginParam> {
+fn parse_xml(in_emailaddr: &str, xml_raw: &str) -> Result<LoginParam> {
     let mut reader = quick_xml::Reader::from_str(xml_raw);
     reader.trim_text(true);
 

--- a/src/configure/auto_outlook.rs
+++ b/src/configure/auto_outlook.rs
@@ -9,10 +9,10 @@ use crate::constants::*;
 use crate::context::Context;
 use crate::login_param::LoginParam;
 
-use super::read_autoconf_file;
+use super::read_url::read_url;
 
 #[derive(Debug, Fail)]
-enum Error {
+pub enum Error {
     #[fail(display = "XML error at position {}", position)]
     InvalidXml {
         position: usize,
@@ -23,6 +23,8 @@ enum Error {
     #[fail(display = "Bad or incomplete autoconfig")]
     IncompleteAutoconfig(LoginParam),
 }
+
+pub type Result<T> = std::result::Result<T, Error>;
 
 struct OutlookAutodiscover {
     pub out: LoginParam,
@@ -133,9 +135,9 @@ pub fn outlk_autodiscover(
     _param_in: &LoginParam,
 ) -> Option<LoginParam> {
     let mut url = url.to_string();
-    /* Follow up to 10 xml-redirects (http-redirects are followed in read_autoconf_file() */
+    /* Follow up to 10 xml-redirects (http-redirects are followed in read_url() */
     for _i in 0..10 {
-        if let Some(xml_raw) = read_autoconf_file(context, &url) {
+        if let Ok(xml_raw) = read_url(context, &url) {
             match parse_xml(&xml_raw) {
                 Err(err) => {
                     warn!(context, "{}", err);

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -193,7 +193,7 @@ pub fn JobConfigureImap(context: &Context) {
                         "https://{}{}/autodiscover/autodiscover.xml",
                         "", param_domain
                     );
-                    param_autoconfig = outlk_autodiscover(context, &url, &param);
+                    param_autoconfig = outlk_autodiscover(context, &url, &param).ok();
                 }
                 true
             }
@@ -204,7 +204,7 @@ pub fn JobConfigureImap(context: &Context) {
                         "https://{}{}/autodiscover/autodiscover.xml",
                         "autodiscover.", param_domain
                     );
-                    param_autoconfig = outlk_autodiscover(context, &url, &param);
+                    param_autoconfig = outlk_autodiscover(context, &url, &param).ok();
                 }
                 true
             }

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -1,5 +1,9 @@
 //! Email accounts autoconfiguration process module
 
+mod auto_mozilla;
+mod auto_outlook;
+mod read_url;
+
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
 use crate::config::Config;
@@ -12,10 +16,8 @@ use crate::login_param::LoginParam;
 use crate::oauth2::*;
 use crate::param::Params;
 
-mod auto_outlook;
-use auto_outlook::outlk_autodiscover;
-mod auto_mozilla;
 use auto_mozilla::moz_autoconfigure;
+use auto_outlook::outlk_autodiscover;
 
 macro_rules! progress {
     ($context:tt, $progress:expr) => {
@@ -565,23 +567,6 @@ fn try_smtp_one_param(context: &Context, param: &LoginParam) -> Option<bool> {
 /*******************************************************************************
  * Configure a Context
  ******************************************************************************/
-
-pub fn read_autoconf_file(context: &Context, url: &str) -> Option<String> {
-    info!(context, "Testing {} ...", url);
-
-    match reqwest::Client::new()
-        .get(url)
-        .send()
-        .and_then(|mut res| res.text())
-    {
-        Ok(res) => Some(res),
-        Err(_err) => {
-            info!(context, "Can\'t read file.",);
-
-            None
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -564,10 +564,6 @@ fn try_smtp_one_param(context: &Context, param: &LoginParam) -> Option<bool> {
     }
 }
 
-/*******************************************************************************
- * Configure a Context
- ******************************************************************************/
-
 #[cfg(test)]
 mod tests {
 

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -168,7 +168,7 @@ pub fn JobConfigureImap(context: &Context) {
                         "https://autoconfig.{}/mail/config-v1.1.xml?emailaddress={}",
                         param_domain, param_addr_urlencoded
                     );
-                    param_autoconfig = moz_autoconfigure(context, &url, &param);
+                    param_autoconfig = moz_autoconfigure(context, &url, &param).ok();
                 }
                 true
             }
@@ -180,7 +180,7 @@ pub fn JobConfigureImap(context: &Context) {
                         "https://{}/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress={}",
                         param_domain, param_addr_urlencoded
                     );
-                    param_autoconfig = moz_autoconfigure(context, &url, &param);
+                    param_autoconfig = moz_autoconfigure(context, &url, &param).ok();
                 }
                 true
             }
@@ -216,7 +216,7 @@ pub fn JobConfigureImap(context: &Context) {
                         "http://autoconfig.{}/mail/config-v1.1.xml?emailaddress={}",
                         param_domain, param_addr_urlencoded
                     );
-                    param_autoconfig = moz_autoconfigure(context, &url, &param);
+                    param_autoconfig = moz_autoconfigure(context, &url, &param).ok();
                 }
                 true
             }
@@ -228,7 +228,7 @@ pub fn JobConfigureImap(context: &Context) {
                         "http://{}/.well-known/autoconfig/mail/config-v1.1.xml",
                         param_domain
                     );
-                    param_autoconfig = moz_autoconfigure(context, &url, &param);
+                    param_autoconfig = moz_autoconfigure(context, &url, &param).ok();
                 }
                 true
             }
@@ -238,7 +238,7 @@ pub fn JobConfigureImap(context: &Context) {
                 if param_autoconfig.is_none() {
                     /* always SSL for Thunderbird's database */
                     let url = format!("https://autoconfig.thunderbird.net/v1.1/{}", param_domain);
-                    param_autoconfig = moz_autoconfigure(context, &url, &param);
+                    param_autoconfig = moz_autoconfigure(context, &url, &param).ok();
                 }
                 true
             }

--- a/src/configure/read_url.rs
+++ b/src/configure/read_url.rs
@@ -1,0 +1,27 @@
+use crate::context::Context;
+use failure::Fail;
+
+#[derive(Debug, Fail)]
+pub enum Error {
+    #[fail(display = "URL request error")]
+    GetError(#[cause] reqwest::Error),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+pub fn read_url(context: &Context, url: &str) -> Result<String> {
+    info!(context, "Requesting URL {}", url);
+
+    match reqwest::Client::new()
+        .get(url)
+        .send()
+        .and_then(|mut res| res.text())
+    {
+        Ok(res) => Ok(res),
+        Err(err) => {
+            info!(context, "Can\'t read URL {}", url);
+
+            Err(Error::GetError(err))
+        }
+    }
+}


### PR DESCRIPTION
The configure module itself (`mod.rs`) is not resultified yet and just uses `ok()`. That is left for the blocking configure, CBOR etc. refactoring of the configured function itself.

Carefully split into separate commits, do not squash.