### PR TITLE
and a function to create & update device chats

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1140,6 +1140,24 @@ uint32_t        dc_add_device_msg            (dc_context_t* context, const char*
 
 
 /**
+ * Init device-messages and saved-messages chat.
+ * This function adds the device-chat and saved-messages chat
+ * and adds one or more welcome or update-messages.
+ * The ui can add messages on its own using dc_add_device_msg() -
+ * for ordering, either before or after or even without calling this function.
+ *
+ * Chat and message creation is done only once.
+ * So if the user has manually deleted things, they won't be re-created
+ * (however, not seen device messages are added and may re-create the device-chat).
+ *
+ * @memberof dc_context_t
+ * @param context The context as created by dc_context_new().
+ * @return None.
+ */
+void            dc_update_device_chats       (dc_context_t* context);
+
+
+/**
  * Check if a device-message with a given label was ever added.
  * Device-messages can be added dc_add_device_msg().
  *

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -852,6 +852,21 @@ pub unsafe extern "C" fn dc_add_device_msg(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_update_device_chats(context: *mut dc_context_t) {
+    if context.is_null() {
+        eprintln!("ignoring careless call to dc_update_device_chats()");
+        return;
+    }
+    let ffi_context = &mut *context;
+    ffi_context
+        .with_inner(|ctx| {
+            ctx.update_device_chats()
+                .unwrap_or_log_default(ctx, "Failed to add device message")
+        })
+        .unwrap_or(())
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_was_device_msg_ever_added(
     context: *mut dc_context_t,
     label: *const libc::c_char,

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -837,6 +837,9 @@ pub unsafe fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::E
             msg.set_text(Some(arg1.to_string()));
             chat::add_device_msg(context, None, Some(&mut msg))?;
         }
+        "updatedevicechats" => {
+            context.update_device_chats()?;
+        }
         "listmedia" => {
             ensure!(sel_chat.is_some(), "No chat selected.");
 

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -121,20 +121,21 @@ pub enum StockMessage {
     #[strum(props(fallback = "Saved messages"))]
     SavedMessages = 69,
 
-    #[strum(props(fallback = "These messages in this chat \
-                              are generated locally by the Delta Chat app.\n\n\
-                              Delta Chat does not have your e-mail-address."))]
+    #[strum(props(
+        fallback = "Messages in this chat are generated locally by your Delta Chat app. \
+                    Its makers use it to inform about app updates and problems during usage."
+    ))]
     DeviceMessagesHint = 70,
 
     #[strum(props(fallback = "Welcome to Delta Chat! – \
-    Delta Chat looks and feels like other popular messenger apps, \
-    but does not involve centralized control, \
-    tracking or selling you, friends, colleagues or family out to large organizations.\n\n\
-    Technically, Delta Chat is an email application with a modern chat interface. \
-    Email in a new dress if you will 👻\n\n\
-    Use Delta Chat with anyone out of billions of people: just use their e-mail address. \
-    Recipients don't need to install Delta Chat, visit websites or sign up anywhere - \
-    however, of course, if they like, you may point them to 👉 https://get.delta.chat"))]
+                    Delta Chat looks and feels like other popular messenger apps, \
+                    but does not involve centralized control, \
+                    tracking or selling you, friends, colleagues or family out to large organizations.\n\n\
+                    Technically, Delta Chat is an email application with a modern chat interface. \
+                    Email in a new dress if you will 👻\n\n\
+                    Use Delta Chat with anyone out of billions of people: just use their e-mail address. \
+                    Recipients don't need to install Delta Chat, visit websites or sign up anywhere - \
+                    however, of course, if they like, you may point them to 👉 https://get.delta.chat"))]
     WelcomeMessage = 71,
 }
 

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -318,6 +318,7 @@ mod tests {
 
     use crate::constants::DC_CONTACT_ID_SELF;
 
+    use crate::chatlist::Chatlist;
     use num_traits::ToPrimitive;
 
     #[test]
@@ -472,5 +473,23 @@ mod tests {
                 .stock_system_msg(StockMessage::MsgGrpName, "Some chat", "Other chat", id,),
             "Group name changed from \"Some chat\" to \"Other chat\" by Alice (alice@example.com)."
         )
+    }
+
+    #[test]
+    fn test_update_device_chats() {
+        let t = dummy_context();
+        t.ctx.update_device_chats().ok();
+        let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
+        assert_eq!(chats.len(), 2);
+
+        chat::delete(&t.ctx, chats.get_chat_id(0)).ok();
+        chat::delete(&t.ctx, chats.get_chat_id(1)).ok();
+        let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
+        assert_eq!(chats.len(), 0);
+
+        // a subsequent call to update_device_chats() must not re-add manally deleted messages or chats
+        t.ctx.update_device_chats().ok();
+        let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
+        assert_eq!(chats.len(), 0);
     }
 }


### PR DESCRIPTION
dc_update_device_chats() add some welcome-messages to the device chat and also sets up the saved-messages-chat.

once merged, it can just be used by the ui, which, however, can add their own messages as needed.

also, after being merged, the strings will be added to transifex to get the message translated.

<img width="339" alt="Screen Shot 2019-12-02 at 16 41 48" src="https://user-images.githubusercontent.com/9800740/69974025-c5d07380-1524-11ea-8581-d1312690c556.png">

closes #937