### PR TITLE
calculate image-size in device-messages

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1984,6 +1984,7 @@ pub fn add_device_msg(
         chat_id = create_or_lookup_by_contact_id(context, DC_CONTACT_ID_DEVICE, Blocked::Not)?.0;
 
         let rfc724_mid = dc_create_outgoing_rfc724_mid(None, "@device");
+        msg.try_calc_and_set_dimensions(context).ok();
         prepare_msg_blob(context, msg)?;
         unarchive(context, chat_id)?;
 


### PR DESCRIPTION
eg. android relies on that and fallsback to wrong aspect ratios otherwise.
also, this makes job.rs a little more readable
as some things are moved to message.rs :)