### PR TITLE
test for sending out a file twice, with html.zip like exts preserved

### DIFF
--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -1,7 +1,6 @@
 """ The Message object. """
 
 import os
-import shutil
 from . import props
 from .cutil import from_dc_charpointer, as_dc_charpointer
 from .capi import lib, ffi

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -70,19 +70,6 @@ class Message(object):
         mtype = ffi.NULL if mime_type is None else as_dc_charpointer(mime_type)
         if not os.path.exists(path):
             raise ValueError("path does not exist: {!r}".format(path))
-        blobdir = self.account.get_blobdir()
-        if not path.startswith(blobdir):
-            for i in range(50):
-                ext = "" if i == 0 else "-" + str(i)
-                dest = os.path.join(blobdir, os.path.basename(path) + ext)
-                if os.path.exists(dest):
-                    continue
-                shutil.copyfile(path, dest)
-                break
-            else:
-                raise ValueError("could not create blobdir-path for {}".format(path))
-            path = dest
-        assert path.startswith(blobdir), path
         lib.dc_msg_set_file(self._dc_msg, as_dc_charpointer(path), mtype)
 
     @props.with_doc

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -453,10 +453,10 @@ class TestOnlineAccount:
 
         def send_and_receive_message():
             lp.sec("ac1: prepare and send attachment + text to ac2")
-            msg = Message.new_empty(ac1, "file")
-            msg.set_text("withfile")
-            msg.set_file(p)
-            message = chat.prepare_message(msg)
+            msg1 = Message.new_empty(ac1, "file")
+            msg1.set_text("withfile")
+            msg1.set_file(p)
+            message = chat.prepare_message(msg1)
             assert message.is_out_preparing()
             assert message.text == "withfile"
             chat.send_prepared(message)
@@ -464,7 +464,7 @@ class TestOnlineAccount:
             lp.sec("ac2: receive message")
             ev = ac2._evlogger.get_matching("DC_EVENT_INCOMING_MSG|DC_EVENT_MSGS_CHANGED")
             assert ev[2] > const.DC_CHAT_ID_LAST_SPECIAL
-            return ac2.get_message_by_id(ev[1])
+            return ac2.get_message_by_id(ev[2])
 
         msg = send_and_receive_message()
         assert msg.text == "withfile"

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -725,11 +725,21 @@ fn prepare_msg_blob(context: &Context, msg: &mut Message) -> Result<(), Error> {
     if msg.type_0 == Viewtype::Text {
         // the caller should check if the message text is empty
     } else if msgtype_has_file(msg.type_0) {
-        let blob = msg
-            .param
-            .get_blob(Param::File, context, !msg.is_increation())?
-            .ok_or_else(|| format_err!("Attachment missing for message of type #{}", msg.type_0))?;
-        msg.param.set(Param::File, blob.as_name());
+        let blob = if let Some(f) = msg.param.get_file(Param::File, context)? {
+            match f {
+                ParamsFile::Blob(blob) => blob,
+                ParamsFile::FsPath(path) => {
+                    // path is outside the blobdir, let's copy
+                    let blob = BlobObject::create_and_copy(context, path)?;
+                    msg.param.set(Param::File, blob.as_name());
+
+                    blob
+                }
+            }
+        } else {
+            bail!("Attachment missing for message of type #{}", msg.type_0);
+        };
+
         if msg.type_0 == Viewtype::File || msg.type_0 == Viewtype::Image {
             // Correct the type, take care not to correct already very special
             // formats as GIF or VOICE.


### PR DESCRIPTION
remove python-binding's create-copy logic and rather rely on core

