### PR TITLE
[wip] more precise job_interruption 

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -509,7 +509,7 @@ pub unsafe extern "C" fn dc_interrupt_imap_idle(context: *mut dc_context_t) {
     }
     let ffi_context = &*context;
     ffi_context
-        .with_inner(|ctx| job::interrupt_inbox_idle(ctx, true))
+        .with_inner(|ctx| job::interrupt_inbox_idle(ctx))
         .unwrap_or(())
 }
 

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -491,7 +491,7 @@ pub fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::Error> {
             println!("{:#?}", context.get_info());
         }
         "interrupt" => {
-            interrupt_inbox_idle(context, true);
+            interrupt_inbox_idle(context);
         }
         "maybenetwork" => {
             maybe_network(context);

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -202,7 +202,7 @@ fn stop_threads(context: &Context) {
         println!("Stopping threads");
         IS_RUNNING.store(false, Ordering::Relaxed);
 
-        interrupt_inbox_idle(context, true);
+        interrupt_inbox_idle(context);
         interrupt_mvbox_idle(context);
         interrupt_sentbox_idle(context);
         interrupt_smtp_idle(context);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -104,7 +104,7 @@ fn main() {
     println!("stopping threads");
 
     *running.write().unwrap() = false;
-    deltachat::job::interrupt_inbox_idle(&ctx, true);
+    deltachat::job::interrupt_inbox_idle(&ctx);
     deltachat::job::interrupt_smtp_idle(&ctx);
 
     println!("joining");

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1356,7 +1356,7 @@ pub fn delete(context: &Context, chat_id: u32) -> Result<(), Error> {
     });
 
     job_kill_action(context, Action::Housekeeping);
-    job_add(context, Action::Housekeeping, 0, Params::new(), 10);
+    add_job_with_interrupt(context, Action::Housekeeping, 0, Params::new(), 10);
 
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -143,7 +143,7 @@ impl Context {
             }
             Config::InboxWatch => {
                 let ret = self.sql.set_raw_config(self, key, value);
-                interrupt_inbox_idle(self, true);
+                interrupt_inbox_idle(self);
                 ret
             }
             Config::SentboxWatch => {

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -36,7 +36,7 @@ pub fn configure(context: &Context) {
         return;
     }
     job_kill_action(context, Action::ConfigureImap);
-    job_add(context, Action::ConfigureImap, 0, Params::new(), 0);
+    add_job_with_interrupt(context, Action::ConfigureImap, 0, Params::new(), 0);
 }
 
 /// Check if the context is already configured.

--- a/src/context.rs
+++ b/src/context.rs
@@ -44,7 +44,6 @@ pub struct Context {
     /// Blob directory path
     blobdir: PathBuf,
     pub sql: Sql,
-    pub perform_inbox_jobs_needed: Arc<RwLock<bool>>,
     pub probe_imap_network: Arc<RwLock<bool>>,
     pub inbox_thread: Arc<RwLock<JobThread>>,
     pub sentbox_thread: Arc<RwLock<JobThread>>,
@@ -147,7 +146,6 @@ impl Context {
                 Imap::new(),
             ))),
             probe_imap_network: Arc::new(RwLock::new(false)),
-            perform_inbox_jobs_needed: Arc::new(RwLock::new(false)),
             generating_key_mutex: Mutex::new(()),
             translated_stockstrings: RwLock::new(HashMap::new()),
         };

--- a/src/context.rs
+++ b/src/context.rs
@@ -14,13 +14,11 @@ use crate::contact::*;
 use crate::error::*;
 use crate::events::Event;
 use crate::imap::*;
-use crate::job::*;
 use crate::job_thread::JobThread;
 use crate::key::*;
 use crate::login_param::LoginParam;
 use crate::lot::Lot;
-use crate::message::{self, Message, MsgId};
-use crate::param::Params;
+use crate::message::{self, MsgId};
 use crate::smtp::Smtp;
 use crate::sql::Sql;
 
@@ -434,34 +432,6 @@ impl Context {
             name == folder_name.as_ref()
         } else {
             false
-        }
-    }
-
-    pub fn do_heuristics_moves(&self, folder: &str, msg_id: MsgId) {
-        if !self.get_config_bool(Config::MvboxMove) {
-            return;
-        }
-
-        if self.is_mvbox(folder) {
-            return;
-        }
-        if let Ok(msg) = Message::load_from_db(self, msg_id) {
-            if msg.is_setupmessage() {
-                // do not move setup messages;
-                // there may be a non-delta device that wants to handle it
-                return;
-            }
-
-            // 1 = dc message, 2 = reply to dc message
-            if 0 != msg.is_dc_message {
-                job_add(
-                    self,
-                    Action::MoveMsg,
-                    msg.id.to_u32() as i32,
-                    Params::new(),
-                    0,
-                );
-            }
         }
     }
 }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -250,7 +250,7 @@ pub fn dc_receive_imf(
 
     // if we delete we don't need to try moving messages
     if needs_delete_job && !created_db_entries.is_empty() {
-        job_add(
+        add_job_no_interrupt(
             context,
             Action::DeleteMsgOnImap,
             created_db_entries[0].1.to_u32() as i32,
@@ -258,7 +258,7 @@ pub fn dc_receive_imf(
             0,
         );
     } else {
-        context.do_heuristics_moves(server_folder.as_ref(), insert_msg_id);
+        crate::imap::do_heuristics_moves(context, server_folder.as_ref(), insert_msg_id);
     }
 
     info!(

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1204,7 +1204,7 @@ fn precheck_imf(context: &Context, rfc724_mid: &str, server_folder: &str, server
     {
         if old_server_folder.is_empty() && old_server_uid == 0 {
             info!(context, "[move] detected bbc-self {}", rfc724_mid,);
-            do_heuristics_moves(context, server_folder.as_ref(), msg_id);
+            do_heuristics_moves(context, server_folder, msg_id);
             add_job_no_interrupt(
                 context,
                 Action::MarkseenMsgOnImap,

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -74,7 +74,7 @@ pub fn imex(context: &Context, what: ImexMode, param1: Option<impl AsRef<Path>>)
     }
 
     job_kill_action(context, Action::ImexImap);
-    job_add(context, Action::ImexImap, 0, param, 0);
+    add_job_with_interrupt(context, Action::ImexImap, 0, param, 0);
 }
 
 /// Returns the filename of the backup found (otherwise an error)

--- a/src/job.rs
+++ b/src/job.rs
@@ -466,9 +466,7 @@ pub fn perform_sentbox_idle(context: &Context) {
 }
 
 pub fn interrupt_inbox_idle(context: &Context) {
-    info!(context, "interrupt_inbox_idle begin");
     context.inbox_thread.read().unwrap().interrupt_idle(context);
-    info!(context, "interrupt_inbox_idle finish");
 }
 
 pub fn interrupt_mvbox_idle(context: &Context) {
@@ -555,17 +553,16 @@ pub(crate) fn get_next_wakeup_time(context: &Context, thread: Thread) -> Duratio
         )
         .unwrap_or_default();
 
-    let mut wakeup_time = Duration::new(10 * 60, 0);
-    let now = time();
     if t > 0 {
+        let now = time();
         if t > now {
-            wakeup_time = Duration::new((t - now) as u64, 0);
+            Duration::new((t - now) as u64, 0)
         } else {
-            wakeup_time = Duration::new(0, 0);
+            Duration::new(0, 0)
         }
+    } else {
+        Duration::new(30 * 60, 0)
     }
-
-    wakeup_time
 }
 
 pub fn maybe_network(context: &Context) {

--- a/src/location.rs
+++ b/src/location.rs
@@ -226,7 +226,7 @@ pub fn send_locations_to_chat(context: &Context, chat_id: u32, seconds: i64) {
             context.call_cb(Event::ChatModified(chat_id));
             if 0 != seconds {
                 schedule_MAYBE_SEND_LOCATIONS(context, false);
-                job_add(
+                add_job_with_interrupt(
                     context,
                     Action::MaybeSendLocationsEnded,
                     chat_id as i32,
@@ -241,7 +241,8 @@ pub fn send_locations_to_chat(context: &Context, chat_id: u32, seconds: i64) {
 #[allow(non_snake_case)]
 fn schedule_MAYBE_SEND_LOCATIONS(context: &Context, force_schedule: bool) {
     if force_schedule || !job_action_exists(context, Action::MaybeSendLocations) {
-        job_add(context, Action::MaybeSendLocations, 0, Params::new(), 60);
+        // XXX questionable to interrupt but set a +60secs target
+        add_job_with_interrupt(context, Action::MaybeSendLocations, 0, Params::new(), 60);
     };
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -875,7 +875,7 @@ pub fn delete_msgs(context: &Context, msg_ids: &[MsgId]) {
             }
         }
         update_msg_chat_id(context, *msg_id, DC_CHAT_ID_TRASH);
-        job_add(
+        add_job_with_interrupt(
             context,
             Action::DeleteMsgOnImap,
             msg_id.to_u32() as i32,
@@ -890,7 +890,7 @@ pub fn delete_msgs(context: &Context, msg_ids: &[MsgId]) {
             msg_id: MsgId::new(0),
         });
         job_kill_action(context, Action::Housekeeping);
-        job_add(context, Action::Housekeeping, 0, Params::new(), 10);
+        add_job_with_interrupt(context, Action::Housekeeping, 0, Params::new(), 10);
     };
 }
 
@@ -961,7 +961,7 @@ pub fn markseen_msgs(context: &Context, msg_ids: &[MsgId]) -> bool {
                 update_msg_state(context, *id, MessageState::InSeen);
                 info!(context, "Seen message {}.", id);
 
-                job_add(
+                add_job_with_interrupt(
                     context,
                     Action::MarkseenMsgOnImap,
                     id.to_u32() as i32,
@@ -1319,7 +1319,7 @@ pub fn update_server_uid(
 #[allow(dead_code)]
 pub fn dc_empty_server(context: &Context, flags: u32) {
     job_kill_action(context, Action::EmptyServer);
-    job_add(context, Action::EmptyServer, flags as i32, Params::new(), 0);
+    add_job_with_interrupt(context, Action::EmptyServer, flags as i32, Params::new(), 0);
 }
 
 #[cfg(test)]

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -15,7 +15,7 @@ use crate::dc_tools::*;
 use crate::e2ee;
 use crate::error::Result;
 use crate::headerdef::HeaderDef;
-use crate::job::{job_add, Action};
+use crate::job::{add_job_no_interrupt, Action};
 use crate::location;
 use crate::message;
 use crate::message::MsgId;
@@ -782,7 +782,7 @@ impl<'a> MimeParser<'a> {
                 if self.has_chat_version() && self.context.get_config_bool(Config::MvboxMove) {
                     param.set_int(Param::AlsoMove, 1);
                 }
-                job_add(self.context, Action::MarkseenMdnOnImap, 0, param, 0);
+                add_job_no_interrupt(self.context, Action::MarkseenMdnOnImap, 0, param, 0);
             }
         }
     }


### PR DESCRIPTION
- limits idle-wait to return when the next imap job needs execution
- introcuces add_job_with_interrupt() and add_job_no_interrupt() APIs
- add_job_no_interrupt is called during dc_receive_imf and fetching, i.e. when idle is not active 

TODO: see if we can automatically collapse the two add_job functions into one that knows whether an interrupt is needed or not. 