### PR TITLE
make idle more robust by timing out on idle/done termination 

### DIFF
--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -96,9 +96,8 @@ impl Imap {
                         }
                         // if we can't properly terminate the idle
                         // protocol let's break the connection.
-                        let res = async_std::future::timeout(Duration::from_secs(15), async {
-                            handle.done().await
-                        });
+                        let res =
+                            async_std::future::timeout(Duration::from_secs(15), handle.done());
                         match res.await {
                             Ok(Ok(session)) => {
                                 *self.session.lock().await = Some(Session::Secure(session));
@@ -149,9 +148,8 @@ impl Imap {
                         }
                         // if we can't properly terminate the idle
                         // protocol let's break the connection.
-                        let res = async_std::future::timeout(Duration::from_secs(15), async {
-                            handle.done().await
-                        });
+                        let res =
+                            async_std::future::timeout(Duration::from_secs(15), handle.done());
                         match res.await {
                             Ok(Ok(session)) => {
                                 *self.session.lock().await = Some(Session::Insecure(session));


### PR DESCRIPTION
This should make sure that we often quickly recover from network problems. We wait 15 seconds for receiving the answer when trying to terminate an IDLE loop with "DONE".  If it doesn't arrive we kill the connection and cause a reconnection.  