### PR TITLE
fix incoming text/html attachment in multipart/mixed to remain an attachment

### DIFF
--- a/ci_scripts/remote_tests_python.sh
+++ b/ci_scripts/remote_tests_python.sh
@@ -2,7 +2,7 @@
 
 export BRANCH=${CIRCLE_BRANCH:?branch to build}
 export REPONAME=${CIRCLE_PROJECT_REPONAME:?repository name}
-export SSHTARGET=ci@b1.delta.chat
+export SSHTARGET=${SSHTARGET-ci@b1.delta.chat}
 
 # we construct the BUILDDIR such that we can easily share the
 # CARGO_TARGET_DIR between runs ("..")

--- a/ci_scripts/remote_tests_rust.sh
+++ b/ci_scripts/remote_tests_rust.sh
@@ -2,7 +2,7 @@
 
 export BRANCH=${CIRCLE_BRANCH:?branch to build}
 export REPONAME=${CIRCLE_PROJECT_REPONAME:?repository name}
-export SSHTARGET=ci@b1.delta.chat
+export SSHTARGET=${SSHTARGET-ci@b1.delta.chat}
 
 # we construct the BUILDDIR such that we can easily share the
 # CARGO_TARGET_DIR between runs ("..")

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -32,7 +32,7 @@ commands =
 
 [testenv:lint]
 skipsdist = True
-usedevelop = True
+skip_install = True
 deps =
     flake8
     # pygments required by rst-lint

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -47,10 +47,12 @@ pub fn dc_receive_imf(
         server_uid,
     );
 
+    /*
     if std::env::var(crate::DCC_MIME_DEBUG).is_ok() {
         info!(context, "dc_receive_imf: incoming message mime-body:");
         println!("{}", String::from_utf8_lossy(imf_raw));
     }
+    */
 
     let mime_parser = MimeParser::from_bytes(context, imf_raw);
     let mut mime_parser = if let Err(err) = mime_parser {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -47,12 +47,10 @@ pub fn dc_receive_imf(
         server_uid,
     );
 
-    /*
-    if std::env::var(crate::DCC_MIME_DEBUG).is_ok() {
+    if std::env::var(crate::DCC_MIME_DEBUG).unwrap_or_default() == "2" {
         info!(context, "dc_receive_imf: incoming message mime-body:");
         println!("{}", String::from_utf8_lossy(imf_raw));
     }
-    */
 
     let mime_parser = MimeParser::from_bytes(context, imf_raw);
     let mut mime_parser = if let Err(err) = mime_parser {

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -247,13 +247,13 @@ fn decrypt_if_autocrypt_message<'a>(
     // Errors are returned for failures related to decryption of AC-messages.
 
     let encrypted_data_part = match wrapmime::get_autocrypt_mime(mail) {
-        Err(err) => {
-            // not a proper autocrypt message, abort and ignore
-            info!(context, "Not an autocrypt message: {:?}", err);
+        Err(_) => {
+            // not an autocrypt mime message, abort and ignore
             return Ok(None);
         }
         Ok(res) => res,
     };
+    info!(context, "Detected Autocrypt-mime message");
 
     decrypt_part(
         context,

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -525,6 +525,12 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                 outer_message = outer_message.header(header);
             }
 
+            if std::env::var(crate::DCC_MIME_DEBUG).is_ok() {
+                info!(self.context, "mimefactory: outgoing message mime:");
+                let raw_message = message.clone().build().as_string();
+                println!("{}", raw_message);
+            }
+
             let encrypted =
                 encrypt_helper.encrypt(self.context, min_verified, message, &peerstates)?;
 

--- a/test-data/message/html_attach.eml
+++ b/test-data/message/html_attach.eml
@@ -1,0 +1,25 @@
+Chat-Disposition-Notification-To: tmp_6272287793210918@testrun.org
+Subject: =?utf-8?q?Chat=3A_File_=E2=80=93_test=2Ehtml?=
+Message-ID: Mr.XA6y3og8-az.WGbH9_dNcQx@testrun.org
+Date: Sat, 07 Dec 2019 19:00:27 +0000
+X-Mailer: Delta Chat Core 1.0.0-beta.12/DcFFI
+Chat-Version: 1.0
+To: <tmp_5890965001269692@testrun.org>
+From: "=?utf-8?q??=" <tmp_6272287793210918@testrun.org>
+Content-Type: multipart/mixed; boundary="mwkNRwaJw1M5n2xcr2ODfAqvTjcj9Z"
+
+
+--mwkNRwaJw1M5n2xcr2ODfAqvTjcj9Z
+Content-Type: text/plain; charset=utf-8
+
+-- 
+Sent with my Delta Chat Messenger: https://delta.chat
+
+--mwkNRwaJw1M5n2xcr2ODfAqvTjcj9Z
+Content-Type: text/html
+Content-Disposition: attachment; filename="test.html"
+Content-Transfer-Encoding: base64
+
+PGh0bWw+PGJvZHk+dGV4dDwvYm9keT5kYXRh
+
+--mwkNRwaJw1M5n2xcr2ODfAqvTjcj9Z--

--- a/test-data/message/mail_attach_txt.eml
+++ b/test-data/message/mail_attach_txt.eml
@@ -1,0 +1,40 @@
+From holger@merlinux.eu Sat Dec  7 11:53:58 2019
+Return-Path: <holger@merlinux.eu>
+X-Original-To: holger+test@merlinux.eu
+Delivered-To: holger+test@merlinux.eu
+Received: from [127.0.0.1] (localhost [127.0.0.1])
+	(using TLSv1.2 with cipher AECDH-AES256-SHA (256/256 bits))
+	(No client certificate requested)
+	by mail.merlinux.eu (Postfix) with ESMTPSA id 61825100531;
+	Sat,  7 Dec 2019 10:53:58 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=merlinux.eu;
+	s=default; t=1575716038;
+	bh=xhaPssQzVOHRafcciTQqDnZ1Zi4GMwsmg9pHLH3i8P8=;
+	h=Date:From:To:Subject;
+	b=U4HxGDZ8RwLwRPFtIvRsb+x5BiyICnbbY2ZOGlZdLt12MuDTfiYi/phHiQUC402EY
+	 GXb8dYgYr5+0PDiPBa7dyt2VQLC/h9QRfOA82tb1vpJYC+KksSAH0nYQqJvs7XrqCN
+	 i95/jwZnsWrV7w72+xsrO5qPujIE68TmM5I9Cyec=
+Received: by beto.merlinux.eu (Postfix, from userid 1000)
+	id 229D3820070; Sat,  7 Dec 2019 11:53:58 +0100 (CET)
+Date: Sat, 7 Dec 2019 11:53:57 +0100
+From: holger krekel <holger@merlinux.eu>
+To: holger+test@merlinux.eu
+Subject: hello
+Message-ID: <20191207105357.GA6266@beto>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="YiEDa0DAkWCtVeE4"
+Content-Disposition: inline
+
+--YiEDa0DAkWCtVeE4
+Content-Type: text/plain; charset=us-ascii
+Content-Disposition: inline
+
+siehe anhang
+
+--YiEDa0DAkWCtVeE4
+Content-Type: text/plain; charset=us-ascii
+Content-Disposition: attachment; filename="x.txt"
+
+hello
+
+--YiEDa0DAkWCtVeE4--


### PR DESCRIPTION
simplebot from @adbenitez calls `dc_send_file(fn, "text/html")` which DC on the receiving side does not see as a file but instead tries to parse and simplify.  This PR aims to preserve the attachment and prohibit parsing of attached text/html files.  It also simplifies and cleans up some code and CI invocations. 