### PR TITLE
Define all headers in new headerdef.rs

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1533,7 +1533,7 @@ fn is_known_rfc724_mid(context: &Context, rfc724_mid: &mailparse::MailAddr) -> b
 /// - checks also if any of the referenced IDs are send by a messenger
 /// - it is okay, if the referenced messages are moved to trash here
 /// - no check for the Chat-* headers (function is only called if it is no messenger message itself)
-fn dc_is_reply_to_messenger_message(context: &Context, mime_parser: &MimeParser) -> bool {
+fn is_reply_to_messenger_message(context: &Context, mime_parser: &MimeParser) -> bool {
     if let Some(value) = mime_parser.get(HeaderDef::InReplyTo) {
         if is_msgrmsg_rfc724_mid_in_list(context, &value) {
             return true;

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -1,104 +1,43 @@
-use crate::strum::EnumProperty;
-
-#[derive(Debug, Clone, PartialEq, Eq, EnumProperty)]
+#[derive(Debug, Display, Clone, PartialEq, Eq, EnumVariantNames)]
+#[strum(serialize_all = "kebab_case")]
+#[allow(dead_code)]
 pub enum HeaderDef {
-    #[strum(props(header = "message-id"))]
     MessageId,
-
-    #[strum(props(header = "subject"))]
     Subject,
-
-    #[strum(props(header = "date"))]
     Date,
-
-    #[strum(props(header = "from"))]
     From_,
-
-    #[strum(props(header = "to"))]
     To,
-
-    #[strum(props(header = "cc"))]
     Cc,
-
-    #[strum(props(header = "disposition"))]
     Disposition,
-
-    #[strum(props(header = "original-message-id"))]
     OriginalMessageId,
-
-    #[strum(props(header = "list-id"))]
     ListId,
-
-    #[strum(props(header = "references"))]
     References,
-
-    #[strum(props(header = "in-reply-to"))]
     InReplyTo,
-
-    #[strum(props(header = "precedence"))]
     Precedence,
-
-    #[strum(props(header = "chat-version"))]
     ChatVersion,
-
-    #[strum(props(header = "chat-group-id"))]
     ChatGroupId,
-
-    #[strum(props(header = "chat-group-name"))]
     ChatGroupName,
-
-    #[strum(props(header = "chat-group-name-changed"))]
     ChatGroupNameChanged,
-
-    #[strum(props(header = "chat-verified"))]
     ChatVerified,
-
-    #[strum(props(header = "chat-group-image"))]
     ChatGroupImage,
-
-    #[strum(props(header = "chat-voice-message"))]
     ChatVoiceMessage,
-
-    #[strum(props(header = "chat-group-member-removed"))]
     ChatGroupMemberRemoved,
-
-    #[strum(props(header = "chat-group-member-added"))]
     ChatGroupMemberAdded,
-
-    #[strum(props(header = "chat-content"))]
     ChatContent,
-
-    #[strum(props(header = "chat-duration"))]
     ChatDuration,
-
-    #[strum(props(header = "chat-disposition-notification-to"))]
     ChatDispositionNotificationTo,
-
-    #[strum(props(header = "autocrypt-setup-message"))]
     AutocryptSetupMessage,
-
-    #[strum(props(header = "secure-join"))]
     SecureJoin,
-
-    #[strum(props(header = "secure-join-group"))]
     SecureJoinGroup,
-
-    #[strum(props(header = "secure-join-fingerprint"))]
     SecureJoinFingerprint,
-
-    #[strum(props(header = "secure-join-invitenumber"))]
     SecureJoinInvitenumber,
-
-    #[strum(props(header = "secure-join-group"))]
     SecureJoinAuth,
-
-    #[strum(props(header = "test-header"))]
     _TestHeader,
 }
 
 impl HeaderDef {
     /// Returns the corresponding Event id.
-    pub fn get_headername(&self) -> &str {
-        self.get_str("header").expect("missing header definition")
+    pub fn get_headername(&self) -> String {
+        self.to_string()
     }
 }

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -41,3 +41,16 @@ impl HeaderDef {
         self.to_string()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    /// Test that kebab_case serialization works as expected
+    fn kebab_test() {
+        assert_eq!(HeaderDef::From_.to_string(), "from");
+
+        assert_eq!(HeaderDef::_TestHeader.to_string(), "test-header");
+    }
+}

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -1,0 +1,104 @@
+use crate::strum::EnumProperty;
+
+#[derive(Debug, Clone, PartialEq, Eq, EnumProperty)]
+pub enum HeaderDef {
+    #[strum(props(header = "message-id"))]
+    MessageId,
+
+    #[strum(props(header = "subject"))]
+    Subject,
+
+    #[strum(props(header = "date"))]
+    Date,
+
+    #[strum(props(header = "from"))]
+    From_,
+
+    #[strum(props(header = "to"))]
+    To,
+
+    #[strum(props(header = "cc"))]
+    Cc,
+
+    #[strum(props(header = "disposition"))]
+    Disposition,
+
+    #[strum(props(header = "original-message-id"))]
+    OriginalMessageId,
+
+    #[strum(props(header = "list-id"))]
+    ListId,
+
+    #[strum(props(header = "references"))]
+    References,
+
+    #[strum(props(header = "in-reply-to"))]
+    InReplyTo,
+
+    #[strum(props(header = "precedence"))]
+    Precedence,
+
+    #[strum(props(header = "chat-version"))]
+    ChatVersion,
+
+    #[strum(props(header = "chat-group-id"))]
+    ChatGroupId,
+
+    #[strum(props(header = "chat-group-name"))]
+    ChatGroupName,
+
+    #[strum(props(header = "chat-group-name-changed"))]
+    ChatGroupNameChanged,
+
+    #[strum(props(header = "chat-verified"))]
+    ChatVerified,
+
+    #[strum(props(header = "chat-group-image"))]
+    ChatGroupImage,
+
+    #[strum(props(header = "chat-voice-message"))]
+    ChatVoiceMessage,
+
+    #[strum(props(header = "chat-group-member-removed"))]
+    ChatGroupMemberRemoved,
+
+    #[strum(props(header = "chat-group-member-added"))]
+    ChatGroupMemberAdded,
+
+    #[strum(props(header = "chat-content"))]
+    ChatContent,
+
+    #[strum(props(header = "chat-duration"))]
+    ChatDuration,
+
+    #[strum(props(header = "chat-disposition-notification-to"))]
+    ChatDispositionNotificationTo,
+
+    #[strum(props(header = "autocrypt-setup-message"))]
+    AutocryptSetupMessage,
+
+    #[strum(props(header = "secure-join"))]
+    SecureJoin,
+
+    #[strum(props(header = "secure-join-group"))]
+    SecureJoinGroup,
+
+    #[strum(props(header = "secure-join-fingerprint"))]
+    SecureJoinFingerprint,
+
+    #[strum(props(header = "secure-join-invitenumber"))]
+    SecureJoinInvitenumber,
+
+    #[strum(props(header = "secure-join-group"))]
+    SecureJoinAuth,
+
+    #[strum(props(header = "test-header"))]
+    _TestHeader,
+}
+
+impl HeaderDef {
+    /// Returns the corresponding Event id.
+    pub fn get_headername(&self) -> &str {
+        self.get_str("header").expect("missing header definition")
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ mod log;
 #[macro_use]
 pub mod error;
 
+pub mod headerdef;
+
 pub(crate) mod events;
 pub use events::*;
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -350,7 +350,7 @@ impl<'a> MimeParser<'a> {
     }
 
     pub fn get(&self, headerdef: HeaderDef) -> Option<&String> {
-        self.header.get(headerdef.get_headername())
+        self.header.get(&headerdef.get_headername())
     }
 
     fn parse_mime_recursive(&mut self, mail: &mailparse::ParsedMail<'_>) -> Result<bool> {
@@ -729,9 +729,9 @@ impl<'a> MimeParser<'a> {
 
         // must be present
         let disp = HeaderDef::Disposition.get_headername();
-        if let Some(_disposition) = report_fields.get_first_value(disp).ok().flatten() {
+        if let Some(_disposition) = report_fields.get_first_value(&disp).ok().flatten() {
             if let Some(original_message_id) = report_fields
-                .get_first_value(HeaderDef::OriginalMessageId.get_headername())
+                .get_first_value(&HeaderDef::OriginalMessageId.get_headername())
                 .ok()
                 .flatten()
                 .and_then(|v| parse_message_id(&v))
@@ -1126,9 +1126,9 @@ mod tests {
                     \n\
                     \x00";
         let mimeparser = MimeParser::from_bytes(&context.ctx, &raw[..]).unwrap();
-        
+
         // test that we treat Subject as a protected header that can
-        // bubble upwards 
+        // bubble upwards
         assert_eq!(mimeparser.get_subject(), Some("inner-subject".into()));
 
         let of = mimeparser.get(HeaderDef::SecureJoinGroup).unwrap();


### PR DESCRIPTION
Made some header-name errors before and wanted to avoid them generally now. 

i guess the headerdefs.rs is a bit redundant, but i don't know how to generate the capitalized Mime-Header style from the Rust MimeHeader name.  