### PR TITLE
Fix various issues around group add/remove

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,12 +36,6 @@ jobs:
     executor: default
     steps:
       - checkout
-      - run:
-          name: Update submodules
-          command: git submodule update --init --recursive
-      - run:
-          name: Calculate dependencies
-          command: cargo generate-lockfile
       - restore_cache:
           keys:
             - cargo-v3-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,6 @@ jobs:
       - run: rustup default $(cat rust-toolchain)
       - run: rustup component add --toolchain $(cat rust-toolchain) rustfmt
       - run: rustup component add --toolchain $(cat rust-toolchain) clippy-preview
-      - run: cargo update
       - run: cargo fetch
       - run: rustc +stable --version
       - run: rustc +$(cat rust-toolchain) --version
@@ -91,7 +90,6 @@ jobs:
             curl https://sh.rustup.rs -sSf | sh -s -- -y
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
-      - run: cargo update
       - run: cargo fetch
       - run:
           name: Test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,7 @@ jobs:
       - *restore-cache
       - run:
           name: Run cargo clippy
-          command: cargo clippy --all
+          command: cargo clippy 
 
 
 workflows:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,7 @@ dependencies = [
  "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image-meta 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lettre_email 0.9.2 (git+https://github.com/deltachat/lettre?branch=feat/mail)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,7 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "debug_stub_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "deltachat_derive 0.1.0",
+ "email 0.0.21 (git+https://github.com/deltachat/rust-email)",
  "encoded-words 0.1.0 (git+https://github.com/async-email/encoded-words)",
  "escaper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -827,10 +828,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "email"
 version = "0.0.21"
-source = "git+https://github.com/deltachat/rust-email#265a54a8c31355c506610c032c81112dc0953afb"
+source = "git+https://github.com/deltachat/rust-email#b71c13d7d9a599ebc811a8e2ca350e2793fe58d3"
 dependencies = [
  "base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoded-words 0.1.0 (git+https://github.com/async-email/encoded-words)",
  "encoding 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1.0"
 chrono = "0.4.6"
 failure = "0.1.5"
 failure_derive = "0.1.5"
+indexmap = "1.3.0"
 # TODO: make optional
 rustyline = "4.1.0"
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.9.15", default-features = false, features = ["rustls-tl
 num-derive = "0.2.5"
 num-traits = "0.2.6"
 async-smtp = { git = "https://github.com/async-email/async-smtp" }
+email = { git = "https://github.com/deltachat/rust-email" }
 lettre_email = { git = "https://github.com/deltachat/lettre", branch = "feat/mail" }
 async-imap = { git = "https://github.com/async-email/async-imap", branch="master" }
 async-tls = "0.6"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ install:
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
   - rustc -vV
   - cargo -vV
-  - cargo update
 
 build: false
 

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -94,7 +94,9 @@ pub fn dc_reset_tables(context: &Context, bits: i32) -> i32 {
 fn dc_poke_eml_file(context: &Context, filename: impl AsRef<Path>) -> Result<(), Error> {
     let data = dc_read_file(context, filename)?;
 
-    dc_receive_imf(context, &data, "import", 0, 0);
+    if let Err(err) = dc_receive_imf(context, &data, "import", 0, 0) {
+        println!("dc_receive_imf errored: {:?}", err);
+    }
     Ok(())
 }
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -85,16 +85,21 @@ class SessionLiveConfigFromFile:
 class SessionLiveConfigFromURL:
     def __init__(self, url, create_token):
         self.configlist = []
-        for i in range(2):
-            res = requests.post(url, json={"token_create_user": int(create_token)})
+        self.url = url
+        self.create_token = create_token
+
+    def get(self, index):
+        try:
+            return self.configlist[index]
+        except IndexError:
+            assert index == len(self.configlist), index
+            res = requests.post(self.url, json={"token_create_user": int(self.create_token)})
             if res.status_code != 200:
                 pytest.skip("creating newtmpuser failed {!r}".format(res))
             d = res.json()
             config = dict(addr=d["email"], mail_pw=d["password"])
             self.configlist.append(config)
-
-    def get(self, index):
-        return self.configlist[index]
+            return config
 
     def exists(self):
         return bool(self.configlist)

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -652,6 +652,7 @@ class TestOnlineAccount:
         msg_in = ac2.get_message_by_id(msg_out.id)
         assert msg_in.text == "message1"
         assert not msg_in.is_forwarded()
+        assert msg_in.get_sender_contact().display_name == ac1.get_config("displayname")
 
         lp.sec("check the message arrived in contact-requets/deaddrop")
         chat2 = msg_in.chat

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -632,6 +632,9 @@ class TestOnlineAccount:
     def test_send_and_receive_message_markseen(self, acfactory, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()
 
+        # make DC's life harder wrt to encodings
+        ac1.set_config("displayname", "ä name")
+
         lp.sec("ac1: create chat with ac2")
         chat = self.get_chat(ac1, ac2)
 

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -399,6 +399,7 @@ class TestOfflineChat:
         chat.remove_contact(contacts[3])
         assert len(chat.get_contacts()) == 9
 
+
 class TestOnlineAccount:
     def get_chat(self, ac1, ac2, both_created=False):
         c2 = ac1.create_contact(email=ac2.get_config("addr"))
@@ -1111,8 +1112,12 @@ class TestGroupStressTests:
         assert len(msg.chat.get_contacts()) == 4
 
         lp.sec("ac1: removing one contacts and checking things are right")
-        msg.chat.remove_contact(msg.chat.get_contacts()[-1])
-        assert 0
+        to_remove = msg.chat.get_contacts()[-1]
+        msg.chat.remove_contact(to_remove)
+
+        sysmsg = ac1.wait_next_incoming_message()
+        assert to_remove.addr in sysmsg.text
+        assert len(sysmsg.chat.get_contacts()) == 3
 
 
 class TestOnlineConfigureFails:

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1086,6 +1086,7 @@ fn create_or_lookup_group(
             chat::add_to_chat_contacts_table(context, chat_id, from_id as u32);
         }
         for &to_id in to_ids.iter() {
+            info!(context, "adding to={:?} to chat id={}", to_id, chat_id);
             if !Contact::addr_equals_contact(context, &self_addr, to_id)
                 && (skip.is_none() || !Contact::addr_equals_contact(context, skip.unwrap(), to_id))
             {
@@ -1590,6 +1591,8 @@ fn dc_add_or_lookup_contacts_by_address_list(
     if addrs.is_err() {
         return;
     }
+    info!(context, "dc_add_or_lookup_contacts_by_address-list={:?}", addr_list_raw);
+    info!(context, "addrs={:?}", addrs);
     for addr in addrs.unwrap().iter() {
         match addr {
             mailparse::MailAddr::Single(info) => {
@@ -1636,9 +1639,11 @@ fn add_or_lookup_contact_by_addr(
         *check_self = true;
     }
 
+    /*
     if *check_self {
         return;
     }
+    */
 
     // add addr_spec if missing, update otherwise
     let display_name_normalized = display_name
@@ -1647,6 +1652,7 @@ fn add_or_lookup_contact_by_addr(
         .unwrap_or_default();
 
     // can be NULL
+    info!(context, "looking up addr={:?} display_name={:?}", addr, display_name_normalized);
     let row_id = Contact::add_or_lookup(context, display_name_normalized, addr, origin)
         .map(|(id, _)| id)
         .unwrap_or_default();

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1583,10 +1583,6 @@ fn dc_add_or_lookup_contacts_by_address_list(
     origin: Origin,
     to_ids: &mut ContactIds,
 ) -> Result<()> {
-    // XXX we use manual decoding
-    // https://github.com/staktrace/mailparse/issues/50
-    use email::rfc2047::decode_rfc2047;
-
     let addrs = match mailparse::addrparse(addr_list_raw) {
         Ok(addrs) => addrs,
         Err(err) => {
@@ -1601,22 +1597,18 @@ fn dc_add_or_lookup_contacts_by_address_list(
     for addr in addrs.iter() {
         match addr {
             mailparse::MailAddr::Single(info) => {
-                // mailparse does not give us decoded vals
-                let display_name = decode_rfc2047(&info.display_name.clone().unwrap_or_default());
                 to_ids.insert(add_or_lookup_contact_by_addr(
                     context,
-                    &display_name,
+                    &info.display_name,
                     &info.addr,
                     origin,
                 )?);
             }
             mailparse::MailAddr::Group(infos) => {
                 for info in &infos.addrs {
-                    let display_name =
-                        decode_rfc2047(&info.display_name.clone().unwrap_or_default());
                     to_ids.insert(add_or_lookup_contact_by_addr(
                         context,
-                        &display_name,
+                        &info.display_name,
                         &info.addr,
                         origin,
                     )?);

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -182,22 +182,6 @@ fn encode_66bits_as_base64(v1: u32, v2: u32, fill: u32) -> String {
     String::from_utf8(wrapped_writer).unwrap()
 }
 
-pub(crate) fn dc_create_incoming_rfc724_mid(
-    message_timestamp: i64,
-    contact_id_from: u32,
-    contact_ids_to: &[u32],
-) -> Option<String> {
-    /* create a deterministic rfc724_mid from input such that
-    repeatedly calling it with the same input results in the same Message-id */
-
-    let largest_id_to = contact_ids_to.iter().max().copied().unwrap_or_default();
-    let result = format!(
-        "{}-{}-{}@stub",
-        message_timestamp, contact_id_from, largest_id_to
-    );
-    Some(result)
-}
-
 /// Function generates a Message-ID that can be used for a new outgoing message.
 /// - this function is called for all outgoing messages.
 /// - the message ID should be globally unique
@@ -778,14 +762,6 @@ mod tests {
                 }
             }
         }
-    }
-
-    #[test]
-    fn test_dc_create_incoming_rfc724_mid() {
-        let res = dc_create_incoming_rfc724_mid(123, 45, &[6, 7]);
-        assert_eq!(res, Some("123-45-7@stub".into()));
-        let res = dc_create_incoming_rfc724_mid(123, 45, &[]);
-        assert_eq!(res, Some("123-45-0@stub".into()));
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,12 +28,14 @@ pub enum Error {
     InvalidMsgId,
     #[fail(display = "Watch folder not found {:?}", _0)]
     WatchFolderNotFound(String),
-    #[fail(display = "Inalid Email: {:?}", _0)]
+    #[fail(display = "Invalid Email: {:?}", _0)]
     MailParseError(#[cause] mailparse::MailParseError),
     #[fail(display = "Building invalid Email: {:?}", _0)]
     LettreError(#[cause] lettre_email::error::Error),
     #[fail(display = "FromStr error: {:?}", _0)]
     FromStr(#[cause] mime::FromStrError),
+    #[fail(display = "Not Configured")]
+    NotConfigured,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -713,7 +713,17 @@ impl Imap {
 
             if !is_deleted && msg.body().is_some() {
                 let body = msg.body().unwrap_or_default();
-                dc_receive_imf(context, &body, folder.as_ref(), server_uid, flags as u32);
+                if let Err(err) =
+                    dc_receive_imf(context, &body, folder.as_ref(), server_uid, flags as u32)
+                {
+                    warn!(
+                        context,
+                        "dc_receive_imf failed for imap-message {}/{}: {:?}",
+                        folder.as_ref(),
+                        server_uid,
+                        err
+                    );
+                }
             }
         }
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -394,7 +394,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                 to.push(Address::new_mailbox(addr.clone()));
             } else {
                 to.push(Address::new_mailbox_with_name(
-                    name.to_string(), 
+                    name.to_string(),
                     addr.clone(),
                 ));
             }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -382,7 +382,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
         let mut unprotected_headers: Vec<Header> = Vec::new();
 
         let from = Address::new_mailbox_with_name(
-            encode_words(&self.from_displayname),
+            self.from_displayname.to_string(),
             self.from_addr.clone(),
         );
 
@@ -394,7 +394,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                 to.push(Address::new_mailbox(addr.clone()));
             } else {
                 to.push(Address::new_mailbox_with_name(
-                    encode_words(name),
+                    name.to_string(), 
                     addr.clone(),
                 ));
             }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1055,8 +1055,6 @@ pub fn needs_encoding(to_check: impl AsRef<str>) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use email::rfc2047::decode_rfc2047;
-    use mailparse::{addrparse, MailAddr};
 
     #[test]
     fn test_render_email_address() {
@@ -1071,20 +1069,7 @@ mod tests {
         );
 
         println!("{}", s);
-        assert!(s.is_ascii());
 
         assert_eq!(s, "=?utf-8?q?=C3=A4_space?= <x@y.org>");
-
-        match &addrparse(&s).unwrap()[0] {
-            MailAddr::Single(info) => {
-                // XXX addrparse should not return rfc2047 encoding
-                // but the decoded string, see
-                // https://github.com/staktrace/mailparse/issues/50
-                let s = decode_rfc2047(&info.display_name.clone().unwrap());
-                assert_eq!(s, Some(display_name.to_string()));
-                assert_eq!(info.addr, addr.to_string());
-            }
-            _ => panic!(),
-        }
     }
 }

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -527,7 +527,7 @@ impl<'a> MimeParser<'a> {
         let filename = get_attachment_filename(mail);
         info!(
             self.context,
-            "add_single_part_if_known {:?} {:?} {:?}", mime_type, msg_type, filename
+            "add_single_part_if_known {:?} {:?}", mime_type, msg_type
         );
 
         let old_part_count = self.parts.len();
@@ -663,25 +663,6 @@ impl<'a> MimeParser<'a> {
         } else {
             false
         }
-    }
-
-    pub fn sender_equals_recipient(&self) -> bool {
-        /* get From: and check there is exactly one sender */
-        if let Some(field) = self.get(HeaderDef::From_) {
-            if let Ok(addrs) = mailparse::addrparse(field) {
-                if addrs.len() != 1 {
-                    return false;
-                }
-                if let mailparse::MailAddr::Single(ref info) = addrs[0] {
-                    let from_addr_norm = addr_normalize(&info.addr);
-                    let recipients = get_recipients(self.header.iter());
-                    if recipients.len() == 1 && recipients.contains(from_addr_norm) {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
     }
 
     pub fn repl_msg_by_error(&mut self, error_msg: impl AsRef<str>) {

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -338,6 +338,10 @@ impl<'a> MimeParser<'a> {
         self.header.contains_key("chat-version")
     }
 
+    pub(crate) fn has_headers(&self) -> bool {
+        !self.header.is_empty()
+    }
+
     pub(crate) fn get_subject(&self) -> Option<String> {
         if let Some(s) = self.get(HeaderDef::Subject) {
             if s.is_empty() {

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -604,7 +604,7 @@ pub(crate) fn handle_securejoin_handshake(
                 .get(HeaderDef::ChatGroupMemberAdded)
                 .map(|s| s.as_str())
                 .unwrap_or_else(|| "");
-            if join_vg && !addr_equals_self(context, cg_member_added) {
+            if join_vg && !context.is_self_addr(cg_member_added)? {
                 info!(context, "Message belongs to a different handshake (scaled up contact anyway to allow creation of group).");
                 return Ok(ret);
             }


### PR DESCRIPTION
- [x] fix rust-email to rfc2047-quote displaynames in email-addresses, addresses #976
    
- [x] recreate the group list more carefully, fixes #985
    
- [x] resultify a few functions in the dc_receive pipeline

- [x] create and use a ContactIds type as an ordered set instead of "Vec<u32>".

- [x] fix CI jobs to not do "cargo update" because this will not use Cargo.lock but a random collection of deps
 
