### PR TITLE
[wip] special-case nauta provider to try make it work

### DIFF
--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -161,7 +161,7 @@ pub fn JobConfigureImap(context: &Context) {
 
                     p.send_user = param.addr.clone();
                     p.send_pw = param.mail_pw.clone();
-                    p.send_port = 465;
+                    p.send_port = 25;
                     p.smtp_certificate_checks = CertificateChecks::AcceptInvalidCertificates;
                     p.server_flags = DC_LP_AUTH_NORMAL as i32
                         | DC_LP_IMAP_SOCKET_PLAIN as i32
@@ -169,7 +169,7 @@ pub fn JobConfigureImap(context: &Context) {
 
                     // pretend we did autoconfig, to prevent further tries
                     param_autoconfig = Some(p);
-                    step_counter = STEP_3_INDEX - 1;
+                    step_counter = 12 - 1;
                 } else if param.mail_server.is_empty()
                             && param.mail_port == 0
                             /*&&param.mail_user.is_empty() -- the user can enter a loginname which is used by autoconfig then */

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -112,11 +112,11 @@ impl LoginParam {
         // Rust-TLS does not support nauta.cu's RSA1024 TLS cert.
         // see https://github.com/deltachat/deltachat-core-rust/issues/1007
         if mail_server.ends_with(".nauta.cu") {
-            server_flags |= !0x300; // clear out IMAP_SSL/STARTTLS
+            server_flags &= !0x300; // clear out IMAP_SSL/STARTTLS
             server_flags |= 0x400; // set IMAP_PLAIN
         }
         if send_server.ends_with(".nauta.cu") {
-            server_flags |= !0x30000; // clear out SMTP_SSL/STARTTLS
+            server_flags &= !0x30000; // clear out SMTP_SSL/STARTTLS
             server_flags |= 0x40000; // set SMTP_PLAIN
         }
 

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -106,7 +106,19 @@ impl LoginParam {
             };
 
         let key = format!("{}server_flags", prefix);
-        let server_flags = sql.get_raw_config_int(context, key).unwrap_or_default();
+        let mut server_flags = sql.get_raw_config_int(context, key).unwrap_or_default();
+
+        // XXX special case nauta.cu: enforce cleartext instead of TLS because
+        // Rust-TLS does not support nauta.cu's RSA1024 TLS cert.
+        // see https://github.com/deltachat/deltachat-core-rust/issues/1007
+        if mail_server.ends_with(".nauta.cu") {
+            server_flags |= !0x300; // clear out IMAP_SSL/STARTTLS
+            server_flags |= 0x400; // set IMAP_PLAIN
+        }
+        if send_server.ends_with(".nauta.cu") {
+            server_flags |= !0x30000; // clear out SMTP_SSL/STARTTLS
+            server_flags |= 0x40000; // set SMTP_PLAIN
+        }
 
         LoginParam {
             addr,


### PR DESCRIPTION
this attempts to make nauta work again, at the expense of not using TLS at all, see #1007 for details.

**However, i don't intend to get this PR merged as is -- disabling TLS means that people would have their mail-account login credentials travel in the clear -- and in public WiFis and other network environments that's too much of a risk i think**

Not totally sure if the parameters are all correct -- @adbenitez could you check? (it's a small diff, you will see it if you click on files)  