### PR TITLE
Revert "Enable clippy::unreadable_literal error"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
     clippy::cognitive_complexity,
     clippy::too_many_arguments
 )]
-#![allow(clippy::match_bool)]
+#![allow(clippy::unreadable_literal, clippy::match_bool)]
 #![feature(ptr_wrapping_offset_from)]
 #![feature(drain_filter)]
 


### PR DESCRIPTION
This reverts commit b424ef9ebb7dda5fd934f09dbae42b81589b9d64.