### PR TITLE
Add filename and line no to log entries

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ extern crate strum_macros;
 extern crate debug_stub_derive;
 
 #[macro_use]
-mod log;
+pub mod log;
 #[macro_use]
 pub mod error;
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -7,7 +7,8 @@ macro_rules! info {
     };
     ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
-        emit_event!($ctx, $crate::Event::Info(formatted));
+        let full = format!("{}:{}: {}", file!(), line!(), &formatted);
+        emit_event!($ctx, $crate::Event::Info(full));
     }};
 }
 
@@ -18,7 +19,8 @@ macro_rules! warn {
     };
     ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
-        emit_event!($ctx, $crate::Event::Warning(formatted));
+        let full = format!("{}:{}: {}", file!(), line!(), &formatted);
+        emit_event!($ctx, $crate::Event::Warning(full));
     }};
 }
 
@@ -29,7 +31,8 @@ macro_rules! error {
     };
     ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
-        emit_event!($ctx, $crate::Event::Error(formatted));
+        let full = format!("{}:{}: {}", file!(), line!(), &formatted);
+        emit_event!($ctx, $crate::Event::Error(full));
     }};
 }
 


### PR DESCRIPTION
This is done for all logging calls, also those which call error! which
is normally directly shown to the user.