### PR TITLE
revert printing file/lineno in Error-messages 

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -31,8 +31,7 @@ macro_rules! error {
     };
     ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
-        let full = format!("{}:{}: {}", file!(), line!(), &formatted);
-        emit_event!($ctx, $crate::Event::Error(full));
+        emit_event!($ctx, $crate::Event::Error(formatted));
     }};
 }
 


### PR DESCRIPTION
errors are typically user-visible 
For info and warn it's fine to add file/lineno