### PR TITLE
Add the thread id and name to info and warn log output

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -7,7 +7,13 @@ macro_rules! info {
     };
     ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
-        let full = format!("{}:{}: {}", file!(), line!(), &formatted);
+        let thread = ::std::thread::current();
+        let full = format!("{thid:?}/{thname} {file}:{line}: {msg}",
+                           thid = thread.id(),
+                           thname = thread.name().unwrap_or("unnamed"),
+                           file = file!(),
+                           line = line!(),
+                           msg = &formatted);
         emit_event!($ctx, $crate::Event::Info(full));
     }};
 }
@@ -19,7 +25,13 @@ macro_rules! warn {
     };
     ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
-        let full = format!("{}:{}: {}", file!(), line!(), &formatted);
+        let thread = ::std::thread::current();
+        let full = format!("{thid:?}/{thname} {file}:{line}: {msg}",
+                           thid = thread.id(),
+                           thname = thread.name().unwrap_or("unnamed"),
+                           file = file!(),
+                           line = line!(),
+                           msg = &formatted);
         emit_event!($ctx, $crate::Event::Warning(full));
     }};
 }


### PR DESCRIPTION
I'm not sure how useful the name will be on all the apps.  Probably depends on how they are created.  I believe that if the OS facility to name threads is used the name is respected even if the thread was not started by the rust code.