### PR TITLE
use dcc-stable branch that returns an error on missing greetings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 [[package]]
 name = "async-imap"
 version = "0.1.1"
-source = "git+https://github.com/async-email/async-imap?rev=d7836416766b55d8d03587ea5326eecf501c2030#d7836416766b55d8d03587ea5326eecf501c2030"
+source = "git+https://github.com/async-email/async-imap?branch=dcc-stable#4f0852971c3f397c2b8a343ef1378992c02f61de"
 dependencies = [
  "async-attributes 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-native-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -659,7 +659,7 @@ dependencies = [
 name = "deltachat"
 version = "1.0.0-beta.17"
 dependencies = [
- "async-imap 0.1.1 (git+https://github.com/async-email/async-imap?rev=d7836416766b55d8d03587ea5326eecf501c2030)",
+ "async-imap 0.1.1 (git+https://github.com/async-email/async-imap?branch=dcc-stable)",
  "async-native-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-smtp 0.1.0 (git+https://github.com/async-email/async-smtp)",
  "async-std 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3469,7 +3469,7 @@ dependencies = [
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
 "checksum ascii_utils 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
 "checksum async-attributes 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "efd3d156917d94862e779f356c5acae312b08fd3121e792c857d7928c8088423"
-"checksum async-imap 0.1.1 (git+https://github.com/async-email/async-imap?rev=d7836416766b55d8d03587ea5326eecf501c2030)" = "<none>"
+"checksum async-imap 0.1.1 (git+https://github.com/async-email/async-imap?branch=dcc-stable)" = "<none>"
 "checksum async-macros 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "644a5a8de80f2085a1e7e57cd1544a2a7438f6e003c0790999bd43b92a77cdb2"
 "checksum async-native-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a29e9e4ed87f4070dd6099d0bd5edfc7692c94442c80d656b50a802c6fde23b7"
 "checksum async-smtp 0.1.0 (git+https://github.com/async-email/async-smtp)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ email = { git = "https://github.com/deltachat/rust-email", branch = "master" }
 lettre_email = { git = "https://github.com/deltachat/lettre", branch = "native_tls" }
 
 # XXX newer commits of async-imap lead to import-export tests hanging
-async-imap = { git = "https://github.com/async-email/async-imap", rev="d7836416766b55d8d03587ea5326eecf501c2030"} 
+async-imap = { git = "https://github.com/async-email/async-imap", branch = "dcc-stable" }
 
 async-native-tls = "0.1.1"
 async-std = { version = "1.0", features = ["unstable"] }

--- a/src/imap_client.rs
+++ b/src/imap_client.rs
@@ -46,7 +46,7 @@ impl Client {
         let _greeting = client
             .read_response()
             .await
-            .expect("failed to read greeting");
+            .ok_or_else(|| ImapError::Bad("failed to read greeting".to_string()))?;
 
         Ok(Client::Secure(client))
     }
@@ -61,7 +61,7 @@ impl Client {
         let _greeting = client
             .read_response()
             .await
-            .expect("failed to read greeting");
+            .ok_or_else(|| ImapError::Bad("failed to read greeting".to_string()))?;
 
         Ok(Client::Insecure(client))
     }


### PR DESCRIPTION
a greeting is something like  "*OK Dovecot ready" -- without this PR a missing greeting panics.  see https://github.com/async-email/async-imap/commit/4f0852971c3f397c2b8a343ef1378992c02f61de for the fix in async-imap.  This PR also fixes DCC's own reading of the greeting in imap_client.rs. 

This might address #1054 