### PR TITLE
try doing an smtp-send timeout

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -201,9 +201,17 @@ impl Job {
                         println!("{}", String::from_utf8_lossy(&body));
                     }
                     match task::block_on(smtp.send(context, recipients_list, body, self.job_id)) {
+                        Err(crate::smtp::send::Error::SendTimeout(err)) => {
+                            warn!(context, "SMTP send timed out {:?}", err);
+                            smtp.disconnect();
+                            self.try_again_later(
+                                TryAgain::AtOnce,
+                                Some("send-timeout".to_string()),
+                            );
+                        }
                         Err(crate::smtp::send::Error::SendError(err)) => {
                             // Remote error, retry later.
-                            info!(context, "SMTP failed to send: {}", err);
+                            warn!(context, "SMTP failed to send: {}", err);
                             smtp.disconnect();
                             self.try_again_later(TryAgain::AtOnce, Some(err.to_string()));
                         }

--- a/src/smtp/send.rs
+++ b/src/smtp/send.rs
@@ -57,10 +57,10 @@ impl Smtp {
             message,
         );
         if let Some(ref mut transport) = self.transport {
-            let res = async_std::future::timeout(Duration::from_secs(SEND_TIMEOUT), async move {
-                transport.send(mail).await.map_err(Error::SendError)
-            })
-            .await?;
+            let res =
+                async_std::future::timeout(Duration::from_secs(SEND_TIMEOUT), transport.send(mail))
+                    .await?
+                    .map_err(Error::SendError);
 
             res.map(|_response| {
                 context.call_cb(Event::SmtpMessageSent(format!(


### PR DESCRIPTION
This PR introduces an async-timeout on SMTP send like we do in idle/done() handling. 

alternatively we could try setting a TCP_NODELAY which i think for smtp would be fine as there is no IDLE waiting -- we are basically only doing send() and if that doesn't get traffic for a minute or two it's fine to cancel i guess.  So how about using TCP_NODELAY for smtp? 