### PR TITLE
try trim down logging 

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1546,10 +1546,6 @@ fn dc_add_or_lookup_contacts_by_address_list(
         }
     };
 
-    info!(
-        context,
-        "dc_add_or_lookup_contacts_by_address raw={:?} addrs={:?}", addr_list_raw, addrs
-    );
     for addr in addrs.iter() {
         match addr {
             mailparse::MailAddr::Single(info) => {
@@ -1591,10 +1587,6 @@ fn add_or_lookup_contact_by_addr(
         .map(normalize_name)
         .unwrap_or_default();
 
-    info!(
-        context,
-        "looking up addr={:?} display_name={:?}", addr, display_name_normalized
-    );
     let (row_id, _modified) =
         Contact::add_or_lookup(context, display_name_normalized, addr, origin)?;
     ensure!(row_id > 0, "could not add contact: {:?}", addr);

--- a/src/log.rs
+++ b/src/log.rs
@@ -8,9 +8,8 @@ macro_rules! info {
     ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
         let thread = ::std::thread::current();
-        let full = format!("{thid:?}/{thname} {file}:{line}: {msg}",
+        let full = format!("{thid:?} {file}:{line}: {msg}",
                            thid = thread.id(),
-                           thname = thread.name().unwrap_or("unnamed"),
                            file = file!(),
                            line = line!(),
                            msg = &formatted);
@@ -26,9 +25,8 @@ macro_rules! warn {
     ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
         let formatted = format!($msg, $($args),*);
         let thread = ::std::thread::current();
-        let full = format!("{thid:?}/{thname} {file}:{line}: {msg}",
+        let full = format!("{thid:?} {file}:{line}: {msg}",
                            thid = thread.id(),
-                           thname = thread.name().unwrap_or("unnamed"),
                            file = file!(),
                            line = line!(),
                            msg = &formatted);


### PR DESCRIPTION
- info/warn logging: thread-name seems to be unnamed all the time so it's use is currently theoretic
I'd also like to not print "ThreadId(NUM)" redundantly but not sure what is a good way to get at NUM :/

- remove two info! logs that were too verbose on message-receive and were rather useful for earlier debugging efforts but not now anymore. 