### PR TITLE
fix(smtp): reduce SMTP I/O timeout to 30 seconds

### DIFF
--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -13,8 +13,8 @@ use crate::events::Event;
 use crate::login_param::{dc_build_tls, LoginParam};
 use crate::oauth2::*;
 
-/// SMTP write and read times out after 15 minutes.
-const SMTP_TIMEOUT: u64 = 15 * 60;
+/// SMTP write and read timeout in seconds.
+const SMTP_TIMEOUT: u64 = 30;
 
 #[derive(Debug, Fail)]
 pub enum Error {


### PR DESCRIPTION
15 minute timeout was used because it applied to the whole send()
operation. Now timeout applies to each I/O operation, such as read()
or write(), so it can be made much shorter. In particular, this timeout
applies to read() call right after connection to plain or STARTTLS server,
in which case it is not reasonable to wait 15 minutes to receive one
line of data.

The timeout is triggered only if no progress is made within 30 seconds. It
likely indicates a network failure anyway.

Fixes #1062 