### PR TITLE
never block on interrupt_inbox_idle

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -509,7 +509,7 @@ pub unsafe extern "C" fn dc_interrupt_imap_idle(context: *mut dc_context_t) {
     }
     let ffi_context = &*context;
     ffi_context
-        .with_inner(|ctx| job::interrupt_inbox_idle(ctx, true))
+        .with_inner(|ctx| job::interrupt_inbox_idle(ctx))
         .unwrap_or(())
 }
 

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -491,7 +491,7 @@ pub fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::Error> {
             println!("{:#?}", context.get_info());
         }
         "interrupt" => {
-            interrupt_inbox_idle(context, true);
+            interrupt_inbox_idle(context);
         }
         "maybenetwork" => {
             maybe_network(context);

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -202,7 +202,7 @@ fn stop_threads(context: &Context) {
         println!("Stopping threads");
         IS_RUNNING.store(false, Ordering::Relaxed);
 
-        interrupt_inbox_idle(context, true);
+        interrupt_inbox_idle(context);
         interrupt_mvbox_idle(context);
         interrupt_sentbox_idle(context);
         interrupt_smtp_idle(context);

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -104,7 +104,7 @@ fn main() {
     println!("stopping threads");
 
     *running.write().unwrap() = false;
-    deltachat::job::interrupt_inbox_idle(&ctx, true);
+    deltachat::job::interrupt_inbox_idle(&ctx);
     deltachat::job::interrupt_smtp_idle(&ctx);
 
     println!("joining");

--- a/src/config.rs
+++ b/src/config.rs
@@ -144,7 +144,7 @@ impl Context {
             }
             Config::InboxWatch => {
                 let ret = self.sql.set_raw_config(self, key, value);
-                interrupt_inbox_idle(self, true);
+                interrupt_inbox_idle(self);
                 ret
             }
             Config::SentboxWatch => {


### PR DESCRIPTION
generally, we don't know what the inbox imap thread is concurrently doing so blocking is dangerous. 