### PR TITLE
fix group members not appearing in contact list 

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1209,6 +1209,15 @@ class TestGroupStressTests:
         print("chat is", msg.chat)
         assert len(msg.chat.get_contacts()) == 4
 
+        lp.sec("ac3: checking that 'ac4' is a known contact")
+        ac3 = accounts[1]
+        msg3 = ac3.wait_next_incoming_message()
+        assert msg3.text == "hello"
+        contacts = ac3.get_contacts()
+        assert len(contacts) == 3
+        ac4_contacts = ac3.get_contacts(query=accounts[2].get_config("addr"))
+        assert len(ac4_contacts) == 1
+
         lp.sec("ac1: removing one contacts and checking things are right")
         to_remove = msg.chat.get_contacts()[-1]
         msg.chat.remove_contact(to_remove)

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -401,6 +401,7 @@ impl Contact {
         {
             row_id = sql::get_rowid(context, &context.sql, "contacts", "addr", addr);
             sth_modified = Modifier::Created;
+            info!(context, "added contact id={} addr={}", row_id, addr);
         } else {
             error!(context, "Cannot add contact.");
         }
@@ -486,7 +487,7 @@ impl Contact {
                 params![
                     self_addr,
                     DC_CONTACT_ID_LAST_SPECIAL as i32,
-                    0x100,
+                    Origin::IncomingReplyTo,
                     &s3str_like_cmd,
                     &s3str_like_cmd,
                     if flag_verified_only { 0 } else { 1 },

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -115,14 +115,10 @@ impl Default for Origin {
 
 impl Origin {
     /// Contacts that are known, i. e. they came in via accepted contacts or
-    /// themselves an accepted contact.
+    /// themselves an accepted contact. Known contacts are shown in the
+    /// contact list when one creates a chat and wants to add members etc.
     pub fn is_known(self) -> bool {
         self >= Origin::IncomingReplyTo
-    }
-
-    /// Contacts that are shown in the contact list.
-    pub fn include_in_contactlist(self) -> bool {
-        self as i32 >= DC_ORIGIN_MIN_CONTACT_LIST
     }
 }
 

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -114,9 +114,10 @@ impl Default for Origin {
 }
 
 impl Origin {
-    /// Contacts that are verified and known not to be spam.
-    pub fn is_verified(self) -> bool {
-        self as i32 >= 0x100
+    /// Contacts that are known, i. e. they came in via accepted contacts or
+    /// themselves an accepted contact.
+    pub fn is_known(self) -> bool {
+        self >= Origin::IncomingReplyTo
     }
 
     /// Contacts that are shown in the contact list.

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -137,8 +137,8 @@ pub fn dc_receive_imf(
         }
     }
 
-    for header_def in vec![HeaderDef::To, HeaderDef::Cc] {
-        if let Some(field) = mime_parser.get(header_def) {
+    for header_def in &[HeaderDef::To, HeaderDef::Cc] {
+        if let Some(field) = mime_parser.get(header_def.clone()) {
             dc_add_or_lookup_contacts_by_address_list(
                 context,
                 &field,

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -144,7 +144,7 @@ pub fn dc_receive_imf(
                 &field,
                 if !incoming {
                     Origin::OutgoingTo
-                } else if incoming_origin.is_verified() {
+                } else if incoming_origin.is_known() {
                     Origin::IncomingTo
                 } else {
                     Origin::IncomingUnknownTo
@@ -427,7 +427,7 @@ fn add_parts(
                         context,
                         "Message is a reply to a known message, mark sender as known.",
                     );
-                    if !incoming_origin.is_verified() {
+                    if !incoming_origin.is_known() {
                         incoming_origin = Origin::IncomingReplyTo;
                     }
                 }
@@ -443,7 +443,7 @@ fn add_parts(
         // to not result in a chatlist-contact-request (this would require the state FRESH)
         if Blocked::Not != chat_id_blocked
             && state == MessageState::InFresh
-            && !incoming_origin.is_verified()
+            && !incoming_origin.is_known()
             && msgrmsg == 0
             && show_emails != ShowEmails::All
         {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -176,7 +176,7 @@ pub fn dc_receive_imf(
             &mut mime_parser,
             imf_raw,
             incoming,
-            &mut incoming_origin,
+            incoming_origin,
             server_folder.as_ref(),
             server_uid,
             &to_ids,
@@ -255,7 +255,7 @@ fn add_parts(
     mut mime_parser: &mut MimeParser,
     imf_raw: &[u8],
     incoming: bool,
-    incoming_origin: &mut Origin,
+    incoming_origin: Origin,
     server_folder: impl AsRef<str>,
     server_uid: u32,
     to_ids: &ContactIds,
@@ -278,6 +278,7 @@ fn add_parts(
     let mut rcvd_timestamp = 0;
     let mut mime_in_reply_to = String::new();
     let mut mime_references = String::new();
+    let mut incoming_origin = incoming_origin;
 
     // XXX check usage of and possibly remove the need for this var
     let to_id = to_ids.get_index(0).cloned().unwrap_or_default();
@@ -427,7 +428,7 @@ fn add_parts(
                         "Message is a reply to a known message, mark sender as known.",
                     );
                     if !incoming_origin.is_verified() {
-                        *incoming_origin = Origin::IncomingReplyTo;
+                        incoming_origin = Origin::IncomingReplyTo;
                     }
                 }
             }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -322,7 +322,7 @@ fn add_parts(
         } else {
             MessageState::InFresh
         };
-        to_id = to_ids.get_index(0).cloned().unwrap_or_default();
+        to_id = DC_CONTACT_ID_SELF;
         let mut needs_stop_ongoing_process = false;
 
         // handshake messages must be processed _before_ chats are created
@@ -458,7 +458,7 @@ fn add_parts(
         // the mail is on the IMAP server, probably it is also delivered.
         // We cannot recreate other states (read, error).
         state = MessageState::OutDelivered;
-        to_id = DC_CONTACT_ID_SELF;
+        to_id = to_ids.get_index(0).cloned().unwrap_or_default();
         if !to_ids.is_empty() {
             if *chat_id == 0 {
                 let (new_chat_id, new_chat_id_blocked) = create_or_lookup_group(


### PR DESCRIPTION
- fix ordering of parsing of To header to happen after parsing From header -- the latter determines incoming_origin and therefore To-contacts were not added with the proper incoming_origin. This lead to group contacts not being shown when creating a chat 
- move some vars to become non-mut or not even passed to add_parts(), to ease reasoning about what's going on. (more can be done here but i didn't want to modify too much) 
