### PR TITLE
treat unknown senders to a group chat specially, avoid recreating member list 

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -877,10 +877,15 @@ fn create_or_lookup_group(
                 mime_parser.repl_msg_by_error(s);
             }
         }
-        // check if the sender is a member of the existing group -
-        // if not, we'll recreate the group list
         if !chat::is_contact_in_chat(context, chat_id, from_id as u32) {
-            recreate_member_list = true;
+            // The From-address is not part of this group.
+            // It could be a new user or a DSN from a mailer-daemon.
+            // in any case we do not want to recreate the member list
+            // but still show the message as part of the chat.
+            // After all, the sender has a reference/in-reply-to that
+            // points to this chat.
+            let s = context.stock_str(StockMessage::UnknownSenderForChat);
+            mime_parser.repl_msg_by_error(s.to_string());
         }
     }
 

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -185,6 +185,9 @@ pub enum StockMessage {
                     Recipients don't need to install Delta Chat, visit websites or sign up anywhere - \
                     however, of course, if they like, you may point them to 👉 https://get.delta.chat"))]
     WelcomeMessage = 71,
+
+    #[strum(props(fallback = "Unknown Sender for this chat. See 'info' for more details."))]
+    UnknownSenderForChat = 72,
 }
 
 /*


### PR DESCRIPTION
fix #1077 for unknown senders in a group chat (such as mailer daemons……): 

- don't recreate member list and
- show a special stockstring-ed message advising to hit "more info".

