### PR TITLE
prep beta21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog 
 
+## 1.0.0-beta.21
+
+- #1078 #1082 ensure RFC compliance by producing 78 column lines for
+  encoded attachments. 
+
+- #1080 don't recreate and thus break group membership if an unknown 
+  sender (or mailer-daemon) sends a message referencing the group chat 
+
+- #1081 #1079 some internal cleanups 
+
+- update imap-proto dependency, to fix yandex/oauth 
+
 ## 1.0.0-beta.20
 
 - #1074 fix OAUTH2/gmail

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.0.0-beta.20"
+version = "1.0.0-beta.21"
 dependencies = [
  "async-imap 0.1.1 (git+https://github.com/async-email/async-imap?branch=dcc-stable)",
  "async-native-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.0.0-beta.20"
+version = "1.0.0-beta.21"
 dependencies = [
- "deltachat 1.0.0-beta.20",
+ "deltachat 1.0.0-beta.21",
  "deltachat-provider-database 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-panic 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1418,7 +1418,7 @@ dependencies = [
 [[package]]
 name = "imap-proto"
 version = "0.9.1"
-source = "git+https://github.com/djc/tokio-imap#2b8701b83c50085b7ffcdf26a95146b91f93a6d5"
+source = "git+https://github.com/djc/tokio-imap#de420791b4e240242592616938407b742454c46c"
 dependencies = [
  "nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.0.0-beta.20"
+version = "1.0.0-beta.21"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 license = "MPL"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.0.0-beta.20"
+version = "1.0.0-beta.21"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"


### PR DESCRIPTION
this also pulls in a newer imap-proto that should fix yandex/oauth parsing as it merged a PR from our chief magician @dignifiedquire 