### PR TITLE
Up to date Readme.rst

### DIFF
--- a/python/README.rst
+++ b/python/README.rst
@@ -6,71 +6,41 @@ This package provides bindings to the deltachat-core_ Rust -library
 which provides imap/smtp/crypto handling as well as chat/group/messages
 handling to Android, Desktop and IO user interfaces.
 
-Installing pre-built packages (linux-only)
-==========================================
 
-If you have a linux system you may install the ``deltachat`` binary "wheel" package
-without any "build-from-source" steps.
-
-1. `Install virtualenv <https://virtualenv.pypa.io/en/stable/installation/>`_,
-   then create a fresh python environment and activate it in your shell::
-
-        virtualenv venv  # or: python -m venv
-        source venv/bin/activate
-
-   Afterwards, invoking ``python`` or ``pip install`` will only
-   modify files in your ``venv`` directory and leave your system installation
-   alone.
-
-2. Install the wheel for linux::
-
-        pip install deltachat
-
-    Verify it worked by typing::
-
-        python -c "import deltachat"
-
-
-Installing a wheel from a PR/branch
----------------------------------------
-
-For Linux, we automatically build wheels for all github PR branches
-and push them to a python package index. To install the latest github ``master`` branch::
-
-    pip install -i https://m.devpi.net/dc/master deltachat
-
-.. note::
-
-    If you can help to automate the building of wheels for Mac or Windows,
-    that'd be much appreciated! please then get
-    `in contact with us <https://delta.chat/en/contribute>`_.
-
-
-Installing bindings from source
+Installing bindings from source   (Updated: 21-Dec-2019)
 ===============================
 
-If you can't use "binary" method above then you need to compile
-to core deltachat library::
+To compile and use the Python Bindings from source::
 
-    git clone https://github.com/deltachat/deltachat-core-rust
-    cd deltachat-core-rust
-    cd python
+Lets do a quick package update (using Ubuntu 18.04 with python3.6), make sure you have proper python and pip installed too (I am using python3 and pip3)::
 
-If you don't have one active, create and activate a python "virtualenv":
 
-    python virtualenv venv  # or python -m venv
-    source venv/bin/activate
+   apt update
+   apt install python3-pip
+   pip3 install pytest pytest-timeout pytest-rerunfailures requests
 
-Afterwards ``which python`` tells you that it comes out of the "venv"
-directory that contains all python install artifacts. Let's first
-install test tools::
 
-    pip install pytest pytest-timeout pytest-rerunfailures requests
 
-then cargo-build and install the deltachat bindings::
+Install Rust and Cargo first, we are doing a NIGHTLY Rust install otherwise one of the dependency (Subtle v2.2.2) will fail, it only works with Nightly versions::
 
-    python install_python_bindings.py
+   cd 
+   curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly
+   
+GIT clone the repo and run the Python Binding installation script::
 
+   git clone https://github.com/deltachat/deltachat-core-rust
+   cd deltachat-core-rust
+   cd python
+   python3 install_python_bindings.py
+
+If you still get a error saying compiling failed or !feature not supported in this release/stable, use the following command below and re-run the above command to recompile::
+
+   rustup install nightly
+   ## OR ##
+   /root/.cargo/bin/rustup install nightly
+
+
+The installation takes 20-60 minutes (depending on your machine). 
 The bindings will be installed in release mode but with debug symbols.
 The release mode is necessary because some tests generate RSA keys
 which is prohibitively slow in debug mode.
@@ -102,6 +72,53 @@ If you want to run "liveconfig" functional tests you can set
 
 With ``DCC_PY_LIVECONFIG`` set pytest invocations will use real
 e-mail accounts and run through all functional "liveconfig" tests.
+
+
+============================================================================================================================
+(21-Dec-2019) THE BELOW WHEELS ARE CURRENTLY NOT WORKING/BROKEN, COMPILE FROM SOURCE USING ABOVE INSTRUCTIONS INSTEAD 
+============================================================================================================================
+
+Installing pre-built packages (linux-only)  (OUTDATED)
+==========================================
+
+If you have a linux system you may install the ``deltachat`` binary "wheel" package
+without any "build-from-source" steps.
+
+1. `Install virtualenv <https://virtualenv.pypa.io/en/stable/installation/>`_,
+   then create a fresh python environment and activate it in your shell::
+
+        virtualenv venv  # or: python -m venv
+        source venv/bin/activate
+
+   Afterwards, invoking ``python`` or ``pip install`` will only
+   modify files in your ``venv`` directory and leave your system installation
+   alone.
+
+2. Install the wheel for linux::
+
+        pip install deltachat
+
+    Verify it worked by typing::
+
+        python -c "import deltachat"
+
+
+Installing a wheel from a PR/branch    (OUTDATED)
+---------------------------------------
+
+For Linux, we automatically build wheels for all github PR branches
+and push them to a python package index. To install the latest github ``master`` branch::
+
+    pip install -i https://m.devpi.net/dc/master deltachat
+
+.. note::
+
+    If you can help to automate the building of wheels for Mac or Windows,
+    that'd be much appreciated! please then get
+    `in contact with us <https://delta.chat/en/contribute>`_.
+
+
+
 
 
 


### PR DESCRIPTION
-Moved wheels installation below source installation and added comment that they are outdated and not working atm
-Updated source compilation/installation to a more step by step process as current one was outdated and not working due to Rust now needing nightly build else failing to compile (subtle v2.2.2 do not work without nightly)