### PR TITLE
refactor(smtp): remove unused SendTimeout Error variant

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -201,14 +201,6 @@ impl Job {
                         println!("{}", String::from_utf8_lossy(&body));
                     }
                     match task::block_on(smtp.send(context, recipients_list, body, self.job_id)) {
-                        Err(crate::smtp::send::Error::SendTimeout(err)) => {
-                            warn!(context, "SMTP send timed out {:?}", err);
-                            smtp.disconnect();
-                            self.try_again_later(
-                                TryAgain::AtOnce,
-                                Some("send-timeout".to_string()),
-                            );
-                        }
                         Err(crate::smtp::send::Error::SendError(err)) => {
                             // Remote error, retry later.
                             warn!(context, "SMTP failed to send: {}", err);

--- a/src/smtp/send.rs
+++ b/src/smtp/send.rs
@@ -18,15 +18,6 @@ pub enum Error {
 
     #[fail(display = "SMTP has no transport")]
     NoTransport,
-
-    #[fail(display = "SMTP send timed out")]
-    SendTimeout(#[cause] async_std::future::TimeoutError),
-}
-
-impl From<async_std::future::TimeoutError> for Error {
-    fn from(err: async_std::future::TimeoutError) -> Error {
-        Error::SendTimeout(err)
-    }
 }
 
 impl Smtp {


### PR DESCRIPTION
It was used when timeout was set on the whole smtp.send() operation.
Now only the operations inside smtp.send() can timeout, and such timeout
errors result in SendError, so SendTimeout is unused.