### PR TITLE
Remove unwrap() from time() function

### DIFF
--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -486,7 +486,7 @@ pub(crate) fn dc_get_next_backup_path(
 pub(crate) fn time() -> i64 {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
+        .unwrap_or_default()
         .as_secs() as i64
 }
 


### PR DESCRIPTION
This change is a part of the effort to enable `clippy::option_unwrap_used` and `clippy::result_unwrap_used`