### PR TITLE
Stop using Event callback return values

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -122,74 +122,79 @@ impl ContextWrapper {
     }
 
     /// Translates the callback from the rust style to the C-style version.
-    unsafe fn translate_cb(&self, event: Event) -> uintptr_t {
-        match self.cb {
-            Some(ffi_cb) => {
-                let event_id = event.as_id();
-                match event {
-                    Event::Info(msg)
-                    | Event::SmtpConnected(msg)
-                    | Event::ImapConnected(msg)
-                    | Event::SmtpMessageSent(msg)
-                    | Event::ImapMessageDeleted(msg)
-                    | Event::ImapMessageMoved(msg)
-                    | Event::ImapFolderEmptied(msg)
-                    | Event::NewBlobFile(msg)
-                    | Event::DeletedBlobFile(msg)
-                    | Event::Warning(msg)
-                    | Event::Error(msg)
-                    | Event::ErrorNetwork(msg)
-                    | Event::ErrorSelfNotInGroup(msg) => {
-                        let data2 = CString::new(msg).unwrap_or_default();
-                        ffi_cb(self, event_id, 0, data2.as_ptr() as uintptr_t)
-                    }
-                    Event::MsgsChanged { chat_id, msg_id }
-                    | Event::IncomingMsg { chat_id, msg_id }
-                    | Event::MsgDelivered { chat_id, msg_id }
-                    | Event::MsgFailed { chat_id, msg_id }
-                    | Event::MsgRead { chat_id, msg_id } => ffi_cb(
+    unsafe fn translate_cb(&self, event: Event) {
+        if let Some(ffi_cb) = self.cb {
+            let event_id = event.as_id();
+            match event {
+                Event::Info(msg)
+                | Event::SmtpConnected(msg)
+                | Event::ImapConnected(msg)
+                | Event::SmtpMessageSent(msg)
+                | Event::ImapMessageDeleted(msg)
+                | Event::ImapMessageMoved(msg)
+                | Event::ImapFolderEmptied(msg)
+                | Event::NewBlobFile(msg)
+                | Event::DeletedBlobFile(msg)
+                | Event::Warning(msg)
+                | Event::Error(msg)
+                | Event::ErrorNetwork(msg)
+                | Event::ErrorSelfNotInGroup(msg) => {
+                    let data2 = CString::new(msg).unwrap_or_default();
+                    ffi_cb(self, event_id, 0, data2.as_ptr() as uintptr_t);
+                }
+                Event::MsgsChanged { chat_id, msg_id }
+                | Event::IncomingMsg { chat_id, msg_id }
+                | Event::MsgDelivered { chat_id, msg_id }
+                | Event::MsgFailed { chat_id, msg_id }
+                | Event::MsgRead { chat_id, msg_id } => {
+                    ffi_cb(
                         self,
                         event_id,
                         chat_id as uintptr_t,
                         msg_id.to_u32() as uintptr_t,
-                    ),
-                    Event::ChatModified(chat_id) => ffi_cb(self, event_id, chat_id as uintptr_t, 0),
-                    Event::ContactsChanged(id) | Event::LocationChanged(id) => {
-                        let id = id.unwrap_or_default();
-                        ffi_cb(self, event_id, id as uintptr_t, 0)
-                    }
-                    Event::ConfigureProgress(progress) | Event::ImexProgress(progress) => {
-                        ffi_cb(self, event_id, progress as uintptr_t, 0)
-                    }
-                    Event::ImexFileWritten(file) => {
-                        let data1 = file.to_c_string().unwrap_or_default();
-                        ffi_cb(self, event_id, data1.as_ptr() as uintptr_t, 0)
-                    }
-                    Event::SecurejoinInviterProgress {
-                        contact_id,
-                        progress,
-                    }
-                    | Event::SecurejoinJoinerProgress {
-                        contact_id,
-                        progress,
-                    } => ffi_cb(
+                    );
+                }
+                Event::ChatModified(chat_id) => {
+                    ffi_cb(self, event_id, chat_id as uintptr_t, 0);
+                }
+                Event::ContactsChanged(id) | Event::LocationChanged(id) => {
+                    let id = id.unwrap_or_default();
+                    ffi_cb(self, event_id, id as uintptr_t, 0);
+                }
+                Event::ConfigureProgress(progress) | Event::ImexProgress(progress) => {
+                    ffi_cb(self, event_id, progress as uintptr_t, 0);
+                }
+                Event::ImexFileWritten(file) => {
+                    let data1 = file.to_c_string().unwrap_or_default();
+                    ffi_cb(self, event_id, data1.as_ptr() as uintptr_t, 0);
+                }
+                Event::SecurejoinInviterProgress {
+                    contact_id,
+                    progress,
+                }
+                | Event::SecurejoinJoinerProgress {
+                    contact_id,
+                    progress,
+                } => {
+                    ffi_cb(
                         self,
                         event_id,
                         contact_id as uintptr_t,
                         progress as uintptr_t,
-                    ),
-                    Event::SecurejoinMemberAdded {
-                        chat_id,
-                        contact_id,
-                    } => ffi_cb(
+                    );
+                }
+                Event::SecurejoinMemberAdded {
+                    chat_id,
+                    contact_id,
+                } => {
+                    ffi_cb(
                         self,
                         event_id,
                         chat_id as uintptr_t,
                         contact_id as uintptr_t,
-                    ),
+                    );
                 }
             }
-            None => 0,
         }
     }
 }

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -41,7 +41,7 @@ use self::cmdline::*;
 
 // Event Handler
 
-fn receive_event(_context: &Context, event: Event) -> libc::uintptr_t {
+fn receive_event(_context: &Context, event: Event) {
     match event {
         Event::Info(msg) => {
             /* do not show the event as this would fill the screen */
@@ -111,8 +111,6 @@ fn receive_event(_context: &Context, event: Event) -> libc::uintptr_t {
             print!("\x1b[33m{{Received {:?}}}\n\x1b[0m", event);
         }
     }
-
-    0
 }
 
 // Threads for waiting for messages and for jobs

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -16,21 +16,18 @@ use deltachat::job::{
 };
 use deltachat::Event;
 
-fn cb(_ctx: &Context, event: Event) -> usize {
+fn cb(_ctx: &Context, event: Event) {
     print!("[{:?}]", event);
 
     match event {
         Event::ConfigureProgress(progress) => {
             print!("  progress: {}\n", progress);
-            0
         }
         Event::Info(msg) | Event::Warning(msg) | Event::Error(msg) | Event::ErrorNetwork(msg) => {
             print!("  {}\n", msg);
-            0
         }
         _ => {
             print!("\n");
-            0
         }
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -21,56 +21,38 @@ pub enum Event {
     /// The library-user may write an informational string to the log.
     /// Passed to the callback given to dc_context_new().
     /// This event should not be reported to the end-user using a popup or something like that.
-    ///
-    /// @return 0
     #[strum(props(id = "100"))]
     Info(String),
 
     /// Emitted when SMTP connection is established and login was successful.
-    ///
-    /// @return 0
     #[strum(props(id = "101"))]
     SmtpConnected(String),
 
     /// Emitted when IMAP connection is established and login was successful.
-    ///
-    /// @return 0
     #[strum(props(id = "102"))]
     ImapConnected(String),
 
     /// Emitted when a message was successfully sent to the SMTP server.
-    ///
-    /// @return 0
     #[strum(props(id = "103"))]
     SmtpMessageSent(String),
 
     /// Emitted when an IMAP message has been marked as deleted
-    ///
-    /// @return 0
     #[strum(props(id = "104"))]
     ImapMessageDeleted(String),
 
     /// Emitted when an IMAP message has been moved
-    ///
-    /// @return 0
     #[strum(props(id = "105"))]
     ImapMessageMoved(String),
 
     /// Emitted when an IMAP folder was emptied
-    ///
-    /// @return 0
     #[strum(props(id = "106"))]
     ImapFolderEmptied(String),
 
     /// Emitted when an new file in the $BLOBDIR was created
-    ///
-    /// @return 0
     #[strum(props(id = "150"))]
     NewBlobFile(String),
 
     /// Emitted when an new file in the $BLOBDIR was created
-    ///
-    /// @return 0
     #[strum(props(id = "151"))]
     DeletedBlobFile(String),
 
@@ -78,8 +60,6 @@ pub enum Event {
     /// Passed to the callback given to dc_context_new().
     ///
     /// This event should not be reported to the end-user using a popup or something like that.
-    ///
-    /// @return 0
     #[strum(props(id = "300"))]
     Warning(String),
 
@@ -94,8 +74,6 @@ pub enum Event {
     /// it might be better to delay showing these events until the function has really
     /// failed (returned false). It should be sufficient to report only the *last* error
     /// in a messasge box then.
-    ///
-    /// @return
     #[strum(props(id = "400"))]
     Error(String),
 
@@ -112,8 +90,6 @@ pub enum Event {
     /// Moreover, if the UI detects that the device is offline,
     /// it is probably more useful to report this to the user
     /// instead of the string from data2.
-    ///
-    /// @return 0
     #[strum(props(id = "401"))]
     ErrorNetwork(String),
 
@@ -122,8 +98,6 @@ pub enum Event {
     /// dc_set_chat_name(), dc_set_chat_profile_image(),
     /// dc_add_contact_to_chat(), dc_remove_contact_from_chat(),
     /// dc_send_text_msg() or another sending function.
-    ///
-    /// @return 0
     #[strum(props(id = "410"))]
     ErrorSelfNotInGroup(String),
 
@@ -132,8 +106,6 @@ pub enum Event {
     /// - Messages sent, received or removed
     /// - Chats created, deleted or archived
     /// - A draft has been set
-    ///
-    /// @return 0
     #[strum(props(id = "2000"))]
     MsgsChanged { chat_id: u32, msg_id: MsgId },
 
@@ -141,29 +113,21 @@ pub enum Event {
     /// when receiving this message.
     ///
     /// There is no extra #DC_EVENT_MSGS_CHANGED event send together with this event.
-    ///
-    /// @return 0
     #[strum(props(id = "2005"))]
     IncomingMsg { chat_id: u32, msg_id: MsgId },
 
     /// A single message is sent successfully. State changed from  DC_STATE_OUT_PENDING to
     /// DC_STATE_OUT_DELIVERED, see dc_msg_get_state().
-    ///
-    /// @return 0
     #[strum(props(id = "2010"))]
     MsgDelivered { chat_id: u32, msg_id: MsgId },
 
     /// A single message could not be sent. State changed from DC_STATE_OUT_PENDING or DC_STATE_OUT_DELIVERED to
     /// DC_STATE_OUT_FAILED, see dc_msg_get_state().
-    ///
-    /// @return 0
     #[strum(props(id = "2012"))]
     MsgFailed { chat_id: u32, msg_id: MsgId },
 
     /// A single message is read by the receiver. State changed from DC_STATE_OUT_DELIVERED to
     /// DC_STATE_OUT_MDN_RCVD, see dc_msg_get_state().
-    ///
-    /// @return 0
     #[strum(props(id = "2015"))]
     MsgRead { chat_id: u32, msg_id: MsgId },
 
@@ -171,15 +135,12 @@ pub enum Event {
     /// Or the verify state of a chat has changed.
     /// See dc_set_chat_name(), dc_set_chat_profile_image(), dc_add_contact_to_chat()
     /// and dc_remove_contact_from_chat().
-    ///
-    /// @return 0
     #[strum(props(id = "2020"))]
     ChatModified(u32),
 
     /// Contact(s) created, renamed, blocked or deleted.
     ///
     /// @param data1 (int) If set, this is the contact_id of an added contact that should be selected.
-    /// @return 0
     #[strum(props(id = "2030"))]
     ContactsChanged(Option<u32>),
 
@@ -188,14 +149,12 @@ pub enum Event {
     /// @param data1 (u32) contact_id of the contact for which the location has changed.
     ///     If the locations of several contacts have been changed,
     ///     eg. after calling dc_delete_all_locations(), this parameter is set to `None`.
-    /// @return 0
     #[strum(props(id = "2035"))]
     LocationChanged(Option<u32>),
 
     /// Inform about the configuration progress started by configure().
     ///
     /// @param data1 (usize) 0=error, 1-999=progress in permille, 1000=success and done
-    /// @return 0
     #[strum(props(id = "2041"))]
     ConfigureProgress(usize),
 
@@ -203,7 +162,6 @@ pub enum Event {
     ///
     /// @param data1 (usize) 0=error, 1-999=progress in permille, 1000=success and done
     /// @param data2 0
-    /// @return 0
     #[strum(props(id = "2051"))]
     ImexProgress(usize),
 
@@ -214,7 +172,6 @@ pub enum Event {
     /// services.
     ///
     /// @param data2 0
-    /// @return 0
     #[strum(props(id = "2052"))]
     ImexFileWritten(PathBuf),
 
@@ -230,7 +187,6 @@ pub enum Event {
     ///     600=vg-/vc-request-with-auth received, vg-member-added/vc-contact-confirm sent, typically shown as "bob@addr verified".
     ///     800=vg-member-added-received received, shown as "bob@addr securely joined GROUP", only sent for the verified-group-protocol.
     ///     1000=Protocol finished for this contact.
-    /// @return 0
     #[strum(props(id = "2060"))]
     SecurejoinInviterProgress { contact_id: u32, progress: usize },
 
@@ -242,14 +198,12 @@ pub enum Event {
     /// @param data2 (int) Progress as:
     ///     400=vg-/vc-request-with-auth sent, typically shown as "alice@addr verified, introducing myself."
     ///     (Bob has verified alice and waits until Alice does the same for him)
-    /// @return 0
     #[strum(props(id = "2061"))]
     SecurejoinJoinerProgress { contact_id: u32, progress: usize },
 
     /// This event is sent out to the inviter when a joiner successfully joined a group.
     /// @param data1 (int) chat_id
     /// @param data2 (int) contact_id
-    /// @return 0
     #[strum(props(id = "2062"))]
     SecurejoinMemberAdded { chat_id: u32, contact_id: u32 },
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -2,7 +2,6 @@
 //!
 //! This module is only compiled for test runs.
 
-use libc::uintptr_t;
 use tempfile::{tempdir, TempDir};
 
 use crate::config::Config;
@@ -31,7 +30,7 @@ pub fn test_context(callback: Option<Box<ContextCallback>>) -> TestContext {
     let dbfile = dir.path().join("db.sqlite");
     let cb: Box<ContextCallback> = match callback {
         Some(cb) => cb,
-        None => Box::new(|_, _| 0),
+        None => Box::new(|_, _| ()),
     };
     let ctx = Context::new(cb, "FakeOs".into(), dbfile).unwrap();
     TestContext { ctx, dir }
@@ -46,14 +45,13 @@ pub fn dummy_context() -> TestContext {
     test_context(None)
 }
 
-pub fn logging_cb(_ctx: &Context, evt: Event) -> uintptr_t {
+pub fn logging_cb(_ctx: &Context, evt: Event) {
     match evt {
         Event::Info(msg) => println!("I: {}", msg),
         Event::Warning(msg) => println!("W: {}", msg),
         Event::Error(msg) => println!("E: {}", msg),
         _ => (),
     }
-    0
 }
 
 /// Creates Alice with a pre-generated keypair.

--- a/tests/stress.rs
+++ b/tests/stress.rs
@@ -203,9 +203,7 @@ fn test_encryption_decryption() {
     assert_eq!(plain, original_text);
 }
 
-fn cb(_context: &Context, _event: Event) -> libc::uintptr_t {
-    0
-}
+fn cb(_context: &Context, _event: Event) {}
 
 #[allow(dead_code)]
 struct TestContext {


### PR DESCRIPTION
Since stock string callback has been deprecated, all event callbacks
return 0.

For compatibility, C declarations are not changed and FFI users are
expected to return 0 from their callbacks.