### PR TITLE
Use usize to get pointer size

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -86,12 +86,7 @@ pub fn get_info() -> HashMap<&'static str, String> {
         "sqlite_thread_safe",
         unsafe { rusqlite::ffi::sqlite3_threadsafe() }.to_string(),
     );
-    res.insert(
-        "arch",
-        (std::mem::size_of::<*mut libc::c_void>())
-            .wrapping_mul(8)
-            .to_string(),
-    );
+    res.insert("arch", (std::mem::size_of::<usize>() * 8).to_string());
     res.insert("level", "awesome".into());
     res
 }


### PR DESCRIPTION
According to Rust documentation, usize is "The pointer-sized unsigned
integer type".

This change removes unnecessary libc dependency and makes top_evil_rs
script happier.