### PR TITLE
reset device-chat on import

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2510,6 +2510,25 @@ mod tests {
         assert!(forward_msgs(&t.ctx, &[msg_id], device_chat_id).is_err());
     }
 
+    #[test]
+    fn test_delete_and_reset_all_device_msgs() {
+        let t = test_context(Some(Box::new(logging_cb)));
+        let mut msg = Message::new(Viewtype::Text);
+        msg.text = Some("message text".to_string());
+        let msg_id1 = add_device_msg(&t.ctx, Some("some-label"), Some(&mut msg)).unwrap();
+
+        // adding a device message with the same label won't be executed again ...
+        assert!(was_device_msg_ever_added(&t.ctx, "some-label").unwrap());
+        let msg_id2 = add_device_msg(&t.ctx, Some("some-label"), Some(&mut msg)).unwrap();
+        assert!(msg_id2.is_unset());
+
+        // ... unless everything is deleted and resetted - as needed eg. on device switch
+        delete_and_reset_all_device_msgs(&t.ctx).unwrap();
+        assert!(!was_device_msg_ever_added(&t.ctx, "some-label").unwrap());
+        let msg_id3 = add_device_msg(&t.ctx, Some("some-label"), Some(&mut msg)).unwrap();
+        assert_ne!(msg_id1, msg_id3);
+    }
+
     fn chatlist_len(ctx: &Context, listflags: usize) -> usize {
         Chatlist::try_load(ctx, listflags, None, None)
             .unwrap()

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2197,6 +2197,22 @@ pub fn was_device_msg_ever_added(context: &Context, label: &str) -> Result<bool,
     Ok(false)
 }
 
+// needed on device-switches during export/import;
+// - deletion in `msgs` with `DC_CONTACT_ID_DEVICE` makes sure,
+//   no wrong information are shown in the device chat
+// - deletion in `devmsglabels` makes sure,
+//   deleted messages are resetted and useful messages can be added again
+pub fn delete_and_reset_all_device_msgs(context: &Context) -> Result<(), Error> {
+    context.sql.execute(
+        "DELETE FROM msgs WHERE from_id=?;",
+        params![DC_CONTACT_ID_DEVICE],
+    )?;
+    context
+        .sql
+        .execute("DELETE FROM devmsglabels;", params![])?;
+    Ok(())
+}
+
 /// Adds an informational message to chat.
 ///
 /// For example, it can be a message showing that a member was added to a group.

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -8,6 +8,7 @@ use rand::{thread_rng, Rng};
 
 use crate::blob::BlobObject;
 use crate::chat;
+use crate::chat::delete_and_reset_all_device_msgs;
 use crate::config::Config;
 use crate::configure::*;
 use crate::constants::*;
@@ -440,6 +441,8 @@ fn import_backup(context: &Context, backup_to_import: impl AsRef<Path>) -> Resul
         context.sql.open(&context, &context.get_dbfile(), false),
         "could not re-open db"
     );
+
+    delete_and_reset_all_device_msgs(&context)?;
 
     let total_files_cnt = context
         .sql


### PR DESCRIPTION
if we do not reset the device-chat on import, this may result in 
- wrong information (changelog of the wrong system)
- maybe unfunctional message (tap here to optimize battery won't work on desktop)
- important information that cannot be added again (the user may have deleted the message on the other device as it was no issue there - and labeled message are not added again)

there maybe more sophisticated approaches to solve these issues, but this one is simple :)

fixes https://github.com/deltachat/deltachat-android/issues/1187