### PR TITLE
Make job error handling functional

### DIFF
--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -50,15 +50,15 @@ pub fn dc_is_configured(context: &Context) -> bool {
  * Configure JOB
  ******************************************************************************/
 #[allow(non_snake_case, unused_must_use)]
-pub fn JobConfigureImap(context: &Context) {
+pub fn JobConfigureImap(context: &Context) -> Try {
     if !context.sql.is_open() {
         error!(context, "Cannot configure, database not opened.",);
         progress!(context, 0);
-        return;
+        return Try::Finished(Err(format_err!("Database not opened")));
     }
     if !context.alloc_ongoing() {
         progress!(context, 0);
-        return;
+        return Try::Finished(Err(format_err!("Cannot allocated ongoing process")));
     }
     let mut success = false;
     let mut imap_connected_here = false;
@@ -441,6 +441,7 @@ pub fn JobConfigureImap(context: &Context) {
 
     context.free_ongoing();
     progress!(context, if success { 1000 } else { 0 });
+    Try::Finished(Ok(()))
 }
 
 fn get_offline_autoconfig(context: &Context, param: &LoginParam) -> Option<LoginParam> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,9 @@ pub enum Error {
     #[fail(display = "Building invalid Email: {:?}", _0)]
     LettreError(#[cause] lettre_email::error::Error),
 
+    #[fail(display = "SMTP error: {:?}", _0)]
+    SmtpError(#[cause] async_smtp::error::Error),
+
     #[fail(display = "FromStr error: {:?}", _0)]
     FromStr(#[cause] mime::FromStrError),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 #![allow(clippy::match_bool)]
 #![feature(ptr_wrapping_offset_from)]
 #![feature(drain_filter)]
-#![feature(try_trait)]
 
 #[macro_use]
 extern crate failure_derive;
@@ -43,6 +42,7 @@ mod e2ee;
 mod imap;
 mod imap_client;
 pub mod imex;
+#[macro_use]
 pub mod job;
 mod job_thread;
 pub mod key;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 #![allow(clippy::match_bool)]
 #![feature(ptr_wrapping_offset_from)]
 #![feature(drain_filter)]
+#![feature(try_trait)]
 
 #[macro_use]
 extern crate failure_derive;


### PR DESCRIPTION
This will make it possible to distinguish between successful and unsuccessful finish of job in `job_preform` and log the error there.