### PR TITLE
search for special chat names

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -720,6 +720,28 @@ pub fn update_device_icon(context: &Context) -> Result<(), Error> {
     Ok(())
 }
 
+fn update_special_chat_name(
+    context: &Context,
+    contact_id: u32,
+    stock_id: StockMessage,
+) -> Result<(), Error> {
+    if let Ok((chat_id, _)) = lookup_by_contact_id(context, contact_id) {
+        let name: String = context.stock_str(stock_id).into();
+        // the `!= name` condition avoids unneeded writes
+        context.sql.execute(
+            "UPDATE chats SET name=? WHERE id=? AND name!=?;",
+            params![name, chat_id, name],
+        )?;
+    }
+    Ok(())
+}
+
+pub fn update_special_chat_names(context: &Context) -> Result<(), Error> {
+    update_special_chat_name(context, DC_CONTACT_ID_DEVICE, StockMessage::DeviceMessages)?;
+    update_special_chat_name(context, DC_CONTACT_ID_SELF, StockMessage::SavedMessages)?;
+    Ok(())
+}
+
 pub fn create_or_lookup_by_contact_id(
     context: &Context,
     contact_id: u32,

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -162,6 +162,10 @@ impl Chatlist {
             let query = query.trim().to_string();
             ensure!(!query.is_empty(), "missing query");
 
+            // allow searching over special names that may change at any time
+            // when the ui calls set_stock_translation()
+            update_special_chat_names(context)?;
+
             let str_like_cmd = format!("%{}%", query);
             context.sql.query_map(
                 "SELECT c.id, m.id

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -384,4 +384,27 @@ mod tests {
         let chats = Chatlist::try_load(&t.ctx, DC_GCL_ARCHIVED_ONLY, None, None).unwrap();
         assert_eq!(chats.len(), 1);
     }
+
+    #[test]
+    fn test_search_special_chat_names() {
+        let t = dummy_context();
+        t.ctx.update_device_chats().unwrap();
+
+        let chats = Chatlist::try_load(&t.ctx, 0, Some("t-1234-s"), None).unwrap();
+        assert_eq!(chats.len(), 0);
+        let chats = Chatlist::try_load(&t.ctx, 0, Some("t-5678-b"), None).unwrap();
+        assert_eq!(chats.len(), 0);
+
+        t.ctx
+            .set_stock_translation(StockMessage::SavedMessages, "test-1234-save".to_string())
+            .unwrap();
+        let chats = Chatlist::try_load(&t.ctx, 0, Some("t-1234-s"), None).unwrap();
+        assert_eq!(chats.len(), 1);
+
+        t.ctx
+            .set_stock_translation(StockMessage::DeviceMessages, "test-5678-babbel".to_string())
+            .unwrap();
+        let chats = Chatlist::try_load(&t.ctx, 0, Some("t-5678-b"), None).unwrap();
+        assert_eq!(chats.len(), 1);
+    }
 }


### PR DESCRIPTION
this pr updates the chat names in the database to the ones provided by the ui (localized names).

we have to do that before every search as we currently do not know when the ui changes the names, however, compared to the following search, this should be a quick sql statement.

fixes #1112