### PR TITLE
Mark the ChatInfo struct non_exhaustive

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -523,6 +523,7 @@ impl Chat {
 
 /// The current state of a chat.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ChatInfo {
     /// The chat ID.
     pub id: u32,


### PR DESCRIPTION
This is a new feature in Rust 1.40, it means users outside the crate
will not be able to create these structs, allowing us to add fields
without breaking the public API.