### PR TITLE
do not abort search completely when updating a special name fails

### DIFF
--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -164,7 +164,9 @@ impl Chatlist {
 
             // allow searching over special names that may change at any time
             // when the ui calls set_stock_translation()
-            update_special_chat_names(context)?;
+            if let Err(err) = update_special_chat_names(context) {
+                warn!(context, "cannot update special chat names: {:?}", err)
+            }
 
             let str_like_cmd = format!("%{}%", query);
             context.sql.query_map(


### PR DESCRIPTION
in general, update-special-name-errors should not break getting chatlists.