### PR TITLE
handle plain OPENPGP4FRP qr-codes correctly

### DIFF
--- a/src/qr.rs
+++ b/src/qr.rs
@@ -471,4 +471,24 @@ mod tests {
         assert_eq!(contact.get_addr(), "cli@deltachat.de");
         assert_eq!(contact.get_name(), "Jörn P. P.");
     }
+
+    #[test]
+    fn test_decode_openpgp_without_addr() {
+        let ctx = dummy_context();
+
+        let res = check_qr(
+            &ctx.ctx,
+            "OPENPGP4FPR:1234567890123456789012345678901234567890",
+        );
+        assert_eq!(res.get_state(), LotState::QrFprWithoutAddr);
+        assert_eq!(
+            res.get_text1().unwrap(),
+            "1234 5678 9012 3456 7890\n1234 5678 9012 3456 7890"
+        );
+        assert_eq!(res.get_id(), 0);
+
+        let res = check_qr(&ctx.ctx, "OPENPGP4FPR:12345678901234567890");
+        assert_eq!(res.get_state(), LotState::QrError);
+        assert_eq!(res.get_id(), 0);
+    }
 }


### PR DESCRIPTION
this pr fixes the handling of plain OPENPGP4FRP as used eg. by openkeychain. the possible result values were defined correctly and the ui handles these cases, however, there was an early exit when the addr was not set - which is always the case for plain OPENPGP4FRP qr-codes.

fixes #1127