### PR TITLE
hide messages with Secure-Join headers

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -348,6 +348,10 @@ fn add_parts(
                     needs_stop_ongoing_process = ret.stop_ongoing_process;
                 }
                 Err(err) => {
+                    // maybe this message belongs to an aborted scan,
+                    // however, by the explicit header check we really know
+                    // that it is a Secure-Join message that should be hidden in the chat view.
+                    *hidden = true;
                     warn!(
                         context,
                         "Unexpected messaged passed to Secure-Join handshake protocol: {}", err


### PR DESCRIPTION
this pr hides messages belonging to a failed/incomplete/unknown secure-join from the message list.

we do not delete them from the server, might be that other devices make some use of it or so, not sure.

should fix #1129 