### PR TITLE
Simplify handling of MDNs

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -722,11 +722,13 @@ class TestOnlineAccount:
         ac2.mark_seen_messages([msg])
 
         lp.sec("ac1: waiting for incoming activity")
-        # wait for MOVED event because even ignored read-receipts should be moved
+        # MDN should be moved even though MDNs are already disabled
         ac1._evlogger.get_matching("DC_EVENT_IMAP_MESSAGE_MOVED")
 
         assert len(chat.get_messages()) == 1
-        assert not msg_out.is_out_mdn_received()
+
+        # MDN is received even though MDNs are already disabled
+        assert msg_out.is_out_mdn_received()
 
     def test_send_and_receive_will_encrypt_decrypt(self, acfactory, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -776,28 +776,28 @@ impl<'a> MimeMessage<'a> {
             return;
         }
 
-            let mut mdn_recognized = false;
+        let mut mdn_recognized = false;
         for report in &self.reports {
-                if let Some((chat_id, msg_id)) = message::mdn_from_ext(
-                    self.context,
-                    from_id,
-                    &report.original_message_id,
-                    sent_timestamp,
-                ) {
-                    self.context.call_cb(Event::MsgRead { chat_id, msg_id });
-                    mdn_recognized = true;
-                }
+            if let Some((chat_id, msg_id)) = message::mdn_from_ext(
+                self.context,
+                from_id,
+                &report.original_message_id,
+                sent_timestamp,
+            ) {
+                self.context.call_cb(Event::MsgRead { chat_id, msg_id });
+                mdn_recognized = true;
+            }
         }
 
-            if self.has_chat_version() || mdn_recognized {
-                let mut param = Params::new();
-                param.set(Param::ServerFolder, server_folder.as_ref());
-                param.set_int(Param::ServerUid, server_uid as i32);
-                if self.has_chat_version() && self.context.get_config_bool(Config::MvboxMove) {
-                    param.set_int(Param::AlsoMove, 1);
-                }
-                job_add(self.context, Action::MarkseenMdnOnImap, 0, param, 0);
+        if self.has_chat_version() || mdn_recognized {
+            let mut param = Params::new();
+            param.set(Param::ServerFolder, server_folder.as_ref());
+            param.set_int(Param::ServerUid, server_uid as i32);
+            if self.has_chat_version() && self.context.get_config_bool(Config::MvboxMove) {
+                param.set_int(Param::AlsoMove, 1);
             }
+            job_add(self.context, Action::MarkseenMdnOnImap, 0, param, 0);
+        }
     }
 }
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -776,9 +776,8 @@ impl<'a> MimeMessage<'a> {
             return;
         }
 
-        for report in &self.reports {
             let mut mdn_recognized = false;
-
+        for report in &self.reports {
                 if let Some((chat_id, msg_id)) = message::mdn_from_ext(
                     self.context,
                     from_id,
@@ -788,6 +787,7 @@ impl<'a> MimeMessage<'a> {
                     self.context.call_cb(Event::MsgRead { chat_id, msg_id });
                     mdn_recognized = true;
                 }
+        }
 
             if self.has_chat_version() || mdn_recognized {
                 let mut param = Params::new();
@@ -798,7 +798,6 @@ impl<'a> MimeMessage<'a> {
                 }
                 job_add(self.context, Action::MarkseenMdnOnImap, 0, param, 0);
             }
-        }
     }
 }
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -775,14 +775,10 @@ impl<'a> MimeMessage<'a> {
         if self.reports.is_empty() {
             return;
         }
-        // If a user disabled MDNs we do not show pending incoming ones anymore
-        // but we do want them to potentially get moved from the INBOX still.
-        let mdns_enabled = self.context.get_config_bool(Config::MdnsEnabled);
 
         for report in &self.reports {
             let mut mdn_recognized = false;
 
-            if mdns_enabled {
                 if let Some((chat_id, msg_id)) = message::mdn_from_ext(
                     self.context,
                     from_id,
@@ -792,9 +788,8 @@ impl<'a> MimeMessage<'a> {
                     self.context.call_cb(Event::MsgRead { chat_id, msg_id });
                     mdn_recognized = true;
                 }
-            }
 
-            if self.has_chat_version() || mdn_recognized || !mdns_enabled {
+            if self.has_chat_version() || mdn_recognized {
                 let mut param = Params::new();
                 param.set(Param::ServerFolder, server_folder.as_ref());
                 param.set_int(Param::ServerUid, server_uid as i32);


### PR DESCRIPTION
This is a preparation for #505 

This PR removes dependency of MDN reception on user configuration of MDNs (disabling MDNs only affects sending and *requesting* of them now, not reception) and fixes creation of multiple jobs that mark MDN message as seen and move it when it contains multiple MDNs.