### PR TITLE
send DC_EVENT_CHAT_MODIFIED when adding members to a group

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1663,6 +1663,7 @@ pub(crate) fn add_contact_to_chat_ex(
         chat_id,
         msg_id: MsgId::new(0),
     });
+    context.call_cb(Event::ChatModified(chat_id));
     Ok(true)
 }
 


### PR DESCRIPTION
this fixes sending out DC_EVENT_CHAT_MODIFIED. it was sent out on removing members, changing name etc. - but it was missing on adding members.

add_contact_to_chat_ex() is called during a secure-join and also by the corresponding api-function, in both cases, the event should be sent.

fixes the bug described in https://github.com/deltachat/deltachat-ios/pull/473