### PR TITLE
feat: mute chat

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2952,7 +2952,7 @@ int             dc_chat_is_muted (const dc_chat_t* chat);
  * @param chat The chat object.
  * @return 0=not muted, -1=forever muted, (x>0)=remaining seconds until the mute is lifted
  */
-int64_t          dc_chat_get_mute_duration (const dc_chat_t* chat);
+int64_t          dc_chat_get_remaining_mute_duration (const dc_chat_t* chat);
 
 
 /**

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1577,6 +1577,22 @@ int             dc_set_chat_name             (dc_context_t* context, uint32_t ch
 int             dc_set_chat_profile_image    (dc_context_t* context, uint32_t chat_id, const char* image);
 
 
+
+/**
+ * Set mute duration of a chat.
+ *
+ * This value can be checked by the ui upon recieving a new message to decide whether it should trigger an notification.
+ *
+ * Sends out #DC_EVENT_CHAT_MODIFIED.
+ *
+ * @memberof dc_context_t
+ * @param chat_id The chat ID to set the mute duration.
+ * @param duration The duration (0 for no mute, 1 for forever mute, >1 unix timestamp it until it should be unmuted again)
+ * @param context The context as created by dc_context_new().
+ * @return 1=success, 0=error
+ */
+int             dc_set_chat_muted             (dc_context_t* context, uint32_t chat_id, int64_t duration);
+
 // handle messages
 
 /**
@@ -2917,6 +2933,26 @@ int             dc_chat_is_verified          (const dc_chat_t* chat);
  * @return 1=locations are sent to chat, 0=no locations are sent to chat
  */
 int             dc_chat_is_sending_locations (const dc_chat_t* chat);
+
+
+/**
+ * Check wether the chat is currently muted
+ *
+ * @memberof dc_chat_t
+ * @param chat The chat object.
+ * @return 1=muted, 0=not muted
+ */
+int             dc_chat_is_muted (const dc_chat_t* chat);
+
+
+/**
+ * Get the exact state of the mute of a chat
+ *
+ * @memberof dc_chat_t
+ * @param chat The chat object.
+ * @return 0=not muted, 1=muted, (x>1)=unix timestamp until mute is lifted
+ */
+int64_t          dc_chat_get_mute_duration (const dc_chat_t* chat);
 
 
 /**

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1581,7 +1581,7 @@ int             dc_set_chat_profile_image    (dc_context_t* context, uint32_t ch
 /**
  * Set mute duration of a chat.
  *
- * This value can be checked by the ui upon recieving a new message to decide whether it should trigger an notification.
+ * This value can be checked by the ui upon receiving a new message to decide whether it should trigger an notification.
  *
  * Sends out #DC_EVENT_CHAT_MODIFIED.
  *
@@ -1591,7 +1591,7 @@ int             dc_set_chat_profile_image    (dc_context_t* context, uint32_t ch
  * @param context The context as created by dc_context_new().
  * @return 1=success, 0=error
  */
-int             dc_chat_set_mute_duration             (dc_context_t* context, uint32_t chat_id, int64_t duration);
+int             dc_set_chat_mute_duration             (dc_context_t* context, uint32_t chat_id, int64_t duration);
 
 // handle messages
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1587,7 +1587,7 @@ int             dc_set_chat_profile_image    (dc_context_t* context, uint32_t ch
  *
  * @memberof dc_context_t
  * @param chat_id The chat ID to set the mute duration.
- * @param duration The duration (0 for no mute, 1 for forever mute, >1 unix timestamp it until it should be unmuted again)
+ * @param duration The duration (0 for no mute, -1 for forever mute, >0 unix timestamp it until it should be unmuted again)
  * @param context The context as created by dc_context_new().
  * @return 1=success, 0=error
  */
@@ -2936,7 +2936,7 @@ int             dc_chat_is_sending_locations (const dc_chat_t* chat);
 
 
 /**
- * Check wether the chat is currently muted
+ * Check whether the chat is currently muted
  *
  * @memberof dc_chat_t
  * @param chat The chat object.
@@ -2950,7 +2950,7 @@ int             dc_chat_is_muted (const dc_chat_t* chat);
  *
  * @memberof dc_chat_t
  * @param chat The chat object.
- * @return 0=not muted, 1=muted, (x>1)=unix timestamp until mute is lifted
+ * @return 0=not muted, -1=forever muted, (x>0)=unix timestamp until mute is lifted
  */
 int64_t          dc_chat_get_mute_duration (const dc_chat_t* chat);
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1587,11 +1587,11 @@ int             dc_set_chat_profile_image    (dc_context_t* context, uint32_t ch
  *
  * @memberof dc_context_t
  * @param chat_id The chat ID to set the mute duration.
- * @param duration The duration (0 for no mute, -1 for forever mute, >0 unix timestamp it until it should be unmuted again)
+ * @param duration The duration (0 for no mute, -1 for forever mute, everything else is is the relative mute duration from now in seconds)
  * @param context The context as created by dc_context_new().
  * @return 1=success, 0=error
  */
-int             dc_set_chat_muted             (dc_context_t* context, uint32_t chat_id, int64_t duration);
+int             dc_chat_set_mute_duration             (dc_context_t* context, uint32_t chat_id, int64_t duration);
 
 // handle messages
 
@@ -2950,7 +2950,7 @@ int             dc_chat_is_muted (const dc_chat_t* chat);
  *
  * @memberof dc_chat_t
  * @param chat The chat object.
- * @return 0=not muted, -1=forever muted, (x>0)=unix timestamp until mute is lifted
+ * @return 0=not muted, -1=forever muted, (x>0)=remaining seconds until the mute is lifted
  */
 int64_t          dc_chat_get_mute_duration (const dc_chat_t* chat);
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1431,7 +1431,7 @@ pub unsafe extern "C" fn dc_chat_set_mute_duration(
     let ffi_context = &*context;
     ffi_context
         .with_inner(|ctx| {
-            chat::set_muted(ctx, chat_id, muteDuration)
+            chat::set_muted(ctx, ChatId::new(chat_id), muteDuration)
                 .map(|_| 1)
                 .unwrap_or_log_default(ctx, "Failed to set mute duration")
         })

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2523,9 +2523,9 @@ pub unsafe extern "C" fn dc_chat_is_muted(chat: *mut dc_chat_t) -> libc::c_int {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_chat_get_mute_duration(chat: *mut dc_chat_t) -> i64 {
+pub unsafe extern "C" fn dc_chat_get_remaining_mute_duration(chat: *mut dc_chat_t) -> i64 {
     if chat.is_null() {
-        eprintln!("ignoring careless call to dc_chat_get_mute_duration()");
+        eprintln!("ignoring careless call to dc_chat_get_remaining_mute_duration()");
         return 0;
     }
     let ffi_chat = &*chat;

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1408,6 +1408,26 @@ pub unsafe extern "C" fn dc_set_chat_profile_image(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_set_chat_muted(
+    context: *mut dc_context_t,
+    chat_id: u32,
+    duration: i64,
+) -> libc::c_int {
+    if context.is_null() || chat_id <= constants::DC_CHAT_ID_LAST_SPECIAL as u32 {
+        eprintln!("ignoring careless call to dc_set_chat_muted()");
+        return 0;
+    }
+    let ffi_context = &*context;
+    ffi_context
+        .with_inner(|ctx| {
+            chat::set_muted(ctx, chat_id, chat::MuteDuration::deserialize(duration))
+                .map(|_| 1)
+                .unwrap_or_log_default(ctx, "Failed to set mute duration")
+        })
+        .unwrap_or(0)
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_get_msg_info(
     context: *mut dc_context_t,
     msg_id: u32,
@@ -2479,6 +2499,26 @@ pub unsafe extern "C" fn dc_chat_is_sending_locations(chat: *mut dc_chat_t) -> l
     }
     let ffi_chat = &*chat;
     ffi_chat.chat.is_sending_locations() as libc::c_int
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dc_chat_is_muted(chat: *mut dc_chat_t) -> libc::c_int {
+    if chat.is_null() {
+        eprintln!("ignoring careless call to dc_chat_is_muted()");
+        return 0;
+    }
+    let ffi_chat = &*chat;
+    ffi_chat.chat.is_muted() as libc::c_int
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dc_chat_get_mute_duration(chat: *mut dc_chat_t) -> i64 {
+    if chat.is_null() {
+        eprintln!("ignoring careless call to dc_chat_is_muted()");
+        return 0;
+    }
+    let ffi_chat = &*chat;
+    ffi_chat.chat.mute_duration.serialize() as i64
 }
 
 #[no_mangle]

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1415,7 +1415,7 @@ pub unsafe extern "C" fn dc_set_chat_mute_duration(
     chat_id: u32,
     duration: i64,
 ) -> libc::c_int {
-    if context.is_null() || chat_id <= constants::DC_CHAT_ID_LAST_SPECIAL as u32 {
+    if context.is_null() {
         eprintln!("ignoring careless call to dc_set_chat_mute_duration()");
         return 0;
     }

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1412,13 +1412,13 @@ pub unsafe extern "C" fn dc_set_chat_profile_image(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_chat_set_mute_duration(
+pub unsafe extern "C" fn dc_set_chat_mute_duration(
     context: *mut dc_context_t,
     chat_id: u32,
     duration: i64,
 ) -> libc::c_int {
     if context.is_null() || chat_id <= constants::DC_CHAT_ID_LAST_SPECIAL as u32 {
-        eprintln!("ignoring careless call to dc_chat_set_mute_duration()");
+        eprintln!("ignoring careless call to dc_set_chat_mute_duration()");
         return 0;
     }
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1425,7 +1425,7 @@ pub unsafe extern "C" fn dc_set_chat_mute_duration(
     let muteDuration = match duration {
         0 => MuteDuration::NotMuted,
         -1 => MuteDuration::Forever,
-        _ => MuteDuration::MutedUntilTimestamp(time() + duration),
+        _ => MuteDuration::Until(time() + duration),
     };
 
     let ffi_context = &*context;
@@ -2535,7 +2535,7 @@ pub unsafe extern "C" fn dc_chat_get_remaining_mute_duration(chat: *mut dc_chat_
     match ffi_chat.chat.mute_duration {
         MuteDuration::NotMuted => 0,
         MuteDuration::Forever => -1,
-        MuteDuration::MutedUntilTimestamp(timestamp) => timestamp - time(),
+        MuteDuration::Until(timestamp) => timestamp - time(),
     }
 }
 

--- a/deltachat-ffi/src/tools.rs
+++ b/deltachat-ffi/src/tools.rs
@@ -1,0 +1,8 @@
+use std::time::SystemTime;
+
+pub(crate) fn time() -> i64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -123,7 +123,7 @@ class Chat(object):
         :param duration: 
         :returns: Returns the number of seconds the chat is still muted for. (0 for not muted, -1 forever muted)
         """
-        return bool(lib.dc_chat_get_mute_duration(self.id))
+        return bool(lib.dc_chat_get_remaining_mute_duration(self.id))
 
     def get_type(self):
         """ return type of this chat.

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -101,13 +101,15 @@ class Chat(object):
         """ mutes the chat
 
         :param duration: Number of seconds to mute the chat for. None to mute until unmuted again.
-        :returns:
+        :returns: None
         """
         if duration is None:
             mute_duration = -1
         else:
             mute_duration = duration
-        return bool(lib.dc_set_chat_mute_duration(self._dc_context, self.id, mute_duration))
+        ret = lib.dc_set_chat_mute_duration(self._dc_context, self.id, mute_duration)
+        if not bool(ret):
+            raise ValueError("Call to dc_set_chat_mute_duration failed")
 
     def unmute(self):
         """ unmutes the chat

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -114,9 +114,11 @@ class Chat(object):
     def unmute(self):
         """ unmutes the chat
 
-        :returns:
+        :returns: None
         """
-        return bool(lib.dc_set_chat_mute_duration(self._dc_context, self.id, 0))
+        ret = lib.dc_set_chat_mute_duration(self._dc_context, self.id, 0)
+        if not bool(ret):
+            raise ValueError("Failed to unmute chat")
 
     def get_mute_duration(self):
         """ Returns the number of seconds until the mute of this chat is lifted.

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -108,14 +108,14 @@ class Chat(object):
             mute_duration = -1
         else:
             mute_duration = duration
-        return bool(lib.dc_chat_set_mute_duration(self._dc_context, self.id, mute_duration))
+        return bool(lib.dc_set_chat_mute_duration(self._dc_context, self.id, mute_duration))
 
     def unmute(self):
         """ unmutes the chat
 
         :returns: 
         """
-        return bool(lib.dc_chat_set_mute_duration(self._dc_context, self.id, 0))
+        return bool(lib.dc_set_chat_mute_duration(self._dc_context, self.id, 0))
 
     def get_mute_duration(self):
         """ Returns the number of seconds until the mute of this chat is lifted.

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -5,7 +5,6 @@ import calendar
 import json
 from datetime import datetime
 import os
-import time
 from .cutil import as_dc_charpointer, from_dc_charpointer, iter_array
 from .capi import lib, ffi
 from . import const
@@ -97,12 +96,12 @@ class Chat(object):
         """
         name = as_dc_charpointer(name)
         return lib.dc_set_chat_name(self._dc_context, self.id, name)
-    
+
     def mute(self, duration=None):
         """ mutes the chat
 
         :param duration: Number of seconds to mute the chat for. None to mute until unmuted again.
-        :returns: 
+        :returns:
         """
         if duration is None:
             mute_duration = -1
@@ -113,14 +112,14 @@ class Chat(object):
     def unmute(self):
         """ unmutes the chat
 
-        :returns: 
+        :returns:
         """
         return bool(lib.dc_set_chat_mute_duration(self._dc_context, self.id, 0))
 
     def get_mute_duration(self):
         """ Returns the number of seconds until the mute of this chat is lifted.
 
-        :param duration: 
+        :param duration:
         :returns: Returns the number of seconds the chat is still muted for. (0 for not muted, -1 forever muted)
         """
         return bool(lib.dc_chat_get_remaining_mute_duration(self.id))

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -5,6 +5,7 @@ import calendar
 import json
 from datetime import datetime
 import os
+import time
 from .cutil import as_dc_charpointer, from_dc_charpointer, iter_array
 from .capi import lib, ffi
 from . import const
@@ -58,6 +59,13 @@ class Chat(object):
         """
         return self.id == const.DC_CHAT_ID_DEADDROP
 
+    def is_muted(self):
+        """ return true if this chat is muted.
+
+        :returns: True if chat is muted, False otherwise.
+        """
+        return lib.dc_chat_is_muted(self._dc_chat)
+
     def is_promoted(self):
         """ return True if this chat is promoted, i.e.
         the member contacts are aware of their membership,
@@ -84,11 +92,38 @@ class Chat(object):
     def set_name(self, name):
         """ set name of this chat.
 
-        :param: name as a unicode string.
+        :param name: as a unicode string.
         :returns: None
         """
         name = as_dc_charpointer(name)
         return lib.dc_set_chat_name(self._dc_context, self.id, name)
+    
+    def mute(self, duration=None):
+        """ mutes the chat
+
+        :param duration: Number of seconds to mute the chat for. None to mute until unmuted again.
+        :returns: 
+        """
+        if duration is None:
+            timestamp = -1
+        else:
+            timestamp = int(time.time()) + duration
+        return bool(lib.dc_set_chat_muted(self._dc_context, self.id, timestamp))
+
+    def unmute(self):
+        """ unmutes the chat
+
+        :returns: 
+        """
+        return bool(lib.dc_set_chat_muted(self._dc_context, self.id, 0))
+
+    def get_mute_duration(self):
+        """ mutes the chat
+
+        :param duration: 
+        :returns: Returns the number of seconds the chat is still muted for. (0 for not muted, -1 forever muted)
+        """
+        return bool(lib.dc_chat_get_mute_duration(self.id))
 
     def get_type(self):
         """ return type of this chat.

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -105,20 +105,20 @@ class Chat(object):
         :returns: 
         """
         if duration is None:
-            timestamp = -1
+            mute_duration = -1
         else:
-            timestamp = int(time.time()) + duration
-        return bool(lib.dc_set_chat_muted(self._dc_context, self.id, timestamp))
+            mute_duration = duration
+        return bool(lib.dc_chat_set_mute_duration(self._dc_context, self.id, mute_duration))
 
     def unmute(self):
         """ unmutes the chat
 
         :returns: 
         """
-        return bool(lib.dc_set_chat_muted(self._dc_context, self.id, 0))
+        return bool(lib.dc_chat_set_mute_duration(self._dc_context, self.id, 0))
 
     def get_mute_duration(self):
-        """ mutes the chat
+        """ Returns the number of seconds until the mute of this chat is lifted.
 
         :param duration: 
         :returns: Returns the number of seconds the chat is still muted for. (0 for not muted, -1 forever muted)

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -223,11 +223,11 @@ class TestOfflineChat:
     def test_mute(self, ac1):
         chat = ac1.create_group_chat(name="title1")
         assert not chat.is_muted()
-        assert chat.mute()
+        chat.mute()
         assert chat.is_muted()
-        assert chat.unmute()
+        chat.unmute()
         assert not chat.is_muted()
-        assert chat.mute(50)
+        chat.mute(50)
         assert chat.is_muted()
         with pytest.raises(ValueError):
             chat.mute(-51)

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -229,8 +229,8 @@ class TestOfflineChat:
         assert not chat.is_muted()
         assert chat.mute(50)
         assert chat.is_muted()
-        assert chat.mute(-51)
-        assert not chat.is_muted()
+        with pytest.raises(ValueError):
+            chat.mute(-51)
 
     def test_delete_and_send_fails(self, ac1, chat1):
         chat1.delete()

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -220,6 +220,18 @@ class TestOfflineChat:
         chat.remove_profile_image()
         assert chat.get_profile_image() is None
 
+    def test_mute(self, ac1):
+        chat = ac1.create_group_chat(name="title1")
+        assert not chat.is_muted()
+        assert chat.mute()
+        assert chat.is_muted()
+        assert chat.unmute()
+        assert not chat.is_muted()
+        assert chat.mute(50)
+        assert chat.is_muted()
+        assert chat.mute(-51)
+        assert not chat.is_muted()
+
     def test_delete_and_send_fails(self, ac1, chat1):
         chat1.delete()
         ac1._evlogger.get_matching("DC_EVENT_MSGS_CHANGED")

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1944,7 +1944,6 @@ impl MuteDuration {
 }
 
 pub fn set_muted(context: &Context, chat_id: ChatId, duration: MuteDuration) -> Result<(), Error> {
-    let mut success = false;
     ensure!(!chat_id.is_special(), "Invalid chat ID");
     if real_group_exists(context, chat_id)
         && sql::execute(
@@ -1956,10 +1955,7 @@ pub fn set_muted(context: &Context, chat_id: ChatId, duration: MuteDuration) -> 
         .is_ok()
     {
         context.call_cb(Event::ChatModified(chat_id));
-        success = true;
-    }
-
-    if !success {
+    } else {
         bail!("Failed to set name");
     }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -422,6 +422,7 @@ pub struct Chat {
     blocked: Blocked,
     pub param: Params,
     is_sending_locations: bool,
+    pub mute_duration: MuteDuration,
 }
 
 impl Chat {
@@ -429,7 +430,7 @@ impl Chat {
     pub fn load_from_db(context: &Context, chat_id: ChatId) -> Result<Self, Error> {
         let res = context.sql.query_row(
             "SELECT c.type, c.name, c.grpid, c.param, c.archived,
-                    c.blocked, c.locations_send_until
+                    c.blocked, c.locations_send_until, c.muted_until
              FROM chats c
              WHERE c.id=?;",
             params![chat_id],
@@ -443,6 +444,7 @@ impl Chat {
                     archived: row.get(4)?,
                     blocked: row.get::<_, Option<_>>(5)?.unwrap_or_default(),
                     is_sending_locations: row.get(6)?,
+                    mute_duration: MuteDuration::deserialize(row.get(7)?),
                 };
                 Ok(c)
             },
@@ -658,6 +660,7 @@ impl Chat {
             profile_image: self.get_profile_image(context).unwrap_or_else(PathBuf::new),
             subtitle: self.get_subtitle(context),
             draft,
+            is_muted: self.is_muted(),
         })
     }
 
@@ -682,6 +685,14 @@ impl Chat {
     /// Returns true if location streaming is enabled in the chat.
     pub fn is_sending_locations(&self) -> bool {
         self.is_sending_locations
+    }
+
+    pub fn is_muted(&self) -> bool {
+        match self.mute_duration {
+            MuteDuration::NotMuted => false,
+            MuteDuration::Forever => true,
+            MuteDuration::MutedUntilTimestamp(timestamp) => timestamp > time(),
+        }
     }
 
     fn prepare_msg_raw(
@@ -968,6 +979,11 @@ pub struct ChatInfo {
     ///       which contain non-text parts.  Perhaps it should be a
     ///       simple `has_draft` bool instead.
     pub draft: String,
+
+    /// Wether the chat is muted
+    /// 
+    /// The exact time its muted can be found out via the `chat.mute_duration` property
+    pub is_muted:bool,
     // ToDo:
     // - [ ] deaddrop,
     // - [ ] summary,
@@ -1901,6 +1917,56 @@ pub fn shall_attach_selfavatar(context: &Context, chat_id: ChatId) -> Result<boo
     Ok(needs_attach)
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum MuteDuration {
+    NotMuted,
+    Forever,
+    MutedUntilTimestamp(i64),
+}
+
+impl MuteDuration {
+    // TODO use serde compatible functions?
+    fn serialize (&self) -> i64 {
+        match &self {
+            MuteDuration::NotMuted => 0,
+            MuteDuration::Forever => 1,
+            MuteDuration::MutedUntilTimestamp(timestamp) => *timestamp as i64, // TODO make this pretier?
+        }
+    }
+
+    fn deserialize (value: i64) -> MuteDuration {
+        match value {
+            0 => MuteDuration::NotMuted,
+            1 => MuteDuration::Forever,
+            _ => MuteDuration::MutedUntilTimestamp(value),
+        }
+    }
+}
+
+pub fn set_muted (
+    context: &Context,
+    chat_id: ChatId,
+    duration: MuteDuration
+) -> Result<(), Error>{
+    let mut success = false;
+    ensure!(!chat_id.is_special(), "Invalid chat ID");
+    if real_group_exists(context, chat_id) && sql::execute(
+        context,
+        &context.sql,
+        "UPDATE chats SET muted_until=? WHERE id=?;",
+        params![duration.serialize(), chat_id],
+    ).is_ok() {
+        context.call_cb(Event::ChatModified(chat_id));
+        success = true;  
+    }
+
+    if !success {
+        bail!("Failed to set name");
+    }
+
+    Ok(())
+}
+
 pub fn remove_contact_from_chat(
     context: &Context,
     chat_id: ChatId,
@@ -2386,6 +2452,7 @@ pub fn add_info_msg(context: &Context, chat_id: ChatId, text: impl AsRef<str>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use crate::contact::Contact;
     use crate::test_utils::*;
@@ -2413,7 +2480,8 @@ mod tests {
                 "color": 15895624,
                 "profile_image": "",
                 "subtitle": "bob@example.com",
-                "draft": ""
+                "draft": "",
+                "is_muted": false
             }
         "#;
 
@@ -2776,5 +2844,42 @@ mod tests {
 
         assert!(chat_id.set_selfavatar_timestamp(&t.ctx, time()).is_ok());
         assert!(!shall_attach_selfavatar(&t.ctx, chat_id).unwrap());
+    }
+
+    #[test]
+    fn test_set_mute_duration() {
+        let t = dummy_context();
+        let chat_id = create_group_chat(&t.ctx, VerifiedStatus::Unverified, "foo").unwrap();
+        // Initial
+        assert_eq!(
+            Chat::load_from_db(&t.ctx, chat_id).unwrap().is_muted(),
+            false
+        );
+        // Forever
+        set_muted(&t.ctx, chat_id, MuteDuration::Forever).unwrap();
+        assert_eq!(
+            Chat::load_from_db(&t.ctx, chat_id).unwrap().is_muted(),
+            true
+        );
+        // unMute
+        set_muted(&t.ctx, chat_id, MuteDuration::NotMuted).unwrap();
+        assert_eq!(
+            Chat::load_from_db(&t.ctx, chat_id).unwrap().is_muted(),
+            false
+        );
+        // Timed in the future
+        let current_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap() + Duration::from_secs(3600);
+        set_muted(&t.ctx, chat_id, MuteDuration::MutedUntilTimestamp(current_timestamp.as_secs() as i64)).unwrap();
+        assert_eq!(
+            Chat::load_from_db(&t.ctx, chat_id).unwrap().is_muted(),
+            true
+        );
+        // Time in the past
+        let past_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap() - Duration::from_secs(3600);
+        set_muted(&t.ctx, chat_id, MuteDuration::MutedUntilTimestamp(past_timestamp.as_secs() as i64)).unwrap();
+        assert_eq!(
+            Chat::load_from_db(&t.ctx, chat_id).unwrap().is_muted(),
+            false
+        );
     }
 }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -980,7 +980,7 @@ pub struct ChatInfo {
     ///       simple `has_draft` bool instead.
     pub draft: String,
 
-    /// Wether the chat is muted
+    /// Whether the chat is muted
     ///
     /// The exact time its muted can be found out via the `chat.mute_duration` property
     pub is_muted: bool,
@@ -1929,7 +1929,7 @@ impl MuteDuration {
     pub fn serialize(&self) -> i64 {
         match &self {
             MuteDuration::NotMuted => 0,
-            MuteDuration::Forever => 1,
+            MuteDuration::Forever => -1,
             MuteDuration::MutedUntilTimestamp(timestamp) => *timestamp as i64, // TODO make this pretier?
         }
     }
@@ -1937,7 +1937,7 @@ impl MuteDuration {
     pub fn deserialize(value: i64) -> MuteDuration {
         match value {
             0 => MuteDuration::NotMuted,
-            1 => MuteDuration::Forever,
+            -1 => MuteDuration::Forever,
             _ => MuteDuration::MutedUntilTimestamp(value),
         }
     }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2868,15 +2868,13 @@ mod tests {
             false
         );
         // Timed in the future
-        let current_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap() + Duration::from_secs(3600);
-        set_muted(&t.ctx, chat_id, MuteDuration::MutedUntilTimestamp(current_timestamp.as_secs() as i64)).unwrap();
+        set_muted(&t.ctx, chat_id, MuteDuration::MutedUntilTimestamp(time() + 3600)).unwrap();
         assert_eq!(
             Chat::load_from_db(&t.ctx, chat_id).unwrap().is_muted(),
             true
         );
         // Time in the past
-        let past_timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap() - Duration::from_secs(3600);
-        set_muted(&t.ctx, chat_id, MuteDuration::MutedUntilTimestamp(past_timestamp.as_secs() as i64)).unwrap();
+        set_muted(&t.ctx, chat_id, MuteDuration::MutedUntilTimestamp(time() - 3600)).unwrap();
         assert_eq!(
             Chat::load_from_db(&t.ctx, chat_id).unwrap().is_muted(),
             false

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1926,7 +1926,7 @@ pub enum MuteDuration {
 
 impl MuteDuration {
     // TODO use serde compatible functions?
-    fn serialize(&self) -> i64 {
+    pub fn serialize(&self) -> i64 {
         match &self {
             MuteDuration::NotMuted => 0,
             MuteDuration::Forever => 1,
@@ -1934,7 +1934,7 @@ impl MuteDuration {
         }
     }
 
-    fn deserialize(value: i64) -> MuteDuration {
+    pub fn deserialize(value: i64) -> MuteDuration {
         match value {
             0 => MuteDuration::NotMuted,
             1 => MuteDuration::Forever,
@@ -2451,7 +2451,6 @@ pub fn add_info_msg(context: &Context, chat_id: ChatId, text: impl AsRef<str>) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use crate::contact::Contact;
     use crate::test_utils::*;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -981,9 +981,9 @@ pub struct ChatInfo {
     pub draft: String,
 
     /// Wether the chat is muted
-    /// 
+    ///
     /// The exact time its muted can be found out via the `chat.mute_duration` property
-    pub is_muted:bool,
+    pub is_muted: bool,
     // ToDo:
     // - [ ] deaddrop,
     // - [ ] summary,
@@ -1926,7 +1926,7 @@ pub enum MuteDuration {
 
 impl MuteDuration {
     // TODO use serde compatible functions?
-    fn serialize (&self) -> i64 {
+    fn serialize(&self) -> i64 {
         match &self {
             MuteDuration::NotMuted => 0,
             MuteDuration::Forever => 1,
@@ -1934,7 +1934,7 @@ impl MuteDuration {
         }
     }
 
-    fn deserialize (value: i64) -> MuteDuration {
+    fn deserialize(value: i64) -> MuteDuration {
         match value {
             0 => MuteDuration::NotMuted,
             1 => MuteDuration::Forever,
@@ -1943,21 +1943,20 @@ impl MuteDuration {
     }
 }
 
-pub fn set_muted (
-    context: &Context,
-    chat_id: ChatId,
-    duration: MuteDuration
-) -> Result<(), Error>{
+pub fn set_muted(context: &Context, chat_id: ChatId, duration: MuteDuration) -> Result<(), Error> {
     let mut success = false;
     ensure!(!chat_id.is_special(), "Invalid chat ID");
-    if real_group_exists(context, chat_id) && sql::execute(
-        context,
-        &context.sql,
-        "UPDATE chats SET muted_until=? WHERE id=?;",
-        params![duration.serialize(), chat_id],
-    ).is_ok() {
+    if real_group_exists(context, chat_id)
+        && sql::execute(
+            context,
+            &context.sql,
+            "UPDATE chats SET muted_until=? WHERE id=?;",
+            params![duration.serialize(), chat_id],
+        )
+        .is_ok()
+    {
         context.call_cb(Event::ChatModified(chat_id));
-        success = true;  
+        success = true;
     }
 
     if !success {
@@ -2868,13 +2867,23 @@ mod tests {
             false
         );
         // Timed in the future
-        set_muted(&t.ctx, chat_id, MuteDuration::MutedUntilTimestamp(time() + 3600)).unwrap();
+        set_muted(
+            &t.ctx,
+            chat_id,
+            MuteDuration::MutedUntilTimestamp(time() + 3600),
+        )
+        .unwrap();
         assert_eq!(
             Chat::load_from_db(&t.ctx, chat_id).unwrap().is_muted(),
             true
         );
         // Time in the past
-        set_muted(&t.ctx, chat_id, MuteDuration::MutedUntilTimestamp(time() - 3600)).unwrap();
+        set_muted(
+            &t.ctx,
+            chat_id,
+            MuteDuration::MutedUntilTimestamp(time() - 3600),
+        )
+        .unwrap();
         assert_eq!(
             Chat::load_from_db(&t.ctx, chat_id).unwrap().is_muted(),
             false

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -691,7 +691,7 @@ impl Chat {
         match self.mute_duration {
             MuteDuration::NotMuted => false,
             MuteDuration::Forever => true,
-            MuteDuration::MutedUntilTimestamp(timestamp) => timestamp > time(),
+            MuteDuration::Until(timestamp) => timestamp > time(),
         }
     }
 
@@ -1921,7 +1921,7 @@ pub fn shall_attach_selfavatar(context: &Context, chat_id: ChatId) -> Result<boo
 pub enum MuteDuration {
     NotMuted,
     Forever,
-    MutedUntilTimestamp(i64),
+    Until(i64)
 }
 
 impl rusqlite::types::ToSql for MuteDuration {
@@ -1929,7 +1929,7 @@ impl rusqlite::types::ToSql for MuteDuration {
         let duration = match &self {
             MuteDuration::NotMuted => 0,
             MuteDuration::Forever => -1,
-            MuteDuration::MutedUntilTimestamp(timestamp) => *timestamp as i64,
+            MuteDuration::Until(timestamp) => *timestamp as i64,
         };
         let val = rusqlite::types::Value::Integer(duration as i64);
         let out = rusqlite::types::ToSqlOutput::Owned(val);
@@ -1949,7 +1949,7 @@ impl rusqlite::types::FromSql for MuteDuration {
                         if val <= time() {
                             MuteDuration::NotMuted
                         } else {
-                            MuteDuration::MutedUntilTimestamp(val)
+                            MuteDuration::Until(val)
                         }
                     }
                 }
@@ -2880,7 +2880,7 @@ mod tests {
         set_muted(
             &t.ctx,
             chat_id,
-            MuteDuration::MutedUntilTimestamp(time() + 3600),
+            MuteDuration::Until(time() + 3600),
         )
         .unwrap();
         assert_eq!(
@@ -2891,7 +2891,7 @@ mod tests {
         set_muted(
             &t.ctx,
             chat_id,
-            MuteDuration::MutedUntilTimestamp(time() - 3600),
+            MuteDuration::Until(time() - 3600),
         )
         .unwrap();
         assert_eq!(

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2398,7 +2398,7 @@ mod tests {
         let chat = Chat::load_from_db(&t.ctx, chat_id).unwrap();
         let info = chat.get_info(&t.ctx).unwrap();
 
-        // Ensure we can serialise this.
+        // Ensure we can serialize this.
         println!("{}", serde_json::to_string_pretty(&info).unwrap());
 
         let expected = r#"
@@ -2417,7 +2417,7 @@ mod tests {
             }
         "#;
 
-        // Ensure we can deserialise this.
+        // Ensure we can deserialize this.
         let loaded: ChatInfo = serde_json::from_str(expected).unwrap();
         assert_eq!(info, loaded);
     }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1921,7 +1921,7 @@ pub fn shall_attach_selfavatar(context: &Context, chat_id: ChatId) -> Result<boo
 pub enum MuteDuration {
     NotMuted,
     Forever,
-    Until(i64)
+    Until(i64),
 }
 
 impl rusqlite::types::ToSql for MuteDuration {
@@ -2877,23 +2877,13 @@ mod tests {
             false
         );
         // Timed in the future
-        set_muted(
-            &t.ctx,
-            chat_id,
-            MuteDuration::Until(time() + 3600),
-        )
-        .unwrap();
+        set_muted(&t.ctx, chat_id, MuteDuration::Until(time() + 3600)).unwrap();
         assert_eq!(
             Chat::load_from_db(&t.ctx, chat_id).unwrap().is_muted(),
             true
         );
         // Time in the past
-        set_muted(
-            &t.ctx,
-            chat_id,
-            MuteDuration::Until(time() - 3600),
-        )
-        .unwrap();
+        set_muted(&t.ctx, chat_id, MuteDuration::Until(time() - 3600)).unwrap();
         assert_eq!(
             Chat::load_from_db(&t.ctx, chat_id).unwrap().is_muted(),
             false

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1938,7 +1938,13 @@ impl MuteDuration {
         match value {
             0 => MuteDuration::NotMuted,
             -1 => MuteDuration::Forever,
-            _ => MuteDuration::MutedUntilTimestamp(value),
+            _ => {
+                if value <= time() {
+                    MuteDuration::NotMuted
+                } else {
+                    MuteDuration::MutedUntilTimestamp(value)
+                }
+            }
         }
     }
 }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -885,6 +885,14 @@ fn open(
             update_icons = true;
             sql.set_raw_config_int(context, "dbversion", 61)?;
         }
+        if dbversion < 62 {
+            info!(context, "[migration] v62");
+            sql.execute(
+                "ALTER TABLE chats ADD COLUMN muted_until INTEGER DEFAULT 0;",
+                NO_PARAMS,
+            )?;
+            sql.set_raw_config_int(context, "dbversion", 62)?;
+        }
 
         // (2) updates that require high-level objects
         // (the structure is complete now and all objects are usable)


### PR DESCRIPTION
To Do:
- [X] impl in chat
- [X] rust test
- [X] ffi functions
- [X] python tests

- [x] remodel the ffi-api to only have only two low-level mute-functions:
      - setMuteDuration(mute duration in seconds | -1 for forever | 0 for unmute)
      - getRemainingMuteDuration() -> mute duration in seconds (positive integer) | -1 for forever | 0 for not muted
      -> so the client doesn't need to deal with the unix timestamp too

- [x] use `ToSql` and `FromSql` traits

After thoughts:
- ~~cleanup function that removes expired mute duration from the db once in a while~~
- Android backwards compatibility
- implement in cli/repl? does it have notifications at all?, otherwise it would make no sense.

Note to UI developers:
Basically on message before sending the notification, check `is chat muted`
Also setting and getting mute duration is in relative seconds until the mute is lifted again.