### PR TITLE
Refactor create_chat_from_msg_id

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -34,7 +34,7 @@ use crate::{bail, ensure};
 /// needed for deltachat's purposes.
 ///
 /// It is created by parsing the raw data of an actual MIME message
-/// using the [MimeMessage::from_raw] constructor.
+/// using the [MimeMessage::from_bytes] constructor.
 #[derive(Debug)]
 pub struct MimeMessage<'a> {
     pub context: &'a Context,


### PR DESCRIPTION
The goal here is to not have a `mut chat_id` as I want to change chat
id into an opaque newtype and we can't modify it like that anymore.