### PR TITLE
Update mailparse to 0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,7 +675,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lettre_email 0.9.2 (git+https://github.com/deltachat/lettre)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "mailparse 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mailparse 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "mailparse"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3625,7 +3625,7 @@ dependencies = [
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 "checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
 "checksum mach 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "86dd2487cdfea56def77b88438a2c915fb45113c5319bfe7e14306ca4cd0b0e1"
-"checksum mailparse 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c00eb97cc18f08aaadd02808328dcc9be94948d8e5b54adbfd3414d2f87f7bf1"
+"checksum mailparse 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "04c64e94d3a5d02abe0cf459507689d70fb3b9b1d5fea5773a9f5273117959fb"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum maybe-uninit 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 "checksum md-5 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a18af3dcaf2b0219366cdb4e2af65a6101457b415c3d1a5c71dd9c2b7c77b9c8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ bitflags = "1.1.0"
 debug_stub_derive = "0.3.0"
 sanitize-filename = "0.2.1"
 stop-token = { version = "0.1.1", features = ["unstable"] }
-mailparse = "0.10.1"
+mailparse = "0.10.2"
 encoded-words = { git = "https://github.com/async-email/encoded-words", branch="master" }
 native-tls = "0.2.3"
 image = "0.22.3"

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1142,13 +1142,8 @@ mod tests {
         let of = mimeparser.parse_first_addr(HeaderDef::From_).unwrap();
         assert_eq!(of, mailparse::addrparse("hello@one.org").unwrap()[0]);
 
-        // XXX: the address does not contain "@", so it is wrong
-        // addr-spec according to RFC 2822, but mailparse still parses
-        // is as an address.
-        let of = mimeparser
-            .parse_first_addr(HeaderDef::ChatDispositionNotificationTo)
-            .unwrap();
-        assert_eq!(of, mailparse::addrparse("wrong").unwrap()[0]);
+        let of = mimeparser.parse_first_addr(HeaderDef::ChatDispositionNotificationTo);
+        assert!(of.is_none());
     }
 
     #[test]


### PR DESCRIPTION
It does not allow parsing emails without @