### PR TITLE
in groups, set subject-header to group-name

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -346,12 +346,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                         32,
                         self.context,
                     );
-                    let mut lines = raw.lines();
                     let raw_subject = raw.lines().next().unwrap_or_default();
-                        line
-                    } else {
-                        ""
-                    };
                     format!("Chat: {}", raw_subject)
                 }
             }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -347,7 +347,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                         self.context,
                     );
                     let mut lines = raw.lines();
-                    let raw_subject = if let Some(line) = lines.next() {
+                    let raw_subject = raw.lines().next().unwrap_or_default();
                         line
                     } else {
                         ""


### PR DESCRIPTION
this commit sets the subject of groups to the name of the group.
if the message is a reply in the group, also the prefix `Re:` is added.
the Chat: prefix is removed for groups, also the Fwd: prefix, as it this would be expected to be set to the group name of the forwarded message, which is not really compatible with the rule "group-name = subject" (forwarded messages are detected by the body, not by the subject)

this achieves better compatibility with normal email clients as there is an option to set the subject now. also, as replies go to the same group, related mails are shown together and grouped togehter, in both, delta and the conventional client (this won't be easily the case if we would allow to set the subject completely freely)

targets issues as https://support.delta.chat/t/subject-of-emails/264 or https://github.com/deltachat/deltachat-core/issues/128