### PR TITLE
Remove NOTE about third-party libraries

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,9 +2,6 @@ The files in this directory and under its subdirectories
 are (c) 2019 by Bjoern Petersen and contributors and released under the
 Mozilla Public License Version 2.0, see below for a copy.
 
-NOTE that the files in the "libs" directory are copyrighted by third parties
-and come with their own respective licenses.
-
 Mozilla Public License Version 2.0
 ==================================
 


### PR DESCRIPTION
"libs" directory has been removed during transition to Rust