### PR TITLE
Combine multiple MDNs in a single mail

### DIFF
--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -10,6 +10,10 @@ pub enum HeaderDef {
     Cc,
     Disposition,
     OriginalMessageId,
+
+    /// Delta Chat extension for message IDs in combined MDNs
+    XAdditionalMessageIds,
+
     ListId,
     References,
     InReplyTo,

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -12,7 +12,7 @@ pub enum HeaderDef {
     OriginalMessageId,
 
     /// Delta Chat extension for message IDs in combined MDNs
-    XAdditionalMessageIds,
+    AdditionalMessageIds,
 
     ListId,
     References,

--- a/src/job.rs
+++ b/src/job.rs
@@ -323,6 +323,14 @@ impl Job {
             .get_additional_mdn_jobs(context, contact_id)
             .unwrap_or_default();
 
+        if !additional_rfc724_mids.is_empty() {
+            info!(
+                context,
+                "SendMdn job: aggregating {} additional MDNs",
+                additional_rfc724_mids.len()
+            )
+        }
+
         let msg = job_try!(Message::load_from_db(context, msg_id));
         let mimefactory = job_try!(MimeFactory::from_mdn(context, &msg, additional_rfc724_mids));
         let rendered_msg = job_try!(mimefactory.render());

--- a/src/job.rs
+++ b/src/job.rs
@@ -278,7 +278,7 @@ impl Job {
         };
 
         let msg = job_try!(Message::load_from_db(context, msg_id));
-        let mimefactory = job_try!(MimeFactory::from_mdn(context, &msg));
+        let mimefactory = job_try!(MimeFactory::from_mdn(context, &msg, Vec::new()));
         let rendered_msg = job_try!(mimefactory.render());
         let body = rendered_msg.message;
 

--- a/src/job.rs
+++ b/src/job.rs
@@ -785,7 +785,7 @@ pub fn job_send_msg(context: &Context, msg_id: MsgId) -> Result<()> {
         msg.save_param_to_disk(context);
     }
 
-    add_smtp_job(context, Action::SendMsgToSmtp, &rendered_msg)?;
+    add_smtp_job(context, Action::SendMsgToSmtp, msg.id, &rendered_msg)?;
 
     Ok(())
 }
@@ -1010,7 +1010,12 @@ fn send_mdn(context: &Context, msg_id: MsgId) -> Result<()> {
     Ok(())
 }
 
-fn add_smtp_job(context: &Context, action: Action, rendered_msg: &RenderedEmail) -> Result<()> {
+fn add_smtp_job(
+    context: &Context,
+    action: Action,
+    msg_id: MsgId,
+    rendered_msg: &RenderedEmail,
+) -> Result<()> {
     ensure!(
         !rendered_msg.recipients.is_empty(),
         "no recipients for smtp job set"
@@ -1023,16 +1028,7 @@ fn add_smtp_job(context: &Context, action: Action, rendered_msg: &RenderedEmail)
     param.set(Param::File, blob.as_name());
     param.set(Param::Recipients, &recipients);
 
-    job_add(
-        context,
-        action,
-        rendered_msg
-            .foreign_id
-            .map(|v| v.to_u32() as i32)
-            .unwrap_or_default(),
-        param,
-        0,
-    );
+    job_add(context, action, msg_id.to_u32() as i32, param, 0);
 
     Ok(())
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -88,9 +88,7 @@ pub enum Action {
     // Jobs in the SMTP-thread, range from DC_SMTP_THREAD..DC_SMTP_THREAD+999
     MaybeSendLocations = 5005, // low priority ...
     MaybeSendLocationsEnded = 5007,
-    SendMdnOld = 5010,
     SendMdn = 5011,
-    SendMsgToSmtpOld = 5900,
     SendMsgToSmtp = 5901, // ... high priority
 }
 
@@ -118,9 +116,7 @@ impl From<Action> for Thread {
 
             MaybeSendLocations => Thread::Smtp,
             MaybeSendLocationsEnded => Thread::Smtp,
-            SendMdnOld => Thread::Smtp,
             SendMdn => Thread::Smtp,
-            SendMsgToSmtpOld => Thread::Smtp,
             SendMsgToSmtp => Thread::Smtp,
         }
     }
@@ -814,8 +810,6 @@ fn job_perform(context: &Context, thread: Thread, probe_network: bool) {
                         sql::housekeeping(context);
                         Status::Finished(Ok(()))
                     }
-                    Action::SendMdnOld => Status::Finished(Ok(())),
-                    Action::SendMsgToSmtpOld => Status::Finished(Ok(())),
                 };
 
                 info!(

--- a/src/job.rs
+++ b/src/job.rs
@@ -15,6 +15,7 @@ use crate::chat;
 use crate::config::Config;
 use crate::configure::*;
 use crate::constants::*;
+use crate::contact::Contact;
 use crate::context::{Context, PerformJobsNeeded};
 use crate::dc_tools::*;
 use crate::error::{Error, Result};
@@ -259,6 +260,12 @@ impl Job {
             // User has disabled MDNs after job scheduling but before
             // execution.
             return Status::Finished(Err(format_err!("MDNs are disabled")));
+        }
+
+        let contact_id = self.foreign_id;
+        let contact = job_try!(Contact::load_from_db(context, contact_id));
+        if contact.is_blocked() {
+            return Status::Finished(Err(format_err!("Contact is blocked")));
         }
 
         let msg_id = if let Some(msg_id) = self.param.get_msg_id() {

--- a/src/job.rs
+++ b/src/job.rs
@@ -1079,7 +1079,7 @@ fn suspend_smtp_thread(context: &Context, suspend: bool) {
 
 fn send_mdn(context: &Context, msg: &Message) -> Result<()> {
     let mut param = Params::new();
-    param.set(Param::MessageId, msg.id.to_u32().to_string());
+    param.set(Param::MsgId, msg.id.to_u32().to_string());
 
     job_add(context, Action::SendMdn, msg.from_id as i32, param, 0);
 

--- a/src/job.rs
+++ b/src/job.rs
@@ -255,9 +255,14 @@ impl Job {
 
     #[allow(non_snake_case)]
     fn SendMdn(&mut self, context: &Context) -> Status {
+        if !context.get_config_bool(Config::MdnsEnabled) {
+            // User has disabled MDNs after job scheduling but before
+            // execution.
+            return Status::Finished(Err(format_err!("MDNs are disabled")));
+        }
+
         let msg_id = MsgId::new(self.foreign_id);
         let msg = job_try!(Message::load_from_db(context, msg_id));
-
         let mimefactory = job_try!(MimeFactory::from_mdn(context, &msg));
         let rendered_msg = job_try!(mimefactory.render());
         let body = rendered_msg.message;

--- a/src/message.rs
+++ b/src/message.rs
@@ -610,7 +610,7 @@ impl Message {
     }
 }
 
-#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive, ToSql, FromSql)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive, ToSql, FromSql)]
 #[repr(i32)]
 pub enum MessageState {
     Undefined = 0,
@@ -658,6 +658,27 @@ pub enum MessageState {
 impl Default for MessageState {
     fn default() -> Self {
         MessageState::Undefined
+    }
+}
+
+impl std::fmt::Display for MessageState {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Undefined => "Undefined",
+                Self::InFresh => "Fresh",
+                Self::InNoticed => "Noticed",
+                Self::InSeen => "Seen",
+                Self::OutPreparing => "Preparing",
+                Self::OutDraft => "Draft",
+                Self::OutPending => "Pending",
+                Self::OutFailed => "Failed",
+                Self::OutDelivered => "Delivered",
+                Self::OutMdnRcvd => "Read",
+            }
+        )
     }
 }
 
@@ -815,19 +836,7 @@ pub fn get_msg_info(context: &Context, msg_id: MsgId) -> String {
         }
     }
 
-    ret += "State: ";
-    use MessageState::*;
-    match msg.state {
-        InFresh => ret += "Fresh",
-        InNoticed => ret += "Noticed",
-        InSeen => ret += "Seen",
-        OutDelivered => ret += "Delivered",
-        OutFailed => ret += "Failed",
-        OutMdnRcvd => ret += "Read",
-        OutPending => ret += "Pending",
-        OutPreparing => ret += "Preparing",
-        _ => ret += &format!("{}", msg.state),
-    }
+    ret += &format!("State: {}", msg.state);
 
     if msg.has_location() {
         ret += ", Location sent";

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -159,12 +159,9 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
     }
 
     pub fn from_mdn(context: &'a Context, msg: &'b Message) -> Result<Self, Error> {
-        let contact = Contact::load_from_db(context, msg.from_id)?;
-
-        // Do not send MDNs trash etc.; chats.blocked is already checked by the caller
-        // in dc_markseen_msgs()
-        ensure!(!contact.is_blocked(), "Contact blocked");
         ensure!(msg.chat_id > DC_CHAT_ID_LAST_SPECIAL, "Invalid chat id");
+
+        let contact = Contact::load_from_db(context, msg.from_id)?;
 
         Ok(MimeFactory {
             context,

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -948,7 +948,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
         let extension_fields = if additional_msg_ids.is_empty() {
             "".to_string()
         } else {
-            "X-Additional-Message-IDs: ".to_string()
+            "Additional-Message-IDs: ".to_string()
                 + &additional_msg_ids
                     .iter()
                     .map(|mid| render_rfc724_mid(&mid))

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -159,13 +159,6 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
     }
 
     pub fn from_mdn(context: &'a Context, msg: &'b Message) -> Result<Self, Error> {
-        // MDNs not enabled - check this is late, in the job. the
-        // user may have changed its choice while offline ...
-        ensure!(
-            context.get_config_bool(Config::MdnsEnabled),
-            "MDNs meanwhile disabled"
-        );
-
         let contact = Contact::load_from_db(context, msg.from_id)?;
 
         // Do not send MDNs trash etc.; chats.blocked is already checked by the caller

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -11,7 +11,6 @@ use crate::dc_tools::*;
 use crate::e2ee::*;
 use crate::error::Error;
 use crate::location;
-use crate::message::MsgId;
 use crate::message::{self, Message};
 use crate::mimeparser::SystemMessage;
 use crate::param::*;
@@ -53,8 +52,6 @@ pub struct RenderedEmail {
     pub is_encrypted: bool,
     pub is_gossiped: bool,
     pub last_added_location_id: u32,
-    /// None for MDN, the message id otherwise
-    pub foreign_id: Option<MsgId>,
 
     pub from: String,
     pub recipients: Vec<String>,
@@ -563,8 +560,6 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             recipients,
             from_addr,
             last_added_location_id,
-            msg,
-            loaded,
             ..
         } = self;
 
@@ -574,10 +569,6 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             is_encrypted,
             is_gossiped,
             last_added_location_id,
-            foreign_id: match loaded {
-                Loaded::Message { .. } => Some(msg.id),
-                Loaded::MDN => None,
-            },
             recipients: recipients.into_iter().map(|(_, addr)| addr).collect(),
             from: from_addr,
             rfc724_mid,

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -743,7 +743,7 @@ impl<'a> MimeMessage<'a> {
                 .and_then(|v| parse_message_id(&v))
             {
                 let additional_message_ids = report_fields
-                    .get_first_value(&HeaderDef::XAdditionalMessageIds.get_headername())
+                    .get_first_value(&HeaderDef::AdditionalMessageIds.get_headername())
                     .ok()
                     .flatten()
                     .map_or_else(Vec::new, |v| {
@@ -868,7 +868,7 @@ fn update_gossip_peerstates(
 pub(crate) struct Report {
     /// Original-Message-ID header
     original_message_id: String,
-    /// X-Additional-Message-IDs
+    /// Additional-Message-IDs
     additional_message_ids: Vec<String>,
 }
 
@@ -1430,7 +1430,7 @@ Original-Recipient: rfc822;bob@example.org\n\
 Final-Recipient: rfc822;bob@example.org\n\
 Original-Message-ID: <foo@example.org>\n\
 Disposition: manual-action/MDN-sent-automatically; displayed\n\
-X-Additional-Message-IDs: <foo@example.com> <foo@example.net>\n\
+Additional-Message-IDs: <foo@example.com> <foo@example.net>\n\
 \n\
 \n\
 --kJBbU58X1xeWNHgBtTbMk80M5qnV4N--\n\

--- a/src/param.rs
+++ b/src/param.rs
@@ -119,7 +119,7 @@ pub enum Param {
     GroupName = b'g',
 
     /// For MDN-sending job
-    MessageId = b'I',
+    MsgId = b'I',
 }
 
 /// Possible values for `Param::ForcePlaintext`.
@@ -317,7 +317,7 @@ impl Params {
     }
 
     pub fn get_msg_id(&self) -> Option<MsgId> {
-        self.get(Param::MessageId)
+        self.get(Param::MsgId)
             .and_then(|x| x.parse::<u32>().ok())
             .map(MsgId::new)
     }

--- a/src/param.rs
+++ b/src/param.rs
@@ -8,6 +8,7 @@ use num_traits::FromPrimitive;
 use crate::blob::{BlobError, BlobObject};
 use crate::context::Context;
 use crate::error;
+use crate::message::MsgId;
 use crate::mimeparser::SystemMessage;
 
 /// Available param keys.
@@ -116,6 +117,9 @@ pub enum Param {
 
     /// For QR
     GroupName = b'g',
+
+    /// For MDN-sending job
+    MessageId = b'I',
 }
 
 /// Possible values for `Param::ForcePlaintext`.
@@ -310,6 +314,12 @@ impl Params {
             ParamsFile::Blob(blob) => blob.to_abs_path(),
         };
         Ok(Some(path))
+    }
+
+    pub fn get_msg_id(&self) -> Option<MsgId> {
+        self.get(Param::MessageId)
+            .and_then(|x| x.parse::<u32>().ok())
+            .map(MsgId::new)
     }
 
     /// Set the given paramter to the passed in `i32`.


### PR DESCRIPTION
Major changes:
 - MDNs may now contain an `X-Additional-Message-IDs` field, which complements `Original-Message-ID` and lists IDs of other messages that were read.
 - There is a new SMTP-thread job `SendMdn`, which is different from previous one. It does not have a pre-built MDN message in a blob, but constructs it from scratch on each retry. This way it has an opportunity to consume other `SendMdn` jobs, even if they are added between retries of `SendMdn` job.
 - `SendMdn` stores database message id in its parameters and contact id in its `foreign_id` field. Contact ID can be extracted from the `from_id` field of the message record, so this information is redundard. However, it is easy to filter by `foreign_id` in SQL, to find jobs that can be aggregated.
 - If `SendMdn` succeeds, it removes other `SendMdn` jobs.
 - Previously jobs were loaded in batches and the batch was stored in a memory until processed. Now I load one job at a time, to make sure that `SendMdn` job is not processed if it was deleted by previous `SendMdn` job. It should also improve prioritization as high-priority jobs don't need to wait for the end of batch processing anymore.