### PR TITLE
Introduce a ChatId newtype

### DIFF
--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -20,6 +20,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 
+use deltachat::chat::ChatId;
 use deltachat::config;
 use deltachat::configure::*;
 use deltachat::context::*;
@@ -484,9 +485,10 @@ fn handle_cmd(line: &str, ctx: Arc<RwLock<Context>>) -> Result<ExitResult, failu
         }
         "getqr" | "getbadqr" => {
             start_threads(ctx.clone());
-            if let Some(mut qr) =
-                dc_get_securejoin_qr(&ctx.read().unwrap(), arg1.parse().unwrap_or_default())
-            {
+            if let Some(mut qr) = dc_get_securejoin_qr(
+                &ctx.read().unwrap(),
+                ChatId::new(arg1.parse().unwrap_or_default()),
+            ) {
                 if !qr.is_empty() {
                     if arg0 == "getbadqr" && qr.len() > 40 {
                         qr.replace_range(12..22, "0000000000")

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -49,6 +49,8 @@ pub const DC_HANDSHAKE_CONTINUE_NORMAL_PROCESSING: i32 = 0x01;
 pub const DC_HANDSHAKE_STOP_NORMAL_PROCESSING: i32 = 0x02;
 pub const DC_HANDSHAKE_ADD_DELETE_JOB: i32 = 0x04;
 
+pub(crate) const DC_FROM_HANDSHAKE: i32 = 0x01;
+
 pub const DC_GCL_ARCHIVED_ONLY: usize = 0x01;
 pub const DC_GCL_NO_SPECIALS: usize = 0x02;
 pub const DC_GCL_ADD_ALLDONE_HINT: usize = 0x04;

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -7,6 +7,7 @@ use itertools::Itertools;
 use rusqlite;
 
 use crate::aheader::EncryptPreference;
+use crate::chat::ChatId;
 use crate::config::Config;
 use crate::constants::*;
 use crate::context::Context;
@@ -262,7 +263,7 @@ impl Contact {
         .is_ok()
         {
             context.call_cb(Event::MsgsChanged {
-                chat_id: 0,
+                chat_id: ChatId::new(0),
                 msg_id: MsgId::new(0),
             });
         }

--- a/src/events.rs
+++ b/src/events.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use strum::EnumProperty;
 
+use crate::chat::ChatId;
 use crate::message::MsgId;
 
 impl Event {
@@ -107,36 +108,36 @@ pub enum Event {
     /// - Chats created, deleted or archived
     /// - A draft has been set
     #[strum(props(id = "2000"))]
-    MsgsChanged { chat_id: u32, msg_id: MsgId },
+    MsgsChanged { chat_id: ChatId, msg_id: MsgId },
 
     /// There is a fresh message. Typically, the user will show an notification
     /// when receiving this message.
     ///
     /// There is no extra #DC_EVENT_MSGS_CHANGED event send together with this event.
     #[strum(props(id = "2005"))]
-    IncomingMsg { chat_id: u32, msg_id: MsgId },
+    IncomingMsg { chat_id: ChatId, msg_id: MsgId },
 
     /// A single message is sent successfully. State changed from  DC_STATE_OUT_PENDING to
     /// DC_STATE_OUT_DELIVERED, see dc_msg_get_state().
     #[strum(props(id = "2010"))]
-    MsgDelivered { chat_id: u32, msg_id: MsgId },
+    MsgDelivered { chat_id: ChatId, msg_id: MsgId },
 
     /// A single message could not be sent. State changed from DC_STATE_OUT_PENDING or DC_STATE_OUT_DELIVERED to
     /// DC_STATE_OUT_FAILED, see dc_msg_get_state().
     #[strum(props(id = "2012"))]
-    MsgFailed { chat_id: u32, msg_id: MsgId },
+    MsgFailed { chat_id: ChatId, msg_id: MsgId },
 
     /// A single message is read by the receiver. State changed from DC_STATE_OUT_DELIVERED to
     /// DC_STATE_OUT_MDN_RCVD, see dc_msg_get_state().
     #[strum(props(id = "2015"))]
-    MsgRead { chat_id: u32, msg_id: MsgId },
+    MsgRead { chat_id: ChatId, msg_id: MsgId },
 
     /// Chat changed.  The name or the image of a chat group was changed or members were added or removed.
     /// Or the verify state of a chat has changed.
     /// See dc_set_chat_name(), dc_set_chat_profile_image(), dc_add_contact_to_chat()
     /// and dc_remove_contact_from_chat().
     #[strum(props(id = "2020"))]
-    ChatModified(u32),
+    ChatModified(ChatId),
 
     /// Contact(s) created, renamed, blocked or deleted.
     ///
@@ -205,5 +206,5 @@ pub enum Event {
     /// @param data1 (int) chat_id
     /// @param data2 (int) contact_id
     #[strum(props(id = "2062"))]
-    SecurejoinMemberAdded { chat_id: u32, contact_id: u32 },
+    SecurejoinMemberAdded { chat_id: ChatId, contact_id: u32 },
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -12,7 +12,7 @@ use rand::{thread_rng, Rng};
 use async_std::task;
 
 use crate::blob::BlobObject;
-use crate::chat;
+use crate::chat::{self, ChatId};
 use crate::config::Config;
 use crate::configure::*;
 use crate::constants::*;
@@ -764,7 +764,7 @@ pub fn job_action_exists(context: &Context, action: Action) -> bool {
 
 fn set_delivered(context: &Context, msg_id: MsgId) {
     message::update_msg_state(context, msg_id, MessageState::OutDelivered);
-    let chat_id: i32 = context
+    let chat_id: ChatId = context
         .sql
         .query_get_value(
             context,
@@ -772,10 +772,7 @@ fn set_delivered(context: &Context, msg_id: MsgId) {
             params![msg_id],
         )
         .unwrap_or_default();
-    context.call_cb(Event::MsgDelivered {
-        chat_id: chat_id as u32,
-        msg_id,
-    });
+    context.call_cb(Event::MsgDelivered { chat_id, msg_id });
 }
 
 /* special case for DC_JOB_SEND_MSG_TO_SMTP */

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -83,7 +83,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                  FROM chats_contacts cc  \
                  LEFT JOIN contacts c ON cc.contact_id=c.id  \
                  WHERE cc.chat_id=? AND cc.contact_id>9;",
-                params![msg.chat_id as i32],
+                params![msg.chat_id],
                 |row| {
                     let authname: String = row.get(0)?;
                     let addr: String = row.get(1)?;
@@ -163,7 +163,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
         msg: &'b Message,
         additional_msg_ids: Vec<String>,
     ) -> Result<Self, Error> {
-        ensure!(msg.chat_id > DC_CHAT_ID_LAST_SPECIAL, "Invalid chat id");
+        ensure!(!msg.chat_id.is_special(), "Invalid chat id");
 
         let contact = Contact::load_from_db(context, msg.from_id)?;
 
@@ -613,7 +613,9 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                             email_to_add.into(),
                         ));
                     }
-                    if 0 != self.msg.param.get_int(Param::Arg2).unwrap_or_default() & 0x1 {
+                    if 0 != self.msg.param.get_int(Param::Arg2).unwrap_or_default()
+                        & DC_FROM_HANDSHAKE
+                    {
                         info!(
                             context,
                             "sending secure-join message \'{}\' >>>>>>>>>>>>>>>>>>>>>>>>>",

--- a/src/token.rs
+++ b/src/token.rs
@@ -6,6 +6,7 @@
 
 use deltachat_derive::*;
 
+use crate::chat::ChatId;
 use crate::context::Context;
 use crate::dc_tools::*;
 use crate::sql;
@@ -27,28 +28,28 @@ impl Default for Namespace {
 
 /// Creates a new token and saves it into the database.
 /// Returns created token.
-pub fn save(context: &Context, namespace: Namespace, foreign_id: u32) -> String {
+pub fn save(context: &Context, namespace: Namespace, foreign_id: ChatId) -> String {
     // foreign_id may be 0
     let token = dc_create_id();
     sql::execute(
         context,
         &context.sql,
         "INSERT INTO tokens (namespc, foreign_id, token, timestamp) VALUES (?, ?, ?, ?);",
-        params![namespace, foreign_id as i32, &token, time()],
+        params![namespace, foreign_id, &token, time()],
     )
     .ok();
     token
 }
 
-pub fn lookup(context: &Context, namespace: Namespace, foreign_id: u32) -> Option<String> {
+pub fn lookup(context: &Context, namespace: Namespace, foreign_id: ChatId) -> Option<String> {
     context.sql.query_get_value::<_, String>(
         context,
         "SELECT token FROM tokens WHERE namespc=? AND foreign_id=?;",
-        params![namespace, foreign_id as i32],
+        params![namespace, foreign_id],
     )
 }
 
-pub fn lookup_or_new(context: &Context, namespace: Namespace, foreign_id: u32) -> String {
+pub fn lookup_or_new(context: &Context, namespace: Namespace, foreign_id: ChatId) -> String {
     lookup(context, namespace, foreign_id).unwrap_or_else(|| save(context, namespace, foreign_id))
 }
 


### PR DESCRIPTION
This doesn't try and change the way ChatId is used.  It still allows
creating them with 0 and lets some function use a ChatId(0) as error
return.

The main change and starting point to review is probably chat.rs::ChatId and its various impls.

You might want to look at the changes to ResultExt in deltachat_ffi, they're not just adding ChatId.

Otherwise there should be no real logic refactors happening.