### PR TITLE
Fix the message printed on job success

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -1035,10 +1035,7 @@ fn job_perform(context: &Context, thread: Thread, probe_network: bool) {
                         "{} removes job {} as it failed with error {:?}", thread, job, err
                     );
                 } else {
-                    info!(
-                        context,
-                        "{} removes job {} as it cannot be retried", thread, job
-                    );
+                    info!(context, "{} removes job {} as it succeeded", thread, job);
                 }
 
                 job.delete(context);


### PR DESCRIPTION
"Cannot be retried" does not make it clear if the job succeeded or failed.