### PR TITLE
fix message deletion on server

### DIFF
--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -957,8 +957,8 @@ impl Imap {
                                 remote_message_id,
                                 message_id,
                             );
+                            *uid = 0;
                         }
-                        *uid = 0;
                     }
                     Err(err) => {
                         warn!(


### PR DESCRIPTION
before a message is actually deleted, we verify that server_folder+server_uid matches the Message-ID, so that we do not delete the wrong message by accident.  
the reason for that is that, to my knowledge, server_folder+server_uid are not necessarily stable but Message-ID is.

anyway, this check was broken and set the server_uid to 0 in all cases - where it should be set to 0 _only_ on mismatches.

a test for that would be nice, however, this would require a way to actually check what is going on on the server with an independent imap-toolchain. afaik, this is planned, but just not there :)

closes #1192
closes https://github.com/deltachat/deltachat-desktop/issues/1362