### PR TITLE
remove hardly useful fuzzy test

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1057,17 +1057,6 @@ mod tests {
         assert_eq!(mimeparser.parts.len(), 1);
     }
 
-    proptest! {
-        #[ignore]
-        #[test]
-        fn test_dc_mailmime_parse_crash_fuzzy(data in "[!-~\t ]{2000,}") {
-            let context = dummy_context();
-
-            // just don't crash
-            let _ = MimeMessage::from_bytes(&context.ctx, data.as_bytes());
-        }
-    }
-
     #[test]
     fn test_get_rfc724_mid_exists() {
         let context = dummy_context();


### PR DESCRIPTION
i don't think this fuzzy test is very useful -- the mime-parser will end very early on random-input and DC's parsing machinery probably almost never runs.

If we want to fuzzy our code and parsing handly we have to fill a kind of template structure with random data, so that DC's code paths for looking and parsing at various stuff is even triggered. 