### PR TITLE
Change to normal sematic version number for this sub-crate

### DIFF
--- a/deltachat_derive/Cargo.toml
+++ b/deltachat_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_derive"
-version = "1.0.0-beta.22"
+version = "2.0.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 license = "MPL-2.0"


### PR DESCRIPTION
Having a number that resembles the core version number is confusing.
This doesn't matter at all, it just needs to be a version number.

fixes #1203 