### PR TITLE
do not delete handshake messages possibly belonging to secure-joins on other devices

### DIFF
--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -623,7 +623,7 @@ pub(crate) fn handle_securejoin_handshake(
             ====             Bob - the joiner's side             ====
             ====   Step 7 in "Setup verified contact" protocol   ====
             =======================================================*/
-            let ret = if join_vg {
+            let abort_retval = if join_vg {
                 HandshakeMessage::Propagate
             } else {
                 HandshakeMessage::Ignore
@@ -631,7 +631,7 @@ pub(crate) fn handle_securejoin_handshake(
 
             if context.bob.read().unwrap().expects != DC_VC_CONTACT_CONFIRM {
                 info!(context, "Message belongs to a different handshake.",);
-                return Ok(ret);
+                return Ok(abort_retval);
             }
             let cond = {
                 let bob = context.bob.read().unwrap();
@@ -643,7 +643,7 @@ pub(crate) fn handle_securejoin_handshake(
                     context,
                     "Message out of sync or belongs to a different handshake.",
                 );
-                return Ok(ret);
+                return Ok(abort_retval);
             }
             let scanned_fingerprint_of_alice = get_qr_attr!(context, fingerprint).to_string();
 
@@ -674,7 +674,7 @@ pub(crate) fn handle_securejoin_handshake(
                     "Contact confirm message not encrypted.",
                 );
                 context.bob.write().unwrap().status = 0;
-                return Ok(ret);
+                return Ok(abort_retval);
             }
 
             if mark_peer_as_verified(context, &scanned_fingerprint_of_alice).is_err() {
@@ -683,7 +683,7 @@ pub(crate) fn handle_securejoin_handshake(
                     contact_chat_id,
                     "Fingerprint mismatch on joiner-side.",
                 );
-                return Ok(ret);
+                return Ok(abort_retval);
             }
             Contact::scaleup_origin_by_id(context, contact_id, Origin::SecurejoinJoined);
             emit_event!(context, Event::ContactsChanged(None));
@@ -697,7 +697,7 @@ pub(crate) fn handle_securejoin_handshake(
                     .map_err(|_| HandshakeError::NoSelfAddr)?
             {
                 info!(context, "Message belongs to a different handshake (scaled up contact anyway to allow creation of group).");
-                return Ok(ret);
+                return Ok(abort_retval);
             }
             secure_connection_established(context, contact_chat_id);
             context.bob.write().unwrap().expects = 0;

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -635,7 +635,7 @@ pub(crate) fn handle_securejoin_handshake(
             let cond = {
                 let bob = context.bob.read().unwrap();
                 let scan = bob.qr_scan.as_ref();
-                scan.is_none() || join_vg && scan.unwrap().state != LotState::QrAskVerifyGroup
+                scan.is_none() || (join_vg && scan.unwrap().state != LotState::QrAskVerifyGroup)
             };
             if cond {
                 warn!(

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -626,8 +626,9 @@ pub(crate) fn handle_securejoin_handshake(
             let ret = if join_vg {
                 HandshakeMessage::Propagate
             } else {
-                HandshakeMessage::Done
+                HandshakeMessage::Ignore
             };
+
             if context.bob.read().unwrap().expects != DC_VC_CONTACT_CONFIRM {
                 info!(context, "Message belongs to a different handshake.",);
                 return Ok(ret);
@@ -713,7 +714,11 @@ pub(crate) fn handle_securejoin_handshake(
             }
             context.bob.write().unwrap().status = 1;
             context.stop_ongoing();
-            Ok(ret)
+            Ok(if join_vg {
+                HandshakeMessage::Propagate
+            } else {
+                HandshakeMessage::Done
+            })
         }
         "vg-member-added-received" => {
             /*==========================================================


### PR DESCRIPTION
this is a follow up on https://github.com/deltachat/deltachat-core-rust/pull/1209 and targets my last comment there.

in general, we should not delete handshake messages possibly belonging to secure-joins on other devices - a `HandshakeMessage::Done` deletes the message and will make fail other devices in a multi-device-setup to succeed. therefore, `HandshakeMessage::Done` should be returned only if the message was consumed successfully. 

in case of join_vg, however, we return `HandshakeMessage::Propagage` instead of Done/Ignore as the message is a normal group-added messages that should be handled - esp. if the group is not a verified group. (verified-groups and multi-device seems to be out of scope of this pr)