### PR TITLE
instant success on simple qr-setup-contact

### DIFF
--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -257,11 +257,18 @@ pub fn dc_join_securejoin(context: &Context, qr: &str) -> ChatId {
         );
     }
 
-    while !context.shall_stop_ongoing() {
-        // Don't sleep too long, the user is waiting.
-        std::thread::sleep(std::time::Duration::from_millis(200));
+    if join_vg {
+        // for a group-join, wait until the secure-join is done and the group is created
+        while !context.shall_stop_ongoing() {
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+        cleanup(&context, contact_chat_id, true, join_vg)
+    } else {
+        // for a one-to-one-chat, the chat is already known, return the chat-id,
+        // the verification runs in background
+        context.free_ongoing();
+        contact_chat_id
     }
-    cleanup(&context, contact_chat_id, true, join_vg)
 }
 
 fn send_handshake_msg(

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -143,6 +143,8 @@ fn get_self_fingerprint(context: &Context) -> Option<String> {
     None
 }
 
+/// Take a scanned QR-code and do the setup-contact/join-group handshake.
+/// See the ffi-documentation for more details.
 pub fn dc_join_securejoin(context: &Context, qr: &str) -> ChatId {
     let cleanup =
         |context: &Context, contact_chat_id: ChatId, ongoing_allocated: bool, join_vg: bool| {


### PR DESCRIPTION
this pr changes the behavior when scanning a setup-contact qr-code.
instead of waiting, until the whole protocol is finished,
which may take something between 10 seconds and several minutes,
the dc_join_secure_join() returns instantly;
the uis typically show the created chat then.

the returned chat-id is the same than if we wait for the protocol to finish,
it is the opportunistic one-to-one chat-id, so no changes there.

all this works even when both devices are offline.

after dc_join_secure_join() returns, however,
the usual setup-contact continues. ux-wise, once the protocol finishes,
a system-info-messages is added to the chat (also unchanged),
this is directly visible, in the chat as well as in the chatlist.
while the prococol runs, the user can alredy send message to the chat,
or do other things in the app.

if the user scans a new qr-code while an existing protocol is not finished yet,
the old join will be aborted (however, of course, created chats are kept).
we could also allow multiple joins at the same time,
however, this would be much more effort that this little change
and i am not sure if it is worth the effort.

finally, if a verified-group shall be joined,
this is not possible instantly, this is not affected by this pr.
same for unverified-groups, however, this could maybe be improved,
but also here, not sure if it is worth the effort
(i think most scans are setup-contact scans)

changes in the ui are not required,
i tested this a bit and it seems to work as expected,
not sure, if i've overseen something,
i think it is a HUGE win for the whole setup-contact thingie :)