### PR TITLE
Fix panic in BlobObject::sanitise_name()

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -631,4 +631,11 @@ mod tests {
         assert!(!BlobObject::is_acceptible_blob_name("foo\\bar"));
         assert!(!BlobObject::is_acceptible_blob_name("foo\x00bar"));
     }
+
+    #[test]
+    fn test_sanitise_name() {
+        let (_, ext) =
+            BlobObject::sanitise_name("Я ЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯ.txt");
+        assert_eq!(ext, ".txt");
+    }
 }

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -322,13 +322,12 @@ impl<'a> BlobObject<'a> {
 
         let clean = sanitize_filename::sanitize_with_options(name, opts);
         let mut iter = clean.splitn(2, '.');
-        let mut stem = iter.next().unwrap_or_default().to_string();
-        let mut ext = iter.next().unwrap_or_default().to_string();
-        stem.truncate(64);
-        ext.truncate(32);
-        match ext.len() {
-            0 => (stem, "".to_string()),
-            _ => (stem, format!(".{}", ext).to_lowercase()),
+        let stem: String = iter.next().unwrap_or_default().chars().take(64).collect();
+        let ext: String = iter.next().unwrap_or_default().chars().take(32).collect();
+        if ext.is_empty() {
+            (stem, "".to_string())
+        } else {
+            (stem, format!(".{}", ext).to_lowercase())
         }
     }
 


### PR DESCRIPTION
`.truncate()` is not safe as it may panic: https://doc.rust-lang.org/nightly/std/string/struct.String.html#method.truncate

This resulted in DC crashing when files with cyrillic filenames are received.