### PR TITLE
fix oauth2 login by fixing a Serde call

### DIFF
--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -314,7 +314,12 @@ impl Oauth2 {
             // CAVE: serde_json::Value.as_str() removes the quotes of json-strings
             // but serde_json::Value.to_string() does not!
             if let Some(addr) = response.get("email") {
-                addr.as_str().map(|s| s.to_string())
+                if let Some(s) = addr.as_str() {
+                    Some(s.to_string())
+                } else {
+                    warn!(context, "E-mail in userinfo is not a string: {}", addr);
+                    None
+                }
             } else {
                 warn!(context, "E-mail missing in userinfo.");
                 None

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -311,9 +311,10 @@ impl Oauth2 {
             return None;
         }
         if let Ok(response) = parsed {
-            // serde_json::Value.as_str() removes the quotes of json-strings
+            // CAVE: serde_json::Value.as_str() removes the quotes of json-strings
+            // but serde_json::Value.to_string() does not!
             if let Some(addr) = response.get("email") {
-                Some(addr.to_string())
+                addr.as_str().map(|s| s.to_string())
             } else {
                 warn!(context, "E-mail missing in userinfo.");
                 None


### PR DESCRIPTION
oauth2 crashes in beta23
because we did not let Serde remove the quotes from a parsed JSON email-address.

for autoconfig, we try to get a well-known URL
containing the domain of the used address - with the quote that is
https://autoconfig.gmail.com"/mail/config-v1.1.xml?...

unfortunately, instead of just returning an error,
(the url does not exist anyway)
reqwest crashes on the attempt to get this URL.

the Serde-thing is not obvious to me:
while serde_json::Value.as_str() removes the quotes,
serde_json::Value.to_string() does not.

fixes #1211, fixes https://github.com/deltachat/deltachat-android/issues/1222