### PR TITLE
prepare 1.0.0-beta24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog 
 
+## 1.0.0-beta.24
+
+- fix oauth2/gmail bug introduced in beta23 (not used in releases) #1219
+
+- fix panic when receiving eg. cyrillic filenames #1216
+
+- delete all consumed secure-join handshake messagess #1209 #1212
+
+- rust-level cleanups #1218 #1217 #1210 #1205
+
+- python-level cleanups #1204 #1202 #1201
+
+
 ## 1.0.0-beta.23
 
 - #1197 fix imap-deletion of messages 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -620,7 +620,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.0.0-beta.23"
+version = "1.0.0-beta.24"
 dependencies = [
  "async-imap 0.1.1 (git+https://github.com/async-email/async-imap?branch=dcc-stable)",
  "async-native-tls 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -697,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.0.0-beta.23"
+version = "1.0.0-beta.24"
 dependencies = [
- "deltachat 1.0.0-beta.23",
+ "deltachat 1.0.0-beta.24",
  "deltachat-provider-database 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "human-panic 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.0.0-beta.23"
+version = "1.0.0-beta.24"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.0.0-beta.23"
+version = "1.0.0-beta.24"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"


### PR DESCRIPTION
i did a `git tag 1.0.0-beta.24` and a `git push --tags` on the branch, not sure if this is sufficient.

EDIT: they go directly to master, so, if this is merged, things should be fine. for the future,  `git push --tags` should be done after merging. maybe we should add a hint to set_core_version.py's output, i am always again unsure about that.