### PR TITLE
do not bubble up errors on dc_has_import()

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1755,7 +1755,9 @@ pub unsafe extern "C" fn dc_imex_has_backup(
         .with_inner(|ctx| match imex::has_backup(ctx, to_string_lossy(dir)) {
             Ok(res) => res.strdup(),
             Err(err) => {
-                error!(ctx, "dc_imex_has_backup: {}", err);
+                // do not bubble up error to the user,
+                // the ui will expect that the file does not exist or cannot be accessed
+                warn!(ctx, "dc_imex_has_backup: {}", err);
                 ptr::null_mut()
             }
         })


### PR DESCRIPTION
error!() will show the error directly to the user,
this is not useful in this case,
and also the message with the function-name is not for the end-user.

instead, the ui shall (and already does)
show some explaining text if dc_has_import() returns false;
the error!() is disturbing here as this results in two hints shown to the user.

closes https://github.com/deltachat/deltachat-android/issues/1232