### PR TITLE
Avoid downloading messages that Delta Chat does not display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
  "byte-pool 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "imap-proto 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imap-proto 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1326,7 +1326,7 @@ dependencies = [
 
 [[package]]
 name = "imap-proto"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "nom 5.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3405,7 +3405,7 @@ dependencies = [
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum image 0.22.4 (registry+https://github.com/rust-lang/crates.io-index)" = "53cb19c4e35102e5c6fb9ade5e0e236c5588424dc171a849af3141bf0b47768a"
 "checksum image-meta 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b00861cbbb254a627d8acc0cec786b484297d896ab8f20fdc8e28536a3e918ef"
-"checksum imap-proto 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "11ba57a7d18ba7bca5a50d4723c16a3e532d2b3014d6fd3123910c266214d4f2"
+"checksum imap-proto 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "16a6def1d5ac8975d70b3fd101d57953fe3278ef2ee5d7816cba54b1d1dfc22f"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 "checksum inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1525,7 +1525,7 @@ fn is_reply_to_messenger_message(context: &Context, mime_parser: &MimeMessage) -
     false
 }
 
-pub fn is_msgrmsg_rfc724_mid_in_list(context: &Context, mid_list: &str) -> bool {
+pub(crate) fn is_msgrmsg_rfc724_mid_in_list(context: &Context, mid_list: &str) -> bool {
     if let Ok(ids) = mailparse::addrparse(mid_list) {
         for id in ids.iter() {
             if is_msgrmsg_rfc724_mid(context, id) {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -314,8 +314,7 @@ fn add_parts(
     } else {
         MessengerMessage::No
     };
-    // incoming non-chat messages may be discarded;
-    // maybe this can be optimized later, by checking the state before the message body is downloaded
+    // incoming non-chat messages may be discarded
     let mut allow_creation = true;
     let show_emails =
         ShowEmails::from_i32(context.get_config_int(Config::ShowEmails)).unwrap_or_default();

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -309,11 +309,13 @@ fn add_parts(
         && msgrmsg == MessengerMessage::No
     {
         // this message is a classic email not a chat-message nor a reply to one
-        if show_emails == ShowEmails::Off {
-            *chat_id = ChatId::new(DC_CHAT_ID_TRASH);
-            allow_creation = false
-        } else if show_emails == ShowEmails::AcceptedContacts {
-            allow_creation = false
+        match show_emails {
+            ShowEmails::Off => {
+                *chat_id = ChatId::new(DC_CHAT_ID_TRASH);
+                allow_creation = false;
+            }
+            ShowEmails::AcceptedContacts => allow_creation = false,
+            ShowEmails::All => {}
         }
     }
 
@@ -1510,7 +1512,7 @@ fn is_reply_to_messenger_message(context: &Context, mime_parser: &MimeMessage) -
     false
 }
 
-fn is_msgrmsg_rfc724_mid_in_list(context: &Context, mid_list: &str) -> bool {
+pub fn is_msgrmsg_rfc724_mid_in_list(context: &Context, mid_list: &str) -> bool {
     if let Ok(ids) = mailparse::addrparse(mid_list) {
         for id in ids.iter() {
             if is_msgrmsg_rfc724_mid(context, id) {

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1245,7 +1245,7 @@ fn parse_message_id(message_id: &[u8]) -> crate::error::Result<String> {
 fn prefetch_get_message_id(prefetch_msg: &Fetch) -> Result<String> {
     if prefetch_msg.envelope().is_none() {
         return Err(Error::Other(
-            "prefectch: message has no envelope".to_string(),
+            "prefetch: message has no envelope".to_string(),
         ));
     }
 

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -125,6 +125,7 @@ pub enum ImapActionResult {
 ///   not necessarily sent by Delta Chat.
 const PREFETCH_FLAGS: &str = "(UID BODY.PEEK[HEADER.FIELDS (\
                               MESSAGE-ID \
+                              FROM \
                               IN-REPLY-TO REFERENCES \
                               CHAT-VERSION \
                               AUTOCRYPT-SETUP-MESSAGE\

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1249,12 +1249,11 @@ fn prefetch_get_message_id(prefetch_msg: &Fetch) -> Result<String> {
         ));
     }
 
-    let message_id = prefetch_msg.envelope().unwrap().message_id;
-    if message_id.is_none() {
-        return Err(Error::Other("prefetch: No message ID found".to_string()));
+    if let Some(message_id) = prefetch_msg.envelope().unwrap().message_id {
+        parse_message_id(&message_id).map_err(Into::into)
+    } else {
+        Err(Error::Other("prefetch: No message ID found".to_string()))
     }
-
-    parse_message_id(&message_id.unwrap()).map_err(Into::into)
 }
 
 #[cfg(test)]

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -19,7 +19,9 @@ use mailparse::MailHeaderMap;
 use crate::config::*;
 use crate::constants::*;
 use crate::context::Context;
-use crate::dc_receive_imf::{dc_receive_imf, is_msgrmsg_rfc724_mid_in_list};
+use crate::dc_receive_imf::{
+    dc_receive_imf, from_field_to_contact_id, is_msgrmsg_rfc724_mid_in_list,
+};
 use crate::events::Event;
 use crate::headerdef::HeaderDef;
 use crate::imap_client::*;
@@ -1333,10 +1335,12 @@ fn prefetch_should_download(
     let is_autocrypt_setup_message =
         prefetch_has_header(&headers, HeaderDef::AutocryptSetupMessage)?;
 
-    // TODO: currently we don't check contacts during prefetch
-    // We assume the best case: contact is accepted and not blocked.
-    let accepted_contact = true;
-    let blocked_contact = false;
+    let from_field = headers
+        .get_first_value(&HeaderDef::From_.get_headername())?
+        .unwrap_or_default();
+
+    let (_contact_id, blocked_contact, origin) = from_field_to_contact_id(context, &from_field)?;
+    let accepted_contact = origin.is_known();
 
     let show = is_autocrypt_setup_message
         || match show_emails {

--- a/src/job_thread.rs
+++ b/src/job_thread.rs
@@ -143,7 +143,7 @@ impl JobThread {
             if state.jobs_needed {
                 info!(
                     context,
-                    "{}-IDLE will not be started as it was interrupted while not ideling.",
+                    "{}-IDLE will not be started as it was interrupted while not idling.",
                     self.name,
                 );
                 state.jobs_needed = false;


### PR DESCRIPTION
Fix for #1214

 - [x] Do not mark skipped emails as Seen, update `last_seen_uid` in the config instead. For example, use `BODY.PEEK` to avoid implicitly marking messages as seen. Classical email clients should still display skipped messages as unseen.
 - [x] Detect and download Autocrypt Setup Messages without `Chat-Version` when `ShowEmails` is `Off`
 - [x] Prefetch `In-Reply-To:` and `References:`, they are not part of the envelope.
 - [x] Check if message is a reply to chat message
 - [x] Download Message-ID header and From field instead of envelope for consistency with dc_receive_imf and possibly sharing some code.
 - [x] Ignore messages from blocked contacts
 - [x] Ignore emails from non-accepted contacts if `ShowEmails` is set to `AcceptedContacts`