### PR TITLE
Add an integration tests which generates a key

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -243,10 +243,12 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, datadir):
             wait_configuration_progress(ac2, 1000)
             return ac1, ac2
 
-        def clone_online_account(self, account):
+        def clone_online_account(self, account, pre_generated_key=True):
             self.live_count += 1
             tmpdb = tmpdir.join("livedb%d" % self.live_count)
             ac = self.make_account(tmpdb.strpath, logid="ac{}".format(self.live_count))
+            if pre_generated_key:
+                self._preconfigure_key(ac, account.get_config("addr"))
             ac._evlogger.init_time = self.init_time
             ac._evlogger.set_timeout(30)
             ac.configure(addr=account.get_config("addr"), mail_pw=account.get_config("mail_pw"))

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -417,6 +417,12 @@ class TestOfflineChat:
 
 
 class TestOnlineAccount:
+    @pytest.mark.ignored
+    def test_configure_generate_key(self, acfactory):
+        # A slow test which will generate a new key.
+        ac = acfactory.get_one_online_account(pre_generated_key=False)
+        ac.check_is_configured()
+
     def get_chat(self, ac1, ac2, both_created=False):
         c2 = ac1.create_contact(email=ac2.get_config("addr"))
         chat = ac1.create_chat_by_contact(c2)

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -7,7 +7,7 @@ envlist =
 
 [testenv]
 commands = 
-    pytest -n6 --reruns 2 --reruns-delay 5 -v -rsXx {posargs:tests} 
+    pytest -n6 --reruns 2 --reruns-delay 5 -v -rsXx --ignored {posargs:tests}
     python tests/package_wheels.py {toxworkdir}/wheelhouse
 passenv = 
     TRAVIS 
@@ -65,7 +65,7 @@ commands =
 
 
 [pytest]
-addopts = -v -ra
+addopts = -v -ra --strict-markers
 python_files = tests/test_*.py
 norecursedirs = .tox 
 xfail_strict=true


### PR DESCRIPTION
Configuring an online account generates a key, we would like this
code-path tested too.  So add some functionality to the AccountManager
to not use the pre-generated keys.

Because this slows down interactively running the tests by hand add an
ignored marker which only runs if --ignored is used.  This name was
chosen because this matches the naming used by rust/cargo #[ignored].
The difference however is that --ignored on cargo *only* runs ignored
tests while here it runs *all* tests.

To ensure the ignored/slow tests are run on CI we add it as an
argument to the tox configuration, which is used by the CI to run the
tests.