### PR TITLE
Use SystemTime instead of i64

### DIFF
--- a/deltachat-ffi/src/tools.rs
+++ b/deltachat-ffi/src/tools.rs
@@ -1,8 +1,0 @@
-use std::time::SystemTime;
-
-pub(crate) fn time() -> i64 {
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs() as i64
-}


### PR DESCRIPTION
This clarifies some behaviour with negative times and propagates
errors a bit better around places.