### PR TITLE
Fix test_one_account_send_bcc_setting

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -194,11 +194,6 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, datadir):
             lib.dc_set_config(ac._dc_context, b"configured", b"1")
             return ac
 
-        def peek_online_config(self):
-            if not session_liveconfig:
-                pytest.skip("specify DCC_PY_LIVECONFIG or --liveconfig")
-            return session_liveconfig.get(self.live_count)
-
         def get_online_config(self, pre_generated_key=True):
             if not session_liveconfig:
                 pytest.skip("specify DCC_PY_LIVECONFIG or --liveconfig")


### PR DESCRIPTION
Fixes #1252 

Using peek_online_config() results in a message being sent to some
other account, used by previous test. If tests are run in parallel,
for example with pytest-xdist, we could be sending a message to a still
online DC client.