### PR TITLE
Add .strdup() method to Option<AsRef<str>>

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3222,7 +3222,7 @@ pub unsafe extern "C" fn dc_lot_get_text1(lot: *mut dc_lot_t) -> *mut libc::c_ch
     }
 
     let lot = &*lot;
-    strdup_opt(lot.get_text1())
+    lot.get_text1().strdup()
 }
 
 #[no_mangle]
@@ -3233,7 +3233,7 @@ pub unsafe extern "C" fn dc_lot_get_text2(lot: *mut dc_lot_t) -> *mut libc::c_ch
     }
 
     let lot = &*lot;
-    strdup_opt(lot.get_text2())
+    lot.get_text2().strdup()
 }
 
 #[no_mangle]
@@ -3315,13 +3315,6 @@ impl<T: Default, E: std::fmt::Display> ResultExt<T, E> for Result<T, E> {
             }
             err
         })
-    }
-}
-
-unsafe fn strdup_opt(s: Option<impl AsRef<str>>) -> *mut libc::c_char {
-    match s {
-        Some(s) => s.as_ref().strdup(),
-        None => ptr::null_mut(),
     }
 }
 


### PR DESCRIPTION
I know this really doesn't matter, but I couldn't help myself wanting to figure this out.  This is the most elegant way I could achieve this, but please correct me if I am wrong about the need to create a new trait.

We already have a .strdup() method on AsRef<str>, this adds this
method also to an option of this.  In case the option is None a NULL
pointer is returned.

This is done by using a new trait, as the type system otherwise
considers such an implementation conflicting with the existing one.