### PR TITLE
clean up and simplify the ffi code a little bit

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -109,10 +109,6 @@ impl ContextWrapper {
     /// the appropriate return value for an error return since this
     /// differs for various functions on the FFI API: sometimes 0,
     /// NULL, an empty string etc.
-    ///
-    /// Prefer to use [ContextWrapper::try_inner], we might want to
-    /// remove this function at some point to reduce the cognitive
-    /// overload of having two functions which are too similar.
     unsafe fn with_inner<T, F>(&self, ctxfn: F) -> Result<T, ()>
     where
         F: FnOnce(&Context) -> T,

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -86,17 +86,6 @@ pub type dc_callback_t =
 pub type dc_context_t = ContextWrapper;
 
 impl ContextWrapper {
-    /// Log an error on the FFI context.
-    ///
-    /// As soon as a [ContextWrapper] exist it can be used to log an
-    /// error using the callback, even before [dc_context_open] is
-    /// called and an actual [Context] exists.
-    ///
-    /// This function makes it easy to log an error.
-    unsafe fn error(&self, msg: &str) {
-        self.translate_cb(Event::Error(msg.to_string()));
-    }
-
     /// Log a warning on the FFI context.
     ///
     /// Like [error] but logs as a warning which only goes to the
@@ -367,7 +356,7 @@ pub unsafe extern "C" fn dc_set_config(
             })
             .unwrap_or(0),
         Err(_) => {
-            ffi_context.error("dc_set_config(): invalid key");
+            ffi_context.warning("dc_set_config(): invalid key");
             0
         }
     }
@@ -388,7 +377,7 @@ pub unsafe extern "C" fn dc_get_config(
             .with_inner(|ctx| ctx.get_config(key).unwrap_or_default().strdup())
             .unwrap_or_else(|_| "".strdup()),
         Err(_) => {
-            ffi_context.error("dc_get_config(): invalid key");
+            ffi_context.warning("dc_get_config(): invalid key");
             "".strdup()
         }
     }


### PR DESCRIPTION
A couple of straight forward cleanups that should make future life that little bit easier.

Most importantly remove the option to display errors to the user, this is none of the ffi's business.

See commits for step-wise justifications.