### PR TITLE
Change generated key type to Ed25519

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -364,6 +364,12 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    also show all mails of confirmed contacts,
  *                    DC_SHOW_EMAILS_ALL (2)=
  *                    also show mails of unconfirmed contacts in the deaddrop.
+ * - `key_gen_type` = DC_KEY_GEN_DEFAULT (0)=
+ *                    generate recommended key type (default),
+ *                    DC_KEY_GEN_RSA2048 (1)=
+ *                    generate RSA 2048 keypair
+ *                    DC_KEY_GEN_ED25519 (2)=
+ *                    generate Ed25519 keypair
  * - `save_mime_headers` = 1=save mime headers
  *                    and make dc_get_mime_headers() work for subsequent calls,
  *                    0=do not save mime headers (default)
@@ -4528,6 +4534,13 @@ void            dc_array_add_id              (dc_array_t*, uint32_t); // depreca
 #define DC_SHOW_EMAILS_OFF               0
 #define DC_SHOW_EMAILS_ACCEPTED_CONTACTS 1
 #define DC_SHOW_EMAILS_ALL               2
+
+/*
+ * Values for dc_get|set_config("key_gen_type")
+ */
+#define DC_KEY_GEN_DEFAULT 0
+#define DC_KEY_GEN_RSA2048 1
+#define DC_KEY_GEN_ED25519 2
 
 
 /**

--- a/python/src/deltachat/const.py
+++ b/python/src/deltachat/const.py
@@ -105,6 +105,9 @@ DC_EVENT_FILE_COPIED = 2055
 DC_EVENT_IS_OFFLINE = 2081
 DC_EVENT_GET_STRING = 2091
 DC_STR_SELFNOTINGRP = 21
+DC_KEY_GEN_DEFAULT = 0
+DC_KEY_GEN_RSA2048 = 1
+DC_KEY_GEN_ED25519 = 2
 DC_PROVIDER_STATUS_OK = 1
 DC_PROVIDER_STATUS_PREPARATION = 2
 DC_PROVIDER_STATUS_BROKEN = 3
@@ -160,7 +163,7 @@ DC_STR_COUNT = 68
 
 def read_event_defines(f):
     rex = re.compile(r'#define\s+((?:DC_EVENT|DC_QR|DC_MSG|DC_LP|DC_EMPTY|DC_CERTCK|DC_STATE|DC_STR|'
-                     r'DC_CONTACT_ID|DC_GCL|DC_CHAT|DC_PROVIDER)_\S+)\s+([x\d]+).*')
+                     r'DC_CONTACT_ID|DC_GCL|DC_CHAT|DC_PROVIDER|DC_KEY_GEN)_\S+)\s+([x\d]+).*')
     for line in f:
         m = rex.match(line)
         if m:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -213,9 +213,10 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, datadir):
             return ac, dict(configdict)
 
         def get_online_configuring_account(self, mvbox=False, sentbox=False,
-                                           pre_generated_key=True):
+                                           pre_generated_key=True, config={}):
             ac, configdict = self.get_online_config(
                 pre_generated_key=pre_generated_key)
+            configdict.update(config)
             ac.configure(**configdict)
             ac.start_threads(mvbox=mvbox, sentbox=sentbox)
             return ac

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,9 @@ pub enum Config {
     #[strum(props(default = "0"))] // also change ShowEmails.default() on changes
     ShowEmails,
 
+    #[strum(props(default = "0"))]
+    KeyGenType,
+
     SaveMimeHeaders,
     ConfiguredAddr,
     ConfiguredMailServer,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -57,6 +57,20 @@ impl Default for ShowEmails {
     }
 }
 
+#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive, FromSql, ToSql)]
+#[repr(u8)]
+pub enum KeyGenType {
+    Default = 0,
+    Rsa2048 = 1,
+    Ed25519 = 2,
+}
+
+impl Default for KeyGenType {
+    fn default() -> Self {
+        KeyGenType::Default
+    }
+}
+
 pub const DC_HANDSHAKE_CONTINUE_NORMAL_PROCESSING: i32 = 0x01;
 pub const DC_HANDSHAKE_STOP_NORMAL_PROCESSING: i32 = 0x02;
 pub const DC_HANDSHAKE_ADD_DELETE_JOB: i32 = 0x04;

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -8,6 +8,7 @@ use num_traits::FromPrimitive;
 
 use crate::aheader::*;
 use crate::config::Config;
+use crate::constants::KeyGenType;
 use crate::context::Context;
 use crate::dc_tools::EmailAddress;
 use crate::error::*;
@@ -211,11 +212,11 @@ fn load_or_generate_self_public_key(
     }
 
     let start = std::time::Instant::now();
-    info!(
-        context,
-        "Generating keypair with {} bits, e={} ...", 2048, 65537,
-    );
-    let keypair = pgp::create_keypair(EmailAddress::new(self_addr.as_ref())?)?;
+
+    let keygen_type =
+        KeyGenType::from_i32(context.get_config_int(Config::KeyGenType)).unwrap_or_default();
+    info!(context, "Generating keypair with type {}", keygen_type);
+    let keypair = pgp::create_keypair(EmailAddress::new(self_addr.as_ref())?, keygen_type)?;
     key::store_self_keypair(context, &keypair, KeyPairUse::Default)?;
     info!(
         context,

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -150,7 +150,7 @@ pub struct KeyPair {
 pub(crate) fn create_keypair(addr: EmailAddress) -> std::result::Result<KeyPair, PgpKeygenError> {
     let user_id = format!("<{}>", addr);
     let key_params = SecretKeyParamsBuilder::default()
-        .key_type(PgpKeyType::Rsa(2048))
+        .key_type(PgpKeyType::EdDSA)
         .can_create_certificates(true)
         .can_sign(true)
         .primary_user_id(user_id)
@@ -173,7 +173,7 @@ pub(crate) fn create_keypair(addr: EmailAddress) -> std::result::Result<KeyPair,
         ])
         .subkey(
             SubkeyParamsBuilder::default()
-                .key_type(PgpKeyType::Rsa(2048))
+                .key_type(PgpKeyType::ECDH)
                 .can_encrypt(true)
                 .passphrase(None)
                 .build()


### PR DESCRIPTION
rPGP generates EdDSA and and ECDH keys using Ed25519 only, so there is
no need to specify it explicitly anywhere.

Fixes #818 

 - [x] Add C and Python constants for key types
 - [x] Add python interoperability test: 2 clients with different key types sending messages to each other.
