### PR TITLE
alter the memberlist more carefully

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,6 +1,6 @@
 # Chat-over-Email specification
 
-Version 0.20.0
+Version 0.30.0
 
 This document describes how emails can be used
 to implement typical messenger functions
@@ -32,8 +32,7 @@ Messages SHOULD be encrypted by the
 Meta data (at least the subject and all chat-headers) SHOULD be encrypted
 by the [Memoryhole](https://github.com/autocrypt/memoryhole) standard.
 If Memoryhole is not used,
-the subject of encrypted messages SHOULD be replaced by the string
-`Chat: Encrypted message` where the part after the colon MAY be localized.
+the subject of encrypted messages SHOULD be replaced by the string `...`.
 
 
 # Outgoing messages
@@ -116,6 +115,7 @@ but MUAs typically expose the sender in the UI.
 Groups are chats with usually more than one recipient,
 each defined by an email-address.
 The sender plus the recipients are the group members.
+All group members form the member list.
 
 To allow different groups with the same members,
 groups are identified by a group-id.
@@ -138,8 +138,7 @@ The group-name MUST be written to `Chat-Group-Name` header
 to join a group chat on a second device any time).
 
 The `Subject` header of outgoing group messages
-SHOULD start with the characters `Chat:`
-followed by the group-name and a colon followed by an excerpt of the message.
+SHOULD be set to the group-name.
 
 To identify the group-id on replies from normal MUAs,
 the group-id MUST also be added to the message-id of outgoing messages.
@@ -180,12 +179,22 @@ to a normal single-user chat with the email-address given in `From`.
 
 ## Add and remove members
 
-Messenger clients MUST construct the member list
-from the `From`/`To` headers only on the first group message
-or if they see a `Chat-Group-Member-Added`
-or `Chat-Group-Member-Removed` action header.
-Both headers MUST have the email-address
-of the added or removed member as the value.
+Messenger clients MUST init the member list
+from the `From`/`To` headers on the first group message.
+
+When a member is added later,
+a `Chat-Group-Member-Added` action header must be sent
+with the value set to the email-address of the added member.
+When receiving a `Chat-Group-Member-Added` header, however,
+_all missing_ members  the `From`/`To` headers has to be added.
+This is to mitigate problems when receiving messages
+in different orders, esp. on creating new groups.
+
+To remove a member, a `Chat-Group-Member-Removed` header must be sent
+with the value set to the email-address of the member to remove.
+When receiving a `Chat-Group-Member-Removed` header,
+only exaxtly the given member has to be removed from the member list.
+
 Messenger clients MUST NOT construct the member list
 on other group messages
 (this is to avoid accidentally altered To-lists in normal MUAs;
@@ -429,4 +438,4 @@ as the sending time of the message as indicated by its Date header,
 or the time of first receipt if that date is in the future or unavailable.
 
 
-Copyright © 2017-2019 Delta Chat contributors.
+Copyright © 2017-2020 Delta Chat contributors.

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1750,8 +1750,6 @@ pub fn create_group_chat(
     Ok(chat_id)
 }
 
-/* you MUST NOT modify this or the following strings */
-// Context functions to work with chats
 pub fn add_to_chat_contacts_table(context: &Context, chat_id: ChatId, contact_id: u32) -> bool {
     // add a contact to a chat; the function does not check the type or if any of the record exist or are already
     // added to the chat!
@@ -1759,6 +1757,22 @@ pub fn add_to_chat_contacts_table(context: &Context, chat_id: ChatId, contact_id
         context,
         &context.sql,
         "INSERT INTO chats_contacts (chat_id, contact_id) VALUES(?, ?)",
+        params![chat_id, contact_id as i32],
+    )
+    .is_ok()
+}
+
+pub fn remove_from_chat_contacts_table(
+    context: &Context,
+    chat_id: ChatId,
+    contact_id: u32,
+) -> bool {
+    // remove a contact from the chats_contact table unconditionally
+    // the function does not check the type or if the record exist
+    sql::execute(
+        context,
+        &context.sql,
+        "DELETE FROM chats_contacts WHERE chat_id=? AND contact_id=?",
         params![chat_id, contact_id as i32],
     )
     .is_ok()
@@ -2075,14 +2089,7 @@ pub fn remove_contact_from_chat(
                         });
                     }
                 }
-                if sql::execute(
-                    context,
-                    &context.sql,
-                    "DELETE FROM chats_contacts WHERE chat_id=? AND contact_id=?;",
-                    params![chat_id, contact_id as i32],
-                )
-                .is_ok()
-                {
+                if remove_from_chat_contacts_table(context, chat_id, contact_id) {
                     context.call_cb(Event::ChatModified(chat_id));
                     success = true;
                 }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1025,7 +1025,7 @@ fn create_or_lookup_group(
         if !chat::is_contact_in_chat(context, chat_id, DC_CONTACT_ID_SELF) {
             chat::add_to_chat_contacts_table(context, chat_id, DC_CONTACT_ID_SELF);
         }
-        if from_id > DC_CHAT_ID_LAST_SPECIAL
+        if from_id > DC_CONTACT_ID_LAST_SPECIAL
             && !Contact::addr_equals_contact(context, &self_addr, from_id as u32)
             && !chat::is_contact_in_chat(context, chat_id, from_id)
         {


### PR DESCRIPTION
up to now, `Chat-Group-Member-Added` and `Chat-Group-Member-Removed` commands result in a complete recreation of the memberlist by collecting all addresses from the From: and To: headers.
    
this easily results in missed and accidentally removed members, esp. when several people at the same time scan a qr code to join a group.
    
this pr changes the behavior of adding members by _not removing_ members on the `Chat-Group-Member-Added` command. instead the existing memberlist is conjuncted with the memberlist seen in the message.
    
_only_ adding the member from the `Chat-Group-Member-Added`-header seems not to be sufficient - imaging a group of Alice and Bob:
- Alice adds Claire
- Bob adds Dave _before_ seeing that Alice added Claire
- Dave would never get the information that Claire is in the group
    
wrt `Chat-Group-Member-Removed`: this command does no longer recreate the memberlist but just remove _exactly_ the member mentioned in the header. there are situations, where a just removed member will be readded by out-of-order-messages, however, compared to missed members, this is seems to be acceptable - also as this is more visible and easier to fix (just remove the member again).  
might be that, in practise, this is not a big issue. while adding members is typically done in masses on bootstraping a group, this is typically not true for removing members.