### PR TITLE
directly attempt to re-connect if the smtp connection is maybe stale

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -205,17 +205,12 @@ impl Job {
                         Status::RetryLater
                     }
                     _ => {
-                        // if the connection was successfully used more than 60
-                        // seconds ago, try an immediate reconnect.
-                        let mut res2 = Status::RetryLater;
-                        if let Some(secs) = smtp.secs_since_last_success() {
-                            if secs > 60 {
-                                info!(context, "stale connection? triggering reconnect");
-                                res2 = Status::RetryNow;
-                            }
+                        if smtp.has_maybe_stale_connection() {
+                            info!(context, "stale connection? immediately reconnecting");
+                            Status::RetryNow
+                        } else {
+                            Status::RetryLater
                         }
-
-                        res2
                     }
                 };
 

--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -57,7 +57,7 @@ pub struct Smtp {
     /// Email address we are sending from.
     from: Option<EmailAddress>,
 
-    /// Timestamp of last successfull send/receive network interaction
+    /// Timestamp of last successful send/receive network interaction
     /// (eg connect or send succeeded). On initialization and disconnect
     /// it is set to None.
     last_success: Option<Instant>,

--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -77,13 +77,13 @@ impl Smtp {
         self.last_success = None;
     }
 
-    /// Return number of seconds since last success or None if
-    /// no success-time is recorded in this session.
-    pub fn secs_since_last_success(&self) -> Option<u64> {
+    /// Return true if smtp was connected but is not known to
+    /// have been successfully used the last 60 seconds
+    pub fn has_maybe_stale_connection(&self) -> bool {
         if let Some(last_success) = self.last_success {
-            Some(Instant::now().duration_since(last_success).as_secs())
+            Instant::now().duration_since(last_success).as_secs() > 60
         } else {
-            None
+            false
         }
     }
 

--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod send;
 
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_smtp::smtp::client::net::*;
 use async_smtp::*;
@@ -53,8 +53,14 @@ pub type Result<T> = std::result::Result<T, Error>;
 pub struct Smtp {
     #[debug_stub(some = "SmtpTransport")]
     transport: Option<smtp::SmtpTransport>,
+
     /// Email address we are sending from.
     from: Option<EmailAddress>,
+
+    /// Timestamp of last successfull send/receive network interaction
+    /// (eg connect or send succeeded). On initialization and disconnect
+    /// it is set to None.
+    last_success: Option<Instant>,
 }
 
 impl Smtp {
@@ -67,6 +73,17 @@ impl Smtp {
     pub fn disconnect(&mut self) {
         if let Some(mut transport) = self.transport.take() {
             async_std::task::block_on(transport.close()).ok();
+        }
+        self.last_success = None;
+    }
+
+    /// Return number of seconds since last success or None if
+    /// no success-time is recorded in this session.
+    pub fn secs_since_last_success(&self) -> Option<u64> {
+        if let Some(last_success) = self.last_success {
+            Some(Instant::now().duration_since(last_success).as_secs())
+        } else {
+            None
         }
     }
 
@@ -161,6 +178,7 @@ impl Smtp {
         trans.connect().await.map_err(Error::ConnectionFailure)?;
 
         self.transport = Some(trans);
+        self.last_success = Some(Instant::now());
         context.call_cb(Event::SmtpConnected(format!(
             "SMTP-LOGIN as {} ok",
             lp.send_user,

--- a/src/smtp/send.rs
+++ b/src/smtp/send.rs
@@ -53,6 +53,8 @@ impl Smtp {
                 "Message len={} was smtp-sent to {}",
                 message_len, recipients_display
             )));
+            self.last_success = Some(std::time::Instant::now());
+
             Ok(())
         } else {
             warn!(


### PR DESCRIPTION
This likely fixes #1214  also refactors performing the job-action into an own function removes the slightly complicated map().find() iterative 2-tries loop. 

The PR will immediately attempt to reconnect in case of an smtp-send error, if the last success connect or send is more than 60 seconds ago.  Previously the send-job was scheduled to retrying later which can be some 10-60 seconds (or more if the smtp-job is already retried!) delay before a message goes out.  Note that if the connect-attempt fails (because we are really offline) the send-job will be retried later (with expontential back-off delays). 

Note that without the "<60 secs" check, we might enter a busy loop producing network traffic, i.e. if we successfully connect but then somehow (SSL error or whatever) fail to send the message. 

