### PR TITLE
Delete messages from IMAP server and device after user-configurable time

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -379,9 +379,8 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    Messages are deleted whether they were seen or not, the UI should clearly point that out.
  * - `delete_server_after` = 0=do not delete messages from server automatically (default),
  *                    >=1=seconds, after which messages are deleted automatically from the server.
- *                    Messages in the "saved messages" chat (see dc_chat_is_self_talk()) are skipped.
- *                    Also emails matching the `show_emails` settings above are deleted from the server,
- *                    the UI should clearly point that out.
+ *                    "Saved messages" are deleted from the server as well as
+ *                    emails matching the `show_emails` settings above, the UI should clearly point that out.
  *
  * If you want to retrieve a value, use dc_get_config().
  *

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -376,11 +376,12 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  * - `delete_device_after` = 0=do not delete messages from device automatically (default),
  *                    >=1=seconds, after which messages are deleted automatically from the device.
  *                    Messages in the "saved messages" chat (see dc_chat_is_self_talk()) are skipped.
+ *                    Messages are deleted whether they were seen or not, the UI should clearly point that out.
  * - `delete_server_after` = 0=do not delete messages from server automatically (default),
  *                    >=1=seconds, after which messages are deleted automatically from the server.
+ *                    Messages in the "saved messages" chat (see dc_chat_is_self_talk()) are skipped.
  *                    Also emails matching the `show_emails` settings above are deleted from the server,
  *                    the UI should clearly point that out.
- *                    Messages in the "saved messages" chat (see dc_chat_is_self_talk()) are skipped.
  *
  * If you want to retrieve a value, use dc_get_config().
  *
@@ -1305,7 +1306,7 @@ int             dc_get_fresh_msg_cnt         (dc_context_t* context, uint32_t ch
 
 
 /**
- * Estimte the number of messages that will be deleted
+ * Estimate the number of messages that will be deleted
  * by the dc_set_config()-options `delete_device_after` or `delete_server_after`.
  * This is typically used to show the estimated impact to the user before actually enabling ephemeral messages.
  *

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -373,6 +373,14 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  * - `save_mime_headers` = 1=save mime headers
  *                    and make dc_get_mime_headers() work for subsequent calls,
  *                    0=do not save mime headers (default)
+ * - `delete_device_after` = 0=do not delete messages from device automatically (default),
+ *                    >=1=seconds, after which messages are deleted automatically from the device.
+ *                    Messages in the "saved messages" chat (see dc_chat_is_self_talk()) are skipped.
+ * - `delete_server_after` = 0=do not delete messages from server automatically (default),
+ *                    >=1=seconds, after which messages are deleted automatically from the server.
+ *                    Also emails matching the `show_emails` settings above are deleted from the server,
+ *                    the UI should clearly point that out.
+ *                    Messages in the "saved messages" chat (see dc_chat_is_self_talk()) are skipped.
  *
  * If you want to retrieve a value, use dc_get_config().
  *
@@ -1295,6 +1303,21 @@ int             dc_get_msg_cnt               (dc_context_t* context, uint32_t ch
 int             dc_get_fresh_msg_cnt         (dc_context_t* context, uint32_t chat_id);
 
 
+
+/**
+ * Estimte the number of messages that will be deleted
+ * by the dc_set_config()-options `delete_device_after` or `delete_server_after`.
+ * This is typically used to show the estimated impact to the user before actually enabling ephemeral messages.
+ *
+ * @param context The context object as returned from dc_context_new().
+ * @param from_server 1=Estimate deletion count for server, 0=Estimate deletion count for device
+ * @param seconds Count messages older than the given number of seconds.
+ * @return Number of messages that are older than the given number of seconds.
+ *     This includes emails downloaded due to the `show_emails` option.
+ *     Messages in the "saved messages" folder are not counted as they will not be deleted automatically.
+ */
+int             dc_estimate_deletion_cnt    (dc_context_t* context, int from_server, int64_t seconds);
+
 /**
  * Returns the message IDs of all _fresh_ messages of any chat.
  * Typically used for implementing notification summaries.
@@ -1658,8 +1681,9 @@ char*           dc_get_mime_headers          (dc_context_t* context, uint32_t ms
  */
 void            dc_delete_msgs               (dc_context_t* context, const uint32_t* msg_ids, int msg_cnt);
 
-/**
+/*
  * Empty IMAP server folder: delete all messages.
+ * Deprecated, use dc_set_config() with the key "delete_server_after" instead.
  *
  * @memberof dc_context_t
  * @param context The context object as created by dc_context_new()
@@ -4127,28 +4151,8 @@ int64_t          dc_lot_get_timestamp     (const dc_lot_t* lot);
  */
 
 
-/**
- * @defgroup DC_EMPTY DC_EMPTY
- *
- * These constants configure emptying imap folders with dc_empty_server()
- *
- * @addtogroup DC_EMPTY
- * @{
- */
-
-/**
- * Clear all mvbox messages.
- */
-#define DC_EMPTY_MVBOX 0x01
-
-/**
- * Clear all INBOX messages.
- */
-#define DC_EMPTY_INBOX 0x02
-
-/**
- * @}
- */
+#define DC_EMPTY_MVBOX 0x01 // Deprecated, flag for dc_empty_server(): Clear all mvbox messages
+#define DC_EMPTY_INBOX 0x02 // Deprecated, flag for dc_empty_server(): Clear all INBOX messages
 
 
 /**

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1046,6 +1046,25 @@ pub unsafe extern "C" fn dc_get_fresh_msg_cnt(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_estimate_deletion_cnt(
+    context: *mut dc_context_t,
+    from_server: libc::c_int,
+    seconds: i64,
+) -> libc::c_int {
+    if context.is_null() || seconds < 0 {
+        eprintln!("ignoring careless call to dc_estimate_deletion_cnt()");
+        return 0;
+    }
+    let ffi_context = &*context;
+    ffi_context
+        .with_inner(|ctx| {
+            message::estimate_deletion_cnt(ctx, from_server as bool, seconds).unwrap_or(0)
+                as libc::c_int
+        })
+        .unwrap_or(0)
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_get_fresh_msgs(
     context: *mut dc_context_t,
 ) -> *mut dc_array::dc_array_t {

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1058,7 +1058,7 @@ pub unsafe extern "C" fn dc_estimate_deletion_cnt(
     let ffi_context = &*context;
     ffi_context
         .with_inner(|ctx| {
-            message::estimate_deletion_cnt(ctx, from_server as bool, seconds).unwrap_or(0)
+            message::estimate_deletion_cnt(ctx, from_server != 0, seconds).unwrap_or(0)
                 as libc::c_int
         })
         .unwrap_or(0)

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -397,6 +397,7 @@ pub fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::Error> {
                  providerinfo <addr>\n\
                  event <event-id to test>\n\
                  fileinfo <file>\n\
+                 estimatedeletion <seconds>\n\
                  emptyserver <flags> (1=MVBOX 2=INBOX)\n\
                  clear -- clear screen\n\
                  exit or quit\n\
@@ -1027,6 +1028,16 @@ pub fn dc_cmdline(context: &Context, line: &str) -> Result<(), failure::Error> {
             } else {
                 bail!("Command failed.");
             }
+        }
+        "estimatedeletion" => {
+            ensure!(!arg1.is_empty(), "Argument <seconds> missing");
+            let seconds = arg1.parse()?;
+            let device_cnt = message::estimate_deletion_cnt(context, false, seconds)?;
+            let server_cnt = message::estimate_deletion_cnt(context, true, seconds)?;
+            println!(
+                "estimated count of messages older than {} seconds:\non device: {}\non server: {}",
+                seconds, device_cnt, server_cnt
+            );
         }
         "emptyserver" => {
             ensure!(!arg1.is_empty(), "Argument <flags> missing");

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -308,8 +308,17 @@ const CONTACT_COMMANDS: [&str; 6] = [
     "delcontact",
     "cleanupcontacts",
 ];
-const MISC_COMMANDS: [&str; 9] = [
-    "getqr", "getbadqr", "checkqr", "event", "fileinfo", "clear", "exit", "quit", "help",
+const MISC_COMMANDS: [&str; 10] = [
+    "getqr",
+    "getbadqr",
+    "checkqr",
+    "event",
+    "fileinfo",
+    "clear",
+    "exit",
+    "quit",
+    "help",
+    "estimatedeletion",
 ];
 
 impl Hinter for DcHelper {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2522,15 +2522,19 @@ pub fn delete_device_expired_messages(context: &Context) -> sql::Result<()> {
              WHERE timestamp < ?",
             params![threshold_timestamp],
         )?;
-
-        // Delete hidden messages that are removed from the server.
-        context.sql.execute(
-            "DELETE FROM msgs \
-             WHERE (chat_id = ? OR hidden) \
-             AND server_uid = 0",
-            params![DC_CHAT_ID_TRASH],
-        )?;
     }
+    Ok(())
+}
+
+/// Removes from the database locally deleted messages that also don't
+/// have a server UID.
+pub fn prune_tombstones(context: &Context) -> sql::Result<()> {
+    context.sql.execute(
+        "DELETE FROM msgs \
+         WHERE (chat_id = ? OR hidden) \
+         AND server_uid = 0",
+        params![DC_CHAT_ID_TRASH],
+    )?;
     Ok(())
 }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2522,7 +2522,7 @@ pub fn delete_device_expired_messages(context: &Context) -> sql::Result<()> {
         // Hide expired messages
         context.sql.execute(
             "UPDATE msgs \
-             SET txt = '', hidden = 1 \
+             SET txt = 'DELETED', hidden = 1 \
              WHERE timestamp < ? \
              AND chat_id > ?",
             params![threshold_timestamp, DC_CHAT_ID_LAST_SPECIAL],

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1630,6 +1630,28 @@ pub fn marknoticed_all_chats(context: &Context) -> Result<(), Error> {
     Ok(())
 }
 
+pub fn delete_device_expired_messages_all_chats(context: &Context) -> Result<(), Error> {
+    let chat_ids = context.sql.query_map(
+        "SELECT id FROM chats WHERE id > 9",
+        params![],
+        |row| row.get::<_, ChatId>(0),
+        |ids| {
+            let mut ret = Vec::new();
+            for id in ids {
+                if let Ok(chat_id) = id {
+                    ret.push(chat_id)
+                }
+            }
+            Ok(ret)
+        },
+    )?;
+
+    for chat_id in chat_ids {
+        chat_id.delete_device_expired_messages(context)?;
+    }
+    Ok(())
+}
+
 pub fn get_chat_media(
     context: &Context,
     chat_id: ChatId,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -359,6 +359,25 @@ impl ChatId {
             .unwrap_or_default() as usize
     }
 
+    pub(crate) fn get_param(self, context: &Context) -> Result<Params, Error> {
+        let res: Option<String> = context
+            .sql
+            .query_get_value_result::<_, _>("SELECT param FROM chats WHERE id=?", params![self])?;
+        Ok(res
+            .map(|s| s.parse().unwrap_or_default())
+            .unwrap_or_default())
+    }
+
+    // Returns true if chat is a saved messages chat.
+    pub fn is_self_talk(self, context: &Context) -> Result<bool, Error> {
+        Ok(self.get_param(context)?.exists(Param::Selftalk))
+    }
+
+    /// Returns true if chat is a device chat.
+    pub fn is_device_talk(self, context: &Context) -> Result<bool, Error> {
+        Ok(self.get_param(context)?.exists(Param::Devicetalk))
+    }
+
     /// Bad evil escape hatch.
     ///
     /// Avoid using this, eventually types should be cleaned up enough

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2530,18 +2530,6 @@ pub fn delete_device_expired_messages(context: &Context) -> sql::Result<()> {
     Ok(())
 }
 
-/// Removes from the database locally deleted messages that also don't
-/// have a server UID.
-pub fn prune_tombstones(context: &Context) -> sql::Result<()> {
-    context.sql.execute(
-        "DELETE FROM msgs \
-         WHERE (chat_id = ? OR hidden) \
-         AND server_uid = 0",
-        params![DC_CHAT_ID_TRASH],
-    )?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2509,6 +2509,31 @@ pub(crate) fn add_info_msg(context: &Context, chat_id: ChatId, text: impl AsRef<
     });
 }
 
+/// Hides or deletes messages which are expired according to
+/// "delete_device_after" setting.
+pub fn delete_device_expired_messages(context: &Context) -> sql::Result<()> {
+    if let Some(delete_device_after) = context.get_config_delete_device_after() {
+        let threshold_timestamp = time() - delete_device_after;
+
+        // Hide expired messages
+        context.sql.execute(
+            "UPDATE msgs \
+             SET txt = '', hidden = 1 \
+             WHERE timestamp < ?",
+            params![threshold_timestamp],
+        )?;
+
+        // Delete hidden messages that are removed from the server.
+        context.sql.execute(
+            "DELETE FROM msgs \
+             WHERE (chat_id = ? OR hidden) \
+             AND server_uid = 0",
+            params![DC_CHAT_ID_TRASH],
+        )?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2523,8 +2523,9 @@ pub fn delete_device_expired_messages(context: &Context) -> sql::Result<()> {
         context.sql.execute(
             "UPDATE msgs \
              SET txt = '', hidden = 1 \
-             WHERE timestamp < ?",
-            params![threshold_timestamp],
+             WHERE timestamp < ? \
+             AND chat_id > ?",
+            params![threshold_timestamp, DC_CHAT_ID_LAST_SPECIAL],
         )?;
     }
     Ok(())

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -287,7 +287,7 @@ impl ChatId {
     fn maybe_delete_draft(self, context: &Context) -> bool {
         match self.get_draft_msg_id(context) {
             Some(msg_id) => {
-                Message::delete_from_db(context, msg_id);
+                msg_id.delete_from_db(context);
                 true
             }
             None => false,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1447,6 +1447,10 @@ pub fn get_chat_msgs(
     flags: u32,
     marker1before: Option<MsgId>,
 ) -> Vec<MsgId> {
+    if let Err(err) = delete_device_expired_messages(context) {
+        warn!(context, "Failed to delete expired messages: {}", err);
+    }
+
     let process_row =
         |row: &rusqlite::Row| Ok((row.get::<_, MsgId>("id")?, row.get::<_, i64>("timestamp")?));
     let process_rows = |rows: rusqlite::MappedRows<_>| {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -286,10 +286,7 @@ impl ChatId {
     /// Returns `true`, if message was deleted, `false` otherwise.
     fn maybe_delete_draft(self, context: &Context) -> bool {
         match self.get_draft_msg_id(context) {
-            Some(msg_id) => {
-                msg_id.delete_from_db(context);
-                true
-            }
+            Some(msg_id) => msg_id.delete_from_db(context).is_ok(),
             None => false,
         }
     }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -389,13 +389,17 @@ impl ChatId {
             let threshold_timestamp = time() - delete_device_after;
 
             // Hide expired messages
-            context.sql.execute(
+            let rows_modified = context.sql.execute(
                 "UPDATE msgs \
                  SET txt = 'DELETED', hidden = 1 \
                  WHERE timestamp < ? \
                  AND chat_id == ?",
                 params![threshold_timestamp, self],
             )?;
+
+            if rows_modified > 0 {
+                context.call_cb(Event::ChatModified(self));
+            }
         }
         Ok(())
     }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -362,7 +362,7 @@ impl ChatId {
     pub(crate) fn get_param(self, context: &Context) -> Result<Params, Error> {
         let res: Option<String> = context
             .sql
-            .query_get_value_result::<_, _>("SELECT param FROM chats WHERE id=?", params![self])?;
+            .query_get_value_result("SELECT param FROM chats WHERE id=?", params![self])?;
         Ok(res
             .map(|s| s.parse().unwrap_or_default())
             .unwrap_or_default())

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -389,11 +389,15 @@ impl ChatId {
             let threshold_timestamp = time() - delete_device_after;
 
             // Hide expired messages
+            //
+            // Only update the rows that have to be updated, to avoid emitting
+            // unnecessary "chat modified" events.
             let rows_modified = context.sql.execute(
                 "UPDATE msgs \
                  SET txt = 'DELETED', hidden = 1 \
                  WHERE timestamp < ? \
-                 AND chat_id == ?",
+                 AND chat_id == ? \
+                 AND NOT hidden",
                 params![threshold_timestamp, self],
             )?;
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -378,6 +378,28 @@ impl ChatId {
         Ok(self.get_param(context)?.exists(Param::Devicetalk))
     }
 
+    /// Hides or deletes messages which are expired according to
+    /// "delete_device_after" setting.
+    pub fn delete_device_expired_messages(self, context: &Context) -> Result<(), Error> {
+        if self.is_special() || self.is_self_talk(context)? || self.is_device_talk(context)? {
+            return Ok(());
+        }
+
+        if let Some(delete_device_after) = context.get_config_delete_device_after() {
+            let threshold_timestamp = time() - delete_device_after;
+
+            // Hide expired messages
+            context.sql.execute(
+                "UPDATE msgs \
+                 SET txt = 'DELETED', hidden = 1 \
+                 WHERE timestamp < ? \
+                 AND chat_id == ?",
+                params![threshold_timestamp, self],
+            )?;
+        }
+        Ok(())
+    }
+
     /// Bad evil escape hatch.
     ///
     /// Avoid using this, eventually types should be cleaned up enough
@@ -1466,7 +1488,7 @@ pub fn get_chat_msgs(
     flags: u32,
     marker1before: Option<MsgId>,
 ) -> Vec<MsgId> {
-    if let Err(err) = delete_device_expired_messages(context) {
+    if let Err(err) = chat_id.delete_device_expired_messages(context) {
         warn!(context, "Failed to delete expired messages: {}", err);
     }
 
@@ -2530,24 +2552,6 @@ pub(crate) fn add_info_msg(context: &Context, chat_id: ChatId, text: impl AsRef<
         chat_id,
         msg_id: MsgId::new(row_id),
     });
-}
-
-/// Hides or deletes messages which are expired according to
-/// "delete_device_after" setting.
-pub fn delete_device_expired_messages(context: &Context) -> sql::Result<()> {
-    if let Some(delete_device_after) = context.get_config_delete_device_after() {
-        let threshold_timestamp = time() - delete_device_after;
-
-        // Hide expired messages
-        context.sql.execute(
-            "UPDATE msgs \
-             SET txt = 'DELETED', hidden = 1 \
-             WHERE timestamp < ? \
-             AND chat_id > ?",
-            params![threshold_timestamp, DC_CHAT_ID_LAST_SPECIAL],
-        )?;
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -91,6 +91,8 @@ impl Chatlist {
         query: Option<&str>,
         query_contact_id: Option<u32>,
     ) -> Result<Self> {
+        delete_device_expired_messages_all_chats(context)?;
+
         let mut add_archived_link_item = false;
 
         let process_row = |row: &rusqlite::Row| {

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -91,7 +91,9 @@ impl Chatlist {
         query: Option<&str>,
         query_contact_id: Option<u32>,
     ) -> Result<Self> {
-        delete_device_expired_messages_all_chats(context)?;
+        // Note that we do not emit DC_EVENT_MSGS_MODIFIED here even if some
+        // messages get hidden to avoid reloading the same chatlist.
+        hide_device_expired_messages(context)?;
 
         let mut add_archived_link_item = false;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,9 +68,12 @@ pub enum Config {
     /// Timer in seconds after which the message is deleted from the
     /// server.
     ///
-    /// Equals to -1 by default, which means the message is never
+    /// Equals to 0 by default, which means the message is never
     /// deleted.
-    #[strum(props(default = "-1"))]
+    ///
+    /// Value 1 is treated as "delete at once": messages are deleted
+    /// immediately, without moving to DeltaChat folder.
+    #[strum(props(default = "0"))]
     DeleteServerAfter,
 
     SaveMimeHeaders,
@@ -134,6 +137,18 @@ impl Context {
 
     pub fn get_config_bool(&self, key: Config) -> bool {
         self.get_config_int(key) != 0
+    }
+
+    /// Gets configured "delete_server_after" value.
+    ///
+    /// `None` means never delete the message, `Some(0)` means delete
+    /// at once, `Some(x)` means delete after `x` seconds.
+    pub fn get_config_delete_server_after(&self) -> Option<i64> {
+        match self.get_config_int(Config::DeleteServerAfter) {
+            0 => None,
+            1 => Some(0),
+            x => Some(x as i64),
+        }
     }
 
     /// Set the given config key.

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,6 +76,14 @@ pub enum Config {
     #[strum(props(default = "0"))]
     DeleteServerAfter,
 
+    /// Timer in seconds after which the message is deleted from the
+    /// device.
+    ///
+    /// Equals to 0 by default, which means the message is never
+    /// deleted.
+    #[strum(props(default = "0"))]
+    DeleteDeviceAfter,
+
     SaveMimeHeaders,
     ConfiguredAddr,
     ConfiguredMailServer,

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,14 @@ pub enum Config {
     #[strum(props(default = "0"))]
     KeyGenType,
 
+    /// Timer in seconds after which the message is deleted from the
+    /// server.
+    ///
+    /// Equals to -1 by default, which means the message is never
+    /// deleted.
+    #[strum(props(default = "-1"))]
+    DeleteServerAfter,
+
     SaveMimeHeaders,
     ConfiguredAddr,
     ConfiguredMailServer,

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,6 +159,17 @@ impl Context {
         }
     }
 
+    /// Gets configured "delete_device_after" value.
+    ///
+    /// `None` means never delete the message, `Some(x)` means delete
+    /// after `x` seconds.
+    pub fn get_config_delete_device_after(&self) -> Option<i64> {
+        match self.get_config_int(Config::DeleteDeviceAfter) {
+            0 => None,
+            x => Some(x as i64),
+        }
+    }
+
     /// Set the given config key.
     /// If `None` is passed as a value the value is cleared and set to the default if there is one.
     pub fn set_config(&self, key: Config, value: Option<&str>) -> crate::sql::Result<()> {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -194,13 +194,15 @@ pub fn dc_receive_imf(
 
     // if we delete we don't need to try moving messages
     if needs_delete_job && !created_db_entries.is_empty() {
-        job_add(
-            context,
-            Action::DeleteMsgOnImap,
-            created_db_entries[0].1.to_u32() as i32,
-            Params::new(),
-            0,
-        );
+        for db_entry in &created_db_entries {
+            job_add(
+                context,
+                Action::DeleteMsgOnImap,
+                db_entry.1.to_u32() as i32,
+                Params::new(),
+                0,
+            );
+        }
     } else {
         context.do_heuristics_moves(server_folder.as_ref(), insert_msg_id);
     }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -204,14 +204,14 @@ pub fn dc_receive_imf(
         }
     } else {
         // Get user-configured server deletion
-        let delete_server_after = context.get_config_int(Config::DeleteServerAfter);
+        let delete_server_after = context.get_config_delete_server_after();
 
-        if delete_server_after != 0 {
+        if delete_server_after != Some(0) {
             // Move message if we don't delete it immediately.
             context.do_heuristics_moves(server_folder.as_ref(), insert_msg_id);
         }
 
-        if delete_server_after >= 0 {
+        if let Some(delete_server_after) = delete_server_after {
             info!(
                 context,
                 "Scheduling message deletion in {} seconds", delete_server_after

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -606,10 +606,13 @@ fn add_parts(
             let subject = mime_parser.get_subject().unwrap_or_default();
 
             for part in mime_parser.parts.iter_mut() {
-                if mime_parser.location_kml.is_some()
+                let is_mdn = !mime_parser.reports.is_empty();
+
+                let is_location_kml = mime_parser.location_kml.is_some()
                     && icnt == 1
-                    && (part.msg == "-location-" || part.msg.is_empty())
-                {
+                    && (part.msg == "-location-" || part.msg.is_empty());
+
+                if is_mdn || is_location_kml {
                     *hidden = true;
                     if state == MessageState::InFresh {
                         state = MessageState::InNoticed;

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -219,7 +219,7 @@ pub fn dc_receive_imf(
 
     cleanup(context, &create_event_to_send, created_db_entries);
 
-    mime_parser.handle_reports(context, from_id, sent_timestamp, &server_folder, server_uid);
+    mime_parser.handle_reports(context, from_id, sent_timestamp);
 
     Ok(())
 }

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -794,7 +794,6 @@ impl Imap {
         folder: &str,
         uid: u32,
         dest_folder: &str,
-        dest_uid: &mut u32,
     ) -> ImapActionResult {
         task::block_on(async move {
             if folder == dest_folder {
@@ -811,10 +810,6 @@ impl Imap {
                 return imapresult;
             }
             // we are connected, and the folder is selected
-
-            // XXX Rust-Imap provides no target uid on mv, so just set it to 0
-            *dest_uid = 0;
-
             let set = format!("{}", uid);
             let display_folder_id = format!("{}/{}", folder, uid);
 

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1301,7 +1301,10 @@ fn precheck_imf(context: &Context, rfc724_mid: &str, server_folder: &str, server
         message::rfc724_mid_exists(context, &rfc724_mid)
     {
         if old_server_folder.is_empty() && old_server_uid == 0 {
-            info!(context, "[move] detected bcc-self {}", rfc724_mid,);
+            info!(
+                context,
+                "[move] detected bcc-self {} as {}/{}", rfc724_mid, server_folder, server_uid
+            );
 
             let delete_server_after = context.get_config_delete_server_after();
 
@@ -1316,7 +1319,34 @@ fn precheck_imf(context: &Context, rfc724_mid: &str, server_folder: &str, server
                 );
             }
         } else if old_server_folder != server_folder {
-            info!(context, "[move] detected moved message {}", rfc724_mid,);
+            info!(
+                context,
+                "[move] detected message {} moved by other device from {}/{} to {}/{}",
+                rfc724_mid,
+                old_server_folder,
+                old_server_uid,
+                server_folder,
+                server_uid
+            );
+        } else if old_server_uid == 0 {
+            info!(
+                context,
+                "[move] detected message {} moved by us from {}/{} to {}/{}",
+                rfc724_mid,
+                old_server_folder,
+                old_server_uid,
+                server_folder,
+                server_uid
+            );
+        } else if old_server_uid != server_uid {
+            warn!(
+                context,
+                "UID for message {} in folder {} changed from {} to {}",
+                rfc724_mid,
+                server_folder,
+                old_server_uid,
+                server_uid
+            );
         }
 
         if old_server_folder != server_folder || old_server_uid != server_uid {

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1320,35 +1320,6 @@ fn precheck_imf(context: &Context, rfc724_mid: &str, server_folder: &str, server
                     0,
                 );
             }
-
-            if let Some(delete_server_after) = delete_server_after {
-                info!(
-                    context,
-                    "Scheduling BCC-self deletion in {} seconds", delete_server_after
-                );
-
-                let msg_ids = match message::get_all_by_rfc724_mid(context, &rfc724_mid) {
-                    Err(err) => {
-                        warn!(
-                            context,
-                            "Cannot get all database records for Message-ID {}: {}",
-                            &rfc724_mid,
-                            err
-                        );
-                        vec![msg_id] // Remove at least the MsgId we know about
-                    }
-                    Ok(msg_ids) => msg_ids,
-                };
-                for part_msg_id in msg_ids {
-                    job_add(
-                        context,
-                        Action::DeleteMsgOnImap,
-                        part_msg_id.to_u32() as i32,
-                        Params::new(),
-                        delete_server_after as i64,
-                    );
-                }
-            }
         } else if old_server_folder != server_folder {
             info!(context, "[move] detected moved message {}", rfc724_mid,);
         }

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1308,9 +1308,9 @@ fn precheck_imf(context: &Context, rfc724_mid: &str, server_folder: &str, server
         if old_server_folder.is_empty() && old_server_uid == 0 {
             info!(context, "[move] detected bcc-self {}", rfc724_mid,);
 
-            let delete_server_after = context.get_config_int(Config::DeleteServerAfter);
+            let delete_server_after = context.get_config_delete_server_after();
 
-            if delete_server_after != 0 {
+            if delete_server_after != Some(0) {
                 context.do_heuristics_moves(server_folder.as_ref(), msg_id);
                 job_add(
                     context,
@@ -1321,7 +1321,7 @@ fn precheck_imf(context: &Context, rfc724_mid: &str, server_folder: &str, server
                 );
             }
 
-            if delete_server_after >= 0 {
+            if let Some(delete_server_after) = delete_server_after {
                 info!(
                     context,
                     "Scheduling BCC-self deletion in {} seconds", delete_server_after

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1019,7 +1019,7 @@ impl Imap {
                                 display_imap_id,
                                 message_id,
                             );
-                            return ImapActionResult::Failed;
+                            return ImapActionResult::AlreadyDone;
                         };
 
                         let remote_message_id = get_fetch_headers(fetch)

--- a/src/job.rs
+++ b/src/job.rs
@@ -860,6 +860,7 @@ pub fn job_send_msg(context: &Context, msg_id: MsgId) -> Result<()> {
         .unwrap_or_default();
     let lowercase_from = from.to_lowercase();
     if context.get_config_bool(Config::BccSelf)
+        && context.get_config_int(Config::DeleteServerAfter) != 0
         && !recipients
             .iter()
             .any(|x| x.to_lowercase() == lowercase_from)

--- a/src/job.rs
+++ b/src/job.rs
@@ -452,7 +452,14 @@ impl Job {
         let msg = job_try!(Message::load_from_db(context, MsgId::new(self.foreign_id)));
 
         if !msg.rfc724_mid.is_empty() {
-            if message::rfc724_mid_cnt(context, &msg.rfc724_mid) > 1 {
+            let cnt = message::rfc724_mid_cnt(context, &msg.rfc724_mid);
+            info!(
+                context,
+                "Running delete job for message {} which has {} entries in the database",
+                &msg.rfc724_mid,
+                cnt
+            );
+            if cnt > 1 {
                 info!(
                     context,
                     "The message is deleted from the server when all parts are deleted.",

--- a/src/job.rs
+++ b/src/job.rs
@@ -487,7 +487,7 @@ impl Job {
                 // Hidden messages are similar to trashed, but are
                 // related to some chat. We also delete their
                 // database records.
-                msg.id.delete_from_db(context);
+                job_try!(msg.id.delete_from_db(context))
             } else {
                 // Remove server UID from the database record.
                 //

--- a/src/job.rs
+++ b/src/job.rs
@@ -80,9 +80,14 @@ pub enum Action {
     // Jobs in the INBOX-thread, range from DC_IMAP_THREAD..DC_IMAP_THREAD+999
     Housekeeping = 105, // low priority ...
     EmptyServer = 107,
-    DeleteMsgOnImap = 110,
+    OldDeleteMsgOnImap = 110,
     MarkseenMsgOnImap = 130,
+
+    // Moving message is prioritized lower than deletion so we don't
+    // bother moving message if it is already scheduled for deletion.
     MoveMsg = 200,
+
+    DeleteMsgOnImap = 210,
     ConfigureImap = 900,
     ImexImap = 910, // ... high priority
 
@@ -107,6 +112,7 @@ impl From<Action> for Thread {
             Unknown => Thread::Unknown,
 
             Housekeeping => Thread::Imap,
+            OldDeleteMsgOnImap => Thread::Imap,
             DeleteMsgOnImap => Thread::Imap,
             EmptyServer => Thread::Imap,
             MarkseenMsgOnImap => Thread::Imap,
@@ -1091,6 +1097,7 @@ fn perform_job_action(context: &Context, mut job: &mut Job, thread: Thread, trie
         Action::Unknown => Status::Finished(Err(format_err!("Unknown job id found"))),
         Action::SendMsgToSmtp => job.SendMsgToSmtp(context),
         Action::EmptyServer => job.EmptyServer(context),
+        Action::OldDeleteMsgOnImap => job.DeleteMsgOnImap(context),
         Action::DeleteMsgOnImap => job.DeleteMsgOnImap(context),
         Action::MarkseenMsgOnImap => job.MarkseenMsgOnImap(context),
         Action::MoveMsg => job.MoveMsg(context),

--- a/src/job.rs
+++ b/src/job.rs
@@ -947,25 +947,15 @@ fn add_imap_deletion_jobs(context: &Context) -> sql::Result<()> {
     if let Some(delete_server_after) = context.get_config_delete_server_after() {
         let threshold_timestamp = time() - delete_server_after;
 
-        // Only try to delete messages in 2 weeks window
-        // (oldest_timestamp, threshold_timestamp). Otherwise we may
-        // waste a lot of traffic attempting to delete all the
-        // messages since the beginning of Delta Chat usage.
-        let oldest_timestamp = threshold_timestamp - 2 * 7 * 24 * 60 * 60;
-
         // Select all expired messages which don't have a
         // corresponding message deletion job yet.
         let msg_ids = context.sql.query_map(
             "SELECT id FROM msgs
-             WHERE timestamp < ? AND timestamp > ?
+             WHERE timestamp < ?
              AND server_uid != 0
              AND NOT EXISTS (SELECT 1 FROM jobs WHERE foreign_id = msgs.id
                                                       AND action = ?)",
-            params![
-                threshold_timestamp,
-                oldest_timestamp,
-                Action::DeleteMsgOnImap
-            ],
+            params![threshold_timestamp, Action::DeleteMsgOnImap],
             |row| row.get::<_, MsgId>(0),
             |ids| {
                 ids.collect::<std::result::Result<Vec<_>, _>>()

--- a/src/job.rs
+++ b/src/job.rs
@@ -473,7 +473,7 @@ impl Job {
                     }
                 }
             }
-            Message::delete_from_db(context, msg.id);
+            msg.id.delete_from_db(context);
             Status::Finished(Ok(()))
         } else {
             /* eg. device messages have no Message-ID */

--- a/src/job.rs
+++ b/src/job.rs
@@ -859,8 +859,11 @@ pub fn job_send_msg(context: &Context, msg_id: MsgId) -> Result<()> {
         .get_config(Config::ConfiguredAddr)
         .unwrap_or_default();
     let lowercase_from = from.to_lowercase();
+
+    // Send BCC to self if it is enabled and we are not going to
+    // delete it immediately.
     if context.get_config_bool(Config::BccSelf)
-        && context.get_config_int(Config::DeleteServerAfter) != 0
+        && context.get_config_delete_server_after() != Some(0)
         && !recipients
             .iter()
             .any(|x| x.to_lowercase() == lowercase_from)

--- a/src/job.rs
+++ b/src/job.rs
@@ -918,11 +918,11 @@ fn add_imap_deletion_jobs(context: &Context) -> sql::Result<()> {
         // Select all expired messages which don't have a
         // corresponding message deletion job yet.
         let msg_ids = context.sql.query_map(
-            "SELECT id FROM msgs
-             WHERE timestamp < ?
-             AND server_uid != 0
-             AND NOT EXISTS (SELECT 1 FROM jobs WHERE foreign_id = msgs.id
-                                                      AND action = ?)",
+            "SELECT id FROM msgs \
+             WHERE timestamp < ? \
+             AND server_uid != 0 \
+             AND NOT EXISTS (SELECT 1 FROM jobs WHERE foreign_id = msgs.id \
+             AND action = ?)",
             params![threshold_timestamp, Action::DeleteMsgOnImap],
             |row| row.get::<_, MsgId>(0),
             |ids| {

--- a/src/job.rs
+++ b/src/job.rs
@@ -946,11 +946,12 @@ fn add_imap_deletion_jobs(context: &Context) -> sql::Result<()> {
         // Select all expired messages which don't have a
         // corresponding message deletion job yet.
         let msg_ids = context.sql.query_map(
-            "SELECT id FROM msgs \
-             WHERE timestamp < ? \
-             AND server_uid != 0 \
-             AND NOT EXISTS (SELECT 1 FROM jobs WHERE foreign_id = msgs.id)",
-            params![threshold_timestamp],
+            "SELECT id FROM msgs
+             WHERE timestamp < ?
+             AND server_uid != 0
+             AND NOT EXISTS (SELECT 1 FROM jobs WHERE foreign_id = msgs.id
+                                                      AND action = ?)",
+            params![threshold_timestamp, Action::DeleteMsgOnImap],
             |row| row.get::<_, MsgId>(0),
             |ids| {
                 ids.collect::<std::result::Result<Vec<_>, _>>()

--- a/src/job.rs
+++ b/src/job.rs
@@ -437,6 +437,14 @@ impl Job {
         }
     }
 
+    /// Deletes a message on the server.
+    ///
+    /// foreign_id is a MsgId pointing to a message in the trash chat
+    /// or a hidden message.
+    ///
+    /// This job removes the database record. If there are no more
+    /// records pointing to the same message on the server, the job
+    /// also removes the message on the server.
     #[allow(non_snake_case)]
     fn DeleteMsgOnImap(&mut self, context: &Context) -> Status {
         let imap_inbox = &context.inbox_thread.read().unwrap().imap;

--- a/src/message.rs
+++ b/src/message.rs
@@ -128,7 +128,7 @@ impl MsgId {
             context,
             &context.sql,
             "UPDATE msgs \
-             SET unlinked=1, server_folder='', server_uid=0 \
+             SET server_folder='', server_uid=0 \
              WHERE id=?",
             params![self],
         )
@@ -1376,7 +1376,7 @@ pub fn get_deaddrop_msg_cnt(context: &Context) -> usize {
 pub fn rfc724_mid_cnt(context: &Context, rfc724_mid: &str) -> i32 {
     // check the number of messages with the same rfc724_mid
     match context.sql.query_row(
-        "SELECT COUNT(*) FROM msgs WHERE rfc724_mid=? AND NOT unlinked",
+        "SELECT COUNT(*) FROM msgs WHERE rfc724_mid=? AND NOT server_uid = 0",
         &[rfc724_mid],
         |row| row.get(0),
     ) {
@@ -1417,7 +1417,7 @@ pub fn update_server_uid(
     server_uid: u32,
 ) {
     match context.sql.execute(
-        "UPDATE msgs SET server_folder=?, server_uid=?, unlinked=0 \
+        "UPDATE msgs SET server_folder=?, server_uid=? \
          WHERE rfc724_mid=?",
         params![server_folder.as_ref(), server_uid, rfc724_mid],
     ) {

--- a/src/message.rs
+++ b/src/message.rs
@@ -100,7 +100,7 @@ impl MsgId {
     }
 
     /// Deletes a message and corresponding MDNs from the database.
-    pub fn delete_from_db(self, context: &Context) {
+    pub fn delete_from_db(self, context: &Context) -> crate::sql::Result<()> {
         // We don't use transactions yet, so remove MDNs first to make
         // sure they are not left while the message is deleted.
         sql::execute(
@@ -108,15 +108,14 @@ impl MsgId {
             &context.sql,
             "DELETE FROM msgs_mdns WHERE msg_id=?;",
             params![self],
-        )
-        .ok();
+        )?;
         sql::execute(
             context,
             &context.sql,
             "DELETE FROM msgs WHERE id=?;",
             params![self],
-        )
-        .ok();
+        )?;
+        Ok(())
     }
 
     /// Removes IMAP server UID and folder from the database record.

--- a/src/message.rs
+++ b/src/message.rs
@@ -1369,6 +1369,14 @@ pub fn get_deaddrop_msg_cnt(context: &Context) -> usize {
     }
 }
 
+pub fn estimate_deletion_cnt(
+    _context: &Context,
+    _from_server: bool,
+    _seconds: i64,
+) -> Result<usize, Error> {
+    Ok(0)
+}
+
 /// Counts number of database records pointing to specified
 /// Message-ID.
 ///

--- a/src/message.rs
+++ b/src/message.rs
@@ -1417,8 +1417,8 @@ pub fn update_server_uid(
     server_uid: u32,
 ) {
     match context.sql.execute(
-        "UPDATE msgs SET server_folder=?, server_uid=? \
-         WHERE rfc724_mid=? AND NOT unlinked",
+        "UPDATE msgs SET server_folder=?, server_uid=?, unlinked=0 \
+         WHERE rfc724_mid=?",
         params![server_folder.as_ref(), server_uid, rfc724_mid],
     ) {
         Ok(_) => {}

--- a/src/message.rs
+++ b/src/message.rs
@@ -1411,6 +1411,28 @@ pub(crate) fn rfc724_mid_exists(
         .map_err(Into::into)
 }
 
+/// Returns all MsgIds corresponding to Message-ID
+pub(crate) fn get_all_by_rfc724_mid(
+    context: &Context,
+    rfc724_mid: &str,
+) -> Result<Vec<MsgId>, Error> {
+    ensure!(!rfc724_mid.is_empty(), "empty rfc724_mid");
+
+    let msg_ids = context.sql.query_map(
+        "SELECT id FROM msgs WHERE rfc724_mid=?",
+        params![rfc724_mid],
+        |row| row.get::<_, MsgId>("id"),
+        |ids| {
+            let mut ret: Vec<MsgId> = Vec::new();
+            for id in ids {
+                ret.push(id?);
+            }
+            Ok(ret)
+        },
+    )?;
+    Ok(msg_ids)
+}
+
 pub fn update_server_uid(
     context: &Context,
     rfc724_mid: &str,

--- a/src/message.rs
+++ b/src/message.rs
@@ -951,7 +951,7 @@ pub fn get_mime_headers(context: &Context, msg_id: MsgId) -> Option<String> {
 }
 
 pub fn delete_msgs(context: &Context, msg_ids: &[MsgId]) {
-    for msg_id in msg_ids.iter() {
+    for msg_id in msg_ids {
         if let Ok(msg) = Message::load_from_db(context, *msg_id) {
             if msg.location_id > 0 {
                 delete_poi_location(context, msg.location_id);

--- a/src/message.rs
+++ b/src/message.rs
@@ -988,7 +988,7 @@ pub fn delete_msgs(context: &Context, msg_ids: &[MsgId]) {
             }
         }
         if let Err(err) = msg_id.trash(context) {
-            warn!(context, "Unable to trash message {}: {}", msg_id, err);
+            error!(context, "Unable to trash message {}: {}", msg_id, err);
         }
         job_add(
             context,

--- a/src/message.rs
+++ b/src/message.rs
@@ -99,6 +99,24 @@ impl MsgId {
         )
     }
 
+    /// Deletes a message and corresponding MDNs from the database.
+    pub fn delete_from_db(self, context: &Context) {
+        sql::execute(
+            context,
+            &context.sql,
+            "DELETE FROM msgs WHERE id=?;",
+            params![self],
+        )
+        .ok();
+        sql::execute(
+            context,
+            &context.sql,
+            "DELETE FROM msgs_mdns WHERE msg_id=?;",
+            params![self],
+        )
+        .ok();
+    }
+
     /// Bad evil escape hatch.
     ///
     /// Avoid using this, eventually types should be cleaned up enough
@@ -317,25 +335,6 @@ impl Message {
                 },
             )
             .map_err(Into::into)
-    }
-
-    pub fn delete_from_db(context: &Context, msg_id: MsgId) {
-        if let Ok(msg) = Message::load_from_db(context, msg_id) {
-            sql::execute(
-                context,
-                &context.sql,
-                "DELETE FROM msgs WHERE id=?;",
-                params![msg.id],
-            )
-            .ok();
-            sql::execute(
-                context,
-                &context.sql,
-                "DELETE FROM msgs_mdns WHERE msg_id=?;",
-                params![msg.id],
-            )
-            .ok();
-        }
     }
 
     pub fn get_filemime(&self) -> Option<String> {

--- a/src/message.rs
+++ b/src/message.rs
@@ -119,6 +119,23 @@ impl MsgId {
         .ok();
     }
 
+    /// Removes Message-ID, IMAP server UID, folder from the database
+    /// record.
+    ///
+    /// It is used to avoid trying to remove the message from the
+    /// server multiple times when there are multiple message records
+    /// pointing to the same server UID.
+    pub(crate) fn unlink(self, context: &Context) -> sql::Result<()> {
+        sql::execute(
+            context,
+            &context.sql,
+            "UPDATE msgs \
+             SET rfc724_mid='', server_folder='', server_uid=0 \
+             WHERE id=?",
+            params![self],
+        )
+    }
+
     /// Bad evil escape hatch.
     ///
     /// Avoid using this, eventually types should be cleaned up enough

--- a/src/message.rs
+++ b/src/message.rs
@@ -1354,6 +1354,8 @@ pub fn get_deaddrop_msg_cnt(context: &Context) -> usize {
     }
 }
 
+/// Counts number of database records pointing to specified
+/// Message-ID.
 pub fn rfc724_mid_cnt(context: &Context, rfc724_mid: &str) -> i32 {
     // check the number of messages with the same rfc724_mid
     match context.sql.query_row(

--- a/src/message.rs
+++ b/src/message.rs
@@ -1385,17 +1385,10 @@ pub fn estimate_deletion_cnt(
             "SELECT COUNT(*)
              FROM msgs m
              WHERE m.id > ?
-               AND (state = ? OR state >= ?)
-               AND chat_id != ?
                AND timestamp < ?
+               AND chat_id != ?
                AND server_uid != 0;",
-            params![
-                DC_MSG_ID_LAST_SPECIAL,
-                MessageState::InSeen,
-                MessageState::OutFailed,
-                self_chat_id,
-                threshold_timestamp
-            ],
+            params![DC_MSG_ID_LAST_SPECIAL, threshold_timestamp, self_chat_id],
             |row| row.get(0),
         )?;
     } else {
@@ -1403,16 +1396,13 @@ pub fn estimate_deletion_cnt(
             "SELECT COUNT(*)
              FROM msgs m
              WHERE m.id > ?
-               AND (state = ? OR state >= ?)
-               AND chat_id != ?
                AND timestamp < ?
-               AND chat_id != ?;",
+               AND chat_id != ?
+               AND chat_id != ? AND hidden = 0;",
             params![
                 DC_MSG_ID_LAST_SPECIAL,
-                MessageState::InSeen,
-                MessageState::OutFailed,
-                self_chat_id,
                 threshold_timestamp,
+                self_chat_id,
                 ChatId::new(DC_CHAT_ID_TRASH)
             ],
             |row| row.get(0),

--- a/src/message.rs
+++ b/src/message.rs
@@ -1410,28 +1410,6 @@ pub(crate) fn rfc724_mid_exists(
         .map_err(Into::into)
 }
 
-/// Returns all MsgIds corresponding to Message-ID
-pub(crate) fn get_all_by_rfc724_mid(
-    context: &Context,
-    rfc724_mid: &str,
-) -> Result<Vec<MsgId>, Error> {
-    ensure!(!rfc724_mid.is_empty(), "empty rfc724_mid");
-
-    let msg_ids = context.sql.query_map(
-        "SELECT id FROM msgs WHERE rfc724_mid=?",
-        params![rfc724_mid],
-        |row| row.get::<_, MsgId>("id"),
-        |ids| {
-            let mut ret: Vec<MsgId> = Vec::new();
-            for id in ids {
-                ret.push(id?);
-            }
-            Ok(ret)
-        },
-    )?;
-    Ok(msg_ids)
-}
-
 pub fn update_server_uid(
     context: &Context,
     rfc724_mid: &str,

--- a/src/message.rs
+++ b/src/message.rs
@@ -1379,9 +1379,8 @@ pub fn estimate_deletion_cnt(
         .0;
     let threshold_timestamp = time() - seconds;
 
-    let cnt: isize;
-    if from_server {
-        cnt = context.sql.query_row(
+    let cnt: isize = if from_server {
+        context.sql.query_row(
             "SELECT COUNT(*)
              FROM msgs m
              WHERE m.id > ?
@@ -1390,9 +1389,9 @@ pub fn estimate_deletion_cnt(
                AND server_uid != 0;",
             params![DC_MSG_ID_LAST_SPECIAL, threshold_timestamp, self_chat_id],
             |row| row.get(0),
-        )?;
+        )?
     } else {
-        cnt = context.sql.query_row(
+        context.sql.query_row(
             "SELECT COUNT(*)
              FROM msgs m
              WHERE m.id > ?
@@ -1406,8 +1405,8 @@ pub fn estimate_deletion_cnt(
                 ChatId::new(DC_CHAT_ID_TRASH)
             ],
             |row| row.get(0),
-        )?;
-    }
+        )?
+    };
     Ok(cnt as usize)
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -101,17 +101,19 @@ impl MsgId {
 
     /// Deletes a message and corresponding MDNs from the database.
     pub fn delete_from_db(self, context: &Context) {
+        // We don't use transactions yet, so remove MDNs first to make
+        // sure they are not left while the message is deleted.
         sql::execute(
             context,
             &context.sql,
-            "DELETE FROM msgs WHERE id=?;",
+            "DELETE FROM msgs_mdns WHERE msg_id=?;",
             params![self],
         )
         .ok();
         sql::execute(
             context,
             &context.sql,
-            "DELETE FROM msgs_mdns WHERE msg_id=?;",
+            "DELETE FROM msgs WHERE id=?;",
             params![self],
         )
         .ok();

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -7,7 +7,6 @@ use mailparse::{DispositionType, MailAddr, MailHeaderMap};
 use crate::aheader::Aheader;
 use crate::bail;
 use crate::blob::BlobObject;
-use crate::config::Config;
 use crate::constants::Viewtype;
 use crate::contact::*;
 use crate::context::Context;
@@ -17,7 +16,6 @@ use crate::e2ee;
 use crate::error::Result;
 use crate::events::Event;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
-use crate::job::{job_add, Action};
 use crate::location;
 use crate::message;
 use crate::param::*;
@@ -817,19 +815,11 @@ impl MimeMessage {
     }
 
     /// Handle reports (only MDNs for now)
-    pub fn handle_reports(
-        &self,
-        context: &Context,
-        from_id: u32,
-        sent_timestamp: i64,
-        server_folder: impl AsRef<str>,
-        server_uid: u32,
-    ) {
+    pub fn handle_reports(&self, context: &Context, from_id: u32, sent_timestamp: i64) {
         if self.reports.is_empty() {
             return;
         }
 
-        let mut mdn_recognized = false;
         for report in &self.reports {
             for original_message_id in
                 std::iter::once(&report.original_message_id).chain(&report.additional_message_ids)
@@ -838,19 +828,8 @@ impl MimeMessage {
                     message::mdn_from_ext(context, from_id, original_message_id, sent_timestamp)
                 {
                     context.call_cb(Event::MsgRead { chat_id, msg_id });
-                    mdn_recognized = true;
                 }
             }
-        }
-
-        if self.has_chat_version() || mdn_recognized {
-            let mut param = Params::new();
-            param.set(Param::ServerFolder, server_folder.as_ref());
-            param.set_int(Param::ServerUid, server_uid as i32);
-            if self.has_chat_version() && context.get_config_bool(Config::MvboxMove) {
-                param.set_int(Param::AlsoMove, 1);
-            }
-            job_add(context, Action::MarkseenMdnOnImap, 0, param, 0);
         }
     }
 }

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -545,6 +545,16 @@ impl MimeMessage {
                             if let Some(report) = self.process_report(context, mail)? {
                                 self.reports.push(report);
                             }
+
+                            // Add MDN part so we can track it, avoid
+                            // downloading the message again and
+                            // delete if automatic message deletion is
+                            // enabled.
+                            let mut part = Part::default();
+                            part.typ = Viewtype::Unknown;
+                            self.parts.push(part);
+
+                            any_part_added = true;
                         } else {
                             /* eg. `report-type=delivery-status`;
                             maybe we should show them as a little error icon */
@@ -1369,7 +1379,7 @@ Disposition: manual-action/MDN-sent-automatically; displayed\n\
             Some("Chat: Message opened".to_string())
         );
 
-        assert_eq!(message.parts.len(), 0);
+        assert_eq!(message.parts.len(), 1);
         assert_eq!(message.reports.len(), 1);
     }
 
@@ -1447,7 +1457,7 @@ Disposition: manual-action/MDN-sent-automatically; displayed\n\
             Some("Chat: Message opened".to_string())
         );
 
-        assert_eq!(message.parts.len(), 0);
+        assert_eq!(message.parts.len(), 2);
         assert_eq!(message.reports.len(), 2);
     }
 
@@ -1492,7 +1502,7 @@ Additional-Message-IDs: <foo@example.com> <foo@example.net>\n\
             Some("Chat: Message opened".to_string())
         );
 
-        assert_eq!(message.parts.len(), 0);
+        assert_eq!(message.parts.len(), 1);
         assert_eq!(message.reports.len(), 1);
         assert_eq!(message.reports[0].original_message_id, "foo@example.org");
         assert_eq!(

--- a/src/param.rs
+++ b/src/param.rs
@@ -89,12 +89,6 @@ pub enum Param {
     SetLongitude = b'n',
 
     /// For Jobs
-    ServerFolder = b'Z',
-
-    /// For Jobs
-    ServerUid = b'z',
-
-    /// For Jobs
     AlsoMove = b'M',
 
     /// For Jobs: space-separated list of message recipients

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -898,6 +898,14 @@ fn open(
             sql.execute("UPDATE chats SET grpid='' WHERE type=100", NO_PARAMS)?;
             sql.set_raw_config_int(context, "dbversion", 63)?;
         }
+        if dbversion < 64 {
+            info!(context, "[migration] v64");
+            sql.execute(
+                "ALTER TABLE msgs ADD COLUMN unlinked INTEGER DEFAULT 0",
+                NO_PARAMS,
+            )?;
+            sql.set_raw_config_int(context, "dbversion", 64)?;
+        }
 
         // (2) updates that require high-level objects
         // (the structure is complete now and all objects are usable)

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -898,14 +898,6 @@ fn open(
             sql.execute("UPDATE chats SET grpid='' WHERE type=100", NO_PARAMS)?;
             sql.set_raw_config_int(context, "dbversion", 63)?;
         }
-        if dbversion < 64 {
-            info!(context, "[migration] v64");
-            sql.execute(
-                "ALTER TABLE msgs ADD COLUMN unlinked INTEGER DEFAULT 0",
-                NO_PARAMS,
-            )?;
-            sql.set_raw_config_int(context, "dbversion", 64)?;
-        }
 
         // (2) updates that require high-level objects
         // (the structure is complete now and all objects are usable)


### PR DESCRIPTION
Update: now this PR includes local message deletion as well.

----
Summary of this PR:

 - New setting `delete_server_after` is added, specifying the number of seconds after which the message should be deleted on the server. It is 0 (off) by default, 1 for "at once" option, > 1 is the number of seconds after which the message should be deleted. "1 second" is not an option.
 - `delete_device_after` is planned for local deletion, but is not implemented in this PR
 - A hidden entry is added to the chat for MDN messages, just like we did for `location.kml` messages before. It is needed to track MDN `server_uid`, so we can delete it on the server when it expires.
 - `MarkseenMdnOnImap` job type is removed. Its name is misleading, it also moved MDNs to DeltaChat folder. Now that MDNs are treated as normal, but hidden, messages, they are moved by `MoveMsg` job.
 - Deleting messages is prioritized over moving them. If we see an expired message, we delete it first and don't bother moving it.
 - A new `MsgId.unlink()` method is added, clearing `server_uid` and `server_folder` for deleted messages. It is used in `DeleteMsgOnImap` job for messages that are displayed. For non-displayed messages (hidden or moved to the trash chat) we delete the database entry as before.
 - `add_imap_deletion_jobs()` is a new method that adds deletion job for all expired messages. It is called before running IMAP jobs. If nothing happens for a long time it is possible to have one or two expired messages around on the server, but they will be deleted on the next app restart or IDLE interrupt. We don't start any timer to delete messages as soon as needed, it is planned for the future when threads are moved into rust.
 - (Merged PR #1331) A new C function `dc_estimate_deletion_cnt` is added, estimating the number of messages that are going to be deleted on the server or locally right after setting `delete_server_after` or `delete_device_after` setting.


----

Here I am doing first batch of message deletion changes related to issues #1206 and #1308.

It was decided to implement two settings: one timer for message deletion on IMAP server and one timer for local message deletion.

In this PR I plan to implement IMAP message deletion only.

Initially, received message creates one or more database records in `msgs` table, sharing the same `rfc724_mid`. As message deletion is implemented now, when user deletes a message, it is moved into "trash" chat, which is never displayed, and a `DeleteMsgOnImap` job is created to remove the message from IMAP server.

A job checks if there are more database records pointing to the same `Message-ID`. If there are, it simply removes trash database record and does not delete the message on the server. Only when the last database record is deleted, message is removed from the server.

Since we want to remove displayed messages from IMAP now, we can no longer simply delete database records for them. So, for displayed messages, I implemented a `MsgId.unlink()` operation, which unlinks the message from the server message by setting `rfc724_mid` to empty string.

If such unlinked message is removed locally later, `DeleteMsgOnImap` job will detect it, and set result of IMAP message deletion operation to `ImapActionResult::AlreadyDone` and remove database record as usual.