### PR TITLE
do not ignore keypair generation test

### DIFF
--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -417,7 +417,6 @@ Sent with my Delta Chat Messenger: https://delta.chat";
         }
 
         #[test]
-        #[ignore] // generating keys is expensive
         fn test_generate() {
             let t = dummy_context();
             let addr = "alice@example.org";
@@ -429,7 +428,6 @@ Sent with my Delta Chat Messenger: https://delta.chat";
         }
 
         #[test]
-        #[ignore]
         fn test_generate_concurrent() {
             use std::sync::Arc;
             use std::thread;

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -394,7 +394,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // is too expensive
     fn test_create_keypair() {
         let keypair0 = create_keypair(
             EmailAddress::new("foo@bar.de").unwrap(),


### PR DESCRIPTION
due to the ecc-move, they are no longer expensive.