### PR TITLE
multi-device secure join

### DIFF
--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -622,7 +622,7 @@ pub(crate) fn handle_securejoin_handshake(
                 send_handshake_msg(context, contact_chat_id, "vc-contact-confirm", "", None, "");
                 inviter_progress!(context, contact_id, 1000);
             }
-            Ok(HandshakeMessage::Done)
+            Ok(HandshakeMessage::Ignore) // "Done" would delete the message and break multi-device (the key from Autocrypt-header is needed)
         }
         "vg-member-added" | "vc-contact-confirm" => {
             /*=======================================================
@@ -723,7 +723,7 @@ pub(crate) fn handle_securejoin_handshake(
             Ok(if join_vg {
                 HandshakeMessage::Propagate
             } else {
-                HandshakeMessage::Done
+                HandshakeMessage::Ignore // "Done" deletes the message and breaks multi-device
             })
         }
         "vg-member-added-received" => {
@@ -754,7 +754,7 @@ pub(crate) fn handle_securejoin_handshake(
                     chat_id: group_chat_id,
                     contact_id,
                 });
-                Ok(HandshakeMessage::Done)
+                Ok(HandshakeMessage::Ignore) // "Done" deletes the message and breaks multi-device
             } else {
                 warn!(context, "vg-member-added-received invalid.",);
                 Ok(HandshakeMessage::Ignore)


### PR DESCRIPTION
this pr implements secure-join multi-device as described at https://github.com/deltachat/deltachat-core-rust/pull/1314/files#diff-8dd1fb9fed67be11d40e43966774d5d0R773

this adds some complexity, not sure if it is the right way to go.

maybe some simple self-sent-sync message is easier and solves more problems.

otoh, this one is done, needs some testing, however :)