### PR TITLE
remove linebreaks from summary

### DIFF
--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -421,4 +421,18 @@ mod tests {
         let chats = Chatlist::try_load(&t.ctx, 0, Some("t-5678-b"), None).unwrap();
         assert_eq!(chats.len(), 1);
     }
+
+    #[test]
+    fn test_get_summary_unwrap() {
+        let t = dummy_context();
+        let chat_id1 = create_group_chat(&t.ctx, VerifiedStatus::Unverified, "a chat").unwrap();
+
+        let mut msg = Message::new(Viewtype::Text);
+        msg.set_text(Some("foo:\nbar \r\n test".to_string()));
+        chat_id1.set_draft(&t.ctx, Some(&mut msg));
+
+        let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
+        let summary = chats.get_summary(&t.ctx, 0, None);
+        assert_eq!(summary.get_text2().unwrap(), "foo: bar test"); // the linebreak should be removed from summary
+    }
 }

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -21,8 +21,8 @@ pub(crate) fn dc_exactly_one_bit_set(v: i32) -> bool {
 
 /// Shortens a string to a specified length and adds "..." or "[...]" to the end of
 /// the shortened string.
-pub(crate) fn dc_truncate(buf: &str, approx_chars: usize, do_unwrap: bool) -> Cow<str> {
-    let ellipse = if do_unwrap { "..." } else { "[...]" };
+pub(crate) fn dc_truncate(buf: &str, approx_chars: usize) -> Cow<str> {
+    let ellipse = "[...]";
 
     let count = buf.chars().count();
     if approx_chars > 0 && count > approx_chars + ellipse.len() {
@@ -538,54 +538,42 @@ mod tests {
     #[test]
     fn test_dc_truncate_1() {
         let s = "this is a little test string";
-        assert_eq!(dc_truncate(s, 16, false), "this is a [...]");
-        assert_eq!(dc_truncate(s, 16, true), "this is a ...");
+        assert_eq!(dc_truncate(s, 16), "this is a [...]");
     }
 
     #[test]
     fn test_dc_truncate_2() {
-        assert_eq!(dc_truncate("1234", 2, false), "1234");
-        assert_eq!(dc_truncate("1234", 2, true), "1234");
+        assert_eq!(dc_truncate("1234", 2), "1234");
     }
 
     #[test]
     fn test_dc_truncate_3() {
-        assert_eq!(dc_truncate("1234567", 1, false), "1[...]");
-        assert_eq!(dc_truncate("1234567", 1, true), "1...");
+        assert_eq!(dc_truncate("1234567", 1), "1[...]");
     }
 
     #[test]
     fn test_dc_truncate_4() {
-        assert_eq!(dc_truncate("123456", 4, false), "123456");
-        assert_eq!(dc_truncate("123456", 4, true), "123456");
+        assert_eq!(dc_truncate("123456", 4), "123456");
     }
 
     #[test]
     fn test_dc_truncate_edge() {
-        assert_eq!(dc_truncate("", 4, false), "");
-        assert_eq!(dc_truncate("", 4, true), "");
+        assert_eq!(dc_truncate("", 4), "");
 
-        assert_eq!(dc_truncate("\n  hello \n world", 4, false), "\n  [...]");
-        assert_eq!(dc_truncate("\n  hello \n world", 4, true), "\n  ...");
+        assert_eq!(dc_truncate("\n  hello \n world", 4), "\n  [...]");
 
+        assert_eq!(dc_truncate("𐠈0Aᝮa𫝀®!ꫛa¡0A𐢧00𐹠®A  丽ⷐએ", 1), "𐠈[...]");
         assert_eq!(
-            dc_truncate("𐠈0Aᝮa𫝀®!ꫛa¡0A𐢧00𐹠®A  丽ⷐએ", 1, false),
-            "𐠈[...]"
-        );
-        assert_eq!(
-            dc_truncate("𐠈0Aᝮa𫝀®!ꫛa¡0A𐢧00𐹠®A  丽ⷐએ", 0, false),
+            dc_truncate("𐠈0Aᝮa𫝀®!ꫛa¡0A𐢧00𐹠®A  丽ⷐએ", 0),
             "𐠈0Aᝮa𫝀®!ꫛa¡0A𐢧00𐹠®A  丽ⷐએ"
         );
 
         // 9 characters, so no truncation
-        assert_eq!(
-            dc_truncate("𑒀ὐ￠🜀\u{1e01b}A a🟠", 6, false),
-            "𑒀ὐ￠🜀\u{1e01b}A a🟠",
-        );
+        assert_eq!(dc_truncate("𑒀ὐ￠🜀\u{1e01b}A a🟠", 6), "𑒀ὐ￠🜀\u{1e01b}A a🟠",);
 
         // 12 characters, truncation
         assert_eq!(
-            dc_truncate("𑒀ὐ￠🜀\u{1e01b}A a🟠bcd", 6, false),
+            dc_truncate("𑒀ὐ￠🜀\u{1e01b}A a🟠bcd", 6),
             "𑒀ὐ￠🜀\u{1e01b}A[...]",
         );
     }
@@ -701,11 +689,10 @@ mod tests {
         #[test]
         fn test_dc_truncate(
             buf: String,
-            approx_chars in 0..10000usize,
-            do_unwrap: bool,
+            approx_chars in 0..10000usize
         ) {
-            let res = dc_truncate(&buf, approx_chars, do_unwrap);
-            let el_len = if do_unwrap { 3 } else { 5 };
+            let res = dc_truncate(&buf, approx_chars);
+            let el_len = 5;
             let l = res.chars().count();
             if approx_chars > 0 {
                 assert!(
@@ -719,11 +706,7 @@ mod tests {
 
             if approx_chars > 0 && buf.chars().count() > approx_chars + el_len {
                 let l = res.len();
-                if do_unwrap {
-                    assert_eq!(&res[l-3..l], "...", "missing ellipsis in {}", &res);
-                } else {
-                    assert_eq!(&res[l-5..l], "[...]", "missing ellipsis in {}", &res);
-                }
+                assert_eq!(&res[l-5..l], "[...]", "missing ellipsis in {}", &res);
             }
         }
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 
 use deltachat_derive::{FromSql, ToSql};
 use failure::Fail;
+use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 
 use crate::chat::{self, Chat, ChatId};
@@ -20,6 +21,10 @@ use crate::param::*;
 use crate::pgp::*;
 use crate::sql;
 use crate::stock::StockMessage;
+
+lazy_static! {
+    static ref UNWRAP_RE: regex::Regex = regex::Regex::new(r"\s+").unwrap();
+}
 
 // In practice, the user additionally cuts the string themselves
 // pixel-accurate.
@@ -1141,7 +1146,7 @@ pub fn get_summarytext_by_raw(
         return prefix;
     }
 
-    if let Some(text) = text {
+    let summary = if let Some(text) = text {
         if text.as_ref().is_empty() {
             prefix
         } else if prefix.is_empty() {
@@ -1152,7 +1157,9 @@ pub fn get_summarytext_by_raw(
         }
     } else {
         prefix
-    }
+    };
+
+    UNWRAP_RE.replace_all(&summary, " ").to_string()
 }
 
 // as we do not cut inside words, this results in about 32-42 characters.

--- a/src/message.rs
+++ b/src/message.rs
@@ -443,7 +443,7 @@ impl Message {
     pub fn get_text(&self) -> Option<String> {
         self.text
             .as_ref()
-            .map(|text| dc_truncate(text, 30000, false).to_string())
+            .map(|text| dc_truncate(text, 30000).to_string())
     }
 
     pub fn get_filename(&self) -> Option<String> {
@@ -814,7 +814,7 @@ pub fn get_msg_info(context: &Context, msg_id: MsgId) -> String {
         return ret;
     }
     let rawtxt = rawtxt.unwrap_or_default();
-    let rawtxt = dc_truncate(rawtxt.trim(), 100_000, false);
+    let rawtxt = dc_truncate(rawtxt.trim(), 100_000);
 
     let fts = dc_timestamp_to_str(msg.get_timestamp());
     ret += &format!("Sent: {}", fts);
@@ -1150,10 +1150,10 @@ pub fn get_summarytext_by_raw(
         if text.as_ref().is_empty() {
             prefix
         } else if prefix.is_empty() {
-            dc_truncate(text.as_ref(), approx_characters, true).to_string()
+            dc_truncate(text.as_ref(), approx_characters).to_string()
         } else {
             let tmp = format!("{} – {}", prefix, text.as_ref());
-            dc_truncate(&tmp, approx_characters, true).to_string()
+            dc_truncate(&tmp, approx_characters).to_string()
         }
     } else {
         prefix


### PR DESCRIPTION
this pr removes linebreaks from the summaries so that they appear nicely in the chatlist and no unexpected additional text appears when a message is viewed in detail. the ellipsis is now only shown when the summary is really too long.

there was a flag "unwrap" in the called dc_truncate() function, but it did not work this way (it was okay in core-c, probably lost by some refactoring). in fact, the flag was used to choose between different ellipsis, however, this is not needed as all uis will truncate the text pixel-accurate anyway.

so, this pr also removes this unused flag.