### PR TITLE
revert generating ecc keys for now

### DIFF
--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -153,8 +153,8 @@ pub(crate) fn create_keypair(
     keygen_type: KeyGenType,
 ) -> std::result::Result<KeyPair, PgpKeygenError> {
     let (secret_key_type, public_key_type) = match keygen_type {
-        KeyGenType::Rsa2048 => (PgpKeyType::Rsa(2048), PgpKeyType::Rsa(2048)),
-        KeyGenType::Ed25519 | KeyGenType::Default => (PgpKeyType::EdDSA, PgpKeyType::ECDH),
+        KeyGenType::Rsa2048 | KeyGenType::Default => (PgpKeyType::Rsa(2048), PgpKeyType::Rsa(2048)),
+        KeyGenType::Ed25519 => (PgpKeyType::EdDSA, PgpKeyType::ECDH),
     };
 
     let user_id = format!("<{}>", addr);


### PR DESCRIPTION
the currently released versions fail sometimes in encrypting to ecc keys,
see #1313, the issue is about to be fixed,
however, we should not generate ecc keys until the
fix is rolled out - otherwise new users will get encryption errors every some
messages if their counterpart is not yet using the most recent version.

we can start generating ecc keys a few weeks after the fix is rolled out.