### PR TITLE
Reset server_folder and server_uid in Imap.empty_folder()

### DIFF
--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1234,6 +1234,18 @@ impl Imap {
                     error!(context, "expunge failed {}: {:?}", folder, err);
                 }
             }
+
+            if let Err(err) = crate::sql::execute(
+                context,
+                &context.sql,
+                "UPDATE msgs SET server_folder='',server_uid=0 WHERE server_folder=?",
+                params![folder],
+            ) {
+                warn!(
+                    context,
+                    "Failed to reset server_uid and server_folder for deleted messages: {}", err
+                );
+            }
         });
     }
 }


### PR DESCRIPTION
This way we avoid trying to delete already deleted messages in the future.