### PR TITLE
Local message deletion

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2522,15 +2522,19 @@ pub fn delete_device_expired_messages(context: &Context) -> sql::Result<()> {
              WHERE timestamp < ?",
             params![threshold_timestamp],
         )?;
-
-        // Delete hidden messages that are removed from the server.
-        context.sql.execute(
-            "DELETE FROM msgs \
-             WHERE (chat_id = ? OR hidden) \
-             AND server_uid = 0",
-            params![DC_CHAT_ID_TRASH],
-        )?;
     }
+    Ok(())
+}
+
+/// Removes from the database locally deleted messages that also don't
+/// have a server UID.
+pub fn prune_tombstones(context: &Context) -> sql::Result<()> {
+    context.sql.execute(
+        "DELETE FROM msgs \
+         WHERE (chat_id = ? OR hidden) \
+         AND server_uid = 0",
+        params![DC_CHAT_ID_TRASH],
+    )?;
     Ok(())
 }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2522,7 +2522,7 @@ pub fn delete_device_expired_messages(context: &Context) -> sql::Result<()> {
         // Hide expired messages
         context.sql.execute(
             "UPDATE msgs \
-             SET txt = '', hidden = 1 \
+             SET txt = 'DELETED', hidden = 1 \
              WHERE timestamp < ? \
              AND chat_id > ?",
             params![threshold_timestamp, DC_CHAT_ID_LAST_SPECIAL],

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -359,6 +359,25 @@ impl ChatId {
             .unwrap_or_default() as usize
     }
 
+    pub(crate) fn get_param(self, context: &Context) -> Result<Params, Error> {
+        let res: Option<String> = context
+            .sql
+            .query_get_value_result::<_, _>("SELECT param FROM chats WHERE id=?", params![self])?;
+        Ok(res
+            .map(|s| s.parse().unwrap_or_default())
+            .unwrap_or_default())
+    }
+
+    // Returns true if chat is a saved messages chat.
+    pub fn is_self_talk(self, context: &Context) -> Result<bool, Error> {
+        Ok(self.get_param(context)?.exists(Param::Selftalk))
+    }
+
+    /// Returns true if chat is a device chat.
+    pub fn is_device_talk(self, context: &Context) -> Result<bool, Error> {
+        Ok(self.get_param(context)?.exists(Param::Devicetalk))
+    }
+
     /// Bad evil escape hatch.
     ///
     /// Avoid using this, eventually types should be cleaned up enough

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2530,18 +2530,6 @@ pub fn delete_device_expired_messages(context: &Context) -> sql::Result<()> {
     Ok(())
 }
 
-/// Removes from the database locally deleted messages that also don't
-/// have a server UID.
-pub fn prune_tombstones(context: &Context) -> sql::Result<()> {
-    context.sql.execute(
-        "DELETE FROM msgs \
-         WHERE (chat_id = ? OR hidden) \
-         AND server_uid = 0",
-        params![DC_CHAT_ID_TRASH],
-    )?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2509,6 +2509,31 @@ pub(crate) fn add_info_msg(context: &Context, chat_id: ChatId, text: impl AsRef<
     });
 }
 
+/// Hides or deletes messages which are expired according to
+/// "delete_device_after" setting.
+pub fn delete_device_expired_messages(context: &Context) -> sql::Result<()> {
+    if let Some(delete_device_after) = context.get_config_delete_device_after() {
+        let threshold_timestamp = time() - delete_device_after;
+
+        // Hide expired messages
+        context.sql.execute(
+            "UPDATE msgs \
+             SET txt = '', hidden = 1 \
+             WHERE timestamp < ?",
+            params![threshold_timestamp],
+        )?;
+
+        // Delete hidden messages that are removed from the server.
+        context.sql.execute(
+            "DELETE FROM msgs \
+             WHERE (chat_id = ? OR hidden) \
+             AND server_uid = 0",
+            params![DC_CHAT_ID_TRASH],
+        )?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2523,8 +2523,9 @@ pub fn delete_device_expired_messages(context: &Context) -> sql::Result<()> {
         context.sql.execute(
             "UPDATE msgs \
              SET txt = '', hidden = 1 \
-             WHERE timestamp < ?",
-            params![threshold_timestamp],
+             WHERE timestamp < ? \
+             AND chat_id > ?",
+            params![threshold_timestamp, DC_CHAT_ID_LAST_SPECIAL],
         )?;
     }
     Ok(())

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1447,6 +1447,10 @@ pub fn get_chat_msgs(
     flags: u32,
     marker1before: Option<MsgId>,
 ) -> Vec<MsgId> {
+    if let Err(err) = delete_device_expired_messages(context) {
+        warn!(context, "Failed to delete expired messages: {}", err);
+    }
+
     let process_row =
         |row: &rusqlite::Row| Ok((row.get::<_, MsgId>("id")?, row.get::<_, i64>("timestamp")?));
     let process_rows = |rows: rusqlite::MappedRows<_>| {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -378,6 +378,28 @@ impl ChatId {
         Ok(self.get_param(context)?.exists(Param::Devicetalk))
     }
 
+    /// Hides or deletes messages which are expired according to
+    /// "delete_device_after" setting.
+    pub fn delete_device_expired_messages(self, context: &Context) -> Result<(), Error> {
+        if self.is_special() || self.is_self_talk(context)? || self.is_device_talk(context)? {
+            return Ok(());
+        }
+
+        if let Some(delete_device_after) = context.get_config_delete_device_after() {
+            let threshold_timestamp = time() - delete_device_after;
+
+            // Hide expired messages
+            context.sql.execute(
+                "UPDATE msgs \
+                 SET txt = 'DELETED', hidden = 1 \
+                 WHERE timestamp < ? \
+                 AND chat_id == ?",
+                params![threshold_timestamp, self],
+            )?;
+        }
+        Ok(())
+    }
+
     /// Bad evil escape hatch.
     ///
     /// Avoid using this, eventually types should be cleaned up enough
@@ -1466,7 +1488,7 @@ pub fn get_chat_msgs(
     flags: u32,
     marker1before: Option<MsgId>,
 ) -> Vec<MsgId> {
-    if let Err(err) = delete_device_expired_messages(context) {
+    if let Err(err) = chat_id.delete_device_expired_messages(context) {
         warn!(context, "Failed to delete expired messages: {}", err);
     }
 
@@ -2530,24 +2552,6 @@ pub(crate) fn add_info_msg(context: &Context, chat_id: ChatId, text: impl AsRef<
         chat_id,
         msg_id: MsgId::new(row_id),
     });
-}
-
-/// Hides or deletes messages which are expired according to
-/// "delete_device_after" setting.
-pub fn delete_device_expired_messages(context: &Context) -> sql::Result<()> {
-    if let Some(delete_device_after) = context.get_config_delete_device_after() {
-        let threshold_timestamp = time() - delete_device_after;
-
-        // Hide expired messages
-        context.sql.execute(
-            "UPDATE msgs \
-             SET txt = 'DELETED', hidden = 1 \
-             WHERE timestamp < ? \
-             AND chat_id > ?",
-            params![threshold_timestamp, DC_CHAT_ID_LAST_SPECIAL],
-        )?;
-    }
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -76,6 +76,14 @@ pub enum Config {
     #[strum(props(default = "0"))]
     DeleteServerAfter,
 
+    /// Timer in seconds after which the message is deleted from the
+    /// device.
+    ///
+    /// Equals to 0 by default, which means the message is never
+    /// deleted.
+    #[strum(props(default = "0"))]
+    DeleteDeviceAfter,
+
     SaveMimeHeaders,
     ConfiguredAddr,
     ConfiguredMailServer,

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,6 +159,17 @@ impl Context {
         }
     }
 
+    /// Gets configured "delete_device_after" value.
+    ///
+    /// `None` means never delete the message, `Some(x)` means delete
+    /// after `x` seconds.
+    pub fn get_config_delete_device_after(&self) -> Option<i64> {
+        match self.get_config_int(Config::DeleteDeviceAfter) {
+            0 => None,
+            x => Some(x as i64),
+        }
+    }
+
     /// Set the given config key.
     /// If `None` is passed as a value the value is cleared and set to the default if there is one.
     pub fn set_config(&self, key: Config, value: Option<&str>) -> crate::sql::Result<()> {


### PR DESCRIPTION
This is a follow-up for PR #1310 to delete old messages locally.

Messages should be deleted at least when chat messages are requested by the application, and maybe also during housekeeping or even from a separate thread to clean up chats that user does not open frequently.