### PR TITLE
fix showing non-dc replies

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1623,6 +1623,7 @@ fn dc_create_incoming_rfc724_mid(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::message::Message;
     use crate::test_utils::dummy_context;
 
     #[test]
@@ -1681,5 +1682,39 @@ mod tests {
             dc_create_incoming_rfc724_mid(123, 45, &members),
             Some("123-45-9@stub".into())
         );
+    }
+
+    #[test]
+    fn test_is_known_rfc724_mid() {
+        let t = dummy_context();
+        let mut msg = Message::new(Viewtype::Text);
+        msg.text = Some("first message".to_string());
+        let msg_id = chat::add_device_msg(&t.ctx, None, Some(&mut msg)).unwrap();
+        let msg = Message::load_from_db(&t.ctx, msg_id).unwrap();
+
+        // Message-IDs may or may not be surrounded by angle brackets
+        assert!(is_known_rfc724_mid(
+            &t.ctx,
+            format!("<{}>", msg.rfc724_mid).as_str()
+        ));
+        assert!(is_known_rfc724_mid(&t.ctx, &msg.rfc724_mid));
+        assert!(!is_known_rfc724_mid(&t.ctx, "unexistant@message.id"));
+    }
+
+    #[test]
+    fn test_is_msgrmsg_rfc724_mid() {
+        let t = dummy_context();
+        let mut msg = Message::new(Viewtype::Text);
+        msg.text = Some("first message".to_string());
+        let msg_id = chat::add_device_msg(&t.ctx, None, Some(&mut msg)).unwrap();
+        let msg = Message::load_from_db(&t.ctx, msg_id).unwrap();
+
+        // Message-IDs may or may not be surrounded by angle brackets
+        assert!(is_msgrmsg_rfc724_mid(
+            &t.ctx,
+            format!("<{}>", msg.rfc724_mid).as_str()
+        ));
+        assert!(is_msgrmsg_rfc724_mid(&t.ctx, &msg.rfc724_mid));
+        assert!(!is_msgrmsg_rfc724_mid(&t.ctx, "unexistant@message.id"));
     }
 }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1488,6 +1488,7 @@ fn is_known_rfc724_mid_in_list(context: &Context, mid_list: &str) -> bool {
 
 /// Check if a message is a reply to a known message (messenger or non-messenger).
 fn is_known_rfc724_mid(context: &Context, rfc724_mid: &str) -> bool {
+    let rfc724_mid = rfc724_mid.trim_start_matches('<').trim_end_matches('>');
     context
         .sql
         .exists(
@@ -1534,6 +1535,7 @@ pub(crate) fn is_msgrmsg_rfc724_mid_in_list(context: &Context, mid_list: &str) -
 
 /// Check if a message is a reply to any messenger message.
 fn is_msgrmsg_rfc724_mid(context: &Context, rfc724_mid: &str) -> bool {
+    let rfc724_mid = rfc724_mid.trim_start_matches('<').trim_end_matches('>');
     context
         .sql
         .exists(

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1700,7 +1700,7 @@ mod tests {
             format!("<{}>", msg.rfc724_mid).as_str()
         ));
         assert!(is_known_rfc724_mid(&t.ctx, &msg.rfc724_mid));
-        assert!(!is_known_rfc724_mid(&t.ctx, "unexistant@message.id"));
+        assert!(!is_known_rfc724_mid(&t.ctx, "nonexistant@message.id"));
     }
 
     #[test]
@@ -1717,6 +1717,6 @@ mod tests {
             format!("<{}>", msg.rfc724_mid).as_str()
         ));
         assert!(is_msgrmsg_rfc724_mid(&t.ctx, &msg.rfc724_mid));
-        assert!(!is_msgrmsg_rfc724_mid(&t.ctx, "unexistant@message.id"));
+        assert!(!is_msgrmsg_rfc724_mid(&t.ctx, "nonexistant@message.id"));
     }
 }


### PR DESCRIPTION
at least the last release does not show replies from non-dc-clients.

reason is that the Message-ID is stored without angle brackets in the database, but the mimeparser returns list that include them. the checks `is_known_rfc724_mid()` and `is_msgrmsg_rfc724_mid()` fails then (not sure if we really need both functions, but that is out of scope of this fix)

this pr adds a failing tests and makes `is_known_rfc724_mid()` and `is_msgrmsg_rfc724_mid()` more resilient, accepting both the square-angle-format and the raw-format, it seems to be hard and errorprone to force the one or the other, there are various deeply nested paths where the IDs come from, the used libs may change etc.

btw, i think, this fix justifies new releases, as the communication with non-dc-clients is a core feature and does not work by default without this fix.

fixes #1352 