### PR TITLE
fix crash in self-only-groups with bcc_self enabled

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -76,6 +76,20 @@ class TestOfflineAccountBasic:
         with pytest.raises(KeyError):
             ac1.get_config("123123")
 
+    def test_empty_group_bcc_self_enabled(self, acfactory):
+        ac1 = acfactory.get_configured_offline_account()
+        ac1.set_config("bcc_self", "1")
+        chat = ac1.create_group_chat(name="group1")
+        msg = chat.send_text("msg1")
+        assert msg in chat.get_messages()
+
+    def test_empty_group_bcc_self_disabled(self, acfactory):
+        ac1 = acfactory.get_configured_offline_account()
+        ac1.set_config("bcc_self", "0")
+        chat = ac1.create_group_chat(name="group1")
+        msg = chat.send_text("msg1")
+        assert msg in chat.get_messages()
+
 
 class TestOfflineContact:
     def test_contact_attr(self, acfactory):

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -368,7 +368,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             self.from_addr.clone(),
         );
 
-        let mut to = Vec::with_capacity(self.recipients.len());
+        let mut to = Vec::new();
         for (name, addr) in self.recipients.iter() {
             if name.is_empty() {
                 to.push(Address::new_mailbox(addr.clone()));
@@ -378,6 +378,10 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                     addr.clone(),
                 ));
             }
+        }
+
+        if to.is_empty() {
+            to.push(from.clone());
         }
 
         if !self.references.is_empty() {


### PR DESCRIPTION
this pr corrects the To:-list for groups with only SELF as member.

before, the list was empty and trying to send to groups that only contain SELF lead to a crash.

in theory, this happens for both, bcc_self enabled or not, however, if bcc_self was disabled (default setting), things worked as the whole mimerendering was skipped on a higher level. also, the saved-messages-chat was not affected as this was checked explicitly.

this pr changes the mimerendering so that From: is used as To: for all groups that contain only SELF.

successor of #1346, fixes #1320 