### PR TITLE
fix imap delimiter

### DIFF
--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -371,7 +371,7 @@ pub(crate) fn JobConfigureImap(context: &Context) -> job::Status {
                 let create_mvbox = context.get_config_bool(Config::MvboxWatch)
                     || context.get_config_bool(Config::MvboxMove);
                 let imap = &context.inbox_thread.read().unwrap().imap;
-                if let Err(err) = imap.ensure_configured_folders(context, create_mvbox) {
+                if let Err(err) = imap.configure_folders(context, create_mvbox) {
                     warn!(context, "configuring folders failed: {:?}", err);
                     false
                 } else {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -214,6 +214,9 @@ pub const DC_BOB_SUCCESS: i32 = 1;
 // max. width/height of an avatar
 pub const AVATAR_SIZE: u32 = 192;
 
+// this value can be increased if the folder configuration is changed and must be redone on next program start
+pub const DC_FOLDERS_CONFIGURED_VERSION: i32 = 3;
+
 #[derive(
     Debug,
     Display,

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1105,8 +1105,8 @@ impl Imap {
                 info!(context, "sentbox folder is {:?}", sentbox_folder);
 
                 let mut delimiter = ".";
-                if !folders.is_empty() {
-                    if let Some(d) = &folders[0].delimiter() {
+                if let Some(folder) = folders.first() {
+                    if let Some(d) = folder.delimiter() {
                         if !d.is_empty() {
                             delimiter = d;
                         }

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1078,6 +1078,10 @@ impl Imap {
             return Ok(());
         }
 
+        self.configure_folders(context, create_mvbox)
+    }
+
+    pub fn configure_folders(&self, context: &Context, create_mvbox: bool) -> Result<()> {
         task::block_on(async move {
             if !self.is_connected().await {
                 return Err(Error::NoConnection);

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -188,7 +188,6 @@ struct ImapConfig {
     /// True if the server has MOVE capability as defined in
     /// https://tools.ietf.org/html/rfc6851
     pub can_move: bool,
-    pub imap_delimiter: char,
 }
 
 impl Default for ImapConfig {
@@ -206,7 +205,6 @@ impl Default for ImapConfig {
             selected_folder_needs_expunge: false,
             can_idle: false,
             can_move: false,
-            imap_delimiter: '.',
         }
     }
 }

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1106,7 +1106,15 @@ impl Imap {
                         });
                 info!(context, "sentbox folder is {:?}", sentbox_folder);
 
-                let delimiter = self.config.read().await.imap_delimiter;
+                let mut delimiter = ".";
+                if !folders.is_empty() {
+                    if let Some(d) = &folders[0].delimiter() {
+                        if !d.is_empty() {
+                            delimiter = d;
+                        }
+                    }
+                }
+                info!(context, "Using \"{}\" as folder-delimiter.", delimiter);
                 let fallback_folder = format!("INBOX{}DeltaChat", delimiter);
 
                 let mut mvbox_folder = folders

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1074,9 +1074,7 @@ impl Imap {
         let folders_configured = context
             .sql
             .get_raw_config_int(context, "folders_configured");
-        if folders_configured.unwrap_or_default() >= 3 {
-            // the "3" here we increase if we have future updates to
-            // to folder configuration
+        if folders_configured.unwrap_or_default() >= DC_FOLDERS_CONFIGURED_VERSION {
             return Ok(());
         }
 
@@ -1168,9 +1166,11 @@ impl Imap {
                         Some(sentbox_folder.name()),
                     )?;
                 }
-                context
-                    .sql
-                    .set_raw_config_int(context, "folders_configured", 3)?;
+                context.sql.set_raw_config_int(
+                    context,
+                    "folders_configured",
+                    DC_FOLDERS_CONFIGURED_VERSION,
+                )?;
             }
             info!(context, "FINISHED configuring IMAP-folders.");
             Ok(())


### PR DESCRIPTION
this pr actually uses the folder-delimiter provided by the imap-server in the LIST-command.

moreover, this pr really does a folder-reconfigure on dc_configure() - this is needed as configure may change the whole server; this folder-reconfigure on dc_configure() was also done in core-c and somehow lost.

closes #1360 