### PR TITLE
Add system message only if contact was removed successfully

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2063,7 +2063,7 @@ pub fn remove_contact_from_chat(
                         "Cannot remove contact from chat; self not in group.".into()
                     )
                 );
-            } else {
+            } else if remove_from_chat_contacts_table(context, chat_id, contact_id) {
                 /* we should respect this - whatever we send to the group, it gets discarded anyway! */
                 if let Ok(contact) = Contact::get_by_id(context, contact_id) {
                     if chat.is_promoted() {
@@ -2093,10 +2093,9 @@ pub fn remove_contact_from_chat(
                         });
                     }
                 }
-                if remove_from_chat_contacts_table(context, chat_id, contact_id) {
-                    context.call_cb(Event::ChatModified(chat_id));
-                    success = true;
-                }
+
+                context.call_cb(Event::ChatModified(chat_id));
+                success = true;
             }
         }
     }


### PR DESCRIPTION
I have a verified chat where one user can't be removed for whatever reason. The problem is that even though error is displayed and user is not removed, the message "user ... removed by me" is added to the chat each time. With this fix error is displayed, but the system message is not added.