### PR TITLE
[WIP] Fix #1330 Keep retrying message sending on permanent errors

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -201,7 +201,8 @@ impl Job {
 
                 let res = match err {
                     async_smtp::smtp::error::Error::Permanent(_) => {
-                        Status::Finished(Err(format_err!("Permanent SMTP error: {}", err)))
+                        info!(context, "Permanent SMTP error, we will try again anyway because sometimes servers send a permanent error when actually it is a temporary error");
+                        Status::RetryLater
                     }
                     async_smtp::smtp::error::Error::Transient(_) => {
                         // We got a transient 4xx response from SMTP server.


### PR DESCRIPTION
However, maybe we should somehow retry less often on permanent errors? Esp. on metered connections? @link2xt ?

Because it sounds pretty bad that we could retry sending a large attachment multiple times if it actually is a permanent error. 

(also is there a function we can call to determine whether this is a metered connection or not?)