### PR TITLE
Emit an event when SMTP fails (the same is already done for IMAP), fix #1377

### DIFF
--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -175,7 +175,11 @@ impl Smtp {
             .timeout(Some(Duration::from_secs(SMTP_TIMEOUT)));
 
         let mut trans = client.into_transport();
-        trans.connect().await.map_err(Error::ConnectionFailure)?;
+
+        trans.connect().await.map_err(|err| {
+            emit_event!(context, Event::ErrorNetwork(err.to_string()));
+            Error::ConnectionFailure(err)
+        })?;
 
         self.transport = Some(trans);
         self.last_success = Some(Instant::now());


### PR DESCRIPTION
This only makes SMTP behave the same as IMAP (see https://github.com/deltachat/deltachat-core-rust/blob/master/src/imap/mod.rs#L294 called at https://github.com/deltachat/deltachat-core-rust/blob/master/src/imap/mod.rs#L407) but it fixes #1377.