### PR TITLE
For permanent smtp error 5.5.0, try again. For others, send info message.

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -218,11 +218,19 @@ impl Job {
                             _ => {
                                 // If we do not retry, add an info message to the chat
                                 // Error 5.7.1 should definitely go here: Yandex sends 5.7.1 with a link when it thinks that the email is SPAM.
-                                chat::add_info_msg(
-                                    context,
-                                    ChatId::new(self.foreign_id),
-                                    err.to_string(),
-                                );
+                                match Message::load_from_db(context, MsgId::new(self.foreign_id)) {
+                                    Ok(message) => chat::add_info_msg(
+                                        context,
+                                        message.chat_id,
+                                        err.to_string(),
+                                    ),
+                                    Err(e) => warn!(
+                                        context,
+                                        "couldn't load chat_id to inform user about SMTP error: {}",
+                                        e
+                                    ),
+                                };
+
                                 Status::Finished(Err(format_err!("Permanent SMTP error: {}", err)))
                             }
                         }

--- a/src/job.rs
+++ b/src/job.rs
@@ -210,10 +210,11 @@ impl Job {
 
                             // Code 5.5.0, see https://support.delta.chat/t/every-other-message-gets-stuck/877/2
                             Code {
-                                severity: _,
                                 category: Category::MailSystem,
                                 detail: Detail::Zero,
+                                ..
                             } => Status::RetryLater,
+
                             _ => {
                                 // If we do not retry, add an info message to the chat
                                 // Error 5.7.1 should definitely go here: Yandex sends 5.7.1 with a link when it thinks that the email is SPAM.


### PR DESCRIPTION
Maybe a better approach than #1371, also fixing #1341. Someone (or I) might look through https://tools.ietf.org/html/rfc3463 and decide what error codes might be a temporary error even though they started with 5.x.x. Actually, I think that it is better to wait and see what happens in practice.

@r10s how do I get the ChatID for chat::add_info_msg? I tried `foreign_id` but it didn't work.

fix #1341, fix #1371 