### PR TITLE
Fix #1373, ignore incorrect html close tags

### DIFF
--- a/src/dehtml.rs
+++ b/src/dehtml.rs
@@ -35,6 +35,7 @@ pub fn dehtml(buf: &str) -> String {
     };
 
     let mut reader = quick_xml::Reader::from_str(buf);
+    reader.check_end_names(false);
 
     let mut buf = Vec::new();
 
@@ -224,5 +225,24 @@ mod tests {
             plain,
             "<>\"\'& äÄöÖüÜß fooÆçÇ \u{2666}\u{200e}\u{200f}\u{200c}&noent;\u{200d}"
         );
+    }
+
+    #[test]
+    fn test_unclosed_tags() {
+        let input = r##"
+        <!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01 Transitional//EN'
+        'http://www.w3.org/TR/html4/loose.dtd'>
+        <html>
+        <head>
+        <title>Hi</title>
+        <meta http-equiv='Content-Type' content='text/html; charset=iso-8859-1'>						
+        </head>
+        <body>
+        lots of text
+        </body>
+        </html>
+        "##;
+        let txt = dehtml(input);
+        assert_eq!(txt.trim(), "lots of text");
     }
 }


### PR DESCRIPTION
In both failing emails (https://github.com/deltachat/deltachat-android/files/4175240/Efemerides.del.dia.5.de.febrero.eml.txt, https://github.com/deltachat/deltachat-desktop/files/4213375/owa_normal.txt) there was an unclosed `<meta>` tag. I copied one of the emails into a test.
fix #1373