### PR TITLE
[WIP] Implement receiving mailing lists

### DIFF
--- a/draft/mailing_list.rst
+++ b/draft/mailing_list.rst
@@ -1,0 +1,13 @@
+2. Mailing lists are now only detected by the ListId header, because how should DC sort mailing lists if the ListId header is unset and only the precedence header says it's a mailing list (?). We could just hide these emails (with "junk" or "list" precedence), as we did before, if there is a reason to do so. 
+
+   I do not actually understand why such emails were hidden in the first place, though; if there is an automatic answer stating that someone is out of office or if an email could not be delivered (these are the usual reasons why such emails are sent), I would want to know about this as a user.
+   
+   
+3. for `List-Id: foo <bla>`, bla now is the id and foo is the name. For GitHub and GitLab notifications this is bad because all notifications will go into one chat. Maybe we should instead take the "in-reply-to" header to find out what messages belong together. For normal mailing lists, of course, this will create a second chat if someone does not use the "Reply" button to write to that mailing list.
+
+
+4. Currently a mailing list is shown as an empty group (ChatType `Group`) ("0 members"). 
+
+   Maybe we should change the ChatType to `Single` because this way, the UI would fit better. Disadvantage: We can't show the different senders of the messages. 
+   
+   Or we introduce a `ChatType` `MailingList`. Very big disadvantage: We would have to adapt all UI project and it would be nice if we could keep the changes within the core.

--- a/draft/mailing_list.rst
+++ b/draft/mailing_list.rst
@@ -5,9 +5,13 @@
    
 3. for `List-Id: foo <bla>`, bla now is the id and foo is the name. For GitHub and GitLab notifications this is bad because all notifications will go into one chat. Maybe we should instead take the "in-reply-to" header to find out what messages belong together. For normal mailing lists, of course, this will create a second chat if someone does not use the "Reply" button to write to that mailing list.
 
+  Björn: well, having all notifications in one chat is not that bad. i would just follow the guidelines for now, use the ID and not the Name.
+
 
 4. Currently a mailing list is shown as an empty group (ChatType `Group`) ("0 members"). 
 
    Maybe we should change the ChatType to `Single` because this way, the UI would fit better. Disadvantage: We can't show the different senders of the messages. 
    
    Or we introduce a `ChatType` `MailingList`. Very big disadvantage: We would have to adapt all UI project and it would be nice if we could keep the changes within the core.
+
+5. Contacts from mailings lists stay "unknown" now and are not shown in the contacts suggestion list..

--- a/draft/mailing_list.rst
+++ b/draft/mailing_list.rst
@@ -2,6 +2,8 @@
 
    I do not actually understand why such emails were hidden in the first place, though; if there is an automatic answer stating that someone is out of office or if an email could not be delivered (these are the usual reasons why such emails are sent), I would want to know about this as a user.
    
+  Björn: to the ListId-header: it is already an improvement to use only that and to keep ignoring mails with Precedence-header. historically, i ignored all these mails to reduce noise that is created from them (eg. contacts should not be added to the suggestion list...) and to be able to concentrate on other things first.
+   
    
 3. for `List-Id: foo <bla>`, bla now is the id and foo is the name. For GitHub and GitLab notifications this is bad because all notifications will go into one chat. Maybe we should instead take the "in-reply-to" header to find out what messages belong together. For normal mailing lists, of course, this will create a second chat if someone does not use the "Reply" button to write to that mailing list.
 

--- a/draft/mailing_list_current_state.rst
+++ b/draft/mailing_list_current_state.rst
@@ -9,3 +9,5 @@
 5. In general, only the From: address is taken as the author. If the domain matches with the List-Id domain (like `deltachat.github.com` and `Hocuri <notifications@notification.github.com>`) then the display name is added to the email address -> `Hocuri - notifications@notification.github.com`. This is not really nice, but as the UIs distinguish bettween contacts only based on the address this was the only way I could find without changing the API. 
 
 6. You can't send to mailing lists.
+
+7. TODO: Block a mailing list (currently only the sender can be blocked and when someone else writes to the mailing list then it appears in Contact Requests again).

--- a/draft/mailing_list_current_state.rst
+++ b/draft/mailing_list_current_state.rst
@@ -1,0 +1,13 @@
+1. Mailing lists with Precedence-header and without List-Id are shown as normal messages.
+   
+2. for `List-Id: foo <bla>`, bla now is the id and foo is the name. If foo is not present, bla is taken as the name as well. For GitHub and GitLab notifications all notifications will go into one chat. To distinguish, all subjects are shown in mailing lists.
+
+3. Currently a mailing list is shown as a group with SELF and the List-Id. I could not find any stable way to get a mail address that could be called the "mailing list address". To get this to work, I disabled the may_be_valid_addr check. (to be discussed...)
+
+4. Contacts from mailings lists stay "unknown" and are not shown in the contacts suggestion list.
+
+5. In general, only the From: address is taken as the author. If the domain matches with the List-Id domain (like `deltachat.github.com` and `Hocuri <notifications@notification.github.com>`) then the display name is added to the email address -> `Hocuri - notifications@notification.github.com`. This is not really nice, but as the UIs distinguish bettween contacts only based on the address this was the only way I could find without changing the API. 
+
+   TODO: Prevent the user from sending emails to such contacts (like Hocuri - notifications@notification.github.com)
+
+6. You can't send to mailing lists.

--- a/draft/mailing_list_current_state.rst
+++ b/draft/mailing_list_current_state.rst
@@ -8,6 +8,4 @@
 
 5. In general, only the From: address is taken as the author. If the domain matches with the List-Id domain (like `deltachat.github.com` and `Hocuri <notifications@notification.github.com>`) then the display name is added to the email address -> `Hocuri - notifications@notification.github.com`. This is not really nice, but as the UIs distinguish bettween contacts only based on the address this was the only way I could find without changing the API. 
 
-   TODO: Prevent the user from sending emails to such contacts (like Hocuri - notifications@notification.github.com)
-
 6. You can't send to mailing lists.

--- a/draft/mailing_list_managers.md
+++ b/draft/mailing_list_managers.md
@@ -1,0 +1,71 @@
+# Mailing list integration of Delta Chat
+
+A collection of information to help with the integration of mailing lists into Delta Chat.
+
+## Chat name
+
+How should the chat be titled?
+
+It could be taken from the email header `List-Id`:
+
+### Mailman 
+
+* Schema: `${list-description} <${list-local-part}.${list-domain}>`
+* $list-description could be many words, should be truncated. Could also be empty, though.
+
+### Schleuder
+* Schema: `<${list-local-part}.${list-domain}>`
+* No name available.
+* Could be absent: <https://0xacab.org/schleuder/schleuder/-/blob/master/lib/schleuder/mail/message.rb#L357-358>.
+
+
+### Sympa
+* Schema: `<${list-local-part}.${list-domain}>`
+* No name available.
+* Always present <https://github.com/sympa-community/sympa/blob/sympa-6.2/src/lib/Sympa/Spindle/TransformOutgoing.pm#L110-L118>, <https://github.com/sympa-community/sympa/blob/sympa-6.2/src/lib/Sympa/List.pm#L6832-L6833>.
+
+
+## Sender name
+
+What's the name of the person that actually sent the message?
+
+Some MLM change the sender information to avoid problems with DMARC.
+
+### Mailman
+
+* Since v2.1.16 the `From` depends on the list's configuration and possibly on the sender-domain's DMARC-configuration — i.e. messages from the same list can arrive one of the Variants A-D!
+* Documentation of config options:
+ * <https://wiki.list.org/DOC/Mailman%202.1%20List%20Administrators%20Manual#line-544>,
+ * <https://wiki.list.org/DOC/Mailman%202.1%20List%20Administrators%20Manual#line-163>,
+ * <https://wiki.list.org/DEV/DMARC>
+* Variant A: `From` is unchanged.
+* Variant B. `From` is mangled like this: `${sender-name} via ${list-name} <${list-addr-spec}>`. The original sender is put into `Reply-To`.
+* Variant C. `From` is mangled like this: `${sender-name} <${encoded-sender-addr-spec}@${list-domain}>`. The original sender is put into `Reply-To`.
+* Variant D: `From` is set to ${list-name-addr}, the originally sent message is included as mime-part.
+* Variant E: `From` is set to ${list-name-addr}, original sender information is removed.
+
+### Schleuder
+
+* Visible only in mime-body (which is possibly encrypted), or not at all.
+* The first `text/plain` mime-part may include the information, as taken from the original message: `From: ${sender-name-addr}`.
+
+### Sympa
+* Depends on the list's configuration.
+* Documentation:
+ * <https://sympa-community.github.io/manual/customize/dmarc-protection.html>,
+ * <https://sympa-community.github.io/gpldoc/man/sympa.conf.5.html#dmarc-protection>.
+* Variant A: `From` is unchanged.
+* Variant B: `From` is mangled like Mailman Variant B, but the original sender information is put into `X-Original-From`.
+
+
+## Autocrypt
+
+### Mailman
+* Not supported.
+
+### Schleuder
+* A list's key is included in sent messages (as of version 3.5.0) (optional, by default active): <https://0xacab.org/schleuder/schleuder/-/blob/master/lib/schleuder/mail/message.rb#L349-355>.
+* Incoming keys are not yet looked at (that feature is planned: <https://0xacab.org/schleuder/schleuder/issues/435>).
+
+### Sympa
+* Not supported.

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2466,6 +2466,23 @@ pub(crate) fn get_chat_id_by_grpid(
     )
 }
 
+pub(crate) fn get_chat_id_by_mailinglistid(
+    context: &Context,
+    listid: impl AsRef<str>,
+) -> Result<(ChatId, Blocked), sql::Error> {
+    context.sql.query_row(
+        "SELECT id, blocked, type FROM chats WHERE grpid=?;",
+        params![listid.as_ref()],
+        |row| {
+            let chat_id = row.get::<_, ChatId>(0)?;
+
+            let b = row.get::<_, Option<Blocked>>(1)?.unwrap_or_default();
+            Ok((chat_id, b))
+        },
+    )
+}
+
+
 /// Adds a message to device chat.
 ///
 /// Optional `label` can be provided to ensure that message is added only once.

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1097,6 +1097,11 @@ pub fn create_by_contact_id(context: &Context, contact_id: u32) -> Result<ChatId
                 );
                 return Err(err);
             } else {
+                let c = Contact::load_from_db(context, contact_id)?;
+                if let Some(list_chat_id) = c.param.get_int(Param::MailingListPseudoContact) {
+                    return Ok(ChatId::new(list_chat_id as u32));
+                }
+
                 let (chat_id, _) =
                     create_or_lookup_by_contact_id(context, contact_id, Blocked::Not)?;
                 Contact::scaleup_origin_by_id(context, contact_id, Origin::CreateChat);

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -574,9 +574,13 @@ impl Chat {
         self.param.exists(Param::Devicetalk)
     }
 
+    pub fn is_mailing_list(&self) -> bool {
+        self.param.exists(Param::MailingList)
+    }
+
     /// Returns true if user can send messages to this chat.
     pub fn can_send(&self) -> bool {
-        !self.id.is_special() && !self.is_device_talk()
+        !self.id.is_special() && !self.is_device_talk() && !self.is_mailing_list()
     }
 
     pub fn update_param(&mut self, context: &Context) -> Result<(), Error> {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2486,7 +2486,6 @@ pub(crate) fn get_chat_id_by_mailinglistid(
     )
 }
 
-
 /// Adds a message to device chat.
 ///
 /// Optional `label` can be provided to ensure that message is added only once.

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1065,7 +1065,11 @@ pub fn create_by_msg_id(context: &Context, msg_id: MsgId) -> Result<ChatId, Erro
             msg_id: MsgId::new(0),
         });
     }
-    Contact::scaleup_origin_by_id(context, msg.from_id, Origin::CreateChat);
+
+    // If the message is from a mailing list, the contacts are not counted as "known"
+    if !chat.is_mailing_list() {
+        Contact::scaleup_origin_by_id(context, msg.from_id, Origin::CreateChat);
+    }
     Ok(chat.id)
 }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -126,6 +126,7 @@ pub enum Chattype {
     Single = 100,
     Group = 120,
     VerifiedGroup = 130,
+    MailingList = 140,
 }
 
 impl Default for Chattype {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -126,7 +126,6 @@ pub enum Chattype {
     Single = 100,
     Group = 120,
     VerifiedGroup = 130,
-    MailingList = 140,
 }
 
 impl Default for Chattype {

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -343,20 +343,6 @@ impl Contact {
             return Ok((DC_CONTACT_ID_SELF, sth_modified));
         }
 
-        if !may_be_valid_addr(&addr) {
-            warn!(
-                context,
-                "Bad address \"{}\" for contact \"{}\".",
-                addr,
-                if !name.as_ref().is_empty() {
-                    name.as_ref()
-                } else {
-                    "<unset>"
-                },
-            );
-            bail!("Bad address supplied: {:?}", addr);
-        }
-
         let mut update_addr = false;
         let mut update_name = false;
         let mut update_authname = false;

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1792,10 +1792,12 @@ mod tests {
         assert_eq!(chat.name, "deltachat/deltachat-core-rust");
         assert_eq!(chat::get_chat_contacts(&t.ctx, chat_id).len(), 0);
 
+
         dc_receive_imf(&t.ctx, MAILINGLIST2, "INBOX", 1, false).unwrap();
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
         assert_eq!(chats.len(), 1);
+        assert!(Contact::get_all(&t.ctx, 0, None as Option<String>).unwrap().is_empty());
     }
 
     #[test]

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1281,6 +1281,7 @@ fn create_or_lookup_adhoc_group(
     Ok((new_chat_id, create_blocked))
 }
 
+// Insert a group record into the database. Note that this function is also used by create_mailinglist_record() below.
 fn create_group_record(
     context: &Context,
     grpid: impl AsRef<str>,
@@ -1308,7 +1309,7 @@ fn create_group_record(
     {
         warn!(
             context,
-            "Failed to create group '{}' for grpid={}",
+            "Failed to create group or mailinglist '{}' for grpid={}",
             grpname.as_ref(),
             grpid.as_ref()
         );
@@ -1318,7 +1319,7 @@ fn create_group_record(
     let chat_id = ChatId::new(row_id);
     info!(
         context,
-        "Created group '{}' grpid={} as {}",
+        "Created group or mailinglist '{}' grpid={} as {}",
         grpname.as_ref(),
         grpid.as_ref(),
         chat_id
@@ -1338,13 +1339,6 @@ fn create_mailinglist_record(
         &name,
         create_blocked,
         VerifiedStatus::Unverified,
-    );
-    info!(
-        context,
-        "Created mailinglist '{}' listid={} as {}",
-        name.as_ref(),
-        listid.as_ref(),
-        chat_id
     );
     let mut chat = Chat::load_from_db(context, chat_id)?;
 
@@ -1794,7 +1788,7 @@ mod tests {
         assert_eq!(chat.name, "deltachat/deltachat-core-rust");
         assert_eq!(chat::get_chat_contacts(&t.ctx, chat_id).len(), 0);
 
-        
+
         dc_receive_imf(&t.ctx, MAILINGLIST2, "INBOX", 1, false).unwrap();
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1785,19 +1785,22 @@ mod tests {
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
         assert_eq!(chats.len(), 1);
+
         let chat_id = chat::create_by_msg_id(&t.ctx, chats.get_msg_id(0).unwrap()).unwrap();
         let chat = chat::Chat::load_from_db(&t.ctx, chat_id).unwrap();
+
         assert!(chat.is_mailing_list());
         assert_eq!(chat.can_send(), false);
         assert_eq!(chat.name, "deltachat/deltachat-core-rust");
         assert_eq!(chat::get_chat_contacts(&t.ctx, chat_id).len(), 0);
 
-
+        
         dc_receive_imf(&t.ctx, MAILINGLIST2, "INBOX", 1, false).unwrap();
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
         assert_eq!(chats.len(), 1);
-        assert!(Contact::get_all(&t.ctx, 0, None as Option<String>).unwrap().is_empty());
+        let contacts = Contact::get_all(&t.ctx, 0, None as Option<String>).unwrap();
+        assert_eq!(contacts.len(), 0); // mailing list recipients and senders do not count as "known contacts"
     }
 
     #[test]

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1159,7 +1159,6 @@ fn create_or_lookup_mailinglist(
                     );
                     ChatId::new(0)
                 });
-            println!("err: new chatid {:?}", chat_id);
             Ok((chat_id, create_blocked))
         }
     }
@@ -1767,12 +1766,21 @@ mod tests {
     \n\
     hello\n";
 
+    static MAILINGLIST2: &[u8] = b"From: Github <notifications@github.com>\n\
+    To: deltachat/deltachat-core-rust <deltachat-core-rust@noreply.github.com>\n\
+    Subject: [deltachat/deltachat-core-rust] PR run failed\n\
+    Message-ID: <3334@example.org>\n\
+    List-ID: deltachat/deltachat-core-rust <deltachat-core-rust.deltachat.github.com>\n\
+    Precedence: list\n\
+    Date: Sun, 22 Mar 2020 22:37:57 +0000\n\
+    \n\
+    hello back\n";
+
     #[test]
     fn test_mailing_list() {
-        println!("testing");
-
         let t = configured_offline_context();
         t.ctx.set_config(Config::ShowEmails, Some("2")).unwrap();
+
         dc_receive_imf(&t.ctx, MAILINGLIST, "INBOX", 1, false).unwrap();
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
@@ -1783,6 +1791,11 @@ mod tests {
         assert_eq!(chat.can_send(), false);
         assert_eq!(chat.name, "deltachat/deltachat-core-rust");
         assert_eq!(chat::get_chat_contacts(&t.ctx, chat_id).len(), 0);
+
+        dc_receive_imf(&t.ctx, MAILINGLIST2, "INBOX", 1, false).unwrap();
+
+        let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
+        assert_eq!(chats.len(), 1);
     }
 
     #[test]

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1738,7 +1738,7 @@ fn add_or_lookup_contact_by_addr(
             // addr is not the address of the actual sender but the one of the mailing list.
             // Add the display name to the addr to make it distinguishable from other people
             // who sent to the same mailing list.
-            *addr.to_mut() = format!("{}-{}", display_name_normalized, addr);
+            *addr.to_mut() = format!("{} – {}", display_name_normalized, addr);
         }
     }
 

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1378,7 +1378,11 @@ fn prefetch_should_download(
         .get_header_value(HeaderDef::From_)
         .unwrap_or_default();
 
-    let (_contact_id, blocked_contact, origin) = from_field_to_contact_id(context, &from_field)?;
+    let (_contact_id, blocked_contact, origin) = from_field_to_contact_id(
+        context,
+        &from_field,
+        headers.get_header_value(HeaderDef::ListId).as_ref(),
+    )?;
     let accepted_contact = origin.is_known();
 
     let show = is_autocrypt_setup_message

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -282,6 +282,11 @@ impl MimeMessage {
                     prepend_subject = false
                 }
             }
+            // For mailing lists, always add the subject because sometimes there are different topics
+            // and otherwise it might be hard to keep track:
+            if self.get(HeaderDef::ListId).is_some() {
+                prepend_subject = true;
+            }
             if prepend_subject {
                 let subj = if let Some(n) = subject.find('[') {
                     &subject[0..n]

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -288,17 +288,10 @@ impl MimeMessage {
                 prepend_subject = true;
             }
             if prepend_subject {
-                let subj = if let Some(n) = subject.find('[') {
-                    &subject[0..n]
-                } else {
-                    subject
-                }
-                .trim();
-
-                if !subj.is_empty() {
+                if !subject.is_empty() {
                     for part in self.parts.iter_mut() {
                         if part.typ == Viewtype::Text {
-                            part.msg = format!("{} – {}", subj, part.msg);
+                            part.msg = format!("{} – {}", subject, part.msg);
                             break;
                         }
                     }

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -288,10 +288,13 @@ impl MimeMessage {
                 prepend_subject = true;
             }
             if prepend_subject && !subject.is_empty() {
-                self.parts
+                if let Some(mut part) = self
+                    .parts
                     .iter_mut()
                     .find(|part| part.typ == Viewtype::Text)
-                    .map(|mut part| part.msg = format!("{} – {}", subject, part.msg));
+                {
+                    part.msg = format!("{} – {}", subject, part.msg);
+                }
             }
         }
         if self.is_forwarded {

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -287,15 +287,11 @@ impl MimeMessage {
             if self.get(HeaderDef::ListId).is_some() {
                 prepend_subject = true;
             }
-            if prepend_subject {
-                if !subject.is_empty() {
-                    for part in self.parts.iter_mut() {
-                        if part.typ == Viewtype::Text {
-                            part.msg = format!("{} – {}", subject, part.msg);
-                            break;
-                        }
-                    }
-                }
+            if prepend_subject && !subject.is_empty() {
+                self.parts
+                    .iter_mut()
+                    .find(|part| part.typ == Viewtype::Text)
+                    .map(|mut part| part.msg = format!("{} – {}", subject, part.msg));
             }
         }
         if self.is_forwarded {

--- a/src/param.rs
+++ b/src/param.rs
@@ -118,7 +118,13 @@ pub enum Param {
     /// For MDN-sending job
     MsgId = b'I',
 
+    // 'true' if the chat is a mailing list
     MailingList = b't',
+
+    // If this is not a contact we can send to but a contact that is only shown in a
+    // mailing list and we do not have the actual sender address, then this is set
+    // to the chat id of the mailing list.
+    MailingListPseudoContact = b'p',
 }
 
 /// Possible values for `Param::ForcePlaintext`.

--- a/src/param.rs
+++ b/src/param.rs
@@ -117,6 +117,8 @@ pub enum Param {
 
     /// For MDN-sending job
     MsgId = b'I',
+
+    MailingList = b't'
 }
 
 /// Possible values for `Param::ForcePlaintext`.

--- a/src/param.rs
+++ b/src/param.rs
@@ -118,7 +118,7 @@ pub enum Param {
     /// For MDN-sending job
     MsgId = b'I',
 
-    MailingList = b't'
+    MailingList = b't',
 }
 
 /// Possible values for `Param::ForcePlaintext`.


### PR DESCRIPTION
First part of #748.

Update: See https://github.com/deltachat/deltachat-core-rust/blob/mailinlists/draft/mailing_list.rst.

To decide (opinions welcome):
1. What should be the subtitle? Currently it's empty (better than "0 members").
2. Mailing lists are now only detected by the ListId header, because how should DC sort mailing lists if the ListId header is unset and only the precedence header says it's a mailing list (?). We could just hide these emails (with "junk" or "list" precedence), as we did before, if there is a reason to do so. 

   I do not actually understand why such emails were hidden in the first place, though; if there is an automatic answer stating that someone is out of office or if an email could not be delivered (these are the usual reasons why such emails are sent), I would want to know about this as a user.
3. for `List-Id: foo <bla>`, bla now is the id and foo is the name. For GitHub and GitLab notifications this is bad because all notifications will go into one chat. Maybe we should instead take the "in-reply-to" header to find out what messages belong together. For normal mailing lists, of course, this will create a second chat if someone does not use the "Reply" button to write to that mailing list.