### PR TITLE
Filter parent messages by state instead of UID 

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3119,4 +3119,16 @@ mod tests {
             false
         );
     }
+
+    #[test]
+    fn test_parent_is_encrypted() {
+        let t = dummy_context();
+        let chat_id = create_group_chat(&t.ctx, VerifiedStatus::Unverified, "foo").unwrap();
+        assert!(!chat_id.parent_is_encrypted(&t.ctx).unwrap());
+
+        let mut msg = Message::new(Viewtype::Text);
+        msg.set_text(Some("hello".to_string()));
+        chat_id.set_draft(&t.ctx, Some(&mut msg));
+        assert!(!chat_id.parent_is_encrypted(&t.ctx).unwrap());
+    }
 }


### PR DESCRIPTION
This is a better tested version of #1380 

There is only a basic test, because rust has no API to inject encrypted/unencrypted messages into chat. Instead `INSERT INTO msgs` queries are used everywhere. But even this basic test revealed a bug in #1380:  `parent_is_encrypted` returned an error when there were no messages in the chat.

I have factored out SQL logic to handle "no rows" and `NULL`s into `Sql.query_get_row_option()` and used it here to fix the bug.