### PR TITLE
Delete blobs referenced from hidden messages

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1051,7 +1051,10 @@ pub fn housekeeping(context: &Context) {
     maybe_add_from_param(
         context,
         &mut files_in_use,
-        "SELECT param FROM msgs  WHERE chat_id!=3   AND type!=10;",
+        "SELECT param FROM msgs \
+         WHERE chat_id!=3 \
+         AND type!=10 \
+         AND NOT hidden",
         Param::File,
     );
     maybe_add_from_param(


### PR DESCRIPTION
Messages are hidden when they are removed from device by timer. If the
message is not deleted on the server, the database entry is retained,
but blob file is not needed anymore and can be removed to free disk space.