### PR TITLE
Set subject to Re: <last subject> for better compability with normal MUAs

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -379,7 +379,9 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                                     Some(name) => Some(name),
                                     None => self.context.get_config(Config::Displayname).await,
                                 }
-                                .unwrap_or_else(|| "Delta Chat".to_string());
+                                .unwrap_or_else(|| {
+                                    self.context.stock_str(StockMessage::MessengerName)
+                                });
 
                             self.context
                                 .stock_string_repl_str(

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -377,14 +377,11 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                             let self_name = match self.context.get_config(Config::Displayname).await
                             {
                                 Some(name) => name,
-                                None => match self.context.get_config(Config::Addr).await {
-                                    Some(name) => name,
-                                    None => self
-                                        .context
-                                        .stock_str(StockMessage::MessengerName)
-                                        .await
-                                        .to_string(),
-                                },
+                                None => self
+                                    .context
+                                    .get_config(Config::Addr)
+                                    .await
+                                    .unwrap_or_default(),
                             };
 
                             self.context

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -374,14 +374,18 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                             )
                         }
                         None => {
-                            let self_name =
-                                match self.context.get_config(Config::Displayname).await {
-                                    Some(name) => Some(name),
-                                    None => self.context.get_config(Config::Displayname).await,
-                                }
-                                .unwrap_or_else(|| {
-                                    self.context.stock_str(StockMessage::MessengerName)
-                                });
+                            let self_name = match self.context.get_config(Config::Displayname).await
+                            {
+                                Some(name) => name,
+                                None => match self.context.get_config(Config::Addr).await {
+                                    Some(name) => name,
+                                    None => self
+                                        .context
+                                        .stock_str(StockMessage::MessengerName)
+                                        .await
+                                        .to_string(),
+                                },
+                            };
 
                             self.context
                                 .stock_string_repl_str(
@@ -1344,7 +1348,7 @@ mod tests {
         let mf = MimeFactory::from_msg(&t.ctx, &new_msg, false)
             .await
             .unwrap();
-        assert_eq!(mf.subject_str().await, "Chat: ");
+        assert_eq!(mf.subject_str().await, "Message from alice@example.org");
 
         // 4. Receive messages with unicode characters and make sure that we do not panic (we do not care about the result)
         msg_to_subject_str(

--- a/src/param.rs
+++ b/src/param.rs
@@ -103,6 +103,9 @@ pub enum Param {
     /// For Chats
     Selftalk = b'K',
 
+    /// For Chats: So that on sending a new message we can sent the subject to "Re: <last subject>"
+    LastSubject = b't',
+
     /// For Chats
     Devicetalk = b'D',
 

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -182,9 +182,6 @@ pub enum StockMessage {
 
     #[strum(props(fallback = "Message from %1$s"))]
     SubjectForNewContact = 73,
-
-    #[strum(props(fallback = "Delta Chat"))]
-    MessengerName = 74,
 }
 
 /*

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -182,6 +182,9 @@ pub enum StockMessage {
 
     #[strum(props(fallback = "Message from %1$s"))]
     SubjectForNewContact = 73,
+
+    #[strum(props(fallback = "Delta Chat"))]
+    MessengerName = 74,
 }
 
 /*

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -179,6 +179,9 @@ pub enum StockMessage {
 
     #[strum(props(fallback = "Unknown Sender for this chat. See 'info' for more details."))]
     UnknownSenderForChat = 72,
+
+    #[strum(props(fallback = "Message from %1$s"))]
+    SubjectForNewContact = 73,
 }
 
 /*


### PR DESCRIPTION
The last subject is now set as a param to the chat. It turned out that the subjects are not saved anywhere, only together with the body in txt_raw. 

I could have extracted it from there but this would have felt very hacky. 

I thought about splitting up txt_raw into subject and body but I would have had to change the database structure and I am pretty sure that this is not a good idea because the databases would have to be migrated when updating DC.

Now we have a bit of redundance in the database, but I think that this is the best way.