### PR TITLE
refine generation of member-added and member-removed python-level events

### DIFF
--- a/python/examples/group_tracking.py
+++ b/python/examples/group_tracking.py
@@ -18,24 +18,30 @@ class GroupTrackingPlugin:
             message.chat.send_text("echoing from {}:\n{}".format(addr, text))
 
     @account_hookimpl
+    def ac_outgoing_message(self, message):
+        print("ac_outgoing_message:", message)
+
+    @account_hookimpl
     def ac_configure_completed(self, success):
-        print("*** ac_configure_completed:", success)
+        print("ac_configure_completed:", success)
 
     @account_hookimpl
     def ac_chat_modified(self, chat):
-        print("*** ac_chat_modified:", chat.id, chat.get_name())
-
-    @account_hookimpl
-    def ac_member_added(self, chat, contact, sender):
-        print("*** ac_member_added {} to chat {} from {}".format(
-            contact.addr, chat.id, sender.addr))
+        print("ac_chat_modified:", chat.id, chat.get_name())
         for member in chat.get_contacts():
             print("chat member: {}".format(member.addr))
 
     @account_hookimpl
-    def ac_member_removed(self, chat, contact, sender):
-        print("*** ac_member_removed {} from chat {} by {}".format(
-            contact.addr, chat.id, sender.addr))
+    def ac_member_added(self, chat, contact, message):
+        print("ac_member_added {} to chat {} from {}".format(
+            contact.addr, chat.id, message.get_sender_contact().addr))
+        for member in chat.get_contacts():
+            print("chat member: {}".format(member.addr))
+
+    @account_hookimpl
+    def ac_member_removed(self, chat, contact, message):
+        print("ac_member_removed {} from chat {} by {}".format(
+            contact.addr, chat.id, message.get_sender_contact().addr))
 
 
 def main(argv=None):

--- a/python/examples/group_tracking.py
+++ b/python/examples/group_tracking.py
@@ -22,6 +22,10 @@ class GroupTrackingPlugin:
         print("*** ac_configure_completed:", success)
 
     @account_hookimpl
+    def ac_chat_modified(self, chat):
+        print("*** ac_chat_modified:", chat.id, chat.get_name())
+
+    @account_hookimpl
     def ac_member_added(self, chat, contact, sender):
         print("*** ac_member_added {} to chat {} from {}".format(
             contact.addr, chat.id, sender.addr))

--- a/python/examples/group_tracking.py
+++ b/python/examples/group_tracking.py
@@ -22,14 +22,16 @@ class GroupTrackingPlugin:
         print("*** ac_configure_completed:", success)
 
     @account_hookimpl
-    def ac_member_added(self, chat, contact):
-        print("*** ac_member_added", contact.addr, "from", chat)
+    def ac_member_added(self, chat, contact, sender):
+        print("*** ac_member_added {} to chat {} from {}".format(
+            contact.addr, chat.id, sender.addr))
         for member in chat.get_contacts():
             print("chat member: {}".format(member.addr))
 
     @account_hookimpl
-    def ac_member_removed(self, chat, contact):
-        print("*** ac_member_removed", contact.addr, "from", chat)
+    def ac_member_removed(self, chat, contact, sender):
+        print("*** ac_member_removed {} from chat {} by {}".format(
+            contact.addr, chat.id, sender.addr))
 
 
 def main(argv=None):

--- a/python/examples/test_examples.py
+++ b/python/examples/test_examples.py
@@ -33,12 +33,12 @@ def test_echo_quit_plugin(acfactory):
 
 def test_group_tracking_plugin(acfactory, lp):
     lp.sec("creating one group-tracking bot and two temp accounts")
-    botproc = acfactory.run_bot_process(group_tracking)
+    botproc = acfactory.run_bot_process(group_tracking, ffi=False)
 
     ac1, ac2 = acfactory.get_two_online_accounts(quiet=True)
 
     botproc.fnmatch_lines("""
-        *ac_configure_completed: True*
+        *ac_configure_completed*
     """)
     ac1.add_account_plugin(FFIEventLogger(ac1, "ac1"))
     ac2.add_account_plugin(FFIEventLogger(ac2, "ac2"))
@@ -50,7 +50,7 @@ def test_group_tracking_plugin(acfactory, lp):
     ch.send_text("hello")
 
     botproc.fnmatch_lines("""
-        *ac_chat_modified*
+        *ac_chat_modified*bot test group*
     """.format(ac1.get_config("addr")))
 
     lp.sec("adding third member {}".format(ac2.get_config("addr")))

--- a/python/examples/test_examples.py
+++ b/python/examples/test_examples.py
@@ -43,14 +43,14 @@ def test_group_tracking_plugin(acfactory, lp):
     ac1.add_account_plugin(FFIEventLogger(ac1, "ac1"))
     ac2.add_account_plugin(FFIEventLogger(ac2, "ac2"))
 
-    lp.sec("creating bot test group with all three")
+    lp.sec("creating bot test group with bot")
     bot_contact = ac1.create_contact(botproc.addr)
     ch = ac1.create_group_chat("bot test group")
     ch.add_contact(bot_contact)
     ch.send_text("hello")
 
     botproc.fnmatch_lines("""
-        *ac_member_added {}*
+        *ac_chat_modified*
     """.format(ac1.get_config("addr")))
 
     lp.sec("adding third member {}".format(ac2.get_config("addr")))

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -30,7 +30,7 @@ class Chat(object):
         return not (self == other)
 
     def __repr__(self):
-        return "<Chat id={} name={} dc_context={}>".format(self.id, self.get_name(), self._dc_context)
+        return "<Chat id={} name={}>".format(self.id, self.get_name())
 
     @property
     def _dc_chat(self):

--- a/python/src/deltachat/hookspec.py
+++ b/python/src/deltachat/hookspec.py
@@ -49,6 +49,10 @@ class PerAccount:
         """ Called on any incoming message (to deaddrop or chat). """
 
     @account_hookspec
+    def ac_outgoing_message(self, message):
+        """ Called on each outgoing message (both system and "normal")."""
+
+    @account_hookspec
     def ac_message_delivered(self, message):
         """ Called when an outgoing message has been delivered to SMTP. """
 
@@ -57,12 +61,12 @@ class PerAccount:
         """ Chat was created or modified regarding membership, avatar, title. """
 
     @account_hookspec
-    def ac_member_added(self, chat, contact, sender):
+    def ac_member_added(self, chat, contact, message):
         """ Called for each contact added to an accepted chat. """
 
     @account_hookspec
-    def ac_member_removed(self, chat, contact, sender):
-        """ Called for each contact removed from a chat. """
+    def ac_member_removed(self, chat, contact, message):
+        """ Called for each contact removed from a chat.  """
 
 
 class Global:

--- a/python/src/deltachat/hookspec.py
+++ b/python/src/deltachat/hookspec.py
@@ -53,11 +53,15 @@ class PerAccount:
         """ Called when an outgoing message has been delivered to SMTP. """
 
     @account_hookspec
-    def ac_member_added(self, chat, contact):
-        """ Called for each contact added to a chat. """
+    def ac_chat_modified(self, chat):
+        """ Chat was created or modified regarding membership, avatar, title. """
 
     @account_hookspec
-    def ac_member_removed(self, chat, contact):
+    def ac_member_added(self, chat, contact, sender):
+        """ Called for each contact added to an accepted chat. """
+
+    @account_hookspec
+    def ac_member_removed(self, chat, contact, sender):
         """ Called for each contact removed from a chat. """
 
 

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -28,7 +28,9 @@ class Message(object):
         return self.account == other.account and self.id == other.id
 
     def __repr__(self):
-        return "<Message id={} dc_context={}>".format(self.id, self._dc_context)
+        c = self.get_sender_contact()
+        return "<Message id={} sender={}/{} outgoing={} chat={}/{}>".format(
+            self.id, c.id, c.addr, self.is_outgoing(), self.chat.id, self.chat.get_name())
 
     @classmethod
     def from_db(cls, account, id):
@@ -322,14 +324,17 @@ def get_viewtype_code_from_name(view_type_name):
                      "available {!r}".format(view_type_name, list(_view_type_mapping.values())))
 
 
+#
 # some helper code for turning system messages into hook events
+#
+
 def map_system_message(msg):
     if msg.is_system_message():
         res = parse_system_add_remove(msg.text)
         if res:
             contact = msg.account.get_contact_by_addr(res[1])
             if contact:
-                d = dict(chat=msg.chat, contact=contact, sender=msg.get_sender_contact())
+                d = dict(chat=msg.chat, contact=contact, message=msg)
                 return "ac_member_" + res[0], d
 
 

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -91,6 +91,10 @@ class Message(object):
         """mime type of the file (if it exists)"""
         return from_dc_charpointer(lib.dc_msg_get_filemime(self._dc_msg))
 
+    def is_system_message(self):
+        """ return True if this message is a system/info message. """
+        return lib.dc_msg_is_info(self._dc_msg)
+
     def is_setup_message(self):
         """ return True if this message is a setup message. """
         return lib.dc_msg_is_setupmessage(self._dc_msg)
@@ -223,6 +227,13 @@ class Message(object):
         are not counted as unread but were not marked as read nor resulted in MDNs.
         """
         return self._msgstate == const.DC_STATE_IN_SEEN
+
+    def is_outgoing(self):
+        """Return True if Message is outgoing. """
+        return self._msgstate in (
+            const.DC_STATE_OUT_PREPARING, const.DC_STATE_OUT_PENDING,
+            const.DC_STATE_OUT_FAILED, const.DC_STATE_OUT_MDN_RCVD,
+            const.DC_STATE_OUT_DELIVERED)
 
     def is_out_preparing(self):
         """Return True if Message is outgoing, but its file is being prepared.

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -280,26 +280,28 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
             ac.start()
             return ac
 
-        def run_bot_process(self, module):
+        def run_bot_process(self, module, ffi=True):
             fn = module.__file__
 
             bot_ac, bot_cfg = self.get_online_config()
 
             args = [
                 sys.executable,
+                "-u",
                 fn,
-                "--show-ffi",
                 "--email", bot_cfg["addr"],
                 "--password", bot_cfg["mail_pw"],
                 bot_ac.db_path,
             ]
+            if ffi:
+                args.insert(-1, "--show-ffi")
             print("$", " ".join(args))
             popen = subprocess.Popen(
                 args=args,
                 stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,  # combine stdout/stderr in one stream
-                bufsize=1,                 # line buffering
+                bufsize=0,                 # line buffering
                 close_fds=True,            # close all FDs other than 0/1/2
                 universal_newlines=True    # give back text
             )

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -347,15 +347,21 @@ class BotProcess:
         patterns = [x.strip() for x in Source(pattern_lines.rstrip()).lines if x.strip()]
         for next_pattern in patterns:
             print("+++FNMATCH:", next_pattern)
+            ignored = []
             while 1:
                 line = self.stdout_queue.get(timeout=15)
                 if line is None:
+                    if ignored:
+                        print("BOT stdout terminated after these lines")
+                        for line in ignored:
+                            print(line)
                     raise IOError("BOT stdout-thread terminated")
                 if fnmatch.fnmatch(line, next_pattern):
                     print("+++MATCHED:", line)
                     break
                 else:
                     print("+++IGN:", line)
+                    ignored.append(line)
 
 
 @pytest.fixture

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1053,11 +1053,16 @@ class TestOnlineAccount:
                 message_queue.put(message)
 
         delivered = queue.Queue()
+        out = queue.Queue()
 
         class OutPlugin:
             @account_hookimpl
             def ac_message_delivered(self, message):
                 delivered.put(message)
+
+            @account_hookimpl
+            def ac_outgoing_message(self, message):
+                out.put(message)
 
         ac1.add_account_plugin(OutPlugin())
         ac2.add_account_plugin(InPlugin())
@@ -1069,6 +1074,8 @@ class TestOnlineAccount:
         assert ev.data1 == chat.id
         assert ev.data2 == msg_out.id
         assert msg_out.is_out_delivered()
+        m = out.get()
+        assert m == msg_out
         m = delivered.get()
         assert m == msg_out
 
@@ -1305,12 +1312,12 @@ class TestOnlineAccount:
                 in_list.put(EventHolder(action="chat-modified", chat=chat))
 
             @account_hookimpl
-            def ac_member_added(self, chat, contact, sender):
-                in_list.put(EventHolder(action="added", chat=chat, contact=contact, sender=sender))
+            def ac_member_added(self, chat, contact, message):
+                in_list.put(EventHolder(action="added", chat=chat, contact=contact, message=message))
 
             @account_hookimpl
-            def ac_member_removed(self, chat, contact, sender):
-                in_list.put(EventHolder(action="removed", chat=chat, contact=contact, sender=sender))
+            def ac_member_removed(self, chat, contact, message):
+                in_list.put(EventHolder(action="removed", chat=chat, contact=contact, message=message))
 
         ac2.add_account_plugin(InPlugin())
 
@@ -1336,7 +1343,7 @@ class TestOnlineAccount:
         assert ev.action == "chat-modified"
         ev = in_list.get(timeout=10)
         assert ev.action == "added"
-        assert ev.sender.addr == ac1_addr
+        assert ev.message.get_sender_contact().addr == ac1_addr
         assert ev.contact.addr == "notexistingaccountihope@testrun.org"
 
         lp.sec("ac1: remove address2")
@@ -1346,7 +1353,7 @@ class TestOnlineAccount:
         ev = in_list.get(timeout=10)
         assert ev.action == "removed"
         assert ev.contact.addr == contact2.addr
-        assert ev.sender.addr == ac1_addr
+        assert ev.message.get_sender_contact().addr == ac1_addr
 
         lp.sec("ac1: remove ac2 contact from chat")
         chat.remove_contact(contact)
@@ -1354,7 +1361,7 @@ class TestOnlineAccount:
         assert ev.action == "chat-modified"
         ev = in_list.get(timeout=10)
         assert ev.action == "removed"
-        assert ev.sender.addr == ac1_addr
+        assert ev.message.get_sender_contact().addr == ac1_addr
 
     def test_set_get_group_image(self, acfactory, data, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -16,7 +16,7 @@ from conftest import (wait_configuration_progress,
     ("Member tmp1@x.org added by tmp2@x.org.", ("added", "tmp1@x.org")),
 ])
 def test_parse_system_add_remove(msgtext, res):
-    from deltachat.account import parse_system_add_remove
+    from deltachat.message import parse_system_add_remove
 
     out = parse_system_add_remove(msgtext)
     assert out == res

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -11,6 +11,17 @@ from conftest import (wait_configuration_progress,
                       wait_securejoin_inviter_progress)
 
 
+@pytest.mark.parametrize("msgtext,res", [
+    ("Member Me (tmp1@x.org) removed by tmp2@x.org.", ("removed", "tmp1@x.org")),
+    ("Member tmp1@x.org added by tmp2@x.org.", ("added", "tmp1@x.org")),
+])
+def test_parse_system_add_remove(msgtext, res):
+    from deltachat.account import parse_system_add_remove
+
+    out = parse_system_add_remove(msgtext)
+    assert out == res
+
+
 class TestOfflineAccountBasic:
     def test_wrong_db(self, tmpdir):
         p = tmpdir.join("hello.db")
@@ -169,35 +180,6 @@ class TestOfflineChat:
                 break
         else:
             pytest.fail("could not find chat")
-
-    def test_add_member_event(self, ac1):
-        chat = ac1.create_group_chat(name="title1")
-        assert chat.is_group()
-        contact1 = ac1.create_contact("some1@hello.com", name="some1")
-
-        chat.add_contact(contact1)
-        for ev in ac1.iter_events(timeout=1):
-            if ev.name == "ac_member_added":
-                assert ev.kwargs["chat"] == chat
-                if ev.kwargs["contact"] == ac1.get_self_contact():
-                    continue
-                assert ev.kwargs["contact"] == contact1
-                break
-
-    def test_remove_member_event(self, ac1):
-        chat = ac1.create_group_chat(name="title1")
-        assert chat.is_group()
-        contact1 = ac1.create_contact("some1@hello.com", name="some1")
-        chat.add_contact(contact1)
-        ac1._handle_current_events()
-        chat.remove_contact(contact1)
-        for ev in ac1.iter_events(timeout=1):
-            if ev.name == "ac_member_removed":
-                assert ev.kwargs["chat"] == chat
-                if ev.kwargs["contact"] == ac1.get_self_contact():
-                    continue
-                assert ev.kwargs["contact"] == contact1
-                break
 
     def test_group_chat_creation(self, ac1):
         contact1 = ac1.create_contact("some1@hello.com", name="some1")
@@ -497,7 +479,7 @@ class TestOfflineChat:
         # perform plugin hooks
         ac1._handle_current_events()
 
-        assert len(in_list) == 11
+        assert len(in_list) == 10
         chat_contacts = chat.get_contacts()
         for in_cmd, in_chat, in_contact in in_list:
             assert in_cmd == "added"
@@ -505,19 +487,23 @@ class TestOfflineChat:
             assert in_contact in chat_contacts
             chat_contacts.remove(in_contact)
 
+        assert chat_contacts[0].id == 1  # self contact
+
+        in_list[:] = []
+
         lp.sec("ac1: removing two contacts and checking things are right")
         chat.remove_contact(contacts[9])
         chat.remove_contact(contacts[3])
         assert len(chat.get_contacts()) == 9
 
         ac1._handle_current_events()
-        assert len(in_list) == 13
-        assert in_list[-2][0] == "removed"
-        assert in_list[-2][1] == chat
-        assert in_list[-2][2] == contacts[9]
-        assert in_list[-1][0] == "removed"
-        assert in_list[-1][1] == chat
-        assert in_list[-1][2] == contacts[3]
+        assert len(in_list) == 2
+        assert in_list[0][0] == "removed"
+        assert in_list[0][1] == chat
+        assert in_list[0][2] == contacts[9]
+        assert in_list[1][0] == "removed"
+        assert in_list[1][1] == chat
+        assert in_list[1][2] == contacts[3]
 
 
 class TestOnlineAccount:
@@ -1298,48 +1284,77 @@ class TestOnlineAccount:
 
     def test_add_remove_member_remote_events(self, acfactory, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1_addr = ac1.get_config("addr")
+        ac2_addr = ac2.get_config("addr")
         # activate local plugin for ac2
         in_list = queue.Queue()
 
+        class EventHolder:
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
         class InPlugin:
             @account_hookimpl
-            def ac_member_added(self, chat, contact):
-                in_list.put(("added", chat, contact))
+            def ac_incoming_message(self, message):
+                # we immediately accept the sender because
+                # otherwise we won't see member_added contacts
+                message.accept_sender_contact()
 
             @account_hookimpl
-            def ac_member_removed(self, chat, contact):
-                in_list.put(("removed", chat, contact))
+            def ac_chat_modified(self, chat):
+                in_list.put(EventHolder(action="chat-modified", chat=chat))
+
+            @account_hookimpl
+            def ac_member_added(self, chat, contact, sender):
+                in_list.put(EventHolder(action="added", chat=chat, contact=contact, sender=sender))
+
+            @account_hookimpl
+            def ac_member_removed(self, chat, contact, sender):
+                in_list.put(EventHolder(action="removed", chat=chat, contact=contact, sender=sender))
 
         ac2.add_account_plugin(InPlugin())
 
         lp.sec("ac1: create group chat with ac2")
         chat = ac1.create_group_chat("hello")
-        contact = ac1.create_contact(email=ac2.get_config("addr"))
+        contact = ac1.create_contact(email=ac2_addr)
         chat.add_contact(contact)
 
         lp.sec("ac1: send a message to group chat to promote the group")
         chat.send_text("afterwards promoted")
-        ev1 = in_list.get()
-        ev2 = in_list.get()
-        assert ev1[2] == ac2.get_self_contact()
-        assert ev2[2].addr == ac1.get_config("addr")
+        ev = in_list.get(timeout=10)
+        assert ev.action == "chat-modified"
+        assert chat.is_promoted()
+        assert sorted(x.addr for x in chat.get_contacts()) == \
+            sorted(x.addr for x in ev.chat.get_contacts())
 
         lp.sec("ac1: add address2")
-        contact2 = ac1.create_contact(email="not@example.org")
+        # note that if the above accept_sender_contact() would not
+        # happen we would not receive a proper member_added event
+        contact2 = ac1.create_contact(email="notexistingaccountihope@testrun.org")
         chat.add_contact(contact2)
-        ev1 = in_list.get()
-        assert ev1[2].addr == contact2.addr
+        ev = in_list.get(timeout=10)
+        assert ev.action == "chat-modified"
+        ev = in_list.get(timeout=10)
+        assert ev.action == "added"
+        assert ev.sender.addr == ac1_addr
+        assert ev.contact.addr == "notexistingaccountihope@testrun.org"
 
         lp.sec("ac1: remove address2")
         chat.remove_contact(contact2)
-        ev1 = in_list.get()
-        assert ev1[0] == "removed"
-        assert ev1[2].addr == contact2.addr
+        ev = in_list.get(timeout=10)
+        assert ev.action == "chat-modified"
+        ev = in_list.get(timeout=10)
+        assert ev.action == "removed"
+        assert ev.contact.addr == contact2.addr
+        assert ev.sender.addr == ac1_addr
 
         lp.sec("ac1: remove ac2 contact from chat")
         chat.remove_contact(contact)
-        ev1 = in_list.get()
-        assert ev1[2] == ac2.get_self_contact()
+        ev = in_list.get(timeout=10)
+        assert ev.action == "chat-modified"
+        ev = in_list.get(timeout=10)
+        assert ev.action == "removed"
+        assert ev.sender.addr == ac1_addr
 
     def test_set_get_group_image(self, acfactory, data, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2191,10 +2191,6 @@ pub fn remove_contact_from_chat(
                         msg.param.set_cmd(SystemMessage::MemberRemovedFromGroup);
                         msg.param.set(Param::Arg, contact.get_addr());
                         msg.id = send_msg(context, chat_id, &mut msg)?;
-                        context.call_cb(Event::MsgsChanged {
-                            chat_id,
-                            msg_id: msg.id,
-                        });
                     }
                 }
                 // we remove the member from the chat after constructing the


### PR DESCRIPTION
Python: 
- ignores DC_EVENT_MEMBER_REMOVED/ADDED events and rather looks at system messages to determine to generate python-level ac_member_added and ac_member_removed events 
- add ac_chat_modified hook event
- add account.get_contact_by_addr (thanks @r10s)

rust: avoid duplicate DC_EVENT_MSGS_CHANGED for removed contacts
