### PR TITLE
Delete expired messages instead of hiding them

### DIFF
--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -93,8 +93,8 @@ impl Chatlist {
         query_contact_id: Option<u32>,
     ) -> Result<Self> {
         // Note that we do not emit DC_EVENT_MSGS_MODIFIED here even if some
-        // messages get hidden to avoid reloading the same chatlist.
-        if let Err(err) = hide_device_expired_messages(context) {
+        // messages get deleted to avoid reloading the same chatlist.
+        if let Err(err) = delete_device_expired_messages(context) {
             warn!(context, "Failed to hide expired messages: {}", err);
         }
 


### PR DESCRIPTION
For hidden messages, blobs are not deleted during housekeeping. To
actually free the space used by media files, messages should be moved to
trash instead of being hidden.