### PR TITLE
Log to the stdout and stderr in tests

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -42,14 +42,14 @@ pub(crate) fn test_context(callback: Option<Box<ContextCallback>>) -> TestContex
 /// specified in [test_context] but there is no callback hooked up,
 /// i.e. [Context::call_cb] will always return `0`.
 pub(crate) fn dummy_context() -> TestContext {
-    test_context(None)
+    test_context(Some(Box::new(logging_cb)))
 }
 
 pub(crate) fn logging_cb(_ctx: &Context, evt: Event) {
     match evt {
         Event::Info(msg) => println!("I: {}", msg),
-        Event::Warning(msg) => println!("W: {}", msg),
-        Event::Error(msg) => println!("E: {}", msg),
+        Event::Warning(msg) => eprintln!("=== WARNING ===\n{}\n===============", msg),
+        Event::Error(msg) => eprintln!("\n===================== ERROR =====================\n{}\n=================================================\n", msg),
         _ => (),
     }
 }


### PR DESCRIPTION
Think that it would be useful to see all  output in all tests for debugging. I mean, this output is needed to find out why the test is failing.

If there is a reason no to accept this PR, it doesn't matter, I'll just locally keep these changes for test debugging.