### PR TITLE
Do not ignore database read errors in precheck_imf

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -298,8 +298,8 @@ fn add_parts(
     // check, if the mail is already in our database - if so, just update the folder/uid
     // (if the mail was moved around) and finish. (we may get a mail twice eg. if it is
     // moved between folders. make sure, this check is done eg. before securejoin-processing) */
-    if let Ok((old_server_folder, old_server_uid, _)) =
-        message::rfc724_mid_exists(context, &rfc724_mid)
+    if let Some((old_server_folder, old_server_uid, _)) =
+        message::rfc724_mid_exists(context, &rfc724_mid)?
     {
         if old_server_folder != server_folder.as_ref() || old_server_uid != server_uid {
             message::update_server_uid(context, &rfc724_mid, server_folder.as_ref(), server_uid);

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -604,7 +604,7 @@ impl Imap {
 
             let headers = get_fetch_headers(fetch)?;
             let message_id = prefetch_get_message_id(&headers).unwrap_or_default();
-            if precheck_imf(context, &message_id, folder.as_ref(), cur_uid) {
+            if precheck_imf(context, &message_id, folder.as_ref(), cur_uid)? {
                 // we know the message-id already or don't want the message otherwise.
                 info!(
                     context,
@@ -1266,9 +1266,14 @@ fn get_folder_meaning(folder_name: &Name) -> FolderMeaning {
     }
 }
 
-fn precheck_imf(context: &Context, rfc724_mid: &str, server_folder: &str, server_uid: u32) -> bool {
-    if let Ok((old_server_folder, old_server_uid, msg_id)) =
-        message::rfc724_mid_exists(context, &rfc724_mid)
+fn precheck_imf(
+    context: &Context,
+    rfc724_mid: &str,
+    server_folder: &str,
+    server_uid: u32,
+) -> Result<bool> {
+    if let Some((old_server_folder, old_server_uid, msg_id)) =
+        message::rfc724_mid_exists(context, &rfc724_mid)?
     {
         if old_server_folder.is_empty() && old_server_uid == 0 {
             info!(
@@ -1322,9 +1327,9 @@ fn precheck_imf(context: &Context, rfc724_mid: &str, server_folder: &str, server
         if old_server_folder != server_folder || old_server_uid != server_uid {
             update_server_uid(context, &rfc724_mid, server_folder, server_uid);
         }
-        true
+        Ok(true)
     } else {
-        false
+        Ok(false)
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1431,12 +1431,12 @@ pub fn rfc724_mid_cnt(context: &Context, rfc724_mid: &str) -> i32 {
 pub(crate) fn rfc724_mid_exists(
     context: &Context,
     rfc724_mid: &str,
-) -> Result<(String, u32, MsgId), Error> {
+) -> Result<Option<(String, u32, MsgId)>, Error> {
     ensure!(!rfc724_mid.is_empty(), "empty rfc724_mid");
 
     context
         .sql
-        .query_row(
+        .query_row_optional(
             "SELECT server_folder, server_uid, id FROM msgs WHERE rfc724_mid=?",
             &[rfc724_mid],
             |row| {


### PR DESCRIPTION
If `precheck_imf` fails to check if message with the same rfc724_mid
already exists, the same message may be downloaded twice. Instead,
abort the whole operation and retry later.

An attempt to address #1404