### PR TITLE
add context-uptime to dc_get_info()

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -21,6 +21,7 @@ use crate::message::{self, Message, MessengerMessage, MsgId};
 use crate::param::Params;
 use crate::smtp::Smtp;
 use crate::sql::Sql;
+use std::time::Instant;
 
 /// Callback function type for [Context]
 ///
@@ -57,6 +58,7 @@ pub struct Context {
     /// Mutex to avoid generating the key for the user more than once.
     pub generating_key_mutex: Mutex<()>,
     pub translated_stockstrings: RwLock<HashMap<usize, String>>,
+    creation_time: Instant,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -138,6 +140,7 @@ impl Context {
             perform_inbox_jobs_needed: Arc::new(RwLock::new(false)),
             generating_key_mutex: Mutex::new(()),
             translated_stockstrings: RwLock::new(HashMap::new()),
+            creation_time: std::time::Instant::now(),
         };
 
         ensure!(
@@ -310,6 +313,12 @@ impl Context {
             pub_key_cnt.unwrap_or_default().to_string(),
         );
         res.insert("fingerprint", fingerprint_str);
+
+        let elapsed = self.creation_time.elapsed().as_secs();
+        let hours = elapsed / 3600;
+        let minutes = elapsed % 3600 / 60;
+        let seconds = elapsed % 3600 % 60;
+        res.insert("uptime", format!("{}h {}m {}s", hours, minutes, seconds));
 
         res
     }


### PR DESCRIPTION
this pr adds the context-uptime in the format `1h 2m 3s` (for 1 hour, 2 minutes, 3 seconds) to the string returned by `dc_get_info()`.

as the `dc_get_info()` output is shown on all os, one can now get an idea, how long the app is actually running - this is useful for debugging, so you can easily check if an app was killed in between on android.

it is no perfect tracking, of course, but it can give some basic information about what is going on - with very little effort.

maybe lib-update may be even more useful, however, this would require some struggling with rust-static-globals-lazy-whatever, therefore, i've chosen the simple way and added context-uptime just to the Context object.

the idea was brought up by some recent android-background discussions.