### PR TITLE
fix uptime debug output

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -22,7 +22,7 @@ use crate::message::{self, Message, MessengerMessage, MsgId};
 use crate::param::Params;
 use crate::smtp::Smtp;
 use crate::sql::Sql;
-use std::time::Instant;
+use std::time::SystemTime;
 
 /// Callback function type for [Context]
 ///
@@ -59,7 +59,7 @@ pub struct Context {
     /// Mutex to avoid generating the key for the user more than once.
     pub generating_key_mutex: Mutex<()>,
     pub translated_stockstrings: RwLock<HashMap<usize, String>>,
-    creation_time: Instant,
+    creation_time: SystemTime,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -141,7 +141,7 @@ impl Context {
             perform_inbox_jobs_needed: Arc::new(RwLock::new(false)),
             generating_key_mutex: Mutex::new(()),
             translated_stockstrings: RwLock::new(HashMap::new()),
-            creation_time: std::time::Instant::now(),
+            creation_time: std::time::SystemTime::now(),
         };
 
         ensure!(

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,6 +9,7 @@ use crate::chat::*;
 use crate::config::Config;
 use crate::constants::*;
 use crate::contact::*;
+use crate::dc_tools::duration_to_str;
 use crate::error::*;
 use crate::events::Event;
 use crate::imap::*;
@@ -314,11 +315,8 @@ impl Context {
         );
         res.insert("fingerprint", fingerprint_str);
 
-        let elapsed = self.creation_time.elapsed().as_secs();
-        let hours = elapsed / 3600;
-        let minutes = elapsed % 3600 / 60;
-        let seconds = elapsed % 3600 % 60;
-        res.insert("uptime", format!("{}h {}m {}s", hours, minutes, seconds));
+        let elapsed = self.creation_time.elapsed();
+        res.insert("uptime", duration_to_str(elapsed.unwrap_or_default()));
 
         res
     }

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -5,7 +5,7 @@ use core::cmp::{max, min};
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 use std::{fmt, fs};
 
 use chrono::{Local, TimeZone};
@@ -73,6 +73,14 @@ pub(crate) fn dc_str_to_color(s: impl AsRef<str>) -> u32 {
 pub fn dc_timestamp_to_str(wanted: i64) -> String {
     let ts = Local.timestamp(wanted, 0);
     ts.format("%Y.%m.%d %H:%M:%S").to_string()
+}
+
+pub fn duration_to_str(duration: Duration) -> String {
+    let secs = duration.as_secs();
+    let h = secs / 3600;
+    let m = secs % 3600 / 60;
+    let s = secs % 3600 % 60;
+    format!("{}h {}m {}s", h, m, s)
 }
 
 pub(crate) fn dc_gm2local_offset() -> i64 {
@@ -853,5 +861,38 @@ mod tests {
         let start = dc_create_smeared_timestamps(&t.ctx, count as usize);
         let next = dc_smeared_time(&t.ctx);
         assert!((start + count - 1) < next);
+    }
+
+    #[test]
+    fn test_duration_to_str() {
+        assert_eq!(duration_to_str(Duration::from_secs(0)), "0h 0m 0s");
+        assert_eq!(duration_to_str(Duration::from_secs(59)), "0h 0m 59s");
+        assert_eq!(duration_to_str(Duration::from_secs(60)), "0h 1m 0s");
+        assert_eq!(duration_to_str(Duration::from_secs(61)), "0h 1m 1s");
+        assert_eq!(duration_to_str(Duration::from_secs(59 * 60)), "0h 59m 0s");
+        assert_eq!(
+            duration_to_str(Duration::from_secs(59 * 60 + 59)),
+            "0h 59m 59s"
+        );
+        assert_eq!(
+            duration_to_str(Duration::from_secs(59 * 60 + 60)),
+            "1h 0m 0s"
+        );
+        assert_eq!(
+            duration_to_str(Duration::from_secs(2 * 60 * 60 + 59 * 60 + 59)),
+            "2h 59m 59s"
+        );
+        assert_eq!(
+            duration_to_str(Duration::from_secs(2 * 60 * 60 + 59 * 60 + 60)),
+            "3h 0m 0s"
+        );
+        assert_eq!(
+            duration_to_str(Duration::from_secs(3 * 60 * 60 + 59)),
+            "3h 0m 59s"
+        );
+        assert_eq!(
+            duration_to_str(Duration::from_secs(3 * 60 * 60 + 60)),
+            "3h 1m 0s"
+        );
     }
 }

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -78,8 +78,8 @@ pub fn dc_timestamp_to_str(wanted: i64) -> String {
 pub fn duration_to_str(duration: Duration) -> String {
     let secs = duration.as_secs();
     let h = secs / 3600;
-    let m = secs % 3600 / 60;
-    let s = secs % 3600 % 60;
+    let m = (secs % 3600) / 60;
+    let s = (secs % 3600) % 60;
     format!("{}h {}m {}s", h, m, s)
 }
 


### PR DESCRIPTION
use std::time::SystemTime for uptime calculation, std::time::Instant does not count eg. doze-time on android.

moreover, this pr moves duration-formatting to a separate function and test it (first i suspected the duration-formatting to do weird things :)
