### PR TITLE
sort dc_get_info() by keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -700,6 +700,7 @@ dependencies = [
  "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "deltachat 1.28.0",
  "human-panic 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.67 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -22,6 +22,7 @@ num-traits = "0.2.6"
 serde_json = "1.0"
 anyhow = "1.0.28"
 thiserror = "1.0.14"
+itertools = "0.8.0"
 
 [features]
 default = ["vendored", "nightly"]

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -13,6 +13,7 @@ extern crate human_panic;
 extern crate num_traits;
 extern crate serde_json;
 
+use itertools::Itertools;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::ffi::CString;
@@ -437,8 +438,8 @@ fn render_info(
     info: HashMap<&'static str, String>,
 ) -> std::result::Result<String, std::fmt::Error> {
     let mut res = String::new();
-    for (key, value) in &info {
-        writeln!(&mut res, "{}={}", key, value)?;
+    for key in info.keys().sorted() {
+        writeln!(&mut res, "{}={}", key, info.get(key).unwrap())?;
     }
 
     Ok(res)


### PR DESCRIPTION
[dc_get_info()](https://c.delta.chat/classdc__context__t.html#a2cb5251125fa02a0f997753f2fe905b1) returns lines of key=value pairs that may be displayed directly to the user.

this pr orders the result alphabetically instead of having a random on each call to dc_get_info().