### PR TITLE
regard line with ony '--' as footer mark partly

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -15,6 +15,7 @@ use crate::message::{self, Message};
 use crate::mimeparser::SystemMessage;
 use crate::param::*;
 use crate::peerstate::{Peerstate, PeerstateVerifiedStatus};
+use crate::simplify::escape_message_footer_marks;
 use crate::stock::StockMessage;
 
 // attachments of 25 mb brutto should work on the majority of providers
@@ -807,7 +808,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
         let message_text = format!(
             "{}{}{}{}{}",
             fwdhint.unwrap_or_default(),
-            &final_text,
+            escape_message_footer_marks(final_text),
             if !final_text.is_empty() && !footer.is_empty() {
                 "\r\n\r\n"
             } else {

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -1,3 +1,19 @@
+// protect lines starting with `--` against being treated as a footer.
+// for that, we insert a ZERO WIDTH SPACE (ZWSP, 0x200B);
+// this should be invisible on most systems and there is no need to unescape it again
+// (which won't be done by non-deltas anyway)
+//
+// this escapes a bit more than actually needed by delta (eg. also lines as "-- footer"),
+// but for non-delta-compatibility, that seems to be better.
+// (to be only compatible with delta, only "[\r\n|\n]-- {0,2}[\r\n|\n]" needs to be replaced)
+pub fn escape_message_footer_marks(text: &str) -> String {
+    if text.starts_with("--") {
+        "-\u{200B}-".to_string() + &text[2..].replace("\n--", "\n-\u{200B}-")
+    } else {
+        text.replace("\n--", "\n-\u{200B}-")
+    }
+}
+
 /// Remove standard (RFC 3676, §4.3) footer if it is found.
 fn remove_message_footer<'a>(lines: &'a [&str]) -> &'a [&'a str] {
     let mut nearly_standard_footer = None;
@@ -282,6 +298,15 @@ mod tests {
     }
 
     #[test]
+    fn test_escape_message_footer_marks() {
+        let esc = escape_message_footer_marks("--\n--text --in line");
+        assert_eq!(esc, "-\u{200B}-\n-\u{200B}-text --in line");
+
+        let esc = escape_message_footer_marks("--\r\n--text");
+        assert_eq!(esc, "-\u{200B}-\r\n-\u{200B}-text");
+    }
+
+    #[test]
     fn test_remove_message_footer() {
         let input = "text\n--\nno footer".to_string();
         let (plain, _) = simplify(input, true);
@@ -300,11 +325,20 @@ mod tests {
         assert_eq!(plain, "text\n\n--\nno footer");
 
         let input = "text\n\n--\ntreated as footer when unescaped".to_string();
-        let (plain, _) = simplify(input, true);
+        let (plain, _) = simplify(input.clone(), true);
         assert_eq!(plain, "text"); // see remove_message_footer() for some explanations
+        let escaped = escape_message_footer_marks(&input);
+        let (plain, _) = simplify(escaped, true);
+        assert_eq!(
+            plain,
+            "text\n\n-\u{200B}-\ntreated as footer when unescaped"
+        );
 
         let input = "--\ntreated as footer when unescaped".to_string();
-        let (plain, _) = simplify(input, true);
-        assert_eq!(plain, "");
+        let (plain, _) = simplify(input.clone(), true);
+        assert_eq!(plain, ""); // see remove_message_footer() for some explanations
+        let escaped = escape_message_footer_marks(&input);
+        let (plain, _) = simplify(escaped, true);
+        assert_eq!(plain, "-\u{200B}-\ntreated as footer when unescaped");
     }
 }

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -184,7 +184,8 @@ fn render_message(lines: &[&str], is_cut_at_begin: bool, is_cut_at_end: bool) ->
     if is_cut_at_end && (!is_cut_at_begin || !empty_body) {
         ret += " [...]";
     }
-    ret
+    // redo escaping done by escape_message_footer_marks()
+    ret.replace("\u{200B}", "")
 }
 
 /**
@@ -329,16 +330,13 @@ mod tests {
         assert_eq!(plain, "text"); // see remove_message_footer() for some explanations
         let escaped = escape_message_footer_marks(&input);
         let (plain, _) = simplify(escaped, true);
-        assert_eq!(
-            plain,
-            "text\n\n-\u{200B}-\ntreated as footer when unescaped"
-        );
+        assert_eq!(plain, "text\n\n--\ntreated as footer when unescaped");
 
         let input = "--\ntreated as footer when unescaped".to_string();
         let (plain, _) = simplify(input.clone(), true);
         assert_eq!(plain, ""); // see remove_message_footer() for some explanations
         let escaped = escape_message_footer_marks(&input);
         let (plain, _) = simplify(escaped, true);
-        assert_eq!(plain, "-\u{200B}-\ntreated as footer when unescaped");
+        assert_eq!(plain, "--\ntreated as footer when unescaped");
     }
 }


### PR DESCRIPTION
the footer mark normally used in email-conversations is `-- `, note the trailing space, see RFC 3676, §4.3

unfortunately, the final space is removed by some providers, which lead to footers showing up on delta-to-delta-conversations (on nondc-to-delta, this is not an issue as we cannot be sure anyway
and show a [...] therefore)

this pr accepts lines with only `--` as a footer separator if there is no other footer separator and if the line before is empty and the line after is not.

as there is still some chance to remove text accidentally, the second commit adds protection against that by completely avoiding the string `--` at the beginning of a line of a normal text message.

fixes #1429, fixes https://github.com/deltachat/deltachat-android/issues/1082, fixes https://github.com/open-xchange/ox-coi/issues/221