### PR TITLE
Update Readme.md: Explain database path, fix #1431

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ curl https://sh.rustup.rs -sSf | sh
 Compile and run Delta Chat Core command line utility, using `cargo`:
 
 ```
-cargo run --example repl -- /path/to/db
+cargo run --example repl -- ~/deltachat-db
 ```
+where ~/deltachat-db is the database file. Delta Chat will create it if it does not exist.
 
 Configure your account (if not already configured):
 


### PR DESCRIPTION
Also set the database path to ~/deltachat-db so that nothing has to be changed in the command (it can just be copy-pasted).