### PR TITLE
Use quoted-printable as transfer-encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -665,6 +665,7 @@ dependencies = [
  "pretty_env_logger 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-xml 0.17.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quoted_printable 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2 0.8.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "r2d2_sqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ debug_stub_derive = "0.3.0"
 sanitize-filename = "0.2.1"
 stop-token = { version = "0.1.1", features = ["unstable"] }
 mailparse = "0.12.0"
+quoted_printable = "0.4.2"
 encoded-words = { git = "https://github.com/async-email/encoded-words", branch="master" }
 native-tls = "0.2.3"
 image = { version = "0.22.4", default-features=false, features = ["gif_codec", "jpeg", "ico", "png_codec", "pnm", "webp", "bmp"] }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -807,7 +807,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
         let message_text = format!(
             "{}{}{}{}{}",
             fwdhint.unwrap_or_default(),
-            &final_text,
+            &quoted_printable::encode_to_str(final_text),
             if !final_text.is_empty() && !footer.is_empty() {
                 "\r\n\r\n"
             } else {

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -813,12 +813,13 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             } else {
                 ""
             },
-            if !footer.is_empty() { "-- \r\n" } else { "" },
+            if !footer.is_empty() { "--=20\r\n" } else { "" },
             footer
         );
 
         // Message is sent as text/plain, with charset = utf-8
         let main_part = PartBuilder::new()
+            .header(("Content-Transfer-Encoding", "QUOTED-PRINTABLE"))
             .content_type(&mime::TEXT_PLAIN_UTF_8)
             .body(message_text);
         let mut parts = Vec::new();


### PR DESCRIPTION
Well... Sometimes: fixes #1429, fixes deltachat/deltachat-android#1082, fixes open-xchange/ox-coi#221

This only works when:
1. The message is long enough (I didn't test the threshold but somewhere from 2 to 16 chars
2. AND the message does not contain a special character.

Otherwise there is no change at all. So, might be that I forgot a place where changes have to be made.

--

I also tried what happens if I remove one of the changes I made:

If I leave out setting the transfer-encoding:
```
message

--=20
Sent with my Delta Chat Messenger: https://delta.chat
```
(message as shown to the user).

If I leave out changing the footer, my change does not have any effect at all, again.