### PR TITLE
Fix #1120 Contact requests are not shown when name of sender includes a comma character

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -238,11 +238,11 @@ pub fn dc_receive_imf(
 /// Also returns whether it is blocked or not and its origin.
 pub fn from_field_to_contact_id(
     context: &Context,
-    from_header: &MailAddrList,
+    from_address_list: HashMap<String, String>,
 ) -> Result<(u32, bool, Origin)> {
     let from_ids = dc_add_or_lookup_contacts_by_address_list(
         context,
-        from_header,
+        from_address_list,
         Origin::IncomingUnknownFrom,
     )?;
 
@@ -1589,31 +1589,17 @@ fn is_msgrmsg_rfc724_mid(context: &Context, rfc724_mid: &str) -> bool {
 
 fn dc_add_or_lookup_contacts_by_address_list(
     context: &Context,
-    addrs: &MailAddrList,
+    address_list: &HashMap<String, String>, // That's a HashMap<mail_addr, display_name>
     origin: Origin,
 ) -> Result<ContactIds> {
     let mut contact_ids = ContactIds::new();
-    for addr in addrs.iter() {
-        match addr {
-            mailparse::MailAddr::Single(info) => {
-                contact_ids.insert(add_or_lookup_contact_by_addr(
-                    context,
-                    &info.display_name,
-                    &info.addr,
-                    origin,
-                )?);
-            }
-            mailparse::MailAddr::Group(infos) => {
-                for info in &infos.addrs {
-                    contact_ids.insert(add_or_lookup_contact_by_addr(
-                        context,
-                        &info.display_name,
-                        &info.addr,
-                        origin,
-                    )?);
-                }
-            }
-        }
+    for (addr, display_name) in address_list.iter() {
+        contact_ids.insert(add_or_lookup_contact_by_addr(
+            context,
+            display_name,
+            addr,
+            origin,
+        )?);
     }
 
     Ok(contact_ids)

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2017,7 +2017,7 @@ mod tests {
         let context = &t.ctx;
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
-        assert!(chats.get_msg_id(0).is_ok());
+        assert!(chats.get_msg_id(0).is_err());
 
         dc_receive_imf(
             context,

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2017,7 +2017,7 @@ mod tests {
         let context = &t.ctx;
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
-        assert!(chats.get_msg_id(0).is_none());
+        assert!(chats.get_msg_id(0).is_ok());
 
         dc_receive_imf(
             context,
@@ -2036,6 +2036,6 @@ mod tests {
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
         // Check that the message was added to the database:
-        assert!(chats.get_msg_id(0).is_some());
+        assert!(chats.get_msg_id(0).is_ok());
     }
 }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2066,12 +2066,18 @@ mod tests {
     #[test]
     fn test_escaped_recipients() {
         let t = configured_offline_context();
-        let contact_id = Contact::create(&t.ctx, "foobar", "foobar@example.com").unwrap();
+        Contact::create(&t.ctx, "foobar", "foobar@example.com").unwrap();
+
+        let carl_contact_id =
+            Contact::add_or_lookup(&t.ctx, "Carl", "carl@host.tld", Origin::IncomingUnknownFrom)
+                .unwrap()
+                .0;
+
         dc_receive_imf(
             &t.ctx,
             b"From: Foobar <foobar@example.com>\n\
                  To: =?UTF-8?B?0JjQvNGPLCDQpNCw0LzQuNC70LjRjw==?= alice@example.org\n\
-                 Cc: =?utf-8?q?=3Ch2=3E?= <carl@host.tld>
+                 Cc: =?utf-8?q?=3Ch2=3E?= <carl@host.tld>\n\
                  Subject: foo\n\
                  Message-ID: <asdklfjjaweofi@example.org>\n\
                  Chat-Version: 1.0\n\
@@ -2084,15 +2090,11 @@ mod tests {
             false,
         )
         .unwrap();
-        let carl_contact_id =
-            Contact::add_or_lookup(&t.ctx, "Carl", "carl@host.tld", Origin::Internal)
-                .unwrap()
-                .0;
         assert_eq!(
             Contact::load_from_db(&t.ctx, carl_contact_id)
                 .unwrap()
-                .get_authname(),
-            ""
+                .get_name(),
+            "h2"
         );
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
@@ -2100,5 +2102,44 @@ mod tests {
         assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
         assert_eq!(msg.text.unwrap(), "hello");
         assert_eq!(msg.param.get_int(Param::WantsMdn).unwrap(), 1);
+    }
+
+    #[test]
+    fn test_cc_to_contact() {
+        let t = configured_offline_context();
+        Contact::create(&t.ctx, "foobar", "foobar@example.com").unwrap();
+
+        let carl_contact_id = Contact::add_or_lookup(
+            &t.ctx,
+            "garabage",
+            "carl@host.tld",
+            Origin::IncomingUnknownFrom,
+        )
+        .unwrap()
+        .0;
+
+        dc_receive_imf(
+            &t.ctx,
+            b"From: Foobar <foobar@example.com>\n\
+                 To: alice@example.org\n\
+                 Cc: Carl <carl@host.tld>\n\
+                 Subject: foo\n\
+                 Message-ID: <asdklfjjaweofi@example.org>\n\
+                 Chat-Version: 1.0\n\
+                 Chat-Disposition-Notification-To: <foobar@example.com>\n\
+                 Date: Sun, 22 Mar 2020 22:37:57 +0000\n\
+                 \n\
+                 hello\n",
+            "INBOX",
+            1,
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            Contact::load_from_db(&t.ctx, carl_contact_id)
+                .unwrap()
+                .get_name(),
+            "Carl"
+        );
     }
 }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3,6 +3,8 @@ use sha2::{Digest, Sha256};
 
 use num_traits::FromPrimitive;
 
+use mailparse::MailAddrList;
+
 use crate::chat::{self, Chat, ChatId};
 use crate::config::Config;
 use crate::constants::*;
@@ -110,29 +112,23 @@ pub fn dc_receive_imf(
     // we do not check Return-Path any more as this is unreliable, see
     // https://github.com/deltachat/deltachat-core/issues/150)
     let (from_id, from_id_blocked, incoming_origin) =
-        if let Some(field_from) = mime_parser.get(HeaderDef::From_) {
-            from_field_to_contact_id(context, field_from)?
-        } else {
-            (0, false, Origin::Unknown)
-        };
+        from_field_to_contact_id(context, &mime_parser.from)?;
+
     let incoming = from_id != DC_CONTACT_ID_SELF;
 
     let mut to_ids = ContactIds::new();
-    for header_def in &[HeaderDef::To, HeaderDef::Cc] {
-        if let Some(field) = mime_parser.get(header_def.clone()) {
-            to_ids.extend(&dc_add_or_lookup_contacts_by_address_list(
-                context,
-                &field,
-                if !incoming {
-                    Origin::OutgoingTo
-                } else if incoming_origin.is_known() {
-                    Origin::IncomingTo
-                } else {
-                    Origin::IncomingUnknownTo
-                },
-            )?);
-        }
-    }
+
+    to_ids.extend(&dc_add_or_lookup_contacts_by_address_list(
+        context,
+        &mime_parser.recipients,
+        if !incoming {
+            Origin::OutgoingTo
+        } else if incoming_origin.is_known() {
+            Origin::IncomingTo
+        } else {
+            Origin::IncomingUnknownTo
+        },
+    )?);
 
     // Add parts
 
@@ -242,11 +238,11 @@ pub fn dc_receive_imf(
 /// Also returns whether it is blocked or not and its origin.
 pub fn from_field_to_contact_id(
     context: &Context,
-    field_from: &str,
+    from_header: &MailAddrList,
 ) -> Result<(u32, bool, Origin)> {
     let from_ids = dc_add_or_lookup_contacts_by_address_list(
         context,
-        &field_from,
+        from_header,
         Origin::IncomingUnknownFrom,
     )?;
 
@@ -256,7 +252,7 @@ pub fn from_field_to_contact_id(
         if from_ids.len() > 1 {
             warn!(
                 context,
-                "mail has more than one From address, only using first: {:?}", field_from
+                "mail has more than one From address, only using first: {:?}", from_header
             );
         }
         let from_id = from_ids.get_index(0).cloned().unwrap_or_default();
@@ -269,7 +265,7 @@ pub fn from_field_to_contact_id(
         }
         Ok((from_id, from_id_blocked, incoming_origin))
     } else {
-        warn!(context, "mail has an empty From header: {:?}", field_from);
+        warn!(context, "mail has an empty From header: {:?}", from_header);
         // if there is no from given, from_id stays 0 which is just fine. These messages
         // are very rare, however, we have to add them to the database (they go to the
         // "deaddrop" chat) to avoid a re-download from the server. See also [**]
@@ -1593,16 +1589,9 @@ fn is_msgrmsg_rfc724_mid(context: &Context, rfc724_mid: &str) -> bool {
 
 fn dc_add_or_lookup_contacts_by_address_list(
     context: &Context,
-    addr_list_raw: &str,
+    addrs: &MailAddrList,
     origin: Origin,
 ) -> Result<ContactIds> {
-    let addrs = match mailparse::addrparse(addr_list_raw) {
-        Ok(addrs) => addrs,
-        Err(err) => {
-            bail!("could not parse {:?}: {:?}", addr_list_raw, err);
-        }
-    };
-
     let mut contact_ids = ContactIds::new();
     for addr in addrs.iter() {
         match addr {
@@ -2016,5 +2005,37 @@ mod tests {
         );
         let one2one = Chat::load_from_db(&t.ctx, one2one_id).unwrap();
         assert!(one2one.get_visibility() == ChatVisibility::Archived);
+    }
+
+    #[test]
+    fn test_no_from() {
+        // if there is no from given, from_id stays 0 which is just fine. These messages
+        // are very rare, however, we have to add them to the database (they go to the
+        // "deaddrop" chat) to avoid a re-download from the server. See also [**]
+
+        let t = configured_offline_context();
+        let context = &t.ctx;
+
+        let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
+        assert!(chats.get_msg_id(0).is_none());
+
+        dc_receive_imf(
+            context,
+            b"To: bob@example.org\n\
+                 Subject: foo\n\
+                 Message-ID: <3924@example.org>\n\
+                 Chat-Version: 1.0\n\
+                 Date: Sun, 22 Mar 2020 22:37:57 +0000\n\
+                 \n\
+                 hello\n",
+            "INBOX",
+            1,
+            false,
+        )
+        .unwrap();
+
+        let chats = Chatlist::try_load(&t.ctx, 0, None, None).unwrap();
+        // Check that the message was added to the database:
+        assert!(chats.get_msg_id(0).is_some());
     }
 }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -238,7 +238,7 @@ pub fn dc_receive_imf(
 /// Also returns whether it is blocked or not and its origin.
 pub fn from_field_to_contact_id(
     context: &Context,
-    from_address_list: &Vec<SingleInfo>,
+    from_address_list: &[SingleInfo],
 ) -> Result<(u32, bool, Origin)> {
     let from_ids = dc_add_or_lookup_contacts_by_address_list(
         context,
@@ -1592,7 +1592,7 @@ fn is_msgrmsg_rfc724_mid(context: &Context, rfc724_mid: &str) -> bool {
 
 fn dc_add_or_lookup_contacts_by_address_list(
     context: &Context,
-    address_list: &Vec<SingleInfo>,
+    address_list: &[SingleInfo],
     origin: Origin,
 ) -> Result<ContactIds> {
     let mut contact_ids = ContactIds::new();

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -122,8 +122,14 @@ pub fn try_decrypt(
 ) -> Result<(Option<Vec<u8>>, HashSet<String>)> {
     let from = mail
         .headers
-        .get_header_value(HeaderDef::From_)
-        .and_then(|from_addr| mailparse::addrparse(&from_addr).ok())
+        .iter()
+        .filter(|header| {
+            header
+                .get_key()
+                .eq_ignore_ascii_case(HeaderDef::From_.get_headername())
+        })
+        .next()
+        .and_then(|from_addr| mailparse::addrparse_header(&from_addr).ok())
         .and_then(|from| from.extract_single_info())
         .map(|from| from.addr)
         .unwrap_or_default();

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -9,7 +9,7 @@ use crate::aheader::*;
 use crate::config::Config;
 use crate::context::Context;
 use crate::error::*;
-use crate::headerdef::{HeaderDef, HeaderDefMap};
+use crate::headerdef::HeaderDef;
 use crate::key::{DcKey, Key, SignedPublicKey, SignedSecretKey};
 use crate::keyring::*;
 use crate::peerstate::*;
@@ -123,12 +123,11 @@ pub fn try_decrypt(
     let from = mail
         .headers
         .iter()
-        .filter(|header| {
+        .find(|header| {
             header
                 .get_key()
                 .eq_ignore_ascii_case(HeaderDef::From_.get_headername())
         })
-        .next()
         .and_then(|from_addr| mailparse::addrparse_header(&from_addr).ok())
         .and_then(|from| from.extract_single_info())
         .map(|from| from.addr)

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -10,6 +10,7 @@ use crate::config::Config;
 use crate::context::Context;
 use crate::error::*;
 use crate::headerdef::HeaderDef;
+use crate::headerdef::HeaderDefMap;
 use crate::key::{DcKey, Key, SignedPublicKey, SignedSecretKey};
 use crate::keyring::*;
 use crate::peerstate::*;
@@ -122,12 +123,7 @@ pub fn try_decrypt(
 ) -> Result<(Option<Vec<u8>>, HashSet<String>)> {
     let from = mail
         .headers
-        .iter()
-        .find(|header| {
-            header
-                .get_key()
-                .eq_ignore_ascii_case(HeaderDef::From_.get_headername())
-        })
+        .get_header(HeaderDef::From_)
         .and_then(|from_addr| mailparse::addrparse_header(&from_addr).ok())
         .and_then(|from| from.extract_single_info())
         .map(|from| from.addr)

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -53,11 +53,15 @@ impl HeaderDef {
 
 pub trait HeaderDefMap {
     fn get_header_value(&self, headerdef: HeaderDef) -> Option<String>;
+    fn get_header(&self, headerdef: HeaderDef) -> Option<&MailHeader>;
 }
 
 impl HeaderDefMap for [MailHeader<'_>] {
     fn get_header_value(&self, headerdef: HeaderDef) -> Option<String> {
         self.get_first_value(headerdef.get_headername())
+    }
+    fn get_header(&self, headerdef: HeaderDef) -> Option<&MailHeader> {
+        self.get_first_header(headerdef.get_headername())
     }
 }
 

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -26,6 +26,7 @@ use crate::headerdef::{HeaderDef, HeaderDefMap};
 use crate::job::{job_add, Action};
 use crate::login_param::{CertificateChecks, LoginParam};
 use crate::message::{self, update_server_uid};
+use crate::mimeparser;
 use crate::oauth2::dc_get_oauth2_access_token;
 use crate::param::Params;
 use crate::stock::StockMessage;
@@ -1374,12 +1375,8 @@ fn prefetch_should_download(
         .get_header_value(HeaderDef::AutocryptSetupMessage)
         .is_some();
 
-    let from_field = headers
-        .get_header(HeaderDef::From_)
-        .ok_or_else(|| format_err!("No from field"))?;
-
     let (_contact_id, blocked_contact, origin) =
-        from_field_to_contact_id(context, &mailparse::addrparse_header(from_field)?)?;
+        from_field_to_contact_id(context, &mimeparser::get_from(headers))?;
     let accepted_contact = origin.is_known();
 
     let show = is_autocrypt_setup_message

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -20,7 +20,6 @@ use crate::context::Context;
 use crate::dc_receive_imf::{
     dc_receive_imf, from_field_to_contact_id, is_msgrmsg_rfc724_mid_in_list,
 };
-use crate::error::format_err;
 use crate::events::Event;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
 use crate::job::{job_add, Action};

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -13,7 +13,6 @@ use async_imap::{
 };
 use async_std::sync::{Mutex, RwLock};
 use async_std::task;
-use mailparse::MailHeaderMap;
 
 use crate::config::*;
 use crate::constants::*;
@@ -1376,7 +1375,7 @@ fn prefetch_should_download(
         .is_some();
 
     let from_field = headers
-        .get_first_header("From")
+        .get_header(HeaderDef::From_)
         .ok_or_else(|| format_err!("No from field"))?;
 
     let (_contact_id, blocked_contact, origin) =

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1377,7 +1377,7 @@ fn prefetch_should_download(
 
     let from_field = headers
         .get_first_header("From")
-        .ok_or(format_err!("No from field"))?;
+        .ok_or_else(|| format_err!("No from field"))?;
 
     let (_contact_id, blocked_contact, origin) =
         from_field_to_contact_id(context, &mailparse::addrparse_header(from_field)?)?;

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1141,9 +1141,9 @@ mod tests {
         let context = dummy_context();
         let raw = include_bytes!("../test-data/message/mail_with_cc.txt");
         let mimeparser = MimeMessage::from_bytes(&context.ctx, &raw[..]).unwrap();
-        let recipients = get_recipients(mimeparser.header.iter());
-        assert!(recipients.contains("abc@bcd.com"));
-        assert!(recipients.contains("def@def.de"));
+        let recipients = mimeparser.recipients;
+        assert!(recipients.contains(&mailparse::addrparse("abc@bcd.com").unwrap()[0]));
+        assert!(recipients.contains(&mailparse::addrparse("def@def.de").unwrap()[0]));
         assert_eq!(recipients.len(), 2);
     }
 
@@ -1198,14 +1198,10 @@ mod tests {
 
         let mimeparser = MimeMessage::from_bytes(&context.ctx, &raw[..]).unwrap();
 
-        let of = mimeparser
-            .parse_first_addr(&context.ctx, HeaderDef::From_)
-            .unwrap();
-        assert_eq!(of, mailparse::addrparse("hello@one.org").unwrap()[0]);
+        let of = &mimeparser.from[0];
+        assert_eq!(of, &mailparse::addrparse("hello@one.org").unwrap()[0]);
 
-        let of =
-            mimeparser.parse_first_addr(&context.ctx, HeaderDef::ChatDispositionNotificationTo);
-        assert!(of.is_none());
+        assert!(mimeparser.chat_disposition_notification_to.is_none());
     }
 
     #[test]

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1138,12 +1138,11 @@ mod tests {
 
     #[test]
     fn test_get_recipients() {
-        let context = dummy_context();
         let raw = include_bytes!("../test-data/message/mail_with_cc.txt");
-        let mimeparser = MimeMessage::from_bytes(&context.ctx, &raw[..]).unwrap();
-        let recipients = mimeparser.recipients;
-        assert!(recipients.contains(&mailparse::addrparse("abc@bcd.com").unwrap()[0]));
-        assert!(recipients.contains(&mailparse::addrparse("def@def.de").unwrap()[0]));
+        let mail = mailparse::parse_mail(&raw[..]).unwrap();
+        let recipients = get_recipients(&mail.headers);
+        assert!(recipients.contains("abc@bcd.com"));
+        assert!(recipients.contains("def@def.de"));
         assert_eq!(recipients.len(), 2);
     }
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -3,10 +3,7 @@ use std::collections::{HashMap, HashSet};
 use anyhow::Context as _;
 use deltachat_derive::{FromSql, ToSql};
 use lettre_email::mime::{self, Mime};
-use mailparse::{
-    addrparse_header, DispositionType, MailAddr, MailAddrList, MailHeader, MailHeaderMap,
-    SingleInfo,
-};
+use mailparse::{addrparse_header, DispositionType, MailHeader, MailHeaderMap, SingleInfo};
 
 use crate::aheader::Aheader;
 use crate::blob::BlobObject;
@@ -784,7 +781,7 @@ impl MimeMessage {
                 }
             }
         }
-        let mut recipients_new = get_recipients(fields);
+        let recipients_new = get_recipients(fields);
         if !recipients_new.is_empty() {
             *recipients = recipients_new;
         }
@@ -1078,24 +1075,6 @@ where
         });
 
     result
-}
-
-/// Check if the only addrs match, ignoring names.
-fn compare_addrs(a: &mailparse::MailAddr, b: &mailparse::MailAddr) -> bool {
-    match a {
-        mailparse::MailAddr::Group(group_a) => match b {
-            mailparse::MailAddr::Group(group_b) => group_a
-                .addrs
-                .iter()
-                .zip(group_b.addrs.iter())
-                .all(|(a, b)| a.addr == b.addr),
-            _ => false,
-        },
-        mailparse::MailAddr::Single(single_a) => match b {
-            mailparse::MailAddr::Single(single_b) => single_a.addr == single_b.addr,
-            _ => false,
-        },
-    }
 }
 
 #[cfg(test)]

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1029,7 +1029,6 @@ fn get_attachment_filename(mail: &mailparse::ParsedMail) -> Result<Option<String
     }
 }
 
-/// Returns a HashMap<Address, Display_name>.
 /// Returned addresses are normalized and lowercased.
 fn get_recipients(headers: &[MailHeader]) -> Vec<SingleInfo> {
     get_all_addresses_from_header(headers, |header_key| {
@@ -1037,7 +1036,6 @@ fn get_recipients(headers: &[MailHeader]) -> Vec<SingleInfo> {
     })
 }
 
-/// Returns a HashMap<Address, Display_name>.
 /// Returned addresses are normalized and lowercased.
 pub(crate) fn get_from(headers: &[MailHeader]) -> Vec<SingleInfo> {
     get_all_addresses_from_header(headers, |header_key| header_key == "from")

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -762,7 +762,7 @@ impl MimeMessage {
         chat_disposition_notification_to: &mut Option<MailAddr>,
         fields: &[mailparse::MailHeader<'_>],
     ) {
-        let mut my_receipients = vec![];
+        let mut my_recipients = vec![];
         for field in fields {
             // lowercasing all headers is technically not correct, but makes things work better
             let key = field.get_key().to_lowercase();
@@ -771,7 +771,7 @@ impl MimeMessage {
             {
                 if key == "cc" || key == "to" {
                     match addrparse_header(field) {
-                        Ok(mut addrlist) => my_receipients.append(&mut addrlist),
+                        Ok(mut addrlist) => my_recipients.append(&mut addrlist),
                         Err(e) => warn!(context, "Could not read {} address: {}", key, e),
                     }
                 } else if key == "from" {
@@ -795,9 +795,9 @@ impl MimeMessage {
                 }
             }
         }
-        if !my_receipients.is_empty() {
+        if !my_recipients.is_empty() {
             recipients.clear();
-            recipients.append(&mut my_receipients);
+            recipients.append(&mut my_recipients);
         }
     }
 


### PR DESCRIPTION
Fix #1120 and (I think) fix #1421.

I repaced all `addrparse`s with `addrparse_header` and added some tests. In some cases I have `addrparse_header` has to be invoked and the result has to be stored as the original mail will not be stored and it would be too hard to store it (borrowing problems...). @link2xt explained this nicely in the issues I liked above.

I didn't use `MailAddrLists`s because they can contain `Groups`s of email addresses, which makes iterating over them harder. Instead, I used `Vec<SingleInfo>`.

Two times, (14c19d5a7c107ff82c5e6c80f57f6f2275f45de6 and 6f009b71ef90ec9f48dcfa847dc7d1f6ea474cf8) I tried functional style but failed to get it to compile because of borrowing problems. Maybe someone wants to have a look at it, but maybe it is not possible using functional style.