### PR TITLE
do not send DC_EVENT_MSGS_CHANGED or DC_EVENT_INCOMING_MSG for hidden messages

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -674,7 +674,7 @@ fn add_parts(
     );
 
     // check event to send
-    if chat_id.is_trash() {
+    if chat_id.is_trash() || *hidden {
         *create_event_to_send = None;
     } else if incoming && state == MessageState::InFresh {
         if from_id_blocked {


### PR DESCRIPTION
these events take the message-id as parameter and might be used to update an existing list (although to recommended)

if the event is issued for hidden messages, this might led to "empty" messages flashing up -
the ui tries to get the message from the event, after a moment, on the next update, the message disappears again as hidden messages are of course not returned eg. by dc_get_chat_msgs().

the effect was probably always visible for secure-join-messages on ios, however, become much more visible recently when read-receipts are added as hidden messages as well (to make them auto-deletable).

fixes https://github.com/deltachat/deltachat-ios/issues/659 as ios adds the message from DC_EVENT_INCOMING_MSG unconditionally to the chat, @Jikstra @Simon-Laux doesn't desktop do something similar? at least at some point in the past? however, if so, this should be fixed as well.