### PR TITLE
optionally get default-options from provider-db

### DIFF
--- a/src/provider/data.rs
+++ b/src/provider/data.rs
@@ -18,6 +18,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: STARTTLS, hostname: "newyear.aktivix.org", port: 143, username_pattern: EMAIL },
             Server { protocol: SMTP, socket: STARTTLS, hostname: "newyear.aktivix.org", port: 25, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     // aol.md: aol.com
@@ -28,6 +29,7 @@ lazy_static::lazy_static! {
         overview_page: "https://providers.delta.chat/aol",
         server: vec![
         ],
+        config_defaults: None,
     };
 
     // autistici.org.md: autistici.org
@@ -40,6 +42,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: SSL, hostname: "mail.autistici.org", port: 993, username_pattern: EMAIL },
             Server { protocol: SMTP, socket: SSL, hostname: "smtp.autistici.org", port: 465, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     // bluewin.ch.md: bluewin.ch
@@ -52,6 +55,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: SSL, hostname: "imaps.bluewin.ch", port: 993, username_pattern: EMAIL },
             Server { protocol: SMTP, socket: SSL, hostname: "smtpauths.bluewin.ch", port: 465, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     // comcast.md: xfinity.com, comcast.net
@@ -73,6 +77,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: SSL, hostname: "imap.example.com", port: 1337, username_pattern: EMAIL },
             Server { protocol: SMTP, socket: STARTTLS, hostname: "smtp.example.com", port: 1337, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     // fastmail.md: fastmail.com
@@ -83,6 +88,7 @@ lazy_static::lazy_static! {
         overview_page: "https://providers.delta.chat/fastmail",
         server: vec![
         ],
+        config_defaults: None,
     };
 
     // freenet.de.md: freenet.de
@@ -95,6 +101,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: SSL, hostname: "mx.freenet.de", port: 993, username_pattern: EMAIL },
             Server { protocol: SMTP, socket: STARTTLS, hostname: "mx.freenet.de", port: 587, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     // gmail.md: gmail.com, googlemail.com
@@ -107,6 +114,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: SSL, hostname: "imap.gmail.com", port: 993, username_pattern: EMAIL },
             Server { protocol: SMTP, socket: SSL, hostname: "smtp.gmail.com", port: 465, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     // gmx.net.md: gmx.net, gmx.de, gmx.at, gmx.ch, gmx.org, gmx.eu, gmx.info, gmx.biz, gmx.com
@@ -120,6 +128,7 @@ lazy_static::lazy_static! {
             Server { protocol: SMTP, socket: SSL, hostname: "mail.gmx.net", port: 465, username_pattern: EMAIL },
             Server { protocol: SMTP, socket: STARTTLS, hostname: "mail.gmx.net", port: 587, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     // i.ua.md: i.ua
@@ -135,6 +144,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: SSL, hostname: "imap.mail.me.com", port: 993, username_pattern: EMAILLOCALPART },
             Server { protocol: SMTP, socket: STARTTLS, hostname: "smtp.mail.me.com", port: 587, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     // kolst.com.md: kolst.com
@@ -159,6 +169,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: STARTTLS, hostname: "imap.nauta.cu", port: 143, username_pattern: EMAIL },
             Server { protocol: SMTP, socket: STARTTLS, hostname: "smtp.nauta.cu", port: 25, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     // outlook.com.md: hotmail.com, outlook.com, office365.com, outlook.com.tr, live.com
@@ -171,6 +182,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: SSL, hostname: "imap-mail.outlook.com", port: 993, username_pattern: EMAIL },
             Server { protocol: SMTP, socket: STARTTLS, hostname: "smtp-mail.outlook.com", port: 587, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     // posteo.md: posteo.de
@@ -183,6 +195,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: STARTTLS, hostname: "posteo.de", port: 143, username_pattern: EMAIL },
             Server { protocol: SMTP, socket: STARTTLS, hostname: "posteo.de", port: 587, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     // protonmail.md: protonmail.com, protonmail.ch
@@ -193,6 +206,7 @@ lazy_static::lazy_static! {
         overview_page: "https://providers.delta.chat/protonmail",
         server: vec![
         ],
+        config_defaults: None,
     };
 
     // riseup.net.md: riseup.net
@@ -209,6 +223,7 @@ lazy_static::lazy_static! {
         overview_page: "https://providers.delta.chat/t-online",
         server: vec![
         ],
+        config_defaults: None,
     };
 
     // testrun.md: testrun.org
@@ -222,6 +237,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: STARTTLS, hostname: "testrun.org", port: 143, username_pattern: EMAIL },
             Server { protocol: SMTP, socket: STARTTLS, hostname: "testrun.org", port: 587, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     // tiscali.it.md: tiscali.it
@@ -234,6 +250,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: SSL, hostname: "imap.tiscali.it", port: 993, username_pattern: EMAIL },
             Server { protocol: SMTP, socket: SSL, hostname: "smtp.tiscali.it", port: 465, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     // ukr.net.md: ukr.net
@@ -253,6 +270,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: STARTTLS, hostname: "imap.web.de", port: 143, username_pattern: EMAILLOCALPART },
             Server { protocol: SMTP, socket: STARTTLS, hostname: "smtp.web.de", port: 587, username_pattern: EMAILLOCALPART },
         ],
+        config_defaults: None,
     };
 
     // yahoo.md: yahoo.com, yahoo.de, yahoo.it, yahoo.fr, yahoo.es, yahoo.se, yahoo.co.uk, yahoo.co.nz, yahoo.com.au, yahoo.com.ar, yahoo.com.br, yahoo.com.mx, ymail.com, rocketmail.com, yahoodns.net
@@ -265,6 +283,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: SSL, hostname: "imap.mail.yahoo.com", port: 993, username_pattern: EMAIL },
             Server { protocol: SMTP, socket: SSL, hostname: "smtp.mail.yahoo.com", port: 465, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     // yandex.ru.md: yandex.ru, yandex.com
@@ -275,6 +294,7 @@ lazy_static::lazy_static! {
         overview_page: "https://providers.delta.chat/yandex-ru",
         server: vec![
         ],
+        config_defaults: None,
     };
 
     // ziggo.nl.md: ziggo.nl
@@ -287,6 +307,7 @@ lazy_static::lazy_static! {
             Server { protocol: IMAP, socket: SSL, hostname: "imap.ziggo.nl", port: 993, username_pattern: EMAIL },
             Server { protocol: SMTP, socket: STARTTLS, hostname: "smtp.ziggo.nl", port: 587, username_pattern: EMAIL },
         ],
+        config_defaults: None,
     };
 
     pub static ref PROVIDER_DATA: HashMap<&'static str, &'static Provider> = [

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -2,6 +2,7 @@
 
 mod data;
 
+use crate::config::Config;
 use crate::dc_tools::EmailAddress;
 use crate::provider::data::PROVIDER_DATA;
 
@@ -58,12 +59,19 @@ impl Server {
 }
 
 #[derive(Debug)]
+pub struct ConfigDefault {
+    pub key: Config,
+    pub value: &'static str,
+}
+
+#[derive(Debug)]
 pub struct Provider {
     pub status: Status,
     pub before_login_hint: &'static str,
     pub after_login_hint: &'static str,
     pub overview_page: &'static str,
     pub server: Vec<Server>,
+    pub config_defaults: Option<Vec<ConfigDefault>>,
 }
 
 impl Provider {

--- a/src/provider/update.py
+++ b/src/provider/update.py
@@ -121,7 +121,7 @@ def process_data(data, file):
     # finally, add the provider
     global out_all, out_domains
     out_all += "    // " + file[file.rindex("/")+1:] + ": " + comment.strip(", ") + "\n"
-    if status == "OK" and before_login_hint == "" and after_login_hint == "" and server == "":
+    if status == "OK" and before_login_hint == "" and after_login_hint == "" and server == "" and config_defaults == "None":
         out_all += "    // - skipping provider with status OK and no special things to do\n\n"
     else:
         out_all += provider

--- a/src/provider/update.py
+++ b/src/provider/update.py
@@ -9,6 +9,9 @@ out_all = ""
 out_domains = ""
 domains_dict = {}
 
+def camel(name):
+    words = name.split("_")
+    return "".join(w.capitalize() for i, w in enumerate(words))
 
 def cleanstr(s):
     s = s.strip()
@@ -29,6 +32,18 @@ def file2url(f):
     f = f[f.rindex("/")+1:].replace(".md", "")
     f = f.replace(".", "-")
     return "https://providers.delta.chat/" + f
+
+
+def process_config_defaults(data):
+    if not "config_defaults" in data:
+        return "None"
+    defaults = "Some(vec![\n"
+    config_defaults = data.get("config_defaults", "")
+    for key in config_defaults:
+        value = str(config_defaults[key])
+        defaults += "            ConfigDefault { key: Config::" + camel(key) + ", value: \"" + value + "\" },\n"
+    defaults += "        ])"
+    return defaults
 
 
 def process_data(data, file):
@@ -83,6 +98,8 @@ def process_data(data, file):
             server += ("            Server { protocol: " + protocol + ", socket: " + socket + ", hostname: \""
             + hostname + "\", port: " + str(port) + ", username_pattern: " + username_pattern + " },\n")
 
+    config_defaults = process_config_defaults(data)
+
     provider = ""
     before_login_hint = cleanstr(data.get("before_login_hint", ""))
     after_login_hint = cleanstr(data.get("after_login_hint", ""))
@@ -93,6 +110,7 @@ def process_data(data, file):
         provider += "        after_login_hint: \"" + after_login_hint + "\",\n"
         provider += "        overview_page: \"" + file2url(file) + "\",\n"
         provider += "        server: vec![\n" + server + "        ],\n"
+        provider += "        config_defaults: " + config_defaults + ",\n"
         provider += "    };\n\n"
     else:
         raise TypeError("SMTP and IMAP must be specified together or left out both")


### PR DESCRIPTION
this pr adds the possibility to use provider-specific-defaults for typically user-changeable options.

the options for which you can define provider-specific-defaults are eg.  `bcc_self`, `e2ee_enabled`, `sentbox_watch` and so on, in theory, every option that can be changed by [`dc_set_config()`](https://c.delta.chat/classdc__context__t.html#aff3b894f6cfca46cab5248fdffdf083d)

to get the provider-specific-defaults,  add a section as the following to the [provider-db](https://github.com/deltachat/provider-db/tree/master/_providers):

```
config_defaults:
  bcc_self: 0
  e2ee_enabled: 0
  sentbox_watch: 0
  mvbox_watch: 0
  mvbox_move: 0
  media_quality: 1
```

the provider-specific-defaults are applied once after the first successful configuration, they are not applied later on re-configures or on updates - reason for that is to respect user-choice of changing these values.