### PR TITLE
imap: do not update last_seen_uid on read error

### DIFF
--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -646,10 +646,6 @@ impl Imap {
             }
         }
 
-        if new_last_seen_uid > last_seen_uid {
-            self.set_config_last_seen_uid(context, &folder, uid_validity, new_last_seen_uid);
-        }
-
         if read_errors > 0 {
             warn!(
                 context,
@@ -665,6 +661,10 @@ impl Imap {
                 read_cnt,
                 folder.as_ref()
             );
+
+            if new_last_seen_uid > last_seen_uid {
+                self.set_config_last_seen_uid(context, &folder, uid_validity, new_last_seen_uid);
+            }
         }
 
         Ok(read_cnt > 0)


### PR DESCRIPTION
Otherwise the messages that were not read will be skipped, despite the
log file promising "trying over later" on read errors.

This may cause missing messages on device on database or network errors
during message download.

Addresses https://support.delta.chat/t/reload-partially-recieved-messages/954 and, maybe, #1412

May cause endless loops and not downloading any more messages if there is an error in some IMAP or parsing code, so extensive testing is needed before releasing.