### PR TITLE
fetch_single_msg: do not ignore dc_receive_imf errors

### DIFF
--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -733,13 +733,7 @@ impl Imap {
                 if let Err(err) =
                     dc_receive_imf(context, &body, folder.as_ref(), server_uid, is_seen)
                 {
-                    warn!(
-                        context,
-                        "dc_receive_imf failed for imap-message {}/{}: {:?}",
-                        folder.as_ref(),
-                        server_uid,
-                        err
-                    );
+                    return Err(Error::Other(format!("dc_receive_imf error: {}", err)));
                 }
             }
         } else {


### PR DESCRIPTION
If error is ignored, the message will never be fetched again, even if
there was a database write error.

Addresses https://support.delta.chat/t/reload-partially-recieved-messages/954 and, maybe, #1412

May cause endless loops and not downloading any more messages if there is an error in some IMAP or parsing code, so extensive testing is needed before releasing.