### PR TITLE
Parse attachment filenames from Content-Type "name" attribute

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -984,6 +984,11 @@ fn get_attachment_filename(mail: &mailparse::ParsedMail) -> Result<Option<String
     let desired_filename =
         desired_filename.or_else(|| ct.params.get("name").map(|s| s.to_string()));
 
+    // MS Outlook is known to specify filename in the "name" attribute of
+    // Content-Type and omit Content-Disposition.
+    let desired_filename =
+        desired_filename.or_else(|| mail.ctype.params.get("name").map(|s| s.to_string()));
+
     // If there is no filename, but part is an attachment, guess filename
     if ct.disposition == DispositionType::Attachment && desired_filename.is_none() {
         if let Some(subtype) = mail.ctype.mimetype.split('/').nth(1) {
@@ -1611,6 +1616,78 @@ CWt6wx7fiLp0qS9RrX75g6Gqw7nfCs6EcBERcIPt7DTe8VStJwf3LWqVwxl4gQl46yhfoqwEO+I=
 
         let message = MimeMessage::from_bytes(&context.ctx, &raw[..]).unwrap();
         assert_eq!(message.get_subject(), Some("Test subject".to_string()));
+
+        assert_eq!(message.parts.len(), 1);
+        assert_eq!(message.parts[0].typ, Viewtype::Image);
+        assert_eq!(message.parts[0].msg, "Test");
+    }
+
+    // Outlook specifies filename in the "name" attribute of Content-Type
+    #[test]
+    fn parse_outlook_html_embedded_image() {
+        let context = dummy_context();
+        let raw = br##"From: Anonymous <anonymous@example.org>
+To: Anonymous <anonymous@example.org>
+Subject: Delta Chat is great stuff!
+Date: Tue, 5 May 2020 01:23:45 +0000
+MIME-Version: 1.0
+Content-Type: multipart/related;
+	boundary="----=_NextPart_000_0003_01D622B3.CA753E60"
+X-Mailer: Microsoft Outlook 15.0
+
+This is a multipart message in MIME format.
+
+------=_NextPart_000_0003_01D622B3.CA753E60
+Content-Type: multipart/alternative;
+	boundary="----=_NextPart_001_0004_01D622B3.CA753E60"
+
+
+------=_NextPart_001_0004_01D622B3.CA753E60
+Content-Type: text/plain;
+	charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+
+
+
+
+------=_NextPart_001_0004_01D622B3.CA753E60
+Content-Type: text/html;
+	charset="us-ascii"
+Content-Transfer-Encoding: quoted-printable
+
+<html>
+<body>
+<p>
+Test<img src="cid:image001.jpg@01D622B3.C9D8D750">
+</p>
+</body>
+</html>
+------=_NextPart_001_0004_01D622B3.CA753E60--
+
+------=_NextPart_000_0003_01D622B3.CA753E60
+Content-Type: image/jpeg;
+	name="image001.jpg"
+Content-Transfer-Encoding: base64
+Content-ID: <image001.jpg@01D622B3.C9D8D750>
+
+ISVb1L3m7z15Wy5w97a2cJg6W8P8YKOYfWn3PJ/UCSFcvCPtvBhcXieiN3M3ljguzG4XK7BnGgxG
+acAQdY8e0cWz1n+zKPNeNn4Iu3GXAXz4/IPksHk54inl1//0Lv8ggZjljfjnf0q1SPftYI7lpZWT
+/4aTCkimRrAIcwrQJPnZJRb7BPSC6kfn1QJHMv77mRMz2+4WbdfpyPQQ0CWLJsgVXtBsSMf2Awal
+n+zZzhGpXyCbWTEw1ccqZcK5KaiKNqWv51N4yVXw9dzJoCvxbYtCFGZZJdx7c+ObDotaF1/9KY4C
+xJjgK9/NgTXCZP1jYm0XIBnJsFSNg0pnMRETttTuGbOVi1/s/F1RGv5RNZsCUt21d9FhkWQQXsd2
+rOzDgTdag6BQCN3hSU9eKW/GhNBuMibRN9eS7Sm1y2qFU1HgGJBQfPPRPLKxXaNi++Zt0tnon2IU
+8pg5rP/IvStXYQNUQ9SiFdfAUkLU5b1j8ltnka8xl+oXsleSG44GPz6kM0RmwUrGkl4z/+NfHSsI
+K+TuvC7qOah0WLFhcsXWn2+dDV1bXuAeC769TkqkpHhdXfUHnVgK3Pv7u3rVPT5AMeFUGxRB2dP4
+CWt6wx7fiLp0qS9RrX75g6Gqw7nfCs6EcBERcIPt7DTe8VStJwf3LWqVwxl4gQl46yhfoqwEO+I=
+
+------=_NextPart_000_0003_01D622B3.CA753E60--
+"##;
+
+        let message = MimeMessage::from_bytes(&context.ctx, &raw[..]).unwrap();
+        assert_eq!(
+            message.get_subject(),
+            Some("Delta Chat is great stuff!".to_string())
+        );
 
         assert_eq!(message.parts.len(), 1);
         assert_eq!(message.parts[0].typ, Viewtype::Image);


### PR DESCRIPTION
Outlook specifies filename there and omits Content-Disposition.

Fixes #1122 