### PR TITLE
Do not reply to hidden messages

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -385,7 +385,7 @@ impl ChatId {
         let sql = &context.sql;
         let query = format!(
             "SELECT {} \
-             FROM msgs WHERE chat_id=? AND state NOT IN (?, ?, ?, ?) \
+             FROM msgs WHERE chat_id=? AND state NOT IN (?, ?, ?, ?) AND NOT hidden \
              ORDER BY timestamp DESC, id DESC \
              LIMIT 1;",
             fields


### PR DESCRIPTION
Especially with read receipts, it is wrong, because they are never
encrypted and their Message-IDs are not known to other users in a group.