### PR TITLE
Fix the DC_GCL_NO_SPECIALS flag

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -958,7 +958,7 @@ int             dc_preconfigure_keypair        (dc_context_t* context, const cha
  *       the pseudo-chat DC_CHAT_ID_ARCHIVED_LINK is added if there are _any_ archived
  *       chats
  *     - the flag DC_GCL_FOR_FORWARDING sorts "Saved messages" to the top of the chatlist,
- *       typically used on forwarding, may be combined with DC_GCL_NO_SPECIALS
+ *       typically used on forwarding, implies DC_GCL_NO_SPECIALS
  *     - if the flag DC_GCL_NO_SPECIALS is set, deaddrop and archive link are not added
  *       to the list (may be used eg. for selecting chats on forwarding, the flag is
  *       not needed when DC_GCL_ARCHIVED_ONLY is already set)

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2879,7 +2879,7 @@ mod tests {
         assert!(!chat_id2.is_special());
         assert_eq!(get_chat_cnt(&t.ctx), 2);
         assert_eq!(chatlist_len(&t.ctx, 0), 2);
-        assert_eq!(chatlist_len(&t.ctx, DC_GCL_NO_SPECIALS), 2);
+        assert_eq!(chatlist_len(&t.ctx, DC_GCL_NO_SPECIALS), 1);
         assert_eq!(chatlist_len(&t.ctx, DC_GCL_ARCHIVED_ONLY), 0);
         assert_eq!(DC_GCL_ARCHIVED_ONLY, 0x01);
         assert_eq!(DC_GCL_NO_SPECIALS, 0x02);
@@ -2979,7 +2979,7 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(1000));
         let chat_id3 = create_group_chat(&t.ctx, VerifiedStatus::Unverified, "foo").unwrap();
 
-        let chatlist = get_chats_from_chat_list(&t.ctx, DC_GCL_NO_SPECIALS);
+        let chatlist = get_chats_from_chat_list(&t.ctx, 0);
         assert_eq!(chatlist, vec![chat_id3, chat_id2, chat_id1]);
 
         // pin
@@ -2994,7 +2994,7 @@ mod tests {
         );
 
         // check if chat order changed
-        let chatlist = get_chats_from_chat_list(&t.ctx, DC_GCL_NO_SPECIALS);
+        let chatlist = get_chats_from_chat_list(&t.ctx, 0);
         assert_eq!(chatlist, vec![chat_id1, chat_id3, chat_id2]);
 
         // unpin
@@ -3009,7 +3009,7 @@ mod tests {
         );
 
         // check if chat order changed back
-        let chatlist = get_chats_from_chat_list(&t.ctx, DC_GCL_NO_SPECIALS);
+        let chatlist = get_chats_from_chat_list(&t.ctx, 0);
         assert_eq!(chatlist, vec![chat_id3, chat_id2, chat_id1]);
     }
 


### PR DESCRIPTION
Fix the DC_GCL_NO_SPECIALS flag (previously, it had no effect at all if DC_GCL_FOR_FORWARDING was not set).

Also, add test.

DC_GCL_FOR_FORWARDING now implies DC_GCL_NO_SPECIALS in order to avoid regressions (some UIs may set only DC_GCL_FOR_FORWARDING because this hid the deaddrop, too).

To implement the latter, I created boolean variables from all flags in try_load() so that I can write
let flag_no_specials = flag_no_specials || flag_for_forwarding;

I also changed some tests that _expected_ try_load() to behave exactly the same with and without DC_GCL_NO_SPECIALS.