### PR TITLE
be more tolerant on parsing Message-Id

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1520,7 +1520,7 @@ fn is_known_rfc724_mid_in_list(context: &Context, mid_list: &str) -> bool {
         return false;
     }
 
-    if let Ok(ids) = mailparse::msgidparse(mid_list) {
+    if let Ok(ids) = parse_message_ids(mid_list) {
         for id in ids.iter() {
             if is_known_rfc724_mid(context, id) {
                 return true;
@@ -1568,7 +1568,7 @@ fn is_reply_to_messenger_message(context: &Context, mime_parser: &MimeMessage) -
 }
 
 pub(crate) fn is_msgrmsg_rfc724_mid_in_list(context: &Context, mid_list: &str) -> bool {
-    if let Ok(ids) = mailparse::msgidparse(mid_list) {
+    if let Ok(ids) = parse_message_ids(mid_list) {
         for id in ids.iter() {
             if is_msgrmsg_rfc724_mid(context, id) {
                 return true;

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1713,4 +1713,48 @@ CWt6wx7fiLp0qS9RrX75g6Gqw7nfCs6EcBERcIPt7DTe8VStJwf3LWqVwxl4gQl46yhfoqwEO+I=
         assert_eq!(message.parts[0].typ, Viewtype::Image);
         assert_eq!(message.parts[0].msg, "Test");
     }
+
+    #[test]
+    fn test_parse_message_id() {
+        let test = parse_message_id("<foobar>");
+        assert!(test.is_ok());
+        assert_eq!(test.unwrap(), "foobar");
+
+        let test = parse_message_id("<foo> <bar>");
+        assert!(test.is_ok());
+        assert_eq!(test.unwrap(), "foo");
+
+        let test = parse_message_id("  < foo > <bar>");
+        assert!(test.is_ok());
+        assert_eq!(test.unwrap(), "foo");
+
+        let test = parse_message_id("foo");
+        assert!(test.is_ok());
+        assert_eq!(test.unwrap(), "foo");
+
+        let test = parse_message_id(" foo ");
+        assert!(test.is_ok());
+        assert_eq!(test.unwrap(), "foo");
+
+        let test = parse_message_id("foo bar");
+        assert!(test.is_ok());
+        assert_eq!(test.unwrap(), "foo");
+
+        let test = parse_message_id("  foo  bar ");
+        assert!(test.is_ok());
+        assert_eq!(test.unwrap(), "foo");
+
+        let test = parse_message_id("");
+        assert!(test.is_err());
+
+        let test = parse_message_id(" ");
+        assert!(test.is_err());
+
+        let test = parse_message_id("<>");
+        assert!(test.is_err());
+
+        let test = parse_message_id("<> bar");
+        assert!(test.is_ok());
+        assert_eq!(test.unwrap(), "bar");
+    }
 }


### PR DESCRIPTION
with 0.12.0, Message-Id parsing easily results in errors ... see https://github.com/deltachat/deltachat-core-rust/issues/1461#issuecomment-626320783

closes #1461 

~~TODO, maybe in another pr: avoid other usages of mailparse::msgidparse(), more concrete in is_known_rfc724_mid_in_list() and is_msgrmsg_rfc724_mid_in_list()~~ EDIT: done