### PR TITLE
Do not return "empty rfc724_mid" errors from rfc724_mid_cnt

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1432,7 +1432,10 @@ pub(crate) fn rfc724_mid_exists(
     context: &Context,
     rfc724_mid: &str,
 ) -> Result<Option<(String, u32, MsgId)>, Error> {
-    ensure!(!rfc724_mid.is_empty(), "empty rfc724_mid");
+    if rfc724_mid.is_empty() {
+        warn!(context, "Empty rfc724_mid passed to rfc724_mid_exists");
+        return Ok(None);
+    }
 
     context
         .sql


### PR DESCRIPTION
This function should only return temporary errors, e.g. database errors,
as precheck_imf() and dc_receive_imf::add_parts() treat them as such,
retrying the fetch on failure. When permanent errors, like missing
Message-ID, are bubbled up, they cause infinite fetch loop.

Fixes #1461 