### PR TITLE
sql: do not send DC_EVENT_ERROR on database errors

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -242,7 +242,7 @@ impl Sql {
         match self.query_get_value_result(query, params) {
             Ok(res) => res,
             Err(err) => {
-                error!(context, "sql: Failed query_row: {}", err);
+                warn!(context, "sql: Failed query_row: {}", err);
                 None
             }
         }


### PR DESCRIPTION
These errors are usually just "database busy" errors, it is enough to
write them to the log instead of displaying to the user.