### PR TITLE
Better SMTP ErrorNetwork message

### DIFF
--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -269,7 +269,7 @@ impl Imap {
                     let imap_port = config.imap_port;
                     context.stock_string_repl_str2(
                         StockMessage::ServerResponse,
-                        format!("{}:{}", imap_server, imap_port),
+                        format!("IMAP {}:{}", imap_server, imap_port),
                         err.to_string(),
                     )
                 };


### PR DESCRIPTION
It uses stock string, just as for IMAP errors, and is distinguishable
from IMAP errors: protocol is specified in the error message now.

Follow-up for #1378, maybe addresses https://github.com/deltachat/deltachat-ios/issues/669