### PR TITLE
Revert "imap: simplify select_folder() interface"

### DIFF
--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -59,7 +59,7 @@ impl Imap {
         task::block_on(async move { self.config.read().await.can_idle })
     }
 
-    pub fn idle(&self, context: &Context, watch_folder: String) -> Result<()> {
+    pub fn idle(&self, context: &Context, watch_folder: Option<String>) -> Result<()> {
         task::block_on(async move {
             if !self.can_idle() {
                 return Err(Error::IdleAbilityMissing);
@@ -67,7 +67,7 @@ impl Imap {
 
             self.setup_handle_if_needed(context).await?;
 
-            self.select_folder(context, watch_folder).await?;
+            self.select_folder(context, watch_folder.clone()).await?;
 
             let session = self.session.lock().await.take();
             let timeout = Duration::from_secs(23 * 60);

--- a/src/imap/select_folder.rs
+++ b/src/imap/select_folder.rs
@@ -56,7 +56,7 @@ impl Imap {
     pub(super) async fn select_folder<S: AsRef<str>>(
         &self,
         context: &Context,
-        folder: S,
+        folder: Option<S>,
     ) -> Result<()> {
         if self.session.lock().await.is_none() {
             let mut cfg = self.config.write().await;
@@ -71,41 +71,46 @@ impl Imap {
             self.close_folder(context).await?;
         }
 
-        if self.config.read().await.selected_folder.as_deref() == Some(folder.as_ref()) {
+        let folder_str: Option<&str> = folder.as_ref().map(|x| x.as_ref());
+        if self.config.read().await.selected_folder.as_deref() == folder_str {
             return Ok(());
         }
 
         // select new folder
-        if let Some(ref mut session) = &mut *self.session.lock().await {
-            let res = session.select(&folder).await;
+        if let Some(ref folder) = folder {
+            if let Some(ref mut session) = &mut *self.session.lock().await {
+                let res = session.select(folder).await;
 
-            // https://tools.ietf.org/html/rfc3501#section-6.3.1
-            // says that if the server reports select failure we are in
-            // authenticated (not-select) state.
+                // https://tools.ietf.org/html/rfc3501#section-6.3.1
+                // says that if the server reports select failure we are in
+                // authenticated (not-select) state.
 
-            match res {
-                Ok(mailbox) => {
-                    let mut config = self.config.write().await;
-                    config.selected_folder = Some(folder.as_ref().to_string());
-                    config.selected_mailbox = Some(mailbox);
-                    Ok(())
+                match res {
+                    Ok(mailbox) => {
+                        let mut config = self.config.write().await;
+                        config.selected_folder = Some(folder.as_ref().to_string());
+                        config.selected_mailbox = Some(mailbox);
+                        Ok(())
+                    }
+                    Err(async_imap::error::Error::ConnectionLost) => {
+                        self.trigger_reconnect();
+                        self.config.write().await.selected_folder = None;
+                        Err(Error::ConnectionLost)
+                    }
+                    Err(async_imap::error::Error::Validate(_)) => {
+                        Err(Error::BadFolderName(folder.as_ref().to_string()))
+                    }
+                    Err(err) => {
+                        self.config.write().await.selected_folder = None;
+                        self.trigger_reconnect();
+                        Err(Error::Other(err.to_string()))
+                    }
                 }
-                Err(async_imap::error::Error::ConnectionLost) => {
-                    self.trigger_reconnect();
-                    self.config.write().await.selected_folder = None;
-                    Err(Error::ConnectionLost)
-                }
-                Err(async_imap::error::Error::Validate(_)) => {
-                    Err(Error::BadFolderName(folder.as_ref().to_string()))
-                }
-                Err(err) => {
-                    self.config.write().await.selected_folder = None;
-                    self.trigger_reconnect();
-                    Err(Error::Other(err.to_string()))
-                }
+            } else {
+                Err(Error::NoSession)
             }
         } else {
-            Err(Error::NoSession)
+            Ok(())
         }
     }
 }

--- a/src/job_thread.rs
+++ b/src/job_thread.rs
@@ -173,15 +173,14 @@ impl JobThread {
                 if !self.imap.can_idle() {
                     true // we have to do fake_idle
                 } else {
-                    if let Some(watch_folder) = self.get_watch_folder(context) {
-                        info!(context, "{} started...", prefix);
-                        let res = self.imap.idle(context, watch_folder);
-                        info!(context, "{} ended...", prefix);
-                        if let Err(err) = res {
-                            warn!(context, "{} failed: {} -> reconnecting", prefix, err);
-                            // something is Label { Label }orked, let's start afresh on the next occassion
-                            self.imap.disconnect(context);
-                        }
+                    let watch_folder = self.get_watch_folder(context);
+                    info!(context, "{} started...", prefix);
+                    let res = self.imap.idle(context, watch_folder);
+                    info!(context, "{} ended...", prefix);
+                    if let Err(err) = res {
+                        warn!(context, "{} failed: {} -> reconnecting", prefix, err);
+                        // something is borked, let's start afresh on the next occassion
+                        self.imap.disconnect(context);
                     }
                     false
                 }


### PR DESCRIPTION
This reverts commit b614de2f8062772bd9b042550b5d24a91aa5c8ad.

There is also a corrupted comment in this commit. Let's just revert it to fix #1443 