### PR TITLE
Fix #1474 "Sending message to contact with < or > in Recipient gets treated as "Sent" but is not received"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ bitflags = "1.1.0"
 debug_stub_derive = "0.3.0"
 sanitize-filename = "0.2.1"
 stop-token = { version = "0.1.1", features = ["unstable"] }
-mailparse = "0.12.0"
+mailparse = "0.12.1"
 encoded-words = { git = "https://github.com/async-email/encoded-words", branch="master" }
 native-tls = "0.2.3"
 image = { version = "0.22.4", default-features=false, features = ["gif_codec", "jpeg", "ico", "png_codec", "pnm", "webp", "bmp"] }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -3,6 +3,8 @@
 use async_std::path::PathBuf;
 use deltachat_derive::*;
 use itertools::Itertools;
+use lazy_static::lazy_static;
+use regex::Regex;
 
 use crate::aheader::EncryptPreference;
 use crate::chat::ChatId;
@@ -1527,5 +1529,28 @@ mod tests {
         assert!(addr_cmp("AA@AA.ORG", "aa@aa.ORG"));
         assert!(addr_cmp(" aa@aa.ORG ", "AA@AA.ORG"));
         assert!(addr_cmp(" mailto:AA@AA.ORG", "Aa@Aa.orG"));
+    }
+
+    #[test]
+    fn test_name_in_address() {
+        let t = dummy_context();
+
+        let contact_id = Contact::create(&t.ctx, "", "<dave@example.org>").unwrap();
+        let contact = Contact::load_from_db(&t.ctx, contact_id).unwrap();
+        assert_eq!(contact.get_name(), "");
+        assert_eq!(contact.get_addr(), "dave@example.org");
+
+        let contact_id = Contact::create(&t.ctx, "", "Mueller, Dave <dave@example.org>").unwrap();
+        let contact = Contact::load_from_db(&t.ctx, contact_id).unwrap();
+        assert_eq!(contact.get_name(), "Dave Mueller");
+        assert_eq!(contact.get_addr(), "dave@example.org");
+
+        assert!(Contact::create(&t.ctx, "", "<dskjfdslk@sadklj.dk").is_err());
+        assert!(Contact::create(&t.ctx, "", "<dskjf>dslk@sadklj.dk>").is_err());
+        assert!(Contact::create(&t.ctx, "", "dskjfdslksadklj.dk").is_err());
+        assert!(Contact::create(&t.ctx, "", "dskjfdslk@sadklj.dk>").is_err());
+        assert!(Contact::create(&t.ctx, "", "dskjf@dslk@sadkljdk").is_err());
+        assert!(Contact::create(&t.ctx, "", "dskjf dslk@d.e").is_err());
+        assert!(Contact::create(&t.ctx, "", "<dskjf dslk@sadklj.dk").is_err());
     }
 }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1569,6 +1569,11 @@ mod tests {
         assert_eq!(contact.get_name(), "Dave Mueller");
         assert_eq!(contact.get_addr(), "dave@example.org");
 
+        let contact_id = Contact::create(&t.ctx, "name1", "name2 <dave@example.org>").unwrap();
+        let contact = Contact::load_from_db(&t.ctx, contact_id).unwrap();
+        assert_eq!(contact.get_name(), "name1");
+        assert_eq!(contact.get_addr(), "dave@example.org");
+
         assert!(Contact::create(&t.ctx, "", "<dskjfdslk@sadklj.dk").is_err());
         assert!(Contact::create(&t.ctx, "", "<dskjf>dslk@sadklj.dk>").is_err());
         assert!(Contact::create(&t.ctx, "", "dskjfdslksadklj.dk").is_err());

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1555,31 +1555,49 @@ mod tests {
         assert!(addr_cmp(" mailto:AA@AA.ORG", "Aa@Aa.orG"));
     }
 
-    #[test]
-    fn test_name_in_address() {
-        let t = dummy_context();
+    #[async_std::test]
+    async fn test_name_in_address() {
+        let t = dummy_context().await;
 
-        let contact_id = Contact::create(&t.ctx, "", "<dave@example.org>").unwrap();
-        let contact = Contact::load_from_db(&t.ctx, contact_id).unwrap();
+        let contact_id = Contact::create(&t.ctx, "", "<dave@example.org>")
+            .await
+            .unwrap();
+        let contact = Contact::load_from_db(&t.ctx, contact_id).await.unwrap();
         assert_eq!(contact.get_name(), "");
         assert_eq!(contact.get_addr(), "dave@example.org");
 
-        let contact_id = Contact::create(&t.ctx, "", "Mueller, Dave <dave@example.org>").unwrap();
-        let contact = Contact::load_from_db(&t.ctx, contact_id).unwrap();
+        let contact_id = Contact::create(&t.ctx, "", "Mueller, Dave <dave@example.org>")
+            .await
+            .unwrap();
+        let contact = Contact::load_from_db(&t.ctx, contact_id).await.unwrap();
         assert_eq!(contact.get_name(), "Dave Mueller");
         assert_eq!(contact.get_addr(), "dave@example.org");
 
-        let contact_id = Contact::create(&t.ctx, "name1", "name2 <dave@example.org>").unwrap();
-        let contact = Contact::load_from_db(&t.ctx, contact_id).unwrap();
+        let contact_id = Contact::create(&t.ctx, "name1", "name2 <dave@example.org>")
+            .await
+            .unwrap();
+        let contact = Contact::load_from_db(&t.ctx, contact_id).await.unwrap();
         assert_eq!(contact.get_name(), "name1");
         assert_eq!(contact.get_addr(), "dave@example.org");
 
-        assert!(Contact::create(&t.ctx, "", "<dskjfdslk@sadklj.dk").is_err());
-        assert!(Contact::create(&t.ctx, "", "<dskjf>dslk@sadklj.dk>").is_err());
-        assert!(Contact::create(&t.ctx, "", "dskjfdslksadklj.dk").is_err());
-        assert!(Contact::create(&t.ctx, "", "dskjfdslk@sadklj.dk>").is_err());
-        assert!(Contact::create(&t.ctx, "", "dskjf@dslk@sadkljdk").is_err());
-        assert!(Contact::create(&t.ctx, "", "dskjf dslk@d.e").is_err());
-        assert!(Contact::create(&t.ctx, "", "<dskjf dslk@sadklj.dk").is_err());
+        assert!(Contact::create(&t.ctx, "", "<dskjfdslk@sadklj.dk")
+            .await
+            .is_err());
+        assert!(Contact::create(&t.ctx, "", "<dskjf>dslk@sadklj.dk>")
+            .await
+            .is_err());
+        assert!(Contact::create(&t.ctx, "", "dskjfdslksadklj.dk")
+            .await
+            .is_err());
+        assert!(Contact::create(&t.ctx, "", "dskjfdslk@sadklj.dk>")
+            .await
+            .is_err());
+        assert!(Contact::create(&t.ctx, "", "dskjf@dslk@sadkljdk")
+            .await
+            .is_err());
+        assert!(Contact::create(&t.ctx, "", "dskjf dslk@d.e").await.is_err());
+        assert!(Contact::create(&t.ctx, "", "<dskjf dslk@sadklj.dk")
+            .await
+            .is_err());
     }
 }


### PR DESCRIPTION
Fix #1474 "Sending message to contact with < or > in Recipient gets treated as "Sent" but is not received".

As I was at it, I also extracted the correct name and address from addresses like `Mueller, Dave <dave@domain.com>`.