### PR TITLE
Delete hidden expired messages

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1612,8 +1612,7 @@ pub fn delete_device_expired_messages(context: &Context) -> Result<bool, Error> 
              WHERE timestamp < ? \
              AND chat_id > ? \
              AND chat_id != ? \
-             AND chat_id != ? \
-             AND NOT hidden",
+             AND chat_id != ?",
             params![
                 DC_CHAT_ID_TRASH,
                 threshold_timestamp,


### PR DESCRIPTION
The condition remains from the time when expired messages were hidden
instead of being moved into trash chat. As a result, old hidden
messages, such as location messages, were not deleted.