### PR TITLE
improve finding out the sent-folder

### DIFF
--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1265,7 +1265,7 @@ fn get_folder_meaning(folder_name: &Name) -> FolderMeaning {
             }
         }
     }
-    return FolderMeaning::Unknown;
+    FolderMeaning::Unknown
 }
 
 fn precheck_imf(

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1235,7 +1235,7 @@ impl Imap {
 // CAVE: if possible, take care not to add a name here that is "sent" in one language
 // but sth. different in others - a hard job.
 fn get_folder_meaning_by_name(folder_name: &Name) -> FolderMeaning {
-    let sent_names = vec!["sent", "sent objects", "gesendet"];
+    let sent_names = vec!["sent", "sentmail", "sent objects", "gesendet"];
     let lower = folder_name.name().to_lowercase();
 
     if sent_names.into_iter().any(|s| s == lower) {


### PR DESCRIPTION
this pr adds `sentmail` to the list of known sent-folder-names, the name is actually used for chello.at

moreover, the searching for well-known names is done in a second pass and only when there is not sent-attribute found for any folder, see commit message for some more details.

closes #1486 