### PR TITLE
enable sqlite's WAL mode

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -243,7 +243,7 @@ impl Context {
         let journal_mode = self
             .sql
             .query_get_value(self, "PRAGMA journal_mode;", rusqlite::NO_PARAMS)
-            .unwrap_or("unknown".to_string());
+            .unwrap_or_else(|| "unknown".to_string());
         let e2ee_enabled = self.get_config_int(Config::E2eeEnabled);
         let mdns_enabled = self.get_config_int(Config::MdnsEnabled);
         let bcc_self = self.get_config_int(Config::BccSelf);

--- a/src/context.rs
+++ b/src/context.rs
@@ -240,7 +240,10 @@ impl Context {
             .sql
             .get_raw_config_int(self, "dbversion")
             .unwrap_or_default();
-
+        let journal_mode = self
+            .sql
+            .query_get_value(self, "PRAGMA journal_mode;", rusqlite::NO_PARAMS)
+            .unwrap_or("unknown".to_string());
         let e2ee_enabled = self.get_config_int(Config::E2eeEnabled);
         let mdns_enabled = self.get_config_int(Config::MdnsEnabled);
         let bcc_self = self.get_config_int(Config::BccSelf);
@@ -285,6 +288,7 @@ impl Context {
         res.insert("number_of_contacts", contacts.to_string());
         res.insert("database_dir", self.get_dbfile().display().to_string());
         res.insert("database_version", dbversion.to_string());
+        res.insert("journal_mode", journal_mode);
         res.insert("blobdir", self.get_blobdir().display().to_string());
         res.insert("display_name", displayname.unwrap_or_else(|| unset.into()));
         res.insert(

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -400,7 +400,7 @@ fn open(
     }
     let mgr = r2d2_sqlite::SqliteConnectionManager::file(dbfile.as_ref())
         .with_flags(open_flags)
-        .with_init(|c| c.execute_batch("PRAGMA secure_delete=on;"));
+        .with_init(|c| c.execute_batch("PRAGMA journal_mode=WAL; PRAGMA secure_delete=on;"));
     let pool = r2d2::Pool::builder()
         .min_idle(Some(2))
         .max_size(10)


### PR DESCRIPTION
this pr enables WAL unconditionally and also adds the current state to dc_get_info() which is useful for debugging.

see https://sqlite.org/wal.html and recent discussion on irc and on github eg. on #991 #1489 

@link2xt @dignifiedquire @hpk42 @Hocuri @flub @others anything speaking against enabling that?