### PR TITLE
Implement closing the database (previously there was an error when calling `close`)

### DIFF
--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -448,6 +448,10 @@ fn handle_cmd(line: &str, ctx: Arc<RwLock<Context>>) -> Result<ExitResult, Error
     let arg1 = args.next().unwrap_or_default();
 
     match arg0 {
+        "close" => {
+            let context = ctx.write().unwrap();
+            context.sql.close(&*context);
+        }
         "connect" => {
             start_threads(ctx);
         }


### PR DESCRIPTION
Implement closing the database (previously there was an error when calling `close`).