### PR TITLE
WIP: Try configuration parameters in parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,7 @@ dependencies = [
  "email 0.0.21 (git+https://github.com/deltachat/rust-email)",
  "encoded-words 0.1.0 (git+https://github.com/async-email/encoded-words)",
  "escaper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.22.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "image-meta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ lettre_email = { git = "https://github.com/deltachat/lettre", branch = "master" 
 async-imap = "0.2"
 async-native-tls = "0.3.1"
 async-std = { version = "1.4", features = ["unstable"] }
+futures = "0.3"
 base64 = "0.11"
 charset = "0.1"
 percent-encoding = "2.0"

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -337,7 +337,9 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  * - `send_user`    = SMTP-user, guessed if left out
  * - `send_pw`      = SMTP-password, guessed if left out
  * - `send_port`    = SMTP-port, guessed if left out
- * - `server_flags` = IMAP-/SMTP-flags as a combination of @ref DC_LP flags, guessed if left out
+ * - `auth_scheme`  = authentication scheme to be used, 'plain' for plain login, 'oauth2' for oauth2, 'plain' is used if left out
+ * - `imap_security`  = IMAP connection security strategy to be used, 'plain_socket' for plain plain tcp socket, 'ssl' for ssl socket, 'starttls' for opportunistic TLS, guessed if left out
+ * - `smtp_security`  = SMTP connection security strategy to be used, 'plain_socket' for plain plain tcp socket, 'ssl' for ssl socket, 'starttls' for opportunistic TLS, guessed if left out
  * - `imap_certificate_checks` = how to check IMAP certificates, one of the @ref DC_CERTCK flags, defaults to #DC_CERTCK_AUTO (0)
  * - `smtp_certificate_checks` = how to check SMTP certificates, one of the @ref DC_CERTCK flags, defaults to #DC_CERTCK_AUTO (0)
  * - `displayname`  = Own name to use when sending messages.  MUAs are allowed to spread this way eg. using CC, defaults to empty

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,12 @@ pub enum Config {
     SendPw,
     SendPort,
     SmtpCertificateChecks,
-    ServerFlags,
+
+    #[strum(props(default = "plain"))]
+    AuthScheme,
+
+    ImapSecurity,
+    SmtpSecurity,
 
     #[strum(props(default = "INBOX"))]
     ImapFolder,

--- a/src/configure/auto_mozilla.rs
+++ b/src/configure/auto_mozilla.rs
@@ -3,9 +3,8 @@
 //! Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration */
 use quick_xml::events::{BytesEnd, BytesStart, BytesText};
 
-use crate::constants::*;
 use crate::context::Context;
-use crate::login_param::LoginParam;
+use crate::login_param::{LoginParam, ServerSecurity, Service};
 
 use super::read_url::read_url;
 use super::Error;
@@ -83,10 +82,14 @@ fn parse_xml(in_emailaddr: &str, xml_raw: &str) -> Result<LoginParam, Error> {
         buf.clear();
     }
 
-    if moz_ac.out.mail_server.is_empty()
-        || moz_ac.out.mail_port == 0
-        || moz_ac.out.send_server.is_empty()
-        || moz_ac.out.send_port == 0
+    if moz_ac.out.srv_params[Service::Imap as usize]
+        .hostname
+        .is_empty()
+        || moz_ac.out.srv_params[Service::Imap as usize].port == 0
+        || moz_ac.out.srv_params[Service::Smtp as usize]
+            .hostname
+            .is_empty()
+        || moz_ac.out.srv_params[Service::Smtp as usize].port == 0
     {
         Err(Error::IncompleteAutoconfig(moz_ac.out))
     } else {
@@ -130,38 +133,26 @@ fn moz_autoconfigure_text_cb<B: std::io::BufRead>(
 
     match moz_ac.tag_server {
         MozServer::Imap => match moz_ac.tag_config {
-            MozConfigTag::Hostname => moz_ac.out.mail_server = val,
-            MozConfigTag::Port => moz_ac.out.mail_port = val.parse().unwrap_or_default(),
-            MozConfigTag::Username => moz_ac.out.mail_user = val,
+            MozConfigTag::Hostname => moz_ac.out.srv_params[Service::Imap as usize].hostname = val,
+            MozConfigTag::Port => {
+                moz_ac.out.srv_params[Service::Imap as usize].port = val.parse().unwrap_or_default()
+            }
+            MozConfigTag::Username => moz_ac.out.srv_params[Service::Imap as usize].user = val,
             MozConfigTag::Sockettype => {
-                let val_lower = val.to_lowercase();
-                if val_lower == "ssl" {
-                    moz_ac.out.server_flags |= DC_LP_IMAP_SOCKET_SSL as i32
-                }
-                if val_lower == "starttls" {
-                    moz_ac.out.server_flags |= DC_LP_IMAP_SOCKET_STARTTLS as i32
-                }
-                if val_lower == "plain" {
-                    moz_ac.out.server_flags |= DC_LP_IMAP_SOCKET_PLAIN as i32
-                }
+                moz_ac.out.srv_params[Service::Imap as usize].security =
+                    ServerSecurity::from_str_opt(val.to_lowercase().as_str())
             }
             _ => {}
         },
         MozServer::Smtp => match moz_ac.tag_config {
-            MozConfigTag::Hostname => moz_ac.out.send_server = val,
-            MozConfigTag::Port => moz_ac.out.send_port = val.parse().unwrap_or_default(),
-            MozConfigTag::Username => moz_ac.out.send_user = val,
+            MozConfigTag::Hostname => moz_ac.out.srv_params[Service::Smtp as usize].hostname = val,
+            MozConfigTag::Port => {
+                moz_ac.out.srv_params[Service::Smtp as usize].port = val.parse().unwrap_or_default()
+            }
+            MozConfigTag::Username => moz_ac.out.srv_params[Service::Smtp as usize].user = val,
             MozConfigTag::Sockettype => {
-                let val_lower = val.to_lowercase();
-                if val_lower == "ssl" {
-                    moz_ac.out.server_flags |= DC_LP_SMTP_SOCKET_SSL as i32
-                }
-                if val_lower == "starttls" {
-                    moz_ac.out.server_flags |= DC_LP_SMTP_SOCKET_STARTTLS as i32
-                }
-                if val_lower == "plain" {
-                    moz_ac.out.server_flags |= DC_LP_SMTP_SOCKET_PLAIN as i32
-                }
+                moz_ac.out.srv_params[Service::Smtp as usize].security =
+                    ServerSecurity::from_str_opt(val.to_lowercase().as_str())
             }
             _ => {}
         },

--- a/src/configure/auto_outlook.rs
+++ b/src/configure/auto_outlook.rs
@@ -2,9 +2,8 @@
 
 use quick_xml::events::BytesEnd;
 
-use crate::constants::*;
 use crate::context::Context;
-use crate::login_param::LoginParam;
+use crate::login_param::{LoginParam, ServerSecurity, Service};
 
 use super::read_url::read_url;
 use super::Error;
@@ -98,10 +97,14 @@ fn parse_xml(xml_raw: &str) -> Result<ParsingResult, Error> {
     let res = if outlk_ad.config_redirecturl.is_none()
         || outlk_ad.config_redirecturl.as_ref().unwrap().is_empty()
     {
-        if outlk_ad.out.mail_server.is_empty()
-            || outlk_ad.out.mail_port == 0
-            || outlk_ad.out.send_server.is_empty()
-            || outlk_ad.out.send_port == 0
+        if outlk_ad.out.srv_params[Service::Imap as usize]
+            .hostname
+            .is_empty()
+            || outlk_ad.out.srv_params[Service::Imap as usize].port == 0
+            || outlk_ad.out.srv_params[Service::Smtp as usize]
+                .hostname
+                .is_empty()
+            || outlk_ad.out.srv_params[Service::Smtp as usize].port == 0
         {
             return Err(Error::IncompleteAutoconfig(outlk_ad.out));
         }
@@ -142,23 +145,27 @@ fn outlk_autodiscover_endtag_cb(event: &BytesEnd, outlk_ad: &mut OutlookAutodisc
             let ssl_on = outlk_ad.config_ssl == "on";
             let ssl_off = outlk_ad.config_ssl == "off";
             if type_ == "imap" && !outlk_ad.out_imap_set {
-                outlk_ad.out.mail_server =
+                outlk_ad.out.srv_params[Service::Imap as usize].hostname =
                     std::mem::replace(&mut outlk_ad.config_server, String::new());
-                outlk_ad.out.mail_port = port;
+                outlk_ad.out.srv_params[Service::Imap as usize].port = port;
                 if ssl_on {
-                    outlk_ad.out.server_flags |= DC_LP_IMAP_SOCKET_SSL as i32
+                    outlk_ad.out.srv_params[Service::Imap as usize].security =
+                        Some(ServerSecurity::Ssl);
                 } else if ssl_off {
-                    outlk_ad.out.server_flags |= DC_LP_IMAP_SOCKET_PLAIN as i32
+                    outlk_ad.out.srv_params[Service::Imap as usize].security =
+                        Some(ServerSecurity::PlainSocket);
                 }
                 outlk_ad.out_imap_set = true
             } else if type_ == "smtp" && !outlk_ad.out_smtp_set {
-                outlk_ad.out.send_server =
+                outlk_ad.out.srv_params[Service::Smtp as usize].hostname =
                     std::mem::replace(&mut outlk_ad.config_server, String::new());
-                outlk_ad.out.send_port = outlk_ad.config_port;
+                outlk_ad.out.srv_params[Service::Smtp as usize].port = outlk_ad.config_port;
                 if ssl_on {
-                    outlk_ad.out.server_flags |= DC_LP_SMTP_SOCKET_SSL as i32
+                    outlk_ad.out.srv_params[Service::Smtp as usize].security =
+                        Some(ServerSecurity::Ssl);
                 } else if ssl_off {
-                    outlk_ad.out.server_flags |= DC_LP_SMTP_SOCKET_PLAIN as i32
+                    outlk_ad.out.srv_params[Service::Smtp as usize].security =
+                        Some(ServerSecurity::PlainSocket);
                 }
                 outlk_ad.out_smtp_set = true
             }
@@ -229,10 +236,16 @@ mod tests {
 
         match res {
             ParsingResult::LoginParam(lp) => {
-                assert_eq!(lp.mail_server, "example.com");
-                assert_eq!(lp.mail_port, 993);
-                assert_eq!(lp.send_server, "smtp.example.com");
-                assert_eq!(lp.send_port, 25);
+                assert_eq!(
+                    lp.srv_params[Service::Imap as usize].hostname,
+                    "example.com"
+                );
+                assert_eq!(lp.srv_params[Service::Imap as usize].port, 993);
+                assert_eq!(
+                    lp.srv_params[Service::Smtp as usize].hostname,
+                    "smtp.example.com"
+                );
+                assert_eq!(lp.srv_params[Service::Smtp as usize].port, 25);
             }
             ParsingResult::RedirectUrl(_) => {
                 panic!("RedirectUrl is not expected");

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -171,53 +171,6 @@ pub const DC_CONTACT_ID_DEVICE_ADDR: &str = "device@localhost";
 pub const DC_EMPTY_MVBOX: u32 = 0x01;
 pub const DC_EMPTY_INBOX: u32 = 0x02;
 
-// Flags for configuring IMAP and SMTP servers.
-// These flags are optional
-// and may be set together with the username, password etc.
-// via dc_set_config() using the key "server_flags".
-
-/// Force OAuth2 authorization. This flag does not skip automatic configuration.
-/// Before calling configure() with DC_LP_AUTH_OAUTH2 set,
-/// the user has to confirm access at the URL returned by dc_get_oauth2_url().
-pub const DC_LP_AUTH_OAUTH2: i32 = 0x2;
-
-/// Force NORMAL authorization, this is the default.
-/// If this flag is set, automatic configuration is skipped.
-pub const DC_LP_AUTH_NORMAL: i32 = 0x4;
-
-/// Connect to IMAP via STARTTLS.
-/// If this flag is set, automatic configuration is skipped.
-pub const DC_LP_IMAP_SOCKET_STARTTLS: i32 = 0x100;
-
-/// Connect to IMAP via SSL.
-/// If this flag is set, automatic configuration is skipped.
-pub const DC_LP_IMAP_SOCKET_SSL: i32 = 0x200;
-
-/// Connect to IMAP unencrypted, this should not be used.
-/// If this flag is set, automatic configuration is skipped.
-pub const DC_LP_IMAP_SOCKET_PLAIN: i32 = 0x400;
-
-/// Connect to SMTP via STARTTLS.
-/// If this flag is set, automatic configuration is skipped.
-pub const DC_LP_SMTP_SOCKET_STARTTLS: usize = 0x10000;
-
-/// Connect to SMTP via SSL.
-/// If this flag is set, automatic configuration is skipped.
-pub const DC_LP_SMTP_SOCKET_SSL: usize = 0x20000;
-
-/// Connect to SMTP unencrypted, this should not be used.
-/// If this flag is set, automatic configuration is skipped.
-pub const DC_LP_SMTP_SOCKET_PLAIN: usize = 0x40000;
-
-/// if none of these flags are set, the default is chosen
-pub const DC_LP_AUTH_FLAGS: i32 = DC_LP_AUTH_OAUTH2 | DC_LP_AUTH_NORMAL;
-/// if none of these flags are set, the default is chosen
-pub const DC_LP_IMAP_SOCKET_FLAGS: i32 =
-    DC_LP_IMAP_SOCKET_STARTTLS | DC_LP_IMAP_SOCKET_SSL | DC_LP_IMAP_SOCKET_PLAIN;
-/// if none of these flags are set, the default is chosen
-pub const DC_LP_SMTP_SOCKET_FLAGS: usize =
-    DC_LP_SMTP_SOCKET_STARTTLS | DC_LP_SMTP_SOCKET_SSL | DC_LP_SMTP_SOCKET_PLAIN;
-
 // QR code scanning (view from Bob, the joiner)
 pub const DC_VC_AUTH_REQUIRED: i32 = 2;
 pub const DC_VC_CONTACT_CONFIRM: i32 = 6;

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -14,7 +14,7 @@ use crate::dc_tools::*;
 use crate::error::{bail, ensure, format_err, Result};
 use crate::events::Event;
 use crate::key::{DcKey, Key, SignedPublicKey};
-use crate::login_param::LoginParam;
+use crate::login_param::{LoginParam, ServerSecurity, Service};
 use crate::message::{MessageState, MsgId};
 use crate::mimeparser::AvatarAction;
 use crate::param::*;
@@ -690,8 +690,10 @@ impl Contact {
                     );
                     cat_fingerprint(&mut ret, &loginparam.addr, &fingerprint_self, "");
                 }
-            } else if 0 == loginparam.server_flags & DC_LP_IMAP_SOCKET_PLAIN as i32
-                && 0 == loginparam.server_flags & DC_LP_SMTP_SOCKET_PLAIN as i32
+            } else if Some(ServerSecurity::PlainSocket)
+                == loginparam.srv_params[Service::Imap as usize].security
+                && Some(ServerSecurity::PlainSocket)
+                    == loginparam.srv_params[Service::Smtp as usize].security
             {
                 ret += &context.stock_str(StockMessage::EncrTransp);
             } else {

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -15,10 +15,6 @@ use crate::context::Context;
 use crate::error::{bail, Error};
 use crate::events::Event;
 
-pub(crate) fn dc_exactly_one_bit_set(v: i32) -> bool {
-    0 != v && 0 == v & (v - 1)
-}
-
 /// Shortens a string to a specified length and adds "[...]" to the
 /// end of the shortened string.
 pub(crate) fn dc_truncate(buf: &str, approx_chars: usize) -> Cow<str> {

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -23,7 +23,7 @@ use crate::dc_receive_imf::{
 use crate::events::Event;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
 use crate::job::{job_add, Action};
-use crate::login_param::{CertificateChecks, LoginParam};
+use crate::login_param::{AuthScheme, CertificateChecks, LoginParam, ServerSecurity, Service};
 use crate::message::{self, update_server_uid};
 use crate::mimeparser;
 use crate::oauth2::dc_get_oauth2_access_token;
@@ -150,11 +150,12 @@ struct ImapConfig {
     pub imap_user: String,
     pub imap_pw: String,
     pub certificate_checks: CertificateChecks,
-    pub server_flags: usize,
+    pub server_security: ServerSecurity,
     pub selected_folder: Option<String>,
     pub selected_mailbox: Option<Mailbox>,
     pub selected_folder_needs_expunge: bool,
     pub can_idle: bool,
+    pub auth_scheme: AuthScheme,
 
     /// True if the server has MOVE capability as defined in
     /// https://tools.ietf.org/html/rfc6851
@@ -170,7 +171,8 @@ impl Default for ImapConfig {
             imap_user: "".into(),
             imap_pw: "".into(),
             certificate_checks: Default::default(),
-            server_flags: 0,
+            server_security: ServerSecurity::PlainSocket,
+            auth_scheme: AuthScheme::Plain,
             selected_folder: None,
             selected_mailbox: None,
             selected_folder_needs_expunge: false,
@@ -209,73 +211,71 @@ impl Imap {
             return Ok(());
         }
 
-        let server_flags = self.config.read().await.server_flags as i32;
-
-        let connection_res: ImapResult<Client> =
-            if (server_flags & (DC_LP_IMAP_SOCKET_STARTTLS | DC_LP_IMAP_SOCKET_PLAIN)) != 0 {
-                let config = self.config.read().await;
-                let imap_server: &str = config.imap_server.as_ref();
-                let imap_port = config.imap_port;
-
-                match Client::connect_insecure((imap_server, imap_port)).await {
+        let connection_res: ImapResult<Client> = {
+            let config = self.config.read().await;
+            let server_security = config.server_security;
+            let imap_server: &str = config.imap_server.as_ref();
+            let imap_port = config.imap_port;
+            match server_security {
+                ServerSecurity::Ssl => {
+                    Client::connect_secure(
+                        (imap_server, imap_port),
+                        imap_server,
+                        config.certificate_checks,
+                    )
+                    .await
+                }
+                _ => match Client::connect_insecure((imap_server, imap_port)).await {
                     Ok(client) => {
-                        if (server_flags & DC_LP_IMAP_SOCKET_STARTTLS) != 0 {
+                        if server_security == ServerSecurity::Starttls {
                             client.secure(imap_server, config.certificate_checks).await
                         } else {
                             Ok(client)
                         }
                     }
                     Err(err) => Err(err),
-                }
-            } else {
-                let config = self.config.read().await;
-                let imap_server: &str = config.imap_server.as_ref();
-                let imap_port = config.imap_port;
-
-                Client::connect_secure(
-                    (imap_server, imap_port),
-                    imap_server,
-                    config.certificate_checks,
-                )
-                .await
-            };
-
-        let login_res = match connection_res {
-            Ok(client) => {
-                let config = self.config.read().await;
-                let imap_user: &str = config.imap_user.as_ref();
-                let imap_pw: &str = config.imap_pw.as_ref();
-
-                if (server_flags & DC_LP_AUTH_OAUTH2) != 0 {
-                    let addr: &str = config.addr.as_ref();
-
-                    if let Some(token) = dc_get_oauth2_access_token(context, addr, imap_pw, true) {
-                        let auth = OAuth2 {
-                            user: imap_user.into(),
-                            access_token: token,
-                        };
-                        client.authenticate("XOAUTH2", &auth).await
-                    } else {
-                        return Err(Error::OauthError);
-                    }
-                } else {
-                    client.login(imap_user, imap_pw).await
-                }
+                },
             }
-            Err(err) => {
-                let message = {
-                    let config = self.config.read().await;
-                    let imap_server: &str = config.imap_server.as_ref();
-                    let imap_port = config.imap_port;
-                    context.stock_string_repl_str2(
-                        StockMessage::ServerResponse,
-                        format!("IMAP {}:{}", imap_server, imap_port),
-                        err.to_string(),
-                    )
-                };
-                // IMAP connection failures are reported to users
-                emit_event!(context, Event::ErrorNetwork(message));
-                return Err(Error::ConnectionFailed(err.to_string()));
+        };
+
+        let login_res = {
+            let config = self.config.read().await;
+            let imap_user: &str = config.imap_user.as_ref();
+            let imap_pw: &str = config.imap_pw.as_ref();
+            let auth_scheme = config.auth_scheme;
+            match connection_res {
+                Ok(client) => {
+                    if auth_scheme == AuthScheme::Oauth2 {
+                        let addr: &str = config.addr.as_ref();
+
+                        if let Some(token) = dc_get_oauth2_access_token(context, addr, imap_pw, true) {
+                            let auth = OAuth2 {
+                                user: imap_user.into(),
+                                access_token: token,
+                            };
+                            client.authenticate("XOAUTH2", &auth).await
+                        } else {
+                            return Err(Error::OauthError);
+                        }
+                    } else {
+                        client.login(imap_user, imap_pw).await
+                    }
+                }
+                Err(err) => {
+                    let message = {
+                        let config = self.config.read().await;
+                        let imap_server: &str = config.imap_server.as_ref();
+                        let imap_port = config.imap_port;
+                        context.stock_string_repl_str2(
+                            StockMessage::ServerResponse,
+                            format!("IMAP {}:{}", imap_server, imap_port),
+                            err.to_string(),
+                        )
+                    };
+                    // IMAP connection failures are reported to users
+                    emit_event!(context, Event::ErrorNetwork(message));
+                    return Err(Error::ConnectionFailed(err.to_string()));
+                }
             }
         };
 
@@ -353,17 +353,22 @@ impl Imap {
     /// tries connecting to imap account using the specific login
     /// parameters
     pub async fn connect(&self, context: &Context, lp: &LoginParam) -> bool {
-        if lp.mail_server.is_empty() || lp.mail_user.is_empty() || lp.mail_pw.is_empty() {
+        if lp.srv_params[Service::Imap as usize].hostname.is_empty()
+            || lp.srv_params[Service::Imap as usize].user.is_empty()
+            || lp.srv_params[Service::Imap as usize].pw.is_empty()
+        {
+            context.call_cb(Event::ErrorNetwork("IMAP bad parameters.".into()));
             return false;
         }
 
         {
             let addr = &lp.addr;
-            let imap_server = &lp.mail_server;
-            let imap_port = lp.mail_port as u16;
-            let imap_user = &lp.mail_user;
-            let imap_pw = &lp.mail_pw;
-            let server_flags = lp.server_flags as usize;
+            let imap_server = &lp.srv_params[Service::Imap as usize].hostname;
+            let imap_port = lp.srv_params[Service::Imap as usize].port as u16;
+            let imap_user = &lp.srv_params[Service::Imap as usize].user;
+            let imap_pw = &lp.srv_params[Service::Imap as usize].pw;
+            let server_security = lp.srv_params[Service::Imap as usize].security;
+            let auth_scheme = lp.auth_scheme;
 
             let mut config = self.config.write().await;
             config.addr = addr.to_string();
@@ -371,8 +376,9 @@ impl Imap {
             config.imap_port = imap_port;
             config.imap_user = imap_user.to_string();
             config.imap_pw = imap_pw.to_string();
-            config.certificate_checks = lp.imap_certificate_checks;
-            config.server_flags = server_flags;
+            config.certificate_checks = lp.srv_params[Service::Imap as usize].certificate_checks;
+            config.server_security = server_security.unwrap();
+            config.auth_scheme = auth_scheme;
         }
 
         if let Err(err) = self.setup_handle_if_needed(context).await {
@@ -385,7 +391,11 @@ impl Imap {
             Some(ref mut session) => match session.capabilities().await {
                 Ok(caps) => {
                     if !context.sql.is_open() {
-                        warn!(context, "IMAP-LOGIN as {} ok but ABORTING", lp.mail_user,);
+                        warn!(
+                            context,
+                            "IMAP-LOGIN as {} ok but ABORTING",
+                            lp.srv_params[Service::Imap as usize].user,
+                        );
                         true
                     } else {
                         let can_idle = caps.has_str("IDLE");
@@ -405,7 +415,8 @@ impl Imap {
                             context,
                             Event::ImapConnected(format!(
                                 "IMAP-LOGIN as {}, capabilities: {}",
-                                lp.mail_user, caps_list,
+                                lp.srv_params[Service::Imap as usize].user,
+                                caps_list,
                             ))
                         );
                         false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 #![deny(clippy::correctness, missing_debug_implementations, clippy::all)]
 #![allow(clippy::match_bool)]
+#![recursion_limit = "256"]
 
 #[macro_use]
 extern crate num_derive;

--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -7,10 +7,9 @@ use std::time::{Duration, Instant};
 use async_smtp::smtp::client::net::*;
 use async_smtp::*;
 
-use crate::constants::*;
 use crate::context::Context;
 use crate::events::Event;
-use crate::login_param::{dc_build_tls, LoginParam};
+use crate::login_param::{dc_build_tls, AuthScheme, LoginParam, ServerSecurity, Service};
 use crate::oauth2::*;
 use crate::stock::StockMessage;
 
@@ -100,8 +99,9 @@ impl Smtp {
             warn!(context, "SMTP already connected.");
             return Ok(());
         }
-
-        if lp.send_server.is_empty() || lp.send_port == 0 {
+        if lp.srv_params[Service::Smtp as usize].hostname.is_empty()
+            || lp.srv_params[Service::Smtp as usize].port == 0
+        {
             context.call_cb(Event::ErrorNetwork("SMTP bad parameters.".into()));
             return Err(Error::BadParameters);
         }
@@ -113,23 +113,23 @@ impl Smtp {
             })?;
         self.from = Some(from);
 
-        let domain = &lp.send_server;
-        let port = lp.send_port as u16;
+        let hostname = &lp.srv_params[Service::Smtp as usize].hostname;
+        let port = lp.srv_params[Service::Smtp as usize].port as u16;
 
-        let tls_config = dc_build_tls(lp.smtp_certificate_checks);
-        let tls_parameters = ClientTlsParameters::new(domain.to_string(), tls_config);
+        let tls_config = dc_build_tls(lp.srv_params[Service::Smtp as usize].certificate_checks);
+        let tls_parameters = ClientTlsParameters::new(hostname.to_string(), tls_config);
 
-        let (creds, mechanism) = if 0 != lp.server_flags & (DC_LP_AUTH_OAUTH2 as i32) {
+        let (creds, mechanism) = if lp.auth_scheme == AuthScheme::Oauth2 {
             // oauth2
             let addr = &lp.addr;
-            let send_pw = &lp.send_pw;
-            let access_token = dc_get_oauth2_access_token(context, addr, send_pw, false);
+            let smtp_pw = &lp.srv_params[Service::Smtp as usize].pw;
+            let access_token = dc_get_oauth2_access_token(context, addr, smtp_pw, false);
             if access_token.is_none() {
                 return Err(Error::Oauth2Error {
                     address: addr.to_string(),
                 });
             }
-            let user = &lp.send_user;
+            let user = &lp.srv_params[Service::Smtp as usize].user;
             (
                 smtp::authentication::Credentials::new(
                     user.to_string(),
@@ -139,8 +139,8 @@ impl Smtp {
             )
         } else {
             // plain
-            let user = lp.send_user.clone();
-            let pw = lp.send_pw.clone();
+            let user = lp.srv_params[Service::Smtp as usize].user.clone();
+            let pw = lp.srv_params[Service::Smtp as usize].pw.clone();
             (
                 smtp::authentication::Credentials::new(user, pw),
                 vec![
@@ -150,15 +150,12 @@ impl Smtp {
             )
         };
 
-        let security = if 0
-            != lp.server_flags & (DC_LP_SMTP_SOCKET_STARTTLS | DC_LP_SMTP_SOCKET_PLAIN) as i32
-        {
-            smtp::ClientSecurity::Opportunistic(tls_parameters)
-        } else {
-            smtp::ClientSecurity::Wrapper(tls_parameters)
+        let security = match lp.srv_params[Service::Smtp as usize].security.unwrap() {
+            ServerSecurity::Ssl => smtp::ClientSecurity::Wrapper(tls_parameters),
+            _ => smtp::ClientSecurity::Opportunistic(tls_parameters),
         };
 
-        let client = smtp::SmtpClient::with_security((domain.as_str(), port), security)
+        let client = smtp::SmtpClient::with_security((hostname.as_str(), port), security)
             .await
             .map_err(Error::ConnectionSetupFailure)?;
 
@@ -175,7 +172,7 @@ impl Smtp {
             let message = {
                 context.stock_string_repl_str2(
                     StockMessage::ServerResponse,
-                    format!("SMTP {}:{}", domain, port),
+                    format!("SMTP {}:{}", hostname, port),
                     err.to_string(),
                 )
             };
@@ -187,9 +184,19 @@ impl Smtp {
         self.last_success = Some(Instant::now());
         context.call_cb(Event::SmtpConnected(format!(
             "SMTP-LOGIN as {} ok",
-            lp.send_user,
+            lp.srv_params[Service::Smtp as usize].user,
         )));
 
         Ok(())
+    }
+
+    pub(crate) async fn try_connect(&mut self, context: &Context, lp: &LoginParam) -> bool {
+        match self.inner_connect(context, lp).await {
+            Ok(()) => true,
+            Err(err) => {
+                warn!(context, "SMTP connection error: {}", err);
+                false
+            }
+        }
     }
 }


### PR DESCRIPTION
This pull request 
- reduces configuration time,
- Doesn't configure plain socket connections, when user specifies ports corresponding to TLS connection, but configuration fails. This was considered as a bug in OX COI.
- replaces server flags are with auth_scheme ("plain", "oauth2") and imap_security and smtp_security ("plain_socket", "ssl", "starttls"), these settings are much more straight forward, easier to handle and understand.
- reduces code duplication.

compatibility is not yet implemented, as some feedback from DeltaChat is needed.

How it works:
all imap configuration options and all smtp configuration options are tried in parallel, although imap and smtp connections are configured consequently. So not more than 1 timeout is waited for each of imap and smtp servers.
When no security option and no port are specified, then the following options are tried:
IMAP (143:plain_socket, 993:ssl, 993:starttls)
SMTP (25:plain_socket, 465:ssl, 587:starttls)
When security option is specified, but port is not specified, it is selected accordingly. No other ports are tried.
When port is specified, security option is not specified, then it is selected accordingly to port, if imap_port is specified as 993, then two security options are tried (ssl and starttls), if port is non-standard, then all three security options are tried. 
When both port and security option are specified, then only one combination is tried.

Username options are selected independently for smtp and imap. If username is specified, then there is only one username option. If username is not specified, then full address and left of '@' are the username options. all combinations of username options and port/socket_security are tried.

If both plain socket and ssl/starttls options are in the list, then in case of plain socket connection success, results of secure options are awaited. When there are two successfully connected options: plain and ssl/starttls, then secure option is taken in use. This may result in waiting for one timeout, when only plain socket is available on the server. In other cases no waiting for timeouts if one of the options is valid.