### PR TITLE
Add telepathy-padfoot to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,4 +132,5 @@ or its language bindings:
 - [iOS](https://github.com/deltachat/deltachat-ios)
 - [Desktop](https://github.com/deltachat/deltachat-desktop)
 - [Pidgin](https://code.ur.gs/lupine/purple-plugin-delta/)
+- [Telepathy](https://code.ur.gs/lupine/telepathy-padfoot/)
 - several **Bots**


### PR DESCRIPTION
Per this comment on the forum by @r10s: https://support.delta.chat/t/native-client-for-linux-based-mobile-os/912/12?u=lupine

telepathy-padfoot is still in progress, but already allows desktop and mobile linux text communication, using deltachat-core-rust and telepathy to get the Empathy GTK client to send and receive messages. 