### PR TITLE
forgiving start_io() and stop_io()

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -497,8 +497,8 @@ int             dc_is_configured   (const dc_context_t* context);
 
 /**
  * Start job and IMAP/SMTP tasks.
- * You must not call dc_start_io() if IO is already started,
- * please check the current state using dc_is_io_running() first.
+ * If IO is already running, nothing happens.
+ * To check the current IO state, use dc_is_io_running().
  *
  * @memberof dc_context_t
  * @param context The context object as created by dc_context_new().
@@ -518,6 +518,8 @@ int             dc_is_io_running(const dc_context_t* context);
 
 /**
  * Stop job and IMAP/SMTP tasks and return when they are finished. 
+ * If IO is not running, nothing happens.
+ * To check the current IO state, use dc_is_io_running().
  *
  * @memberof dc_context_t
  * @param context The context object as created by dc_context_new().

--- a/src/context.rs
+++ b/src/context.rs
@@ -138,7 +138,10 @@ impl Context {
     /// Starts the IO scheduler.
     pub async fn start_io(&self) {
         info!(self, "starting IO");
-        assert!(!self.is_io_running().await, "context is already running");
+        if self.is_io_running().await {
+            info!(self, "IO is already running");
+            return;
+        }
 
         let l = &mut *self.inner.scheduler.write().await;
         l.start(self.clone()).await;
@@ -152,6 +155,11 @@ impl Context {
     /// Stops the IO scheduler.
     pub async fn stop_io(&self) {
         info!(self, "stopping IO");
+        if !self.is_io_running().await {
+            info!(self, "IO is not running");
+            return;
+        }
+
         self.inner.stop_io().await;
     }
 


### PR DESCRIPTION
this pr removes the condition to check is_io_running() before start_io() can be called; same for stop_io(), successor of https://github.com/deltachat/deltachat-core-rust/pull/1529#pullrequestreview-417998214

i am not yet deep into async, so not sure, if the calling is correct - or maybe i've overseen sth. :)

also, if this does not fit well into some internal concepts or thinkings, i would also be fine with this being closed again, it is only a tiny detail that can also be handled by the ui - otoh, of course, it is great if there is one thing less the ui has to take care about :)