### PR TITLE
Config refactor pr

### DIFF
--- a/src/configure/auto_mozilla.rs
+++ b/src/configure/auto_mozilla.rs
@@ -3,9 +3,8 @@
 //! Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration */
 use quick_xml::events::{BytesEnd, BytesStart, BytesText};
 
-use crate::constants::*;
 use crate::context::Context;
-use crate::login_param::LoginParam;
+use crate::login_param::{LoginParam, ServerSecurity, IDX_IMAP, IDX_SMTP};
 
 use super::read_url::read_url;
 use super::Error;
@@ -83,10 +82,10 @@ fn parse_xml(in_emailaddr: &str, xml_raw: &str) -> Result<LoginParam, Error> {
         buf.clear();
     }
 
-    if moz_ac.out.mail_server.is_empty()
-        || moz_ac.out.mail_port == 0
-        || moz_ac.out.send_server.is_empty()
-        || moz_ac.out.send_port == 0
+    if moz_ac.out.srv_params[IDX_IMAP].hostname.is_empty()
+        || moz_ac.out.srv_params[IDX_IMAP].port == 0
+        || moz_ac.out.srv_params[IDX_SMTP].hostname.is_empty()
+        || moz_ac.out.srv_params[IDX_SMTP].port == 0
     {
         Err(Error::IncompleteAutoconfig(moz_ac.out))
     } else {
@@ -130,38 +129,26 @@ fn moz_autoconfigure_text_cb<B: std::io::BufRead>(
 
     match moz_ac.tag_server {
         MozServer::Imap => match moz_ac.tag_config {
-            MozConfigTag::Hostname => moz_ac.out.mail_server = val,
-            MozConfigTag::Port => moz_ac.out.mail_port = val.parse().unwrap_or_default(),
-            MozConfigTag::Username => moz_ac.out.mail_user = val,
+            MozConfigTag::Hostname => moz_ac.out.srv_params[IDX_IMAP].hostname = val,
+            MozConfigTag::Port => {
+                moz_ac.out.srv_params[IDX_IMAP].port = val.parse().unwrap_or_default()
+            }
+            MozConfigTag::Username => moz_ac.out.srv_params[IDX_IMAP].user = val,
             MozConfigTag::Sockettype => {
-                let val_lower = val.to_lowercase();
-                if val_lower == "ssl" {
-                    moz_ac.out.server_flags |= DC_LP_IMAP_SOCKET_SSL as i32
-                }
-                if val_lower == "starttls" {
-                    moz_ac.out.server_flags |= DC_LP_IMAP_SOCKET_STARTTLS as i32
-                }
-                if val_lower == "plain" {
-                    moz_ac.out.server_flags |= DC_LP_IMAP_SOCKET_PLAIN as i32
-                }
+                moz_ac.out.srv_params[IDX_IMAP].security =
+                    ServerSecurity::from_str_opt(val.to_lowercase().as_str())
             }
             _ => {}
         },
         MozServer::Smtp => match moz_ac.tag_config {
-            MozConfigTag::Hostname => moz_ac.out.send_server = val,
-            MozConfigTag::Port => moz_ac.out.send_port = val.parse().unwrap_or_default(),
-            MozConfigTag::Username => moz_ac.out.send_user = val,
+            MozConfigTag::Hostname => moz_ac.out.srv_params[IDX_SMTP].hostname = val,
+            MozConfigTag::Port => {
+                moz_ac.out.srv_params[IDX_SMTP].port = val.parse().unwrap_or_default()
+            }
+            MozConfigTag::Username => moz_ac.out.srv_params[IDX_SMTP].user = val,
             MozConfigTag::Sockettype => {
-                let val_lower = val.to_lowercase();
-                if val_lower == "ssl" {
-                    moz_ac.out.server_flags |= DC_LP_SMTP_SOCKET_SSL as i32
-                }
-                if val_lower == "starttls" {
-                    moz_ac.out.server_flags |= DC_LP_SMTP_SOCKET_STARTTLS as i32
-                }
-                if val_lower == "plain" {
-                    moz_ac.out.server_flags |= DC_LP_SMTP_SOCKET_PLAIN as i32
-                }
+                moz_ac.out.srv_params[IDX_SMTP].security =
+                    ServerSecurity::from_str_opt(val.to_lowercase().as_str())
             }
             _ => {}
         },
@@ -314,9 +301,9 @@ mod tests {
   </webMail>
 </clientConfig>";
         let res = parse_xml("example@outlook.com", xml_raw).expect("XML parsing failed");
-        assert_eq!(res.mail_server, "outlook.office365.com");
-        assert_eq!(res.mail_port, 993);
-        assert_eq!(res.send_server, "smtp.office365.com");
-        assert_eq!(res.send_port, 587);
+        assert_eq!(res.srv_params[IDX_IMAP].hostname, "outlook.office365.com");
+        assert_eq!(res.srv_params[IDX_IMAP].port, 993);
+        assert_eq!(res.srv_params[IDX_SMTP].hostname, "smtp.office365.com");
+        assert_eq!(res.srv_params[IDX_SMTP].port, 587);
     }
 }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -15,7 +15,7 @@ use crate::dc_tools::*;
 use crate::error::{bail, ensure, format_err, Result};
 use crate::events::Event;
 use crate::key::{DcKey, SignedPublicKey};
-use crate::login_param::LoginParam;
+use crate::login_param::{LoginParam, ServerSecurity, IDX_IMAP, IDX_SMTP};
 use crate::message::{MessageState, MsgId};
 use crate::mimeparser::AvatarAction;
 use crate::param::*;
@@ -728,12 +728,18 @@ impl Contact {
                     );
                     cat_fingerprint(&mut ret, &loginparam.addr, &fingerprint_self, "");
                 }
-            } else if 0 == loginparam.server_flags & DC_LP_IMAP_SOCKET_PLAIN as i32
-                && 0 == loginparam.server_flags & DC_LP_SMTP_SOCKET_PLAIN as i32
+            } else if loginparam.srv_params[IDX_IMAP]
+                .security
+                .unwrap_or(ServerSecurity::PlainSocket)
+                == ServerSecurity::PlainSocket
+                && loginparam.srv_params[IDX_SMTP]
+                    .security
+                    .unwrap_or(ServerSecurity::PlainSocket)
+                    == ServerSecurity::PlainSocket
             {
-                ret += &context.stock_str(StockMessage::EncrTransp).await;
-            } else {
                 ret += &context.stock_str(StockMessage::EncrNone).await;
+            } else {
+                ret += &context.stock_str(StockMessage::EncrTransp).await;
             }
         }
 

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -16,10 +16,6 @@ use crate::context::Context;
 use crate::error::{bail, Error};
 use crate::events::Event;
 
-pub(crate) fn dc_exactly_one_bit_set(v: i32) -> bool {
-    0 != v && 0 == v & (v - 1)
-}
-
 /// Shortens a string to a specified length and adds "[...]" to the
 /// end of the shortened string.
 pub(crate) fn dc_truncate(buf: &str, approx_chars: usize) -> Cow<str> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 #![deny(clippy::correctness, missing_debug_implementations, clippy::all)]
 #![allow(clippy::match_bool)]
+#![recursion_limit = "256"]
 
 #[macro_use]
 extern crate num_derive;

--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -186,4 +186,14 @@ impl Smtp {
 
         Ok(())
     }
+
+    pub(crate) async fn try_connect(&mut self, context: &Context, lp: &LoginParam) -> bool {
+        match self.connect(context, lp).await {
+            Ok(()) => true,
+            Err(err) => {
+                warn!(context, "SMTP connection error: {}", err);
+                false
+            }
+        }
+    }
 }


### PR DESCRIPTION
This pull request

reduces configuration time,
Doesn't configure plain socket connections, when user specifies ports corresponding to TLS connection, but configuration fails. This was considered as a bug in OX COI.
replaces server flags with enums for authentication scheme and socket security options in login_params, while keeping server flags in DB.
reduces code duplication.

How it works:
all imap configuration options and all smtp configuration options are tried in parallel, although imap and smtp connections are configured consequently. So not more than 1 timeout is waited for each of imap and smtp servers.
When no security option and no port are specified, then the following options are tried:
IMAP (143:plain_socket, 993:ssl, 143:starttls)
SMTP (25:plain_socket, 465:ssl, 587:starttls)
When security option is specified, but port is not specified, it is selected accordingly. No other ports are tried.
When port is specified, security option is not specified, then it is selected accordingly to port, if imap_port is specified as 143, then two security options are tried (plain_socket and starttls), if port is non-standard, then all three security options are tried.
When both port and security option are specified, then only one combination is tried.

Username options are selected independently for smtp and imap. If username is specified, then there is only one username option. If username is not specified, then full address and left of '@' are the username options. all combinations of username options and port/socket_security are tried.

If both plain socket and ssl/starttls options are in the list, then in case of plain socket connection success, results of secure options are awaited. When there are two successfully connected options: plain and ssl/starttls, then secure option is taken in use. This may result in waiting for one timeout, when only plain socket is available on the server. In other cases no waiting for timeouts if one of the options is valid.