### PR TITLE
Do not create ad-hoc groups when message cannot be decrypted

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1293,6 +1293,24 @@ async fn create_or_lookup_adhoc_group(
         return Ok((ChatId::new(0), Blocked::Not));
     }
 
+    if mime_parser.decrypting_failed {
+        // Do not create a new ad-hoc group if the message cannot be
+        // decrypted.
+        //
+        // The subject may be encrypted and contain a placeholder such
+        // as "...". Besides that, it is possible that the message was
+        // sent to a valid, yet unknown group, which was rejected
+        // because Chat-Group-Name, which is in the encrypted part,
+        // was not found. Generating a new ID in this case would
+        // result in creation of a twin group with a different group
+        // ID.
+        warn!(
+            context,
+            "not creating ad-hoc group for message that cannot be decrypted"
+        );
+        return Ok((ChatId::new(0), Blocked::Not));
+    }
+
     // we do not check if the message is a reply to another group, this may result in
     // chats with unclear member list. instead we create a new group in the following lines ...
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -527,6 +527,7 @@ impl MimeMessage {
                 part.typ = Viewtype::Text;
                 part.msg_raw = Some(txt.clone());
                 part.msg = txt;
+                part.param.set(Param::Error, "Decryption failed");
 
                 self.parts.push(part);
 


### PR DESCRIPTION
Trying to reproduce #1565 

`ac1` establishes keys with `ac2` and `ac3`. Then `ac2` is cloned into `ac4` with a new key to simulate reinstallation. `ac1` creates a group with `ac2` and `ac3` and sends two messages there.

Received messages have IDs like `Gr.YhIUVTlAq0F.…`, but `ac4` assigns them to a different group ID:
```
7.47 [events-ac4] DC_EVENT_WARNING data1=0 data2=src/mimeparser.rs:162: decryption failed: missing key
...
7.50 [events-ac4] DC_EVENT_INFO data1=0 data2=src/dc_receive_imf.rs:1348: Created group '...' grpid=96e01a197ee944d4 as Chat#11
```