### PR TITLE
Fix #1575 Messages sent by DeltaChat trigger spam filters due to incorrect/non-compliant formatting options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3322,6 +3322,7 @@ name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+
 [[package]]
 name = "version_check"
 version = "0.9.2"
@@ -3526,8 +3527,3 @@ dependencies = [
  "syn 1.0.30",
  "synstructure",
 ]
-
-[[patch.unused]]
-name = "smol"
-version = "0.1.10"
-source = "git+https://github.com/dignifiedquire/smol-1?branch=isolate-nix#1ba84935e4e48be927c7f8f4a9cb5c05614135c3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 [[package]]
 name = "email"
 version = "0.0.21"
-source = "git+https://github.com/Hocuri/rust-email#6c903a5b1dd91acb191af2987ca29c28bb733c56"
+source = "git+https://github.com/deltachat/rust-email#ace12ee6f8e054dd890589f588d0311604fc25f0"
 dependencies = [
  "base64 0.11.0",
  "chrono",
@@ -1602,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "lettre"
 version = "0.9.2"
-source = "git+https://github.com/Hocuri/lettre#05a94e82269e3d85b7b7b5b88e779daf4f6343db"
+source = "git+https://github.com/deltachat/lettre#12e4f22d8d691fb5d1606e4c9034f5d4d9ba635b"
 dependencies = [
  "fast_chemail",
  "log",
@@ -1611,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "lettre_email"
 version = "0.9.2"
-source = "git+https://github.com/Hocuri/lettre#05a94e82269e3d85b7b7b5b88e779daf4f6343db"
+source = "git+https://github.com/deltachat/lettre#12e4f22d8d691fb5d1606e4c9034f5d4d9ba635b"
 dependencies = [
  "base64 0.11.0",
  "email",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,9 +246,9 @@ checksum = "c17772156ef2829aadc587461c7753af20b7e8db1529bc66855add962a3b35d3"
 
 [[package]]
 name = "async-trait"
-version = "0.1.33"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1c13101a3224fb178860ae372a031ce350bbd92d39968518f016744dde0bf7"
+checksum = "89cb5d814ab2a47fd66d3266e9efccb53ca4c740b7451043b8ffcf9a6208f3f8"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -932,7 +932,7 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 [[package]]
 name = "email"
 version = "0.0.21"
-source = "git+https://github.com/deltachat/rust-email#ace12ee6f8e054dd890589f588d0311604fc25f0"
+source = "git+https://github.com/deltachat/rust-email#9161f2d45d29ae8f0119fde0facdb1b0d7c6f077"
 dependencies = [
  "base64 0.11.0",
  "chrono",
@@ -3058,9 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
 dependencies = [
  "proc-macro2",
  "quote 1.0.7",
@@ -3322,7 +3322,6 @@ name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
-
 [[package]]
 name = "version_check"
 version = "0.9.2"
@@ -3527,3 +3526,8 @@ dependencies = [
  "syn 1.0.30",
  "synstructure",
 ]
+
+[[patch.unused]]
+name = "smol"
+version = "0.1.10"
+source = "git+https://github.com/dignifiedquire/smol-1?branch=isolate-nix#1ba84935e4e48be927c7f8f4a9cb5c05614135c3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,7 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 [[package]]
 name = "email"
 version = "0.0.21"
-source = "git+https://github.com/deltachat/rust-email#ace12ee6f8e054dd890589f588d0311604fc25f0"
+source = "git+https://github.com/Hocuri/rust-email#6c903a5b1dd91acb191af2987ca29c28bb733c56"
 dependencies = [
  "base64 0.11.0",
  "chrono",
@@ -1602,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "lettre"
 version = "0.9.2"
-source = "git+https://github.com/deltachat/lettre#12e4f22d8d691fb5d1606e4c9034f5d4d9ba635b"
+source = "git+https://github.com/Hocuri/lettre#05a94e82269e3d85b7b7b5b88e779daf4f6343db"
 dependencies = [
  "fast_chemail",
  "log",
@@ -1611,7 +1611,7 @@ dependencies = [
 [[package]]
 name = "lettre_email"
 version = "0.9.2"
-source = "git+https://github.com/deltachat/lettre#12e4f22d8d691fb5d1606e4c9034f5d4d9ba635b"
+source = "git+https://github.com/Hocuri/lettre#05a94e82269e3d85b7b7b5b88e779daf4f6343db"
 dependencies = [
  "base64 0.11.0",
  "email",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ surf = { version = "2.0.0-alpha.2", default-features = false, features = ["h1-cl
 num-derive = "0.3.0"
 num-traits = "0.2.6"
 async-smtp = { version = "0.3" }
-email = { git = "https://github.com/deltachat/rust-email", branch = "master" }
-lettre_email = { git = "https://github.com/deltachat/lettre", branch = "master" }
+email = { git = "https://github.com/Hocuri/rust-email", branch = "master" }
+lettre_email = { git = "https://github.com/Hocuri/lettre", branch = "master" }
 async-imap = "0.3.1"
 async-native-tls = { version = "0.3.3" }
 async-std = { version = "1.6.0", features = ["unstable"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ surf = { version = "2.0.0-alpha.2", default-features = false, features = ["h1-cl
 num-derive = "0.3.0"
 num-traits = "0.2.6"
 async-smtp = { version = "0.3" }
-email = { git = "https://github.com/Hocuri/rust-email", branch = "master" }
-lettre_email = { git = "https://github.com/Hocuri/lettre", branch = "master" }
+email = { git = "https://github.com/deltachat/rust-email", branch = "master" }
+lettre_email = { git = "https://github.com/deltachat/lettre", branch = "master" }
 async-imap = "0.3.1"
 async-native-tls = { version = "0.3.3" }
 async-std = { version = "1.6.0", features = ["unstable"] }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1780,7 +1780,7 @@ mod tests {
     use crate::chat::ChatVisibility;
     use crate::chatlist::Chatlist;
     use crate::message::Message;
-    use crate::test_utils::{dummy_context, TestContext};
+    use crate::test_utils::{configured_offline_context, dummy_context};
 
     #[test]
     fn test_hex_hash() {
@@ -1874,23 +1874,6 @@ mod tests {
         assert!(is_msgrmsg_rfc724_mid(&t.ctx, format!("<{}>", msg.rfc724_mid).as_str()).await);
         assert!(is_msgrmsg_rfc724_mid(&t.ctx, &msg.rfc724_mid).await);
         assert!(!is_msgrmsg_rfc724_mid(&t.ctx, "nonexistant@message.id").await);
-    }
-
-    async fn configured_offline_context() -> TestContext {
-        let t = dummy_context().await;
-        t.ctx
-            .set_config(Config::Addr, Some("alice@example.org"))
-            .await
-            .unwrap();
-        t.ctx
-            .set_config(Config::ConfiguredAddr, Some("alice@example.org"))
-            .await
-            .unwrap();
-        t.ctx
-            .set_config(Config::Configured, Some("1"))
-            .await
-            .unwrap();
-        t
     }
 
     static MSGRMSG: &[u8] = b"From: Bob <bob@example.org>\n\

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -440,6 +440,8 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             to.push(from.clone());
         }
 
+        unprotected_headers.push(Header::new("MIME-Version".into(), "1.0".into()));
+
         if !self.references.is_empty() {
             unprotected_headers.push(Header::new("References".into(), self.references.clone()));
         }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1214,6 +1214,9 @@ mod tests {
         let addr = "x@y.org";
 
         assert!(!display_name.is_ascii());
+        assert!(!display_name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == ' '));
 
         let s = format!(
             "{}",
@@ -1225,6 +1228,23 @@ mod tests {
         assert_eq!(s, "=?utf-8?q?=C3=A4_space?= <x@y.org>");
     }
 
+    #[test]
+    fn test_render_email_address_noescape() {
+        let display_name = "a space";
+        let addr = "x@y.org";
+
+        assert!(display_name.is_ascii());
+        assert!(display_name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == ' '));
+
+        let s = format!(
+            "{}",
+            Address::new_mailbox_with_name(display_name.to_string(), addr.to_string())
+        );
+
+        assert_eq!(s, "a space <x@y.org>");
+    }
     #[test]
     fn test_render_rfc724_mid() {
         assert_eq!(

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -40,6 +40,23 @@ pub(crate) async fn dummy_context() -> TestContext {
     test_context().await
 }
 
+pub(crate) async fn configured_offline_context() -> TestContext {
+    let t = dummy_context().await;
+    t.ctx
+        .set_config(Config::Addr, Some("alice@example.org"))
+        .await
+        .unwrap();
+    t.ctx
+        .set_config(Config::ConfiguredAddr, Some("alice@example.org"))
+        .await
+        .unwrap();
+    t.ctx
+        .set_config(Config::Configured, Some("1"))
+        .await
+        .unwrap();
+    t
+}
+
 /// Load a pre-generated keypair for alice@example.com from disk.
 ///
 /// This saves CPU cycles by avoiding having to generate a key.


### PR DESCRIPTION
Fix #1575 Messages sent by DeltaChat trigger spam filters due to incorrect/non-compliant formatting options