### PR TITLE
simplify deltachat python API and testing machinery

### DIFF
--- a/python/examples/test_examples.py
+++ b/python/examples/test_examples.py
@@ -26,15 +26,15 @@ def test_echo_quit_plugin(acfactory, lp):
 
     lp.sec("sending a message to the bot")
     bot_contact = ac1.create_contact(botproc.addr)
-    ch1 = bot_contact.create_chat()
-    ch1.send_text("hello")
+    bot_chat = bot_contact.create_chat()
+    bot_chat.send_text("hello")
 
-    lp.sec("waiting for the bot-reply to arrive")
+    lp.sec("waiting for the reply message from the bot to arrive")
     reply = ac1._evtracker.wait_next_incoming_message()
+    assert reply.chat == bot_chat
     assert "hello" in reply.text
-    assert reply.chat == ch1
     lp.sec("send quit sequence")
-    ch1.send_text("/quit")
+    bot_chat.send_text("/quit")
     botproc.wait()
 
 
@@ -47,8 +47,8 @@ def test_group_tracking_plugin(acfactory, lp):
     botproc.fnmatch_lines("""
         *ac_configure_completed*
     """)
-    ac1.add_account_plugin(FFIEventLogger(ac1, "ac1"))
-    ac2.add_account_plugin(FFIEventLogger(ac2, "ac2"))
+    ac1.add_account_plugin(FFIEventLogger(ac1))
+    ac2.add_account_plugin(FFIEventLogger(ac2))
 
     lp.sec("creating bot test group with bot")
     bot_contact = ac1.create_contact(botproc.addr)

--- a/python/examples/test_examples.py
+++ b/python/examples/test_examples.py
@@ -26,7 +26,7 @@ def test_echo_quit_plugin(acfactory, lp):
 
     lp.sec("sending a message to the bot")
     bot_contact = ac1.create_contact(botproc.addr)
-    ch1 = ac1.create_chat_by_contact(bot_contact)
+    ch1 = bot_contact.create_chat()
     ch1.send_text("hello")
 
     lp.sec("waiting for the bot-reply to arrive")

--- a/python/src/deltachat/__init__.py
+++ b/python/src/deltachat/__init__.py
@@ -60,7 +60,8 @@ def run_cmdline(argv=None, account_plugins=None):
     ac = Account(args.db)
 
     if args.show_ffi:
-        log = events.FFIEventLogger(ac, "bot")
+        ac.set_config("displayname", "bot")
+        log = events.FFIEventLogger(ac)
         ac.add_account_plugin(log)
 
     for plugin in account_plugins or []:

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -213,21 +213,18 @@ class Account(object):
         """
         return Contact(self, const.DC_CONTACT_ID_SELF)
 
-    def create_contact(self, addr, name=None):
-        """ create a (new) Contact. If there already is a Contact
-        with that e-mail address, it is unblocked and its display
-        name is updated.
+    def create_contact(self, obj, name=None):
+        """ create a (new) Contact or return an existing one.
 
-        :param addr: email-address, Account or Contact instance.
-        :param name: display name for this contact (optional)
+        Calling this method will always resulut in the same
+        underlying contact id.  If there already is a Contact
+        with that e-mail address, it is unblocked and its display
+        `name` is updated if specified.
+
+        :param obj: email-address, Account or Contact instance.
+        :param name: (optional) display name for this contact
         :returns: :class:`deltachat.contact.Contact` instance.
         """
-        if not isinstance(addr, (Account, Contact, str)):
-            raise TypeError(str(addr))
-        return self.as_contact(addr, name=name)
-
-    def as_contact(self, obj, name=None):
-        """ Create a contact from an Account, Contact or e-mail address. """
         if isinstance(obj, Account):
             if not obj.is_configured():
                 raise ValueError("can only add addresses from configured accounts")
@@ -309,7 +306,7 @@ class Account(object):
 
     def create_chat(self, obj):
         """ Create a 1:1 chat with Account, Contact or e-mail address. """
-        return self.as_contact(obj).create_chat()
+        return self.create_contact(obj).create_chat()
 
     def _create_chat_by_message_id(self, msg_id):
         return Chat(self, lib.dc_create_chat_by_msg_id(self._dc_context, msg_id))

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -303,7 +303,8 @@ class Account(object):
         if isinstance(obj, Account):
             if not obj.is_configured():
                 raise ValueError("can only add addresses from a configured account")
-            contact = self.create_contact(obj.get_self_contact().addr)
+            addr, name = obj.get_config("addr"), obj.get_config("displayname")
+            contact = self.create_contact(addr, name)
         elif isinstance(obj, Contact):
             contact = self._port_contact(obj)
         elif isinstance(obj, str):
@@ -313,25 +314,8 @@ class Account(object):
             raise TypeError("don't know how to create chat for %r" % (obj, ))
         return contact.create_chat()
 
-    def create_chat_by_message(self, message):
-        """ create or get an existing chat object for the
-        the specified message.
-
-        If this message is in the deaddrop chat then
-        the sender will become an accepted contact.
-
-        :param message: messsage id or message instance.
-        :returns: a :class:`deltachat.chat.Chat` object.
-        """
-        if hasattr(message, "id"):
-            if message.account != self:
-                raise ValueError("Message belongs to a different Account")
-            msg_id = message.id
-        else:
-            assert isinstance(message, int)
-            msg_id = message
-        chat_id = lib.dc_create_chat_by_msg_id(self._dc_context, msg_id)
-        return Chat(self, chat_id)
+    def _create_chat_by_message_id(self, msg_id):
+        return Chat(self, lib.dc_create_chat_by_msg_id(self._dc_context, msg_id))
 
     def create_group_chat(self, name, verified=False):
         """ create a new group chat object.

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -28,7 +28,7 @@ class Account(object):
     """
     MissingCredentials = MissingCredentials
 
-    def __init__(self, db_path, os_name=None, logging=True, logid=None):
+    def __init__(self, db_path, os_name=None, logging=True):
         """ initialize account object.
 
         :param db_path: a path to the account database. The database
@@ -38,7 +38,6 @@ class Account(object):
         # initialize per-account plugin system
         self._pm = hookspec.PerAccount._make_plugin_manager()
         self._logging = logging
-        self.logid = logid
 
         self.add_account_plugin(self)
 

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -18,6 +18,8 @@ class Chat(object):
     """
 
     def __init__(self, account, id):
+        from .account import Account
+        assert isinstance(account, Account), repr(account)
         self.account = account
         self.id = id
 
@@ -328,11 +330,6 @@ class Chat(object):
 
     # ------  group management API ------------------------------
 
-    def _port_contact(self, contact):
-        if contact.account != self.account:
-            contact = self.account.create_contact(contact.addr, contact.display_name)
-        return contact
-
     def add_contact(self, contact):
         """ add a contact to this chat.
 
@@ -343,7 +340,7 @@ class Chat(object):
         :raises ValueError: if contact could not be added
         :returns: None
         """
-        contact = self._port_contact(contact)
+        contact = self.account._port_contact(contact)
         ret = lib.dc_add_contact_to_chat(self.account._dc_context, self.id, contact.id)
         if ret != 1:
             raise ValueError("could not add contact {!r} to chat".format(contact))
@@ -356,7 +353,7 @@ class Chat(object):
         :raises ValueError: if contact could not be removed
         :returns: None
         """
-        contact = self._port_contact(contact)
+        contact = self.account._port_contact(contact)
         ret = lib.dc_remove_contact_from_chat(self.account._dc_context, self.id, contact.id)
         if ret != 1:
             raise ValueError("could not remove contact {!r} from chat".format(contact))

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -337,7 +337,7 @@ class Chat(object):
         :raises ValueError: if contact could not be added
         :returns: None
         """
-        contact = self.account.as_contact(obj)
+        contact = self.account.create_contact(obj)
         ret = lib.dc_add_contact_to_chat(self.account._dc_context, self.id, contact.id)
         if ret != 1:
             raise ValueError("could not add contact {!r} to chat".format(contact))
@@ -350,7 +350,7 @@ class Chat(object):
         :raises ValueError: if contact could not be removed
         :returns: None
         """
-        contact = self.account.as_contact(obj)
+        contact = self.account.create_contact(obj)
         ret = lib.dc_remove_contact_from_chat(self.account._dc_context, self.id, contact.id)
         if ret != 1:
             raise ValueError("could not remove contact {!r} from chat".format(contact))

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -330,39 +330,34 @@ class Chat(object):
 
     # ------  group management API ------------------------------
 
-    def add_contact(self, contact):
+    def add_contact(self, obj):
         """ add a contact to this chat.
 
-        If the contact is from another account create a new
-        contact and add it to the group.
-
-        :params: contact object.
+        :params obj: Contact, Account or e-mail address.
         :raises ValueError: if contact could not be added
         :returns: None
         """
-        contact = self.account._port_contact(contact)
+        contact = self.account.as_contact(obj)
         ret = lib.dc_add_contact_to_chat(self.account._dc_context, self.id, contact.id)
         if ret != 1:
             raise ValueError("could not add contact {!r} to chat".format(contact))
         return contact
 
-    def remove_contact(self, contact):
+    def remove_contact(self, obj):
         """ remove a contact from this chat.
 
-        :params: contact object.
+        :params obj: Contact, Account or e-mail address.
         :raises ValueError: if contact could not be removed
         :returns: None
         """
-        contact = self.account._port_contact(contact)
+        contact = self.account.as_contact(obj)
         ret = lib.dc_remove_contact_from_chat(self.account._dc_context, self.id, contact.id)
         if ret != 1:
             raise ValueError("could not remove contact {!r} from chat".format(contact))
 
     def get_contacts(self):
         """ get all contacts for this chat.
-        :params: contact object.
         :returns: list of :class:`deltachat.contact.Contact` objects for this chat
-
         """
         from .contact import Contact
         dc_array = ffi.gc(

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -328,16 +328,26 @@ class Chat(object):
 
     # ------  group management API ------------------------------
 
+    def _port_contact(self, contact):
+        if contact.account != self.account:
+            contact = self.account.create_contact(contact.addr, contact.display_name)
+        return contact
+
     def add_contact(self, contact):
         """ add a contact to this chat.
+
+        If the contact is from another account create a new
+        contact and add it to the group.
 
         :params: contact object.
         :raises ValueError: if contact could not be added
         :returns: None
         """
+        contact = self._port_contact(contact)
         ret = lib.dc_add_contact_to_chat(self.account._dc_context, self.id, contact.id)
         if ret != 1:
             raise ValueError("could not add contact {!r} to chat".format(contact))
+        return contact
 
     def remove_contact(self, contact):
         """ remove a contact from this chat.
@@ -346,6 +356,7 @@ class Chat(object):
         :raises ValueError: if contact could not be removed
         :returns: None
         """
+        contact = self._port_contact(contact)
         ret = lib.dc_remove_contact_from_chat(self.account._dc_context, self.id, contact.id)
         if ret != 1:
             raise ValueError("could not remove contact {!r} from chat".format(contact))

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -368,6 +368,14 @@ class Chat(object):
             dc_array, lambda id: Contact(self.account, id))
         )
 
+    def num_contacts(self):
+        """ return number of contacts in this chat. """
+        dc_array = ffi.gc(
+            lib.dc_get_chat_contacts(self.account._dc_context, self.id),
+            lib.dc_array_unref
+        )
+        return lib.dc_array_get_cnt(dc_array)
+
     def set_profile_image(self, img_path):
         """Set group profile image.
 

--- a/python/src/deltachat/contact.py
+++ b/python/src/deltachat/contact.py
@@ -36,9 +36,12 @@ class Contact(object):
         return from_dc_charpointer(lib.dc_contact_get_addr(self._dc_contact))
 
     @props.with_doc
-    def display_name(self):
+    def name(self):
         """ display name for this contact. """
         return from_dc_charpointer(lib.dc_contact_get_display_name(self._dc_contact))
+
+    # deprecated alias
+    display_name = name
 
     def is_blocked(self):
         """ Return True if the contact is blocked. """

--- a/python/src/deltachat/contact.py
+++ b/python/src/deltachat/contact.py
@@ -3,6 +3,8 @@
 from . import props
 from .cutil import from_dc_charpointer
 from .capi import lib, ffi
+from .chat import Chat
+from . import const
 
 
 class Contact(object):
@@ -11,6 +13,8 @@ class Contact(object):
     You obtain instances of it through :class:`deltachat.account.Account`.
     """
     def __init__(self, account, id):
+        from .account import Account
+        assert isinstance(account, Account), repr(account)
         self.account = account
         self.id = id
 
@@ -61,6 +65,16 @@ class Contact(object):
             return None
         return from_dc_charpointer(dc_res)
 
-    def get_chat(self):
-        """return 1:1 chat for this contact. """
-        return self.account.create_chat_by_contact(self)
+    def create_chat(self):
+        """ create or get an existing 1:1 chat object for the specified contact or contact id.
+
+        :param contact: chat_id (int) or contact object.
+        :returns: a :class:`deltachat.chat.Chat` object.
+        """
+        dc_context = self.account._dc_context
+        chat_id = lib.dc_create_chat_by_contact_id(dc_context, self.id)
+        assert chat_id > const.DC_CHAT_ID_LAST_SPECIAL, chat_id
+        return Chat(self.account, chat_id)
+
+    # deprecated name
+    get_chat = create_chat

--- a/python/src/deltachat/direct_imap.py
+++ b/python/src/deltachat/direct_imap.py
@@ -24,7 +24,7 @@ def dc_account_extra_configure(account):
     """ Reset the account (we reuse accounts across tests)
     and make 'account.direct_imap' available for direct IMAP ops.
     """
-    imap = DirectImap(account, account.logid)
+    imap = DirectImap(account)
     if imap.select_config_folder("mvbox"):
         imap.delete(ALL, expunge=True)
     assert imap.select_config_folder("inbox")
@@ -42,9 +42,9 @@ def dc_account_after_shutdown(account):
 
 
 class DirectImap:
-    def __init__(self, account, logid):
+    def __init__(self, account):
         self.account = account
-        self.logid = logid
+        self.logid = account.get_config("displayname") or id(account)
         self._idling = False
         self.connect()
 

--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -28,13 +28,9 @@ class FFIEventLogger:
     # to prevent garbled logging
     _loglock = threading.RLock()
 
-    def __init__(self, account, logid):
-        """
-        :param logid: an optional logging prefix that should be used with
-                      the default internal logging.
-        """
+    def __init__(self, account):
         self.account = account
-        self.logid = logid
+        self.logid = self.account.get_config("displayname")
         self.init_time = time.time()
 
     @account_hookimpl

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -54,14 +54,18 @@ class Message(object):
         ))
 
     def create_chat(self):
-        """ create a chat from a message (eg Contact-Request message).
+        """ create or get an existing chat (group) object for this message.
+
+        If the message is a deaddrop contact request
+        the sender will become an accepted contact.
+
+        :returns: a :class:`deltachat.chat.Chat` object.
         """
-        chat = self.account.create_chat_by_message(self)
-        self._dc_msg = ffi.gc(
-                lib.dc_get_msg(self.account._dc_context, self.id),
-                lib.dc_msg_unref
-        )
-        return chat
+        from .chat import Chat
+        chat_id = lib.dc_create_chat_by_msg_id(self.account._dc_context, self.id)
+        ctx = self.account._dc_context
+        self._dc_msg = ffi.gc(lib.dc_get_msg(ctx, self.id), lib.dc_msg_unref)
+        return Chat(self.account, chat_id)
 
     @props.with_doc
     def text(self):

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -229,11 +229,12 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
             deltachat.unregister_global_plugin(direct_imap)
 
         def make_account(self, path, logid, quiet=False):
-            ac = Account(path, logging=self._logging, logid=logid)
+            ac = Account(path, logging=self._logging)
             ac._evtracker = ac.add_account_plugin(FFIEventTracker(ac))
             ac.addr = ac.get_self_contact().addr
+            ac.set_config("displayname", logid)
             if not quiet:
-                ac.add_account_plugin(FFIEventLogger(ac, logid=logid))
+                ac.add_account_plugin(FFIEventLogger(ac))
             self._accounts.append(ac)
             return ac
 
@@ -321,12 +322,16 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
             ac2.start_io()
             return ac1, ac2
 
-        def get_many_online_accounts(self, num, move=True, quiet=True):
-            accounts = [self.get_online_configuring_account(move=move, quiet=quiet)
+        def get_many_online_accounts(self, num, move=True):
+            accounts = [self.get_online_configuring_account(move=move, quiet=True)
                         for i in range(num)]
             for acc in accounts:
                 acc._configtracker.wait_finish()
                 acc.start_io()
+                print("{}: {} account was successfully setup".format(
+                    acc.get_config("displayname"), acc.get_config("addr")))
+            for acc in accounts:
+                acc.add_account_plugin(FFIEventLogger(acc))
             return accounts
 
         def clone_online_account(self, account, pre_generated_key=True):

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -396,15 +396,18 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
             ac2.create_chat(ac1)
             return ac1.create_chat(ac2)
 
-        def accept_each_other(self, accounts, sending=False):
+        def introduce_each_other(self, accounts, sending=True):
+            to_wait = []
             for i, acc in enumerate(accounts):
                 for acc2 in accounts[i + 1:]:
                     chat = self.get_accepted_chat(acc, acc2)
                     if sending:
                         chat.send_text("hi")
-                        acc2._evtracker.wait_next_incoming_message()
+                        to_wait.append(acc2)
                         acc2.create_chat(acc).send_text("hi back")
-                        acc._evtracker.wait_next_incoming_message()
+                        to_wait.append(acc)
+            for acc in to_wait:
+                acc._evtracker.wait_next_incoming_message()
 
     am = AccountMaker()
     request.addfinalizer(am.finalize)

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -396,6 +396,14 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
             ac2.create_chat(ac1)
             return ac1.create_chat(ac2)
 
+        def accept_each_other(self, accounts, sending=False):
+            for i, acc in enumerate(accounts):
+                for acc2 in accounts[i + 1:]:
+                    chat = self.get_accepted_chat(acc, acc2)
+                    if sending:
+                        chat.send_text("hi")
+                        acc2._evtracker.wait_next_incoming_message()
+
     am = AccountMaker()
     request.addfinalizer(am.finalize)
     yield am

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -387,14 +387,9 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
                     imap.dump_account_info(logfile=logfile)
                     imap.dump_imap_structures(tmpdir, logfile=logfile)
 
-        def get_chats(self, ac1, ac2, both=True):
-            chat12 = ac1.create_chat_by_contact(
-                ac1.create_contact(email=ac2.get_config("addr")))
-            chat21 = None
-            if both:
-                chat21 = ac2.create_chat_by_contact(
-                    ac2.create_contact(email=ac1.get_config("addr")))
-            return chat12, chat21
+        def get_accepted_chat(self, ac1, ac2):
+            ac2.create_chat(ac1)
+            return ac1.create_chat(ac2)
 
     am = AccountMaker()
     request.addfinalizer(am.finalize)

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -387,10 +387,6 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
                     imap.dump_account_info(logfile=logfile)
                     imap.dump_imap_structures(tmpdir, logfile=logfile)
 
-        def get_chat(self, ac1, ac2):
-            chat12, chat21 = self.get_chats(ac1, ac2, both=False)
-            return chat12
-
         def get_chats(self, ac1, ac2, both=True):
             chat12 = ac1.create_chat_by_contact(
                 ac1.create_contact(email=ac2.get_config("addr")))

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -403,6 +403,8 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
                     if sending:
                         chat.send_text("hi")
                         acc2._evtracker.wait_next_incoming_message()
+                        acc2.create_chat(acc).send_text("hi back")
+                        acc._evtracker.wait_next_incoming_message()
 
     am = AccountMaker()
     request.addfinalizer(am.finalize)

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -105,8 +105,8 @@ class TestOfflineAccountBasic:
 class TestOfflineContact:
     def test_contact_attr(self, acfactory):
         ac1 = acfactory.get_configured_offline_account()
-        contact1 = ac1.create_contact(addr="some1@hello.com", name="some1")
-        contact2 = ac1.create_contact(addr="some1@hello.com", name="some1")
+        contact1 = ac1.create_contact("some1@hello.com", name="some1")
+        contact2 = ac1.create_contact("some1@hello.com", name="some1")
         str(contact1)
         repr(contact1)
         assert contact1 == contact2
@@ -118,7 +118,7 @@ class TestOfflineContact:
 
     def test_get_contacts_and_delete(self, acfactory):
         ac1 = acfactory.get_configured_offline_account()
-        contact1 = ac1.create_contact(addr="some1@hello.com", name="some1")
+        contact1 = ac1.create_contact("some1@hello.com", name="some1")
         contacts = ac1.get_contacts()
         assert len(contacts) == 1
         assert contact1 in contacts
@@ -133,7 +133,7 @@ class TestOfflineContact:
 
     def test_get_contacts_and_delete_fails(self, acfactory):
         ac1 = acfactory.get_configured_offline_account()
-        contact1 = ac1.create_contact(addr="some1@example.com", name="some1")
+        contact1 = ac1.create_contact("some1@example.com", name="some1")
         msg = contact1.create_chat().send_text("one message")
         assert not ac1.delete_contact(contact1)
         assert not msg.filemime
@@ -802,7 +802,7 @@ class TestOnlineAccount:
 
         lp.sec("ac1: creating group chat, and forward own message")
         group = ac1.create_group_chat("newgroup2")
-        group.add_contact(ac1.create_contact(ac2.get_config("addr")))
+        group.add_contact(ac2)
         ac1.forward_messages([msg_out], group)
 
         # wait for other account to receive
@@ -1485,7 +1485,7 @@ class TestOnlineAccount:
         assert locations[0].accuracy == 0.5
         assert locations[0].timestamp > now
 
-        contact = ac2.create_contact(ac1.get_config("addr"))
+        contact = ac2.create_contact(ac1)
         locations2 = chat2.get_locations(contact=contact)
         assert len(locations2) == 1
         assert locations2 == locations

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1508,7 +1508,7 @@ class TestOnlineAccount:
         lp.sec("creating and configuring three accounts")
         ac1, ac2, ac3 = acfactory.get_many_online_accounts(3)
 
-        acfactory.accept_each_other([ac1, ac2, ac3], sending=True)
+        acfactory.introduce_each_other([ac1, ac2, ac3])
 
         lp.sec("ac3 reinstalls DC and generates a new key")
         ac3.stop_io()
@@ -1568,7 +1568,7 @@ class TestOnlineAccount:
 class TestGroupStressTests:
     def test_group_many_members_add_leave_remove(self, acfactory, lp):
         accounts = acfactory.get_many_online_accounts(5)
-        acfactory.accept_each_other(accounts, sending=True)
+        acfactory.introduce_each_other(accounts)
         ac1, ac5 = accounts.pop(), accounts.pop()
 
         lp.sec("ac1: creating group chat with 3 other members")
@@ -1641,7 +1641,7 @@ class TestGroupStressTests:
         """
         lp.sec("setting up accounts, accepted with each other")
         accounts = acfactory.get_many_online_accounts(3)
-        acfactory.accept_each_other(accounts, sending=True)
+        acfactory.introduce_each_other(accounts)
         ac1, ac2, ac3 = accounts
 
         lp.sec("ac1: creating group chat with 2 other members")

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -126,8 +126,7 @@ class TestOfflineContact:
         assert not ac1.get_contacts(query="some2")
         assert ac1.get_contacts(query="some1")
         assert not ac1.get_contacts(only_verified=True)
-        contacts = ac1.get_contacts(with_self=True)
-        assert len(contacts) == 2
+        assert len(ac1.get_contacts(with_self=True)) == 2
 
         assert ac1.delete_contact(contact1)
         assert contact1 not in ac1.get_contacts()
@@ -471,8 +470,7 @@ class TestOfflineChat:
             lp.sec("add contact")
             chat.add_contact(contact)
 
-        num_contacts = len(chat.get_contacts())
-        assert num_contacts == 11
+        assert chat.num_contacts() == 11
 
         # let's make sure the events perform plugin hooks
         def wait_events(cond):
@@ -501,7 +499,7 @@ class TestOfflineChat:
         lp.sec("ac1: removing two contacts and checking things are right")
         chat.remove_contact(contacts[9])
         chat.remove_contact(contacts[3])
-        assert len(chat.get_contacts()) == 9
+        assert chat.num_contacts() == 9
 
         wait_events(lambda: len(in_list) == 2)
         assert len(in_list) == 2
@@ -1582,15 +1580,14 @@ class TestGroupStressTests:
         gossiped_timestamp = chat.get_summary()["gossiped_timestamp"]
         assert gossiped_timestamp > 0
 
-        num_contacts = len(chat.get_contacts())
-        assert num_contacts == 3 + 1
+        assert chat.num_contacts() == 3 + 1
 
         lp.sec("ac2: checking that the chat arrived correctly")
         ac2 = accounts[0]
         msg2 = ac2._evtracker.wait_next_incoming_message()
         assert msg2.text == "hello"
         print("chat is", msg2.chat)
-        assert len(msg2.chat.get_contacts()) == 4
+        assert msg2.chat.num_contacts() == 4
 
         lp.sec("ac3: checking that 'ac4' is a known contact")
         ac3 = accounts[1]
@@ -1608,7 +1605,7 @@ class TestGroupStressTests:
         lp.sec("ac1: receiving system message about contact removal")
         sysmsg = ac1._evtracker.wait_next_incoming_message()
         assert to_remove.addr in sysmsg.text
-        assert len(sysmsg.chat.get_contacts()) == 3
+        assert sysmsg.chat.num_contacts() == 3
 
         # Receiving message about removed contact does not reset gossip
         assert chat.get_summary()["gossiped_timestamp"] == gossiped_timestamp
@@ -1627,7 +1624,7 @@ class TestGroupStressTests:
         lp.sec("ac2: receiving system message about contact addition")
         sysmsg = ac2._evtracker.wait_next_incoming_message()
         assert ac5.addr in sysmsg.text
-        assert len(sysmsg.chat.get_contacts()) == 4
+        assert sysmsg.chat.num_contacts() == 4
 
         lp.sec("ac5: waiting for message about addition to the chat")
         sysmsg = ac5._evtracker.wait_next_incoming_message()
@@ -1655,15 +1652,14 @@ class TestGroupStressTests:
         msg = chat.send_text("hello")
         assert chat.is_promoted() and msg.is_encrypted()
 
-        num_contacts = len(chat.get_contacts())
-        assert num_contacts == 3
+        assert chat.num_contacts() == 3
 
         lp.sec("checking that the chat arrived correctly")
         for ac in accounts[1:]:
             msg = ac._evtracker.wait_next_incoming_message()
             assert msg.text == "hello"
             print("chat is", msg.chat)
-            assert len(msg.chat.get_contacts()) == 3
+            assert msg.chat.num_contacts() == 3
 
         lp.sec("ac1: removing ac2")
         chat.remove_contact(ac2)
@@ -1682,7 +1678,7 @@ class TestGroupStressTests:
         lp.sec("ac2: check that ac3 is removed")
         msg = ac2._evtracker.wait_next_incoming_message()
 
-        assert len(msg.chat.get_contacts()) == len(chat.get_contacts())
+        assert msg.chat.num_contacts() == chat.num_contacts()
         acfactory.dump_imap_summary(sys.stdout)
 
 

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -105,20 +105,20 @@ class TestOfflineAccountBasic:
 class TestOfflineContact:
     def test_contact_attr(self, acfactory):
         ac1 = acfactory.get_configured_offline_account()
-        contact1 = ac1.create_contact("some1@hello.com", name="some1")
-        contact2 = ac1.create_contact("some1@hello.com", name="some1")
+        contact1 = ac1.create_contact("some1@example.org", name="some1")
+        contact2 = ac1.create_contact("some1@example.org", name="some1")
         str(contact1)
         repr(contact1)
         assert contact1 == contact2
         assert contact1.id
-        assert contact1.addr == "some1@hello.com"
+        assert contact1.addr == "some1@example.org"
         assert contact1.display_name == "some1"
         assert not contact1.is_blocked()
         assert not contact1.is_verified()
 
     def test_get_contacts_and_delete(self, acfactory):
         ac1 = acfactory.get_configured_offline_account()
-        contact1 = ac1.create_contact("some1@hello.com", name="some1")
+        contact1 = ac1.create_contact("some1@example.org", name="some1")
         contacts = ac1.get_contacts()
         assert len(contacts) == 1
         assert contact1 in contacts
@@ -156,7 +156,7 @@ class TestOfflineChat:
 
     @pytest.fixture
     def chat1(self, ac1):
-        return ac1.create_contact("some1@hello.com", name="some1").create_chat()
+        return ac1.create_contact("some1@example.org", name="some1").create_chat()
 
     def test_display(self, chat1):
         str(chat1)
@@ -198,8 +198,8 @@ class TestOfflineChat:
         chat.remove_contact(ac2)
 
     def test_group_chat_creation(self, ac1):
-        contact1 = ac1.create_contact("some1@hello.com", name="some1")
-        contact2 = ac1.create_contact("some2@hello.com", name="some2")
+        contact1 = ac1.create_contact("some1@example.org", name="some1")
+        contact2 = ac1.create_contact("some2@example.org", name="some2")
         chat = ac1.create_group_chat(name="title1", contacts=[contact1, contact2])
         assert chat.get_name() == "title1"
         assert contact1 in chat.get_contacts()
@@ -228,8 +228,8 @@ class TestOfflineChat:
         with pytest.raises(ValueError):
             ac1.set_stock_translation(500, "xyz %1$s")
         ac1._evtracker.get_matching("DC_EVENT_WARNING")
-        contact1 = ac1.create_contact("some1@hello.com", name="some1")
-        contact2 = ac1.create_contact("some2@hello.com", name="some2")
+        contact1 = ac1.create_contact("some1@example.org", name="some1")
+        contact2 = ac1.create_contact("some2@example.org", name="some2")
         chat = ac1.create_group_chat(name="title1", contacts=[contact1, contact2])
         assert chat.get_name() == "title1"
         assert contact1 in chat.get_contacts()
@@ -368,7 +368,7 @@ class TestOfflineChat:
 
     def test_create_chat_simple(self, acfactory):
         ac1 = acfactory.get_configured_offline_account()
-        contact1 = ac1.create_contact("some1@hello.com", name="some1")
+        contact1 = ac1.create_contact("some1@example.org", name="some1")
         contact1.create_chat().send_text("hello")
 
     def test_chat_message_distinctions(self, ac1, chat1):
@@ -390,7 +390,7 @@ class TestOfflineChat:
     def test_import_export_one_contact(self, acfactory, tmpdir):
         backupdir = tmpdir.mkdir("backup")
         ac1 = acfactory.get_configured_offline_account()
-        chat = ac1.create_contact("some1 <some1@hello.com>").create_chat()
+        chat = ac1.create_contact("some1 <some1@example.org>").create_chat()
         # send a text message
         msg = chat.send_text("msg1")
         # send a binary file
@@ -408,7 +408,7 @@ class TestOfflineChat:
         contacts = ac2.get_contacts(query="some1")
         assert len(contacts) == 1
         contact2 = contacts[0]
-        assert contact2.addr == "some1@hello.com"
+        assert contact2.addr == "some1@example.org"
         chat2 = contact2.create_chat()
         messages = chat2.get_messages()
         assert len(messages) == 2
@@ -1139,7 +1139,7 @@ class TestOnlineAccount:
         ac1 = acfactory.get_one_online_account()
 
         lp.sec("create some chat content")
-        contact1 = ac1.create_contact("some1@hello.com", name="some1")
+        contact1 = ac1.create_contact("some1@example.org", name="some1")
         contact1.create_chat().send_text("msg1")
         assert len(ac1.get_contacts(query="some1")) == 1
         backupdir = tmpdir.mkdir("backup")
@@ -1161,7 +1161,7 @@ class TestOnlineAccount:
         contacts = ac2.get_contacts(query="some1")
         assert len(contacts) == 1
         contact2 = contacts[0]
-        assert contact2.addr == "some1@hello.com"
+        assert contact2.addr == "some1@example.org"
         chat2 = contact2.create_chat()
         messages = chat2.get_messages()
         assert len(messages) == 1

--- a/python/tests/test_increation.py
+++ b/python/tests/test_increation.py
@@ -74,7 +74,7 @@ class TestOnlineInCreation:
 
         lp.sec("forward the message while still in creation")
         chat2 = ac1.create_group_chat("newgroup")
-        chat2.add_contact(ac2.get_self_contact())
+        chat2.add_contact(ac2)
         wait_msgs_changed(ac1, [(0, 0)])  # why not chat id?
         ac1.forward_messages([prepared_original], chat2)
         # XXX there might be two EVENT_MSGS_CHANGED and only one of them

--- a/python/tests/test_increation.py
+++ b/python/tests/test_increation.py
@@ -36,9 +36,7 @@ def wait_msgs_changed(account, msgs_list):
 class TestOnlineInCreation:
     def test_increation_not_blobdir(self, tmpdir, acfactory, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()
-
-        c2 = ac1.create_contact(email=ac2.get_config("addr"))
-        chat = ac1.create_chat_by_contact(c2)
+        chat = ac1.create_chat(ac2)
 
         lp.sec("Creating in-creation file outside of blobdir")
         assert tmpdir.strpath != ac1.get_blobdir()
@@ -48,9 +46,7 @@ class TestOnlineInCreation:
 
     def test_no_increation_copies_to_blobdir(self, tmpdir, acfactory, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()
-
-        c2 = ac1.create_contact(email=ac2.get_config("addr"))
-        chat = ac1.create_chat_by_contact(c2)
+        chat = ac1.create_chat(ac2)
 
         lp.sec("Creating file outside of blobdir")
         assert tmpdir.strpath != ac1.get_blobdir()
@@ -64,9 +60,7 @@ class TestOnlineInCreation:
     def test_forward_increation(self, acfactory, data, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()
 
-        c2 = ac1.create_contact(email=ac2.get_config("addr"))
-        chat = ac1.create_chat_by_contact(c2)
-        assert chat.id >= const.DC_CHAT_ID_LAST_SPECIAL
+        chat = ac1.create_chat(ac2)
         wait_msgs_changed(ac1, [(0, 0)])  # why no chat id?
 
         lp.sec("create a message with a file in creation")
@@ -80,7 +74,7 @@ class TestOnlineInCreation:
 
         lp.sec("forward the message while still in creation")
         chat2 = ac1.create_group_chat("newgroup")
-        chat2.add_contact(c2)
+        chat2.add_contact(ac2.get_self_contact())
         wait_msgs_changed(ac1, [(0, 0)])  # why not chat id?
         ac1.forward_messages([prepared_original], chat2)
         # XXX there might be two EVENT_MSGS_CHANGED and only one of them

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -69,8 +69,8 @@ def test_sig():
 def test_markseen_invalid_message_ids(acfactory):
     ac1 = acfactory.get_configured_offline_account()
 
-    contact1 = ac1.create_contact(email="some1@example.com", name="some1")
-    chat = ac1.create_chat_by_contact(contact1)
+    contact1 = ac1.create_contact(addr="some1@example.com", name="some1")
+    chat = contact1.create_chat()
     chat.send_text("one messae")
     ac1._evtracker.get_matching("DC_EVENT_MSGS_CHANGED")
     msg_ids = [9]

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -69,7 +69,7 @@ def test_sig():
 def test_markseen_invalid_message_ids(acfactory):
     ac1 = acfactory.get_configured_offline_account()
 
-    contact1 = ac1.create_contact(addr="some1@example.com", name="some1")
+    contact1 = ac1.create_contact("some1@example.com", name="some1")
     chat = contact1.create_chat()
     chat.send_text("one messae")
     ac1._evtracker.get_matching("DC_EVENT_MSGS_CHANGED")


### PR DESCRIPTION
- make `account.create_chat(obj)` work with Account, Contact or e-mail address objects 
- remove some now unneeded helper functions 
- introduce `account.as_contact(obj) ` to create a contact from an account, contact or e-mail address
- refactor more complex setups into common helpers 
- simplify several tests, reducing LOCs