### PR TITLE
simplify configure(), avoid special attribute in non-test mode

### DIFF
--- a/python/src/deltachat/__init__.py
+++ b/python/src/deltachat/__init__.py
@@ -77,8 +77,8 @@ def run_cmdline(argv=None, account_plugins=None):
         ac.set_config("mvbox_move", "0")
         ac.set_config("mvbox_watch", "0")
         ac.set_config("sentbox_watch", "0")
-        ac.configure()
-        ac.wait_configure_finish()
+        configtracker = ac.configure()
+        configtracker.wait_finish()
 
     # start IO threads and configure if neccessary
     ac.start_io()

--- a/python/src/deltachat/tracker.py
+++ b/python/src/deltachat/tracker.py
@@ -64,6 +64,7 @@ class ConfigureTracker:
         if success:
             self._gm.hook.dc_account_extra_configure(account=self.account)
         self._configure_events.put(success)
+        self.account.remove_account_plugin(self)
 
     def wait_smtp_connected(self):
         """ wait until smtp is configured. """


### PR DESCRIPTION
it caused problems when using it from the command line. 
also, it reduces LOCs. 