### PR TITLE
[WIP] Upload and download large attachements through HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,15 +143,6 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
-
-[[package]]
-name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
@@ -203,7 +194,7 @@ dependencies = [
  "imap-proto",
  "lazy_static",
  "log",
- "nom 5.1.1",
+ "nom 5.1.2",
  "pin-utils",
  "rental",
  "stop-token",
@@ -236,7 +227,7 @@ dependencies = [
  "fast_chemail",
  "hostname",
  "log",
- "nom 5.1.1",
+ "nom 5.1.2",
  "pin-project",
  "pin-utils",
  "serde",
@@ -384,7 +375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.1",
+ "arrayvec",
  "constant_time_eq",
 ]
 
@@ -1556,7 +1547,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16a6def1d5ac8975d70b3fd101d57953fe3278ef2ee5d7816cba54b1d1dfc22f"
 dependencies = [
- "nom 5.1.1",
+ "nom 5.1.2",
 ]
 
 [[package]]
@@ -1678,13 +1669,13 @@ dependencies = [
 
 [[package]]
 name = "lexical-core"
-version = "0.6.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890"
+checksum = "db65c6da02e61f55dae90a0ae427b2a5f6b3e8db09f58d10efab23af92592616"
 dependencies = [
- "arrayvec 0.4.12",
+ "arrayvec",
+ "bitflags",
  "cfg-if",
- "rustc_version",
  "ryu",
  "static_assertions",
 ]
@@ -1857,12 +1848,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
 name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,9 +1859,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "5.1.1"
+version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
  "lexical-core",
  "memchr",
@@ -1926,9 +1911,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
 dependencies = [
  "autocfg 1.0.0",
  "num-traits",
@@ -1936,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb0800a0291891dd9f4fe7bd9c19384f98f7fbe0cd0f39a2c6b88b9868bbc00"
+checksum = "7a6e6b7c748f995c4c29c5f5ae0248536e04a5739927c74ec0fa564805094b9f"
 dependencies = [
  "autocfg 1.0.0",
  "num-integer",
@@ -1958,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
 dependencies = [
  "autocfg 1.0.0",
 ]
@@ -2911,9 +2896,9 @@ dependencies = [
 
 [[package]]
 name = "static_assertions"
-version = "0.3.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stdweb"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,6 +834,7 @@ dependencies = [
  "native-tls",
  "num-derive",
  "num-traits",
+ "open",
  "percent-encoding",
  "pgp",
  "pretty_assertions",
@@ -1977,6 +1978,15 @@ name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "open"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c283bf0114efea9e42f1a60edea9859e8c47528eae09d01df4b29c1e489cc48"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "openssl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ pretty_env_logger = { version = "0.4.0", optional = true }
 log = {version = "0.4.8", optional = true }
 rustyline = { version = "4.1.0", optional = true }
 ansi_term = { version = "0.12.1", optional = true }
+open = { version = "1.4.0", optional = true }
 
 
 [dev-dependencies]
@@ -93,7 +94,7 @@ required-features = ["repl"]
 [features]
 default = []
 internals = []
-repl = ["internals", "rustyline", "log", "pretty_env_logger", "ansi_term"]
+repl = ["internals", "rustyline", "log", "pretty_env_logger", "ansi_term", "open"]
 vendored = ["async-native-tls/vendored", "async-smtp/native-tls-vendored"]
 nightly = ["pgp/nightly"]
 

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -370,6 +370,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                  ===========================Message commands==\n\
                  listmsgs <query>\n\
                  msginfo <msg-id>\n\
+                 openfile <msg-id>\n\
                  listfresh\n\
                  forward <msg-id> <chat-id>\n\
                  markseen <msg-id>\n\
@@ -889,6 +890,15 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             let id = MsgId::new(arg1.parse()?);
             let res = message::get_msg_info(&context, id).await;
             println!("{}", res);
+        }
+        "openfile" => {
+            ensure!(!arg1.is_empty(), "Argument <msg-id> missing.");
+            let id = MsgId::new(arg1.parse()?);
+            let msg = Message::load_from_db(&context, id).await?;
+            let filepath = msg.get_file(&context);
+            ensure!(filepath.is_some(), "Message has no file.");
+            let filepath = filepath.unwrap();
+            open::that(filepath)?;
         }
         "listfresh" => {
             let msglist = context.get_fresh_msgs().await;

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -371,6 +371,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                  listmsgs <query>\n\
                  msginfo <msg-id>\n\
                  openfile <msg-id>\n\
+                 download <msg-id>\n\
                  listfresh\n\
                  forward <msg-id> <chat-id>\n\
                  markseen <msg-id>\n\
@@ -899,6 +900,16 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             ensure!(filepath.is_some(), "Message has no file.");
             let filepath = filepath.unwrap();
             open::that(filepath)?;
+        }
+        "download" => {
+            ensure!(!arg1.is_empty(), "Argument <msg-id> missing.");
+            let id = MsgId::new(arg1.parse()?);
+            let path = if !arg2.is_empty() {
+                Some(arg2.into())
+            } else {
+                None
+            };
+            message::schedule_download(&context, id, path).await?;
         }
         "listfresh" => {
             let msglist = context.get_fresh_msgs().await;

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -186,9 +186,10 @@ const CHAT_COMMANDS: [&str; 26] = [
     "unpin",
     "delchat",
 ];
-const MESSAGE_COMMANDS: [&str; 8] = [
+const MESSAGE_COMMANDS: [&str; 9] = [
     "listmsgs",
     "msginfo",
+    "openfile",
     "listfresh",
     "forward",
     "markseen",

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -186,10 +186,11 @@ const CHAT_COMMANDS: [&str; 26] = [
     "unpin",
     "delchat",
 ];
-const MESSAGE_COMMANDS: [&str; 9] = [
+const MESSAGE_COMMANDS: [&str; 10] = [
     "listmsgs",
     "msginfo",
     "openfile",
+    "download",
     "listfresh",
     "forward",
     "markseen",

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -359,6 +359,10 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
 
             bot_ac, bot_cfg = self.get_online_config()
 
+            # Avoid starting ac so we don't interfere with the bot operating on
+            # the same database.
+            self._accounts.remove(bot_ac)
+
             args = [
                 sys.executable,
                 "-u",

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -599,9 +599,9 @@ async fn add_parts(
     }
     // correct message_timestamp, it should not be used before,
     // however, we cannot do this earlier as we need from_id to be set
-    let (sort_timestamp, new_sent_timestamp, rcvd_timestamp) =
-        calc_timestamps(context, *sent_timestamp, *chat_id, !seen).await;
-    *sent_timestamp = new_sent_timestamp;
+    let rcvd_timestamp = time();
+    let sort_timestamp = calc_sort_timestamp(context, *sent_timestamp, *chat_id, !seen).await;
+    *sent_timestamp = std::cmp::min(*sent_timestamp, rcvd_timestamp);
 
     // unarchive chat
     chat_id.unarchive(context).await?;
@@ -827,17 +827,12 @@ async fn save_locations(
     }
 }
 
-async fn calc_timestamps(
+async fn calc_sort_timestamp(
     context: &Context,
     message_timestamp: i64,
     chat_id: ChatId,
     is_fresh_msg: bool,
-) -> (i64, i64, i64) {
-    let rcvd_timestamp = time();
-    let mut sent_timestamp = message_timestamp;
-    if sent_timestamp > rcvd_timestamp {
-        sent_timestamp = rcvd_timestamp
-    }
+) -> i64 {
     let mut sort_timestamp = message_timestamp;
 
     // get newest non fresh message for this chat
@@ -863,7 +858,7 @@ async fn calc_timestamps(
         sort_timestamp = dc_create_smeared_timestamp(context).await;
     }
 
-    (sort_timestamp, sent_timestamp, rcvd_timestamp)
+    sort_timestamp
 }
 
 /// This function tries extracts the group-id from the message and returns the

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -34,6 +34,7 @@ pub enum HeaderDef {
     ChatContent,
     ChatDuration,
     ChatDispositionNotificationTo,
+    ChatUploadUrl,
     Autocrypt,
     AutocryptSetupMessage,
     SecureJoin,

--- a/src/job.rs
+++ b/src/job.rs
@@ -333,14 +333,11 @@ impl Job {
 
     pub(crate) async fn send_msg_to_smtp(&mut self, context: &Context, smtp: &mut Smtp) -> Status {
         // Upload file to HTTP if set in params.
-        match (
+        if let (Some(upload_url), Ok(Some(upload_path))) = (
             self.param.get_upload_url(),
             self.param.get_upload_path(context),
         ) {
-            (Some(upload_url), Ok(Some(upload_path))) => {
-                job_try!(upload_file(context, upload_url.to_string(), upload_path).await);
-            }
-            _ => {}
+            job_try!(upload_file(context, upload_url.to_string(), upload_path).await);
         }
 
         //  SMTP server, if not yet done

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ mod simplify;
 mod smtp;
 pub mod stock;
 mod token;
+pub(crate) mod upload;
 #[macro_use]
 mod dehtml;
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -50,6 +50,7 @@ pub struct MimeFactory<'a, 'b> {
     context: &'a Context,
     last_added_location_id: u32,
     attach_selfavatar: bool,
+    include_file: bool,
 }
 
 /// Result of rendering a message, ready to be submitted to a send job.
@@ -159,6 +160,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             last_added_location_id: 0,
             attach_selfavatar,
             context,
+            include_file: true,
         };
         Ok(factory)
     }
@@ -206,6 +208,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             req_mdn: false,
             last_added_location_id: 0,
             attach_selfavatar: false,
+            include_file: true,
         };
 
         Ok(res)
@@ -407,6 +410,10 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             .iter()
             .map(|(_, addr)| addr.clone())
             .collect()
+    }
+
+    pub fn set_include_file(&mut self, include_file: bool) {
+        self.include_file = include_file
     }
 
     pub async fn render(mut self) -> Result<RenderedEmail, Error> {
@@ -900,7 +907,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
         let mut parts = Vec::new();
 
         // add attachment part
-        if chat::msgtype_has_file(self.msg.viewtype) {
+        if chat::msgtype_has_file(self.msg.viewtype) && self.include_file {
             if !is_file_size_okay(context, &self.msg).await {
                 bail!(
                     "Message exceeds the recommended {} MB.",

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -50,7 +50,7 @@ pub struct MimeFactory<'a, 'b> {
     context: &'a Context,
     last_added_location_id: u32,
     attach_selfavatar: bool,
-    include_file: bool,
+    upload_url: Option<String>,
 }
 
 /// Result of rendering a message, ready to be submitted to a send job.
@@ -160,7 +160,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             last_added_location_id: 0,
             attach_selfavatar,
             context,
-            include_file: true,
+            upload_url: None,
         };
         Ok(factory)
     }
@@ -208,7 +208,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             req_mdn: false,
             last_added_location_id: 0,
             attach_selfavatar: false,
-            include_file: true,
+            upload_url: None,
         };
 
         Ok(res)
@@ -412,8 +412,8 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             .collect()
     }
 
-    pub fn set_include_file(&mut self, include_file: bool) {
-        self.include_file = include_file
+    pub fn set_upload_url(&mut self, upload_url: String) {
+        self.upload_url = Some(upload_url)
     }
 
     pub async fn render(mut self) -> Result<RenderedEmail, Error> {
@@ -886,11 +886,21 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             }
         };
 
+        // if upload url is present: add as header and to message text
+        // TODO: make text part translatable (or remove)
+        let upload_url_text = if let Some(ref upload_url) = self.upload_url {
+            protected_headers.push(Header::new("Chat-Upload-Url".into(), upload_url.clone()));
+            Some(format!("\n\nFile attachement: {}", upload_url.clone()))
+        } else {
+            None
+        };
+
         let footer = &self.selfstatus;
         let message_text = format!(
-            "{}{}{}{}{}",
+            "{}{}{}{}{}{}",
             fwdhint.unwrap_or_default(),
             escape_message_footer_marks(final_text),
+            upload_url_text.unwrap_or_default(),
             if !final_text.is_empty() && !footer.is_empty() {
                 "\r\n\r\n"
             } else {
@@ -906,8 +916,8 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             .body(message_text);
         let mut parts = Vec::new();
 
-        // add attachment part
-        if chat::msgtype_has_file(self.msg.viewtype) && self.include_file {
+        // add attachment part, skip if upload url was provided
+        if chat::msgtype_has_file(self.msg.viewtype) && self.upload_url.is_none() {
             if !is_file_size_okay(context, &self.msg).await {
                 bail!(
                     "Message exceeds the recommended {} MB.",

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -334,6 +334,13 @@ impl MimeMessage {
             }
         }
 
+        let upload_url = self.get(HeaderDef::ChatUploadUrl).map(|v| v.to_string());
+        if let Some(upload_url) = upload_url {
+            for part in self.parts.iter_mut() {
+                part.param.set_upload_url(upload_url.clone());
+            }
+        }
+
         self.parse_attachments();
 
         // See if an MDN is requested from the other side

--- a/src/param.rs
+++ b/src/param.rs
@@ -120,6 +120,12 @@ pub enum Param {
 
     /// For MDN-sending job
     MsgId = b'I',
+
+    /// For messages that have a HTTP file upload instead of attachement
+    UploadUrl = b'y',
+
+    /// For messages that have a HTTP file upload instead of attachement: Path to local file
+    UploadPath = b'Y',
 }
 
 /// Possible values for `Param::ForcePlaintext`.
@@ -315,6 +321,23 @@ impl Params {
             ParamsFile::Blob(blob) => blob.to_abs_path(),
         };
         Ok(Some(path))
+    }
+
+    pub fn get_upload_url(&self) -> Option<&str> {
+        self.get(Param::UploadUrl)
+    }
+
+    pub fn get_upload_path(&self, context: &Context) -> Result<Option<PathBuf>, BlobError> {
+        self.get_path(Param::UploadPath, context)
+    }
+
+    pub fn set_upload_path(&mut self, path: PathBuf) {
+        // TODO: Remove unwrap? May panic for invalid UTF8 in path.
+        self.set(Param::UploadPath, path.to_str().unwrap());
+    }
+
+    pub fn set_upload_url(&mut self, url: impl AsRef<str>) {
+        self.set(Param::UploadUrl, url);
     }
 
     pub fn get_msg_id(&self) -> Option<MsgId> {

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -1,0 +1,17 @@
+use crate::context::Context;
+use crate::error::{bail, Result};
+use async_std::path::PathBuf;
+
+/// Upload file to a HTTP upload endpoint.
+pub async fn upload_file(_context: &Context, endpoint: String, file: PathBuf) -> Result<String> {
+    // TODO: Use tokens for upload, encrypt file with PGP.
+    let response = surf::post(endpoint).body_file(file)?.await;
+    if let Err(err) = response {
+        bail!("Upload failed: {}", err);
+    }
+    let mut response = response.unwrap();
+    match response.body_string().await {
+        Ok(string) => Ok(string),
+        Err(err) => bail!("Invalid response from upload: {}", err),
+    }
+}

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -1,12 +1,26 @@
 use crate::context::Context;
 use crate::error::{bail, Result};
+use crate::pgp::{symm_decrypt, symm_encrypt_bytes};
+use async_std::fs;
 use async_std::path::PathBuf;
 use rand::Rng;
+use std::io::Cursor;
+use url::Url;
 
 /// Upload file to a HTTP upload endpoint.
-pub async fn upload_file(_context: &Context, url: String, filepath: PathBuf) -> Result<String> {
-    // TODO: Use tokens for upload, encrypt file with PGP.
-    let response = surf::put(url).body_file(filepath)?.await;
+pub async fn upload_file(
+    context: &Context,
+    url: impl AsRef<str>,
+    filepath: PathBuf,
+) -> Result<String> {
+    let (passphrase, url) = parse_upload_url(url)?;
+
+    let content = fs::read(filepath).await?;
+    let encrypted = symm_encrypt_bytes(&passphrase, &content).await?;
+
+    // TODO: Use tokens for upload.
+    info!(context, "uploading encrypted file to {}", &url);
+    let response = surf::put(url).body_bytes(encrypted).await;
     if let Err(err) = response {
         bail!("Upload failed: {}", err);
     }
@@ -17,16 +31,59 @@ pub async fn upload_file(_context: &Context, url: String, filepath: PathBuf) -> 
     }
 }
 
+/// Download and decrypt a file from a HTTP endpoint.
+/// TODO: Use this.
+#[allow(dead_code)]
+pub async fn download_file(context: &Context, url: String) -> Result<Vec<u8>> {
+    let (passphrase, url) = parse_upload_url(url)?;
+    info!(context, "downloading file from {}", &url);
+    let response = surf::get(url).recv_bytes().await;
+    if let Err(err) = response {
+        bail!("Download failed: {}", err);
+    }
+    let reader = Cursor::new(response.unwrap());
+    let decrypted = symm_decrypt(&passphrase, reader).await?;
+    Ok(decrypted)
+}
+
+/// Parse a URL from a string and take out the hash fragment.
+fn parse_upload_url(url: impl AsRef<str>) -> Result<(String, Url)> {
+    let mut url = url::Url::parse(url.as_ref())?;
+    let passphrase = url.fragment();
+    if passphrase.is_none() {
+        bail!("Missing passphrase for upload URL");
+    }
+    let passphrase = passphrase.unwrap().to_string();
+    url.set_fragment(None);
+    Ok((passphrase, url))
+}
+
 /// Generate a random URL based on the provided endpoint.
-pub fn generate_upload_url(_context: &Context, endpoint: String) -> String {
+pub fn generate_upload_url(_context: &Context, mut endpoint: String) -> String {
+    // equals at least 16 random bytes (base32 takes 160% of binary size).
+    const FILENAME_LEN: usize = 26;
+    // equals at least 32 random bytes.
+    const PASSPHRASE_LEN: usize = 52;
+
+    if endpoint.chars().last() == Some('/') {
+        endpoint.pop();
+    }
+    let passphrase = generate_token_string(PASSPHRASE_LEN);
+    let filename = generate_token_string(FILENAME_LEN);
+    format!("{}/{}#{}", endpoint, filename, passphrase)
+}
+
+/// Generate a random string encoded in base32.
+/// Len is the desired string length of the result.
+/// TODO: There's likely better methods to create random tokens.
+pub fn generate_token_string(len: usize) -> String {
     const CROCKFORD_ALPHABET: &[u8] = b"0123456789abcdefghjkmnpqrstvwxyz";
-    const FILENAME_LEN: usize = 27;
     let mut rng = rand::thread_rng();
-    let filename: String = (0..FILENAME_LEN)
+    let token: String = (0..len)
         .map(|_| {
             let idx = rng.gen_range(0, CROCKFORD_ALPHABET.len());
             CROCKFORD_ALPHABET[idx] as char
         })
         .collect();
-    format!("{}{}", endpoint, filename)
+    token
 }

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -1,11 +1,12 @@
 use crate::context::Context;
 use crate::error::{bail, Result};
 use async_std::path::PathBuf;
+use rand::Rng;
 
 /// Upload file to a HTTP upload endpoint.
-pub async fn upload_file(_context: &Context, endpoint: String, file: PathBuf) -> Result<String> {
+pub async fn upload_file(_context: &Context, url: String, filepath: PathBuf) -> Result<String> {
     // TODO: Use tokens for upload, encrypt file with PGP.
-    let response = surf::post(endpoint).body_file(file)?.await;
+    let response = surf::put(url).body_file(filepath)?.await;
     if let Err(err) = response {
         bail!("Upload failed: {}", err);
     }
@@ -14,4 +15,18 @@ pub async fn upload_file(_context: &Context, endpoint: String, file: PathBuf) ->
         Ok(string) => Ok(string),
         Err(err) => bail!("Invalid response from upload: {}", err),
     }
+}
+
+/// Generate a random URL based on the provided endpoint.
+pub fn generate_upload_url(_context: &Context, endpoint: String) -> String {
+    const CROCKFORD_ALPHABET: &[u8] = b"0123456789abcdefghjkmnpqrstvwxyz";
+    const FILENAME_LEN: usize = 27;
+    let mut rng = rand::thread_rng();
+    let filename: String = (0..FILENAME_LEN)
+        .map(|_| {
+            let idx = rng.gen_range(0, CROCKFORD_ALPHABET.len());
+            CROCKFORD_ALPHABET[idx] as char
+        })
+        .collect();
+    format!("{}{}", endpoint, filename)
 }

--- a/upload-server/.gitignore
+++ b/upload-server/.gitignore
@@ -1,0 +1,4 @@
+uploads
+node_modules
+yarn*
+.gitfoo

--- a/upload-server/README.md
+++ b/upload-server/README.md
@@ -1,0 +1,17 @@
+# deltachat-upload-server
+
+Demo server for the HTTP file upload feature.
+
+### Usage
+
+```
+npm install
+node server.js
+```
+
+Configure with environment variables:
+* `UPLOAD_PATH`: Path to upload files to (default: `./uploads`)
+* `PORT`: Port to listen on (default: `8080`)
+* `HOSTNAME`: Hostname to listen on (default: `0.0.0.0`)
+* `BASEURL`: Base URL for generated links (default: `http://[hostname]:[port]/`)
+

--- a/upload-server/package.json
+++ b/upload-server/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "deltachat-upload-server",
+  "version": "1.0.0",
+  "main": "server.js",
+  "license": "MIT",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.17.1"
+  }
+}

--- a/upload-server/package.json
+++ b/upload-server/package.json
@@ -7,6 +7,7 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "base32": "^0.0.6",
     "express": "^4.17.1"
   }
 }

--- a/upload-server/server.js
+++ b/upload-server/server.js
@@ -1,5 +1,4 @@
 const p = require('path')
-const crypto = require('crypto')
 const express = require('express')
 const fs = require('fs')
 const { pipeline } = require('stream')
@@ -10,44 +9,65 @@ const config = {
   path: process.env.UPLOAD_PATH || p.resolve('./uploads'),
   port: process.env.PORT || 8080,
   hostname: process.env.HOSTNAME || '0.0.0.0',
-  baseurl: process.env.BASE_URL || null
+  baseurl: process.env.BASE_URL
 }
 
+if (!config.baseurl) config.baseurl = `http://${config.hostname}:${config.port}/`
 if (!config.baseurl.endsWith('/')) config.baseurl = config.baseurl + '/'
 
 if (!fs.existsSync(config.path)) {
   fs.mkdirSync(config.path, { recursive: true })
 }
 
-const baseUrl = config.baseurl || `http://${config.hostname}:${config.port}/`
+app.use('/:filename', checkFilenameMiddleware)
+app.put('/:filename', (req, res) => {
+  const uploadpath = req.uploadpath
+  const filename = req.params.filename
+  fs.stat(uploadpath, (err, stat) => {
+    if (err && err.code !== 'ENOENT') {
+      console.error('error', err.message)
+      return res.code(500).send('internal server error')
+    }
+    if (stat) return res.status(500).send('filename in use')
 
-app.post('*', (req, res) => {
-  const filename = crypto.randomBytes(12).toString('hex')
-  const ws = fs.createWriteStream(p.join(config.path, filename))
-  pipeline(req, ws, err => {
-    if (err) console.error(err)
-    if (err) res.status(500).send(err.message)
-    const url = baseUrl + filename
-    console.log('file uploaded: ' + filename)
-    res.send(url)
+    const ws = fs.createWriteStream(uploadpath)
+    pipeline(req, ws, err => {
+      if (err) {
+        console.error('error', err.message)
+        return res.status(500).send('internal server error')
+      }
+      console.log('file uploaded: ' + uploadpath)
+      const url = config.baseurl + filename
+      res.end(url)
+    })
   })
 })
 
 app.get('/:filename', (req, res) => {
-  const filepath = p.normalize(p.join(config.path, req.params.filename))
-  if (!filepath.startsWith(config.path)) {
-    return res.code(500).send('bad request')
-  }
-  const rs = fs.createReadStream(filepath)
+  const uploadpath = req.uploadpath
+  const rs = fs.createReadStream(uploadpath)
   res.setHeader('content-type', 'application/octet-stream')
   pipeline(rs, res, err => {
-    if (err) console.error(err)
-    if (err) res.status(500).send(err.message)
-    res.end()
+    if (err) console.error('error', err.message)
+    if (err) return res.status(500).send(err.message)
   })
 })
 
+function checkFilenameMiddleware (req, res, next) {
+  const filename = req.params.filename
+  if (!filename) return res.status(500).send('missing filename')
+  if (!filename.match(/^[a-zA-Z0-9]{26,32}$/)) {
+    return res.status(500).send('illegal filename')
+  }
+  const uploadpath = p.normalize(p.join(config.path, req.params.filename))
+  if (!uploadpath.startsWith(config.path)) {
+    return res.code(500).send('bad request')
+  }
+  req.uploadpath = uploadpath
+  next()
+}
+
 app.listen(config.port, err => {
   if (err) console.error(err)
-  else console.log('Listening on ' + baseUrl)
+  else console.log(`Listening on ${config.baseurl}`)
 })

--- a/upload-server/server.js
+++ b/upload-server/server.js
@@ -1,0 +1,53 @@
+const p = require('path')
+const crypto = require('crypto')
+const express = require('express')
+const fs = require('fs')
+const { pipeline } = require('stream')
+
+const app = express()
+
+const config = {
+  path: process.env.UPLOAD_PATH || p.resolve('./uploads'),
+  port: process.env.PORT || 8080,
+  hostname: process.env.HOSTNAME || '0.0.0.0',
+  baseurl: process.env.BASE_URL || null
+}
+
+if (!config.baseurl.endsWith('/')) config.baseurl = config.baseurl + '/'
+
+if (!fs.existsSync(config.path)) {
+  fs.mkdirSync(config.path, { recursive: true })
+}
+
+const baseUrl = config.baseurl || `http://${config.hostname}:${config.port}/`
+
+app.post('*', (req, res) => {
+  const filename = crypto.randomBytes(12).toString('hex')
+  const ws = fs.createWriteStream(p.join(config.path, filename))
+  pipeline(req, ws, err => {
+    if (err) console.error(err)
+    if (err) res.status(500).send(err.message)
+    const url = baseUrl + filename
+    console.log('file uploaded: ' + filename)
+    res.send(url)
+  })
+})
+
+app.get('/:filename', (req, res) => {
+  const filepath = p.normalize(p.join(config.path, req.params.filename))
+  if (!filepath.startsWith(config.path)) {
+    return res.code(500).send('bad request')
+  }
+  const rs = fs.createReadStream(filepath)
+  res.setHeader('content-type', 'application/octet-stream')
+  pipeline(rs, res, err => {
+    if (err) console.error(err)
+    if (err) res.status(500).send(err.message)
+    res.end()
+  })
+})
+
+app.listen(config.port, err => {
+  if (err) console.error(err)
+  else console.log('Listening on ' + baseUrl)
+})


### PR DESCRIPTION
This PR combines #1589 and #1590, see those for previous discussion.

We want to support uploading large attachements to HTTP upload providers. The upload providers will allow to PUT binary blobs over HTTP to a random unique filename. They should support a simple token-based authentication. This URL will be added to the message body and a deltachat header, and the message will not include a file attachement. When receiving a message with the `Chat-Upload-Url` header, core will offer to download this attachement through through the FFI api. After downloading, the attachement should be exposed as a regular file attachement.

The current HTTP api (as in this PR, will be updated once changed) is as follows:

`{id}` is a random 16 byte id encoded as base32 selected by deltachat-core before the upload.

- `POST {endpoint}/{id}`, body is the file content. Return an error status if file exists.
- `GET {endpoint/{id}`, body is the file content

## Tasks

Rough steps, please add more and/or edit.

#### Upload

- [x] Allow to upload files to a HTTP upload URL if `DCC_UPLOAD_URL` environment variable is set
- [x] The actual pload happens in the smtp send job
- [x] The upload URL is added to the message body and as `Chat-Upload-Url` header
- [ ] Support authenticating to the server with tokens
- [ ] Support sending the original filename and/or mime type to the upload server
- [x] Encrypt files through PGP before uploading (symmetrically), include symmetric key as ~~a protected header `Chat-Upload-Key`~~ hash fragment of the URL that's part of the message
- [ ] Add config options for upload URL and threshold size after which to attach the upload
- [ ] Support scanning QR codes, detect that they are tokens and URLs for an upload provider, and set the related config after scanning

*Possibly follow-up features*
- [ ] Make file uploads resumable if they were cancelled in between. See [this comment](https://github.com/deltachat/deltachat-core-rust/pull/1589#issuecomment-642503241) for details.
- [ ] Investigate if it's worth to use a streaming cipher for symmetric encryption instead of PGP
- [ ]  Support multiple upload providers and allow to switch between them on demand

#### Download

- [x] Add FFI headers to get download status and progress and initiate downloads
- [x] `schedule_download` to start a download `Job` that downloads, decrypts, and saves attachements
- [ ] add status reporting/saving to download job
- [ ] decide on where to run the download (threadwise)
- [ ] Implement FFI API

#### Server
- [x] Add minimal demo upload server (in Node.js)
- [ ] Add token auth to demo upload server
- [ ] Support receiving original filename and/or mime type on upload, somehow save it, and set it on the download response headers
- [ ] Write spec for the HTTP API
- [ ] Settle path to production - likely try to implement server side with only NGINX config and simple command line script for token generation

*Possible follow-up features*
- [ ] Support resumable uploads
- [ ] Implement server in Rust with [tide](https://github.com/http-rs/tide)
- [ ] Support decoding in the browser with a wasm decrypter and the symmetric key provided in the hash part of the URL (which is not sent to the server)


## How to try it out

Start the demo server:

```
$ cd upload-server
$ npm install
$ node server.js

```
Start the repl with a file upload provider:
```
$ DCC_UPLOAD_URL=http://localhost:8080 RUST_LOG=info cargo run --example repl --features repl -- ~/deltachat-db
```

Create a contact and chat, and use `sendfile` or `sendimage` to send a message with an attachement.
