### PR TITLE
Show a better toast and a notification when the password is wrong (because it was changed on the server)

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2670,10 +2670,11 @@ pub(crate) async fn get_chat_id_by_grpid(
 /// Adds a message to device chat.
 ///
 /// Optional `label` can be provided to ensure that message is added only once.
-pub async fn add_device_msg(
+pub async fn add_device_msg_with_importance(
     context: &Context,
     label: Option<&str>,
     msg: Option<&mut Message>,
+    important: bool,
 ) -> Result<MsgId, Error> {
     ensure!(
         label.is_some() || msg.is_some(),
@@ -2697,7 +2698,14 @@ pub async fn add_device_msg(
         let rfc724_mid = dc_create_outgoing_rfc724_mid(None, "@device");
         msg.try_calc_and_set_dimensions(context).await.ok();
         prepare_msg_blob(context, msg).await?;
+
         chat_id.unarchive(context).await?;
+        let muted = if important {
+            MuteDuration::NotMuted
+        } else {
+            MuteDuration::Forever
+        };
+        set_muted(context, chat_id, muted).await?;
 
         context.sql.execute(
             "INSERT INTO msgs (chat_id,from_id,to_id, timestamp,type,state, txt,param,rfc724_mid) \
@@ -2737,6 +2745,14 @@ pub async fn add_device_msg(
     }
 
     Ok(msg_id)
+}
+
+pub async fn add_device_msg(
+    context: &Context,
+    label: Option<&str>,
+    msg: Option<&mut Message>,
+) -> Result<MsgId, Error> {
+    add_device_msg_with_importance(context, label, msg, false).await
 }
 
 pub async fn was_device_msg_ever_added(context: &Context, label: &str) -> Result<bool, Error> {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2670,6 +2670,7 @@ pub(crate) async fn get_chat_id_by_grpid(
 /// Adds a message to device chat.
 ///
 /// Optional `label` can be provided to ensure that message is added only once.
+/// If `important` is true, a notification will be sent.
 pub async fn add_device_msg_with_importance(
     context: &Context,
     label: Option<&str>,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2698,14 +2698,7 @@ pub async fn add_device_msg_with_importance(
         let rfc724_mid = dc_create_outgoing_rfc724_mid(None, "@device");
         msg.try_calc_and_set_dimensions(context).await.ok();
         prepare_msg_blob(context, msg).await?;
-
         chat_id.unarchive(context).await?;
-        let muted = if important {
-            MuteDuration::NotMuted
-        } else {
-            MuteDuration::Forever
-        };
-        set_muted(context, chat_id, muted).await?;
 
         context.sql.execute(
             "INSERT INTO msgs (chat_id,from_id,to_id, timestamp,type,state, txt,param,rfc724_mid) \
@@ -2741,7 +2734,11 @@ pub async fn add_device_msg_with_importance(
     }
 
     if !msg_id.is_unset() {
-        context.emit_event(Event::IncomingMsg { chat_id, msg_id });
+        if important {
+            context.emit_event(Event::IncomingMsg { chat_id, msg_id });
+        } else {
+            context.emit_event(Event::MsgsChanged { chat_id, msg_id });
+        }
     }
 
     Ok(msg_id)

--- a/src/config.rs
+++ b/src/config.rs
@@ -119,7 +119,9 @@ pub enum Config {
     SysConfigKeys,
 
     #[strum(props(default = "0"))]
-    WarnedAboutWrongPw,
+    /// Whether we send a warning if the password is wrong (set to false when we send a warning
+    /// because we do not want to send a second warning)
+    NotifyAboutWrongPw,
 }
 
 impl Context {

--- a/src/config.rs
+++ b/src/config.rs
@@ -117,6 +117,9 @@ pub enum Config {
 
     #[strum(serialize = "sys.config_keys")]
     SysConfigKeys,
+
+    #[strum(props(default = "0"))]
+    WarnedAboutWrongPw,
 }
 
 impl Context {

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -109,7 +109,6 @@ impl Context {
                 Ok(())
             }
             Err(err) => {
-                error!(self, "Configure Failed: {}", err);
                 progress!(self, 0);
                 Err(err)
             }

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -72,6 +72,7 @@ impl Context {
 
         let mut param = LoginParam::from_database(self, "").await;
         let success = configure(self, &mut param).await;
+        self.set_config(Config::NotifyAboutWrongPw, None).await?;
 
         if let Some(provider) = provider::get_provider_info(&param.addr) {
             if let Some(config_defaults) = &provider.config_defaults {
@@ -102,7 +103,8 @@ impl Context {
 
         match success {
             Ok(_) => {
-                self.set_config(Config::WarnedAboutWrongPw, None).await?;
+                self.set_config(Config::NotifyAboutWrongPw, Some("1"))
+                    .await?;
                 progress!(self, 1000);
                 Ok(())
             }

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -461,7 +461,10 @@ async fn try_imap_connections(
         .await
         .is_ok()
     {
-        return Ok(()); // we directly return here if it was autoconfig or the connection succeeded
+        return Ok(());
+    }
+    if was_autoconfig {
+        bail!("autoconfig did not succeed");
     }
 
     progress!(context, 670);
@@ -495,7 +498,7 @@ async fn try_imap_connection(
         return Ok(());
     }
     if was_autoconfig {
-        return Ok(());
+        bail!("autoconfig did not succeed");
     }
 
     progress!(context, 650 + variation * 30);

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -558,7 +558,7 @@ async fn try_smtp_connections(
         return Ok(());
     }
     if was_autoconfig {
-        return Ok(());
+        bail!("No SMTP connection");
     }
     progress!(context, 850);
 

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -102,6 +102,7 @@ impl Context {
 
         match success {
             Ok(_) => {
+                self.set_config(Config::WarnedAboutWrongPw, None).await?;
                 progress!(self, 1000);
                 Ok(())
             }

--- a/src/context.rs
+++ b/src/context.rs
@@ -53,6 +53,8 @@ pub struct InnerContext {
     pub(crate) generating_key_mutex: Mutex<()>,
     /// Mutex to enforce only a single running oauth2 is running.
     pub(crate) oauth2_mutex: Mutex<()>,
+    /// Mutex to prevent a race condition when a "your pw is wrong" warning is sent, resulting in multiple messeges being sent.
+    pub(crate) wrong_pw_warning_mutex: Mutex<()>,
     pub(crate) translated_stockstrings: RwLock<HashMap<usize, String>>,
     pub(crate) events: Events,
 
@@ -120,6 +122,7 @@ impl Context {
             last_smeared_timestamp: RwLock::new(0),
             generating_key_mutex: Mutex::new(()),
             oauth2_mutex: Mutex::new(()),
+            wrong_pw_warning_mutex: Mutex::new(()),
             translated_stockstrings: RwLock::new(HashMap::new()),
             events: Events::default(),
             scheduler: RwLock::new(Scheduler::Stopped),

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -309,7 +309,7 @@ impl Imap {
                     .await;
 
                 warn!(context, "{} ({})", message, err);
-                error!(context, "{}", message);
+                emit_event!(context, Event::ErrorNetwork(message.clone()));
 
                 let lock = context.wrong_pw_warning_mutex.lock().await;
                 if self.login_failed_once

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -303,10 +303,8 @@ impl Imap {
                     .stock_string_repl_str(StockMessage::CannotLogin, &imap_user)
                     .await;
 
-                emit_event!(
-                    context,
-                    Event::ErrorNetwork(format!("{} ({})", message, err))
-                );
+                error!(context, "{}", message);
+
                 self.trigger_reconnect();
                 Err(Error::LoginFailed(format!("cannot login as {}", imap_user)))
             }

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -313,12 +313,9 @@ impl Imap {
 
                 let lock = context.wrong_pw_warning_mutex.lock().await;
                 if self.login_failed_once
-                    && !context.get_config_bool(Config::WarnedAboutWrongPw).await
+                    && context.get_config_bool(Config::NotifyAboutWrongPw).await
                 {
-                    if let Err(e) = context
-                        .set_config(Config::WarnedAboutWrongPw, Some("1"))
-                        .await
-                    {
+                    if let Err(e) = context.set_config(Config::NotifyAboutWrongPw, None).await {
                         warn!(context, "{}", e);
                     }
                     drop(lock);

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -122,7 +122,7 @@ async fn fetch_idle(ctx: &Context, connection: &mut Imap, folder: Config) -> Int
         Some(watch_folder) => {
             // connect and fake idle if unable to connect
             if let Err(err) = connection.connect_configured(&ctx).await {
-                error!(ctx, "imap connection failed: {}", err);
+                warn!(ctx, "imap connection failed: {}", err);
                 return connection.fake_idle(&ctx, None).await;
             }
 

--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -181,7 +181,7 @@ impl Smtp {
                 .stock_string_repl_str2(
                     StockMessage::ServerResponse,
                     format!("SMTP {}:{}", domain, port),
-                    format!("{}, ({:?})", err.to_string(), err),
+                    err.to_string(),
                 )
                 .await;
 

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -130,7 +130,9 @@ pub enum StockMessage {
     ))]
     AcSetupMsgBody = 43,
 
-    #[strum(props(fallback = "Cannot login as %1$s."))]
+    #[strum(props(
+        fallback = "Cannot login as \"%1$s\". Please check if the email address and the password are correct."
+    ))]
     CannotLogin = 60,
 
     #[strum(props(fallback = "Could not connect to %1$s: %2$s"))]


### PR DESCRIPTION
Fix #1605, fix #1687

It is not perfect because it only notifies when the user opens DC or re-connects to the network.

I changed the Event::ErrorNetwork message because this message is shown to the user.

We will have to adapt the UIs to generally send notifications for the device chat. The core now takes care about when a notification should be sent by "only" sending MsgsChanged event when no notification shall be shown. 

How expensive are mutexes (RAM and initialisation)? I added a mutex to Context to prevent a race condition when a "your pw is wrong" warning is sent, resulting in multiple messages being sent.