### PR TITLE
respect image orientation from exif on recoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,7 @@ dependencies = [
  "image-meta",
  "indexmap",
  "itertools",
+ "kamadak-exif",
  "lazy_static",
  "lettre_email",
  "libc",
@@ -1620,6 +1621,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kamadak-exif"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5e66d5b5469321038611f7f0e845a48989e4fd54987b6e5bb4c8ae3adbace7"
+dependencies = [
+ "mutate_once",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,6 +1825,12 @@ checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
 dependencies = [
  "adler32",
 ]
+
+[[package]]
+name = "mutate_once"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b"
 
 [[package]]
 name = "native-tls"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = "0.4.6"
 indexmap = "1.3.0"
+kamadak-exif = "0.5"
 lazy_static = "1.4.0"
 regex = "1.1.6"
 rusqlite = { version = "0.23", features = ["bundled"] }

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 use crate::config::Config;
 use crate::constants::*;
 use crate::context::Context;
+use crate::error::Error;
 use crate::events::Event;
 use crate::message;
 
@@ -408,7 +409,13 @@ impl<'a> BlobObject<'a> {
             return Ok(());
         }
 
-        let img = img.thumbnail(img_wh, img_wh);
+        let mut img = img.thumbnail(img_wh, img_wh);
+        match self.get_exif_orientation() {
+            Ok(90) => img = img.rotate90(),
+            Ok(180) => img = img.rotate180(),
+            Ok(270) => img = img.rotate270(),
+            _ => {}
+        }
 
         img.save(&blob_abs).map_err(|err| BlobError::WriteFailure {
             blobdir: context.get_blobdir().to_path_buf(),
@@ -417,6 +424,10 @@ impl<'a> BlobObject<'a> {
         })?;
 
         Ok(())
+    }
+
+    pub fn get_exif_orientation(&self) -> Result<i32, Error> {
+        Ok(0)
     }
 }
 

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -427,6 +427,18 @@ impl<'a> BlobObject<'a> {
     }
 
     pub fn get_exif_orientation(&self) -> Result<i32, Error> {
+        let file = std::fs::File::open(self.to_abs_path())?;
+        let mut bufreader = std::io::BufReader::new(&file);
+        let exifreader = exif::Reader::new();
+        let exif = exifreader.read_from_container(&mut bufreader)?;
+        if let Some(orientation) = exif.get_field(exif::Tag::Orientation, exif::In::PRIMARY) {
+            match orientation.value.get_uint(0) {
+                Some(3) => return Ok(180),
+                Some(6) => return Ok(90),
+                Some(8) => return Ok(270),
+                _ => {}
+            }
+        }
         Ok(0)
     }
 }


### PR DESCRIPTION
this pr reads the orientation-tag from the exif information and applies that to the recoded pixels.

closes #1586 

nb: [The most evil feature ever conceived: the Exif Orientation Tag](http://keyj.emphy.de/exif-orientation-rant/) - i mostly agree here. things would be much easier if that tag just won't have been invented.