### PR TITLE
Sync heuristically_parse_ndn() and maybe_ndn in prefetch_should_download()

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -903,16 +903,13 @@ impl MimeMessage {
     /// If you improve heuristics here you might also have to change prefetch_should_download() in imap/mod.rs.
     /// Also you should add a test in dc_receive_imf.rs (there already are lots of test_parse_ndn_* tests).
     async fn heuristically_parse_ndn(&mut self, context: &Context) -> Option<()> {
-        if self
-            .get(HeaderDef::Subject)?
-            .to_ascii_lowercase()
-            .contains("fail")
-            && self
-                .get(HeaderDef::From_)?
-                .to_ascii_lowercase()
-                .contains("mailer-daemon")
-            && self.failure_report.is_none()
-        {
+        let maybe_ndn = if let Some(from) = self.get(HeaderDef::From_) {
+            let from = from.to_ascii_lowercase();
+            from.contains("mailer-daemon") || from.contains("mail-daemon")
+        } else {
+            false
+        };
+        if maybe_ndn && self.failure_report.is_none() {
             lazy_static! {
                 static ref RE: regex::Regex = regex::Regex::new(r"Message-ID:(.*)").unwrap();
             }


### PR DESCRIPTION
In heuristically_parse_ndn() we also checked whether the subject contains "fail". Which is not the case for all test emails. Those who do not contain it use the "message/delivery-status" standard by sheer luck so that all tests pass.

Proposed by @r10s in https://github.com/deltachat/deltachat-core-rust/pull/1625#discussion_r440971312 (just that it was not in sync before my tiscali PR)