### PR TITLE
Refactor imap/mod.rs to avoid indexing

### DIFF
--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -1,5 +1,7 @@
 //! # SMTP transport module
 
+#![forbid(clippy::indexing_slicing)]
+
 pub mod send;
 
 use std::time::{Duration, Instant};


### PR DESCRIPTION
Also replace assert! with debug_assert!

An attempt to address https://github.com/deltachat/deltachat-android/issues/1428
I think we should eliminate all indexing and slicing eventually, they have resulted in similar crashes previously which are very hard to debug.

I'm sure this commit doesn't fix the bug, but makes searching for the source of panic a bit easier.