### PR TITLE
Unify some testing interfaces

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -497,7 +497,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_create() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let blob = BlobObject::create(&t.ctx, "foo", b"hello").await.unwrap();
         let fname = t.ctx.get_blobdir().join("foo");
         let data = fs::read(fname).await.unwrap();
@@ -508,7 +508,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_lowercase_ext() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let blob = BlobObject::create(&t.ctx, "foo.TXT", b"hello")
             .await
             .unwrap();
@@ -517,7 +517,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_as_file_name() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let blob = BlobObject::create(&t.ctx, "foo.txt", b"hello")
             .await
             .unwrap();
@@ -526,7 +526,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_as_rel_path() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let blob = BlobObject::create(&t.ctx, "foo.txt", b"hello")
             .await
             .unwrap();
@@ -535,7 +535,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_suffix() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let blob = BlobObject::create(&t.ctx, "foo.txt", b"hello")
             .await
             .unwrap();
@@ -546,7 +546,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_create_dup() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         BlobObject::create(&t.ctx, "foo.txt", b"hello")
             .await
             .unwrap();
@@ -570,7 +570,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_double_ext_preserved() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         BlobObject::create(&t.ctx, "foo.tar.gz", b"hello")
             .await
             .unwrap();
@@ -595,7 +595,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_create_long_names() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let s = "1".repeat(150);
         let blob = BlobObject::create(&t.ctx, &s, b"data").await.unwrap();
         let blobname = blob.as_name().split('/').last().unwrap();
@@ -604,7 +604,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_create_and_copy() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let src = t.dir.path().join("src");
         fs::write(&src, b"boo").await.unwrap();
         let blob = BlobObject::create_and_copy(&t.ctx, &src).await.unwrap();
@@ -620,7 +620,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_create_from_path() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
 
         let src_ext = t.dir.path().join("external");
         fs::write(&src_ext, b"boo").await.unwrap();
@@ -638,7 +638,7 @@ mod tests {
     }
     #[async_std::test]
     async fn test_create_from_name_long() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let src_ext = t.dir.path().join("autocrypt-setup-message-4137848473.html");
         fs::write(&src_ext, b"boo").await.unwrap();
         let blob = BlobObject::new_from_path(&t.ctx, &src_ext).await.unwrap();

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2821,7 +2821,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_chat_info() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let bob = Contact::create(&t.ctx, "bob", "bob@example.com")
             .await
             .unwrap();
@@ -2855,7 +2855,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_get_draft_no_draft() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let chat_id = create_by_contact_id(&t.ctx, DC_CONTACT_ID_SELF)
             .await
             .unwrap();
@@ -2865,7 +2865,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_get_draft_special_chat_id() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let draft = ChatId::new(DC_CHAT_ID_LAST_SPECIAL)
             .get_draft(&t.ctx)
             .await
@@ -2877,14 +2877,14 @@ mod tests {
     async fn test_get_draft_no_chat() {
         // This is a weird case, maybe this should be an error but we
         // do not get this info from the database currently.
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let draft = ChatId::new(42).get_draft(&t.ctx).await.unwrap();
         assert!(draft.is_none());
     }
 
     #[async_std::test]
     async fn test_get_draft() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let chat_id = create_by_contact_id(&t.ctx, DC_CONTACT_ID_SELF)
             .await
             .unwrap();
@@ -2900,7 +2900,7 @@ mod tests {
     #[async_std::test]
     async fn test_add_contact_to_chat_ex_add_self() {
         // Adding self to a contact should succeed, even though it's pointless.
-        let t = test_context().await;
+        let t = TestContext::new().await;
         let chat_id = create_group_chat(&t.ctx, VerifiedStatus::Unverified, "foo")
             .await
             .unwrap();
@@ -2912,7 +2912,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_self_talk() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let chat_id = create_by_contact_id(&t.ctx, DC_CONTACT_ID_SELF)
             .await
             .unwrap();
@@ -2933,7 +2933,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_deaddrop_chat() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let chat = Chat::load_from_db(&t.ctx, ChatId::new(DC_CHAT_ID_DEADDROP))
             .await
             .unwrap();
@@ -2948,7 +2948,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_add_device_msg_unlabelled() {
-        let t = test_context().await;
+        let t = TestContext::new().await;
 
         // add two device-messages
         let mut msg1 = Message::new(Viewtype::Text);
@@ -2983,7 +2983,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_add_device_msg_labelled() {
-        let t = test_context().await;
+        let t = TestContext::new().await;
 
         // add two device-messages with the same label (second attempt is not added)
         let mut msg1 = Message::new(Viewtype::Text);
@@ -3037,7 +3037,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_add_device_msg_label_only() {
-        let t = test_context().await;
+        let t = TestContext::new().await;
         let res = add_device_msg(&t.ctx, Some(""), None).await;
         assert!(res.is_err());
         let res = add_device_msg(&t.ctx, Some("some-label"), None).await;
@@ -3057,7 +3057,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_was_device_msg_ever_added() {
-        let t = test_context().await;
+        let t = TestContext::new().await;
         add_device_msg(&t.ctx, Some("some-label"), None).await.ok();
         assert!(was_device_msg_ever_added(&t.ctx, "some-label")
             .await
@@ -3081,7 +3081,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_delete_device_chat() {
-        let t = test_context().await;
+        let t = TestContext::new().await;
 
         let mut msg = Message::new(Viewtype::Text);
         msg.text = Some("message text".to_string());
@@ -3101,7 +3101,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_device_chat_cannot_sent() {
-        let t = test_context().await;
+        let t = TestContext::new().await;
         t.ctx.update_device_chats().await.unwrap();
         let (device_chat_id, _) =
             create_or_lookup_by_contact_id(&t.ctx, DC_CONTACT_ID_DEVICE, Blocked::Not)
@@ -3121,7 +3121,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_delete_and_reset_all_device_msgs() {
-        let t = test_context().await;
+        let t = TestContext::new().await;
         let mut msg = Message::new(Viewtype::Text);
         msg.text = Some("message text".to_string());
         let msg_id1 = add_device_msg(&t.ctx, Some("some-label"), Some(&mut msg))
@@ -3158,7 +3158,7 @@ mod tests {
     #[async_std::test]
     async fn test_archive() {
         // create two chats
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let mut msg = Message::new(Viewtype::Text);
         msg.text = Some("foo".to_string());
         let msg_id = add_device_msg(&t.ctx, None, Some(&mut msg)).await.unwrap();
@@ -3272,7 +3272,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_pinned() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
 
         // create 3 chats, wait 1 second in between to get a reliable order (we order by time)
         let mut msg = Message::new(Viewtype::Text);
@@ -3331,7 +3331,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_set_chat_name() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let chat_id = create_group_chat(&t.ctx, VerifiedStatus::Unverified, "foo")
             .await
             .unwrap();
@@ -3355,7 +3355,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_create_same_chat_twice() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let contact1 = Contact::create(&context.ctx, "bob", "bob@mail.de")
             .await
             .unwrap();
@@ -3374,7 +3374,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_shall_attach_selfavatar() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let chat_id = create_group_chat(&t.ctx, VerifiedStatus::Unverified, "foo")
             .await
             .unwrap();
@@ -3398,7 +3398,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_set_mute_duration() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let chat_id = create_group_chat(&t.ctx, VerifiedStatus::Unverified, "foo")
             .await
             .unwrap();
@@ -3466,7 +3466,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_parent_is_encrypted() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let chat_id = create_group_chat(&t.ctx, VerifiedStatus::Unverified, "foo")
             .await
             .unwrap();

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -424,7 +424,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_try_load() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let chat_id1 = create_group_chat(&t.ctx, VerifiedStatus::Unverified, "a chat")
             .await
             .unwrap();
@@ -472,7 +472,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_sort_self_talk_up_on_forward() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         t.ctx.update_device_chats().await.unwrap();
         create_group_chat(&t.ctx, VerifiedStatus::Unverified, "a chat")
             .await
@@ -497,7 +497,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_search_special_chat_names() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         t.ctx.update_device_chats().await.unwrap();
 
         let chats = Chatlist::try_load(&t.ctx, 0, Some("t-1234-s"), None)
@@ -530,7 +530,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_get_summary_unwrap() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let chat_id1 = create_group_chat(&t.ctx, VerifiedStatus::Unverified, "a chat")
             .await
             .unwrap();

--- a/src/config.rs
+++ b/src/config.rs
@@ -286,7 +286,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_selfavatar_outside_blobdir() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let avatar_src = t.dir.path().join("avatar.jpg");
         let avatar_bytes = include_bytes!("../test-data/image/avatar1000x1000.jpg");
         File::create(&avatar_src)
@@ -315,7 +315,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_selfavatar_in_blobdir() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let avatar_src = t.ctx.get_blobdir().join("avatar.png");
         let avatar_bytes = include_bytes!("../test-data/image/avatar900x900.png");
         File::create(&avatar_src)
@@ -341,7 +341,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_selfavatar_copy_without_recode() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let avatar_src = t.dir.path().join("avatar.png");
         let avatar_bytes = include_bytes!("../test-data/image/avatar64x64.png");
         File::create(&avatar_src)
@@ -365,7 +365,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_media_quality_config_option() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let media_quality = t.ctx.get_config_int(Config::MediaQuality).await;
         assert_eq!(media_quality, 0);
         let media_quality = constants::MediaQuality::from_i32(media_quality).unwrap_or_default();

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -621,7 +621,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_no_panic_on_bad_credentials() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         t.ctx
             .set_config(Config::Addr, Some("probably@unexistant.addr"))
             .await
@@ -635,7 +635,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_get_offline_autoconfig() {
-        let context = dummy_context().await.ctx;
+        let context = TestContext::new().await.ctx;
 
         let mut params = LoginParam::new();
         params.addr = "someone123@example.org".to_string();

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1270,7 +1270,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_get_contacts() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let contacts = Contact::get_all(&context.ctx, 0, Some("some2"))
             .await
             .unwrap();
@@ -1294,10 +1294,10 @@ mod tests {
 
     #[async_std::test]
     async fn test_is_self_addr() -> Result<()> {
-        let t = test_context().await;
+        let t = TestContext::new().await;
         assert!(t.ctx.is_self_addr("me@me.org").await.is_err());
 
-        let addr = configure_alice_keypair(&t.ctx).await;
+        let addr = t.configure_alice().await;
         assert_eq!(t.ctx.is_self_addr("me@me.org").await?, false);
         assert_eq!(t.ctx.is_self_addr(&addr).await?, true);
 
@@ -1307,7 +1307,7 @@ mod tests {
     #[async_std::test]
     async fn test_add_or_lookup() {
         // add some contacts, this also tests add_address_book()
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let book = concat!(
             "  Name one  \n one@eins.org \n",
             "Name two\ntwo@deux.net\n",
@@ -1420,7 +1420,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_remote_authnames() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
 
         // incoming mail `From: bob1 <bob@example.org>` - this should init authname and name
         let (contact_id, sth_modified) = Contact::add_or_lookup(
@@ -1483,7 +1483,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_remote_authnames_create_empty() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
 
         // manually create "claire@example.org" without a given name
         let contact_id = Contact::create(&t.ctx, "", "claire@example.org")
@@ -1530,7 +1530,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_remote_authnames_edit_empty() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
 
         // manually create "dave@example.org"
         let contact_id = Contact::create(&t.ctx, "dave1", "dave@example.org")
@@ -1574,7 +1574,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_name_in_address() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
 
         let contact_id = Contact::create(&t.ctx, "", "<dave@example.org>")
             .await

--- a/src/context.rs
+++ b/src/context.rs
@@ -540,7 +540,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_get_fresh_msgs() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let fresh = t.ctx.get_fresh_msgs().await;
         assert!(fresh.is_empty())
     }
@@ -595,13 +595,13 @@ mod tests {
 
     #[async_std::test]
     async fn no_crashes_on_context_deref() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         std::mem::drop(t.ctx);
     }
 
     #[async_std::test]
     async fn test_get_info() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
 
         let info = t.ctx.get_info().await;
         assert!(info.get("database_dir").is_some());

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -774,7 +774,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_file_handling() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let context = &t.ctx;
         macro_rules! dc_file_exist {
             ($ctx:expr, $fname:expr) => {
@@ -853,7 +853,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_create_smeared_timestamp() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         assert_ne!(
             dc_create_smeared_timestamp(&t.ctx).await,
             dc_create_smeared_timestamp(&t.ctx).await
@@ -869,7 +869,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_create_smeared_timestamps() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let count = MAX_SECONDS_TO_LEND_FROM_FUTURE - 1;
         let start = dc_create_smeared_timestamps(&t.ctx, count as usize).await;
         let next = dc_smeared_time(&t.ctx).await;

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -327,14 +327,14 @@ mod tests {
 
         #[async_std::test]
         async fn test_prexisting() {
-            let t = dummy_context().await;
-            let test_addr = configure_alice_keypair(&t.ctx).await;
+            let t = TestContext::new().await;
+            let test_addr = t.configure_alice().await;
             assert_eq!(ensure_secret_key_exists(&t.ctx).await.unwrap(), test_addr);
         }
 
         #[async_std::test]
         async fn test_not_configured() {
-            let t = dummy_context().await;
+            let t = TestContext::new().await;
             assert!(ensure_secret_key_exists(&t.ctx).await.is_err());
         }
     }

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -776,9 +776,9 @@ mod tests {
 
     #[async_std::test]
     async fn test_render_setup_file() {
-        let t = test_context().await;
+        let t = TestContext::new().await;
 
-        configure_alice_keypair(&t.ctx).await;
+        t.configure_alice().await;
         let msg = render_setup_file(&t.ctx, "hello").await.unwrap();
         println!("{}", &msg);
         // Check some substrings, indicating things got substituted.
@@ -795,12 +795,12 @@ mod tests {
 
     #[async_std::test]
     async fn test_render_setup_file_newline_replace() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         t.ctx
             .set_stock_translation(StockMessage::AcSetupMsgBody, "hello\r\nthere".to_string())
             .await
             .unwrap();
-        configure_alice_keypair(&t.ctx).await;
+        t.configure_alice().await;
         let msg = render_setup_file(&t.ctx, "pw").await.unwrap();
         println!("{}", &msg);
         assert!(msg.contains("<p>hello<br>there</p>"));
@@ -808,7 +808,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_create_setup_code() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let setupcode = create_setup_code(&t.ctx);
         assert_eq!(setupcode.len(), 44);
         assert_eq!(setupcode.chars().nth(4).unwrap(), '-');
@@ -823,7 +823,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_export_key_to_asc_file() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let key = alice_keypair().public;
         let blobdir = "$BLOBDIR";
         assert!(export_key_to_asc_file(&context.ctx, blobdir, None, &key)

--- a/src/job.rs
+++ b/src/job.rs
@@ -1209,7 +1209,7 @@ mod tests {
         // We want to ensure that loading jobs skips over jobs which
         // fails to load from the database instead of failing to load
         // all jobs.
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         insert_job(&t.ctx, -1).await; // This can not be loaded into Job struct.
         let jobs = load_next(
             &t.ctx,
@@ -1231,7 +1231,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_load_next_job_one() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
 
         insert_job(&t.ctx, 1).await;
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -550,8 +550,8 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
     #[async_std::test]
     async fn test_load_self_existing() {
         let alice = alice_keypair();
-        let t = dummy_context().await;
-        configure_alice_keypair(&t.ctx).await;
+        let t = TestContext::new().await;
+        t.configure_alice().await;
         let pubkey = SignedPublicKey::load_self(&t.ctx).await.unwrap();
         assert_eq!(alice.public, pubkey);
         let seckey = SignedSecretKey::load_self(&t.ctx).await.unwrap();
@@ -560,7 +560,7 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
 
     #[async_std::test]
     async fn test_load_self_generate_public() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         t.ctx
             .set_config(Config::ConfiguredAddr, Some("alice@example.com"))
             .await
@@ -571,7 +571,7 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
 
     #[async_std::test]
     async fn test_load_self_generate_secret() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         t.ctx
             .set_config(Config::ConfiguredAddr, Some("alice@example.com"))
             .await
@@ -584,7 +584,7 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
     async fn test_load_self_generate_concurrent() {
         use std::thread;
 
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         t.ctx
             .set_config(Config::ConfiguredAddr, Some("alice@example.com"))
             .await
@@ -611,7 +611,7 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
     async fn test_save_self_key_twice() {
         // Saving the same key twice should result in only one row in
         // the keypairs table.
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let ctx = Arc::new(t.ctx);
 
         let ctx1 = ctx.clone();

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -79,8 +79,8 @@ mod tests {
     #[async_std::test]
     async fn test_keyring_load_self() {
         // new_self() implies load_self()
-        let t = dummy_context().await;
-        configure_alice_keypair(&t.ctx).await;
+        let t = TestContext::new().await;
+        t.configure_alice().await;
         let alice = alice_keypair();
 
         let pub_ring: Keyring<SignedPublicKey> = Keyring::new_self(&t.ctx).await.unwrap();

--- a/src/location.rs
+++ b/src/location.rs
@@ -724,11 +724,11 @@ pub(crate) async fn job_maybe_send_locations_ended(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::dummy_context;
+    use crate::test_utils::TestContext;
 
     #[async_std::test]
     async fn test_kml_parse() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
 
         let xml =
             b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<kml xmlns=\"http://www.opengis.net/kml/2.2\">\n<Document addr=\"user@example.org\">\n<Placemark><Timestamp><when>2019-03-06T21:09:57Z</when></Timestamp><Point><coordinates accuracy=\"32.000000\">9.423110,53.790302</coordinates></Point></Placemark>\n<PlaceMARK>\n<Timestamp><WHEN > \n\t2018-12-13T22:11:12Z\t</WHEN></Timestamp><Point><coordinates aCCuracy=\"2.500000\"> 19.423110 \t , \n 63.790302\n </coordinates></Point></PlaceMARK>\n</Document>\n</kml>";

--- a/src/message.rs
+++ b/src/message.rs
@@ -1645,7 +1645,7 @@ mod tests {
     async fn test_prepare_message_and_send() {
         use crate::config::Config;
 
-        let d = test::dummy_context().await;
+        let d = test::TestContext::new().await;
         let ctx = &d.ctx;
 
         let contact = Contact::create(ctx, "", "dest@example.com")
@@ -1669,7 +1669,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_get_summarytext_by_raw() {
-        let d = test::dummy_context().await;
+        let d = test::TestContext::new().await;
         let ctx = &d.ctx;
 
         let some_text = Some("bla bla".to_string());

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1210,7 +1210,6 @@ mod tests {
     use crate::chatlist::Chatlist;
     use crate::dc_receive_imf::dc_receive_imf;
     use crate::mimeparser::*;
-    use crate::test_utils::configured_offline_context;
     use crate::test_utils::TestContext;
 
     #[test]
@@ -1300,10 +1299,10 @@ mod tests {
         // 1.: Receive a mail from an MUA or Delta Chat
         assert_eq!(
             msg_to_subject_str(
-                b"From: Bob <bob@example.org>\n\
-                To: alice@example.org\n\
+                b"From: Bob <bob@example.com>\n\
+                To: alice@example.com\n\
                 Subject: Antw: Chat: hello\n\
-                Message-ID: <2222@example.org>\n\
+                Message-ID: <2222@example.com>\n\
                 Date: Sun, 22 Mar 2020 22:37:56 +0000\n\
                 \n\
                 hello\n"
@@ -1314,10 +1313,10 @@ mod tests {
 
         assert_eq!(
             msg_to_subject_str(
-                b"From: Bob <bob@example.org>\n\
-                To: alice@example.org\n\
+                b"From: Bob <bob@example.com>\n\
+                To: alice@example.com\n\
                 Subject: Infos: 42\n\
-                Message-ID: <2222@example.org>\n\
+                Message-ID: <2222@example.com>\n\
                 Date: Sun, 22 Mar 2020 22:37:56 +0000\n\
                 \n\
                 hello\n"
@@ -1329,11 +1328,11 @@ mod tests {
         // 2. Receive a message from Delta Chat when we did not send any messages before
         assert_eq!(
             msg_to_subject_str(
-                b"From: Charlie <charlie@example.org>\n\
-                To: alice@example.org\n\
+                b"From: Charlie <charlie@example.com>\n\
+                To: alice@example.com\n\
                 Subject: Chat: hello\n\
                 Chat-Version: 1.0\n\
-                Message-ID: <2223@example.org>\n\
+                Message-ID: <2223@example.com>\n\
                 Date: Sun, 22 Mar 2020 22:37:56 +0000\n\
                 \n\
                 hello\n"
@@ -1343,10 +1342,11 @@ mod tests {
         );
 
         // 3. Send the first message to a new contact
-        let t = configured_offline_context().await;
-        assert_eq!(first_subject_str(t).await, "Message from alice@example.org");
+        let t = TestContext::new_alice().await;
 
-        let t = configured_offline_context().await;
+        assert_eq!(first_subject_str(t).await, "Message from alice@example.com");
+
+        let t = TestContext::new_alice().await;
         t.ctx
             .set_config(Config::Displayname, Some("Alice"))
             .await
@@ -1355,11 +1355,11 @@ mod tests {
 
         // 4. Receive messages with unicode characters and make sure that we do not panic (we do not care about the result)
         msg_to_subject_str(
-            "From: Charlie <charlie@example.org>\n\
-            To: alice@example.org\n\
+            "From: Charlie <charlie@example.com>\n\
+            To: alice@example.com\n\
             Subject: äääää\n\
             Chat-Version: 1.0\n\
-            Message-ID: <2893@example.org>\n\
+            Message-ID: <2893@example.com>\n\
             Date: Sun, 22 Mar 2020 22:37:56 +0000\n\
             \n\
             hello\n"
@@ -1368,11 +1368,11 @@ mod tests {
         .await;
 
         msg_to_subject_str(
-            "From: Charlie <charlie@example.org>\n\
-            To: alice@example.org\n\
+            "From: Charlie <charlie@example.com>\n\
+            To: alice@example.com\n\
             Subject: aäääää\n\
             Chat-Version: 1.0\n\
-            Message-ID: <2893@example.org>\n\
+            Message-ID: <2893@example.com>\n\
             Date: Sun, 22 Mar 2020 22:37:56 +0000\n\
             \n\
             hello\n"
@@ -1383,7 +1383,7 @@ mod tests {
 
     async fn first_subject_str(t: TestContext) -> String {
         let contact_id =
-            Contact::add_or_lookup(&t.ctx, "Dave", "dave@example.org", Origin::ManuallyCreated)
+            Contact::add_or_lookup(&t.ctx, "Dave", "dave@example.com", Origin::ManuallyCreated)
                 .await
                 .unwrap()
                 .0;
@@ -1407,7 +1407,7 @@ mod tests {
     }
 
     async fn msg_to_subject_str(imf_raw: &[u8]) -> String {
-        let t = configured_offline_context().await;
+        let t = TestContext::new_alice().await;
         let new_msg = incoming_msg_to_reply_msg(imf_raw, &t.ctx).await;
         let mf = MimeFactory::from_msg(&t.ctx, &new_msg, false)
             .await
@@ -1445,15 +1445,15 @@ mod tests {
     #[async_std::test]
     // This test could still be extended
     async fn test_render_reply() {
-        let t = configured_offline_context().await;
+        let t = TestContext::new_alice().await;
         let context = &t.ctx;
 
         let msg = incoming_msg_to_reply_msg(
-            b"From: Charlie <charlie@example.org>\n\
-                To: alice@example.org\n\
+            b"From: Charlie <charlie@example.com>\n\
+                To: alice@example.com\n\
                 Subject: Chat: hello\n\
                 Chat-Version: 1.0\n\
-                Message-ID: <2223@example.org>\n\
+                Message-ID: <2223@example.com>\n\
                 Date: Sun, 22 Mar 2020 22:37:56 +0000\n\
                 \n\
                 hello\n",
@@ -1464,7 +1464,7 @@ mod tests {
         let mimefactory = MimeFactory::from_msg(&t.ctx, &msg, false).await.unwrap();
 
         let recipients = mimefactory.recipients();
-        assert_eq!(recipients, vec!["charlie@example.org"]);
+        assert_eq!(recipients, vec!["charlie@example.com"]);
 
         let rendered_msg = mimefactory.render().await.unwrap();
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1237,7 +1237,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_dc_mimeparser_crash() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let raw = include_bytes!("../test-data/message/issue_523.txt");
         let mimeparser = MimeMessage::from_bytes(&context.ctx, &raw[..])
             .await
@@ -1249,7 +1249,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_get_rfc724_mid_exists() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let raw = include_bytes!("../test-data/message/mail_with_message_id.txt");
         let mimeparser = MimeMessage::from_bytes(&context.ctx, &raw[..])
             .await
@@ -1263,7 +1263,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_get_rfc724_mid_not_exists() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let raw = include_bytes!("../test-data/message/issue_523.txt");
         let mimeparser = MimeMessage::from_bytes(&context.ctx, &raw[..])
             .await
@@ -1321,7 +1321,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_parse_first_addr() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let raw = b"From: hello@one.org, world@two.org\n\
                     Chat-Disposition-Notification-To: wrong\n\
                     Content-Type: text/plain\n\
@@ -1342,7 +1342,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_mimeparser_with_context() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let raw = b"From: hello\n\
                     Content-Type: multipart/mixed; boundary=\"==break==\";\n\
                     Subject: outer-subject\n\
@@ -1392,7 +1392,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_mimeparser_with_avatars() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
 
         let raw = include_bytes!("../test-data/message/mail_attach_txt.eml");
         let mimeparser = MimeMessage::from_bytes(&t.ctx, &raw[..]).await.unwrap();
@@ -1435,7 +1435,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_mimeparser_message_kml() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let raw = b"Chat-Version: 1.0\n\
 From: foo <foo@example.org>\n\
 To: bar <bar@example.org>\n\
@@ -1480,7 +1480,7 @@ Content-Disposition: attachment; filename=\"message.kml\"\n\
 
     #[async_std::test]
     async fn test_parse_mdn() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let raw = b"Subject: =?utf-8?q?Chat=3A_Message_opened?=\n\
 Date: Mon, 10 Jan 2020 00:00:00 +0000\n\
 Chat-Version: 1.0\n\
@@ -1530,7 +1530,7 @@ Disposition: manual-action/MDN-sent-automatically; displayed\n\
     /// multipart MIME messages.
     #[async_std::test]
     async fn test_parse_multiple_mdns() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let raw = b"Subject: =?utf-8?q?Chat=3A_Message_opened?=\n\
 Date: Mon, 10 Jan 2020 00:00:00 +0000\n\
 Chat-Version: 1.0\n\
@@ -1606,7 +1606,7 @@ Disposition: manual-action/MDN-sent-automatically; displayed\n\
 
     #[async_std::test]
     async fn test_parse_mdn_with_additional_message_ids() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let raw = b"Subject: =?utf-8?q?Chat=3A_Message_opened?=\n\
 Date: Mon, 10 Jan 2020 00:00:00 +0000\n\
 Chat-Version: 1.0\n\
@@ -1661,7 +1661,7 @@ Additional-Message-IDs: <foo@example.com> <foo@example.net>\n\
 
     #[async_std::test]
     async fn test_parse_inline_attachment() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let raw = br#"Date: Thu, 13 Feb 2020 22:41:20 +0000 (UTC)
 From: sender@example.com
 To: receiver@example.com
@@ -1701,7 +1701,7 @@ MDYyMDYxNTE1RTlDOEE4Cj4+CnN0YXJ0eHJlZgo4Mjc4CiUlRU9GCg==
 
     #[async_std::test]
     async fn parse_inline_image() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let raw = br#"Message-ID: <foobar@example.org>
 From: foo <foo@example.org>
 Subject: example
@@ -1747,7 +1747,7 @@ CWt6wx7fiLp0qS9RrX75g6Gqw7nfCs6EcBERcIPt7DTe8VStJwf3LWqVwxl4gQl46yhfoqwEO+I=
 
     #[async_std::test]
     async fn parse_thunderbird_html_embedded_image() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let raw = br#"To: Alice <alice@example.org>
 From: Bob <bob@example.org>
 Subject: Test subject
@@ -1820,7 +1820,7 @@ CWt6wx7fiLp0qS9RrX75g6Gqw7nfCs6EcBERcIPt7DTe8VStJwf3LWqVwxl4gQl46yhfoqwEO+I=
     // Outlook specifies filename in the "name" attribute of Content-Type
     #[async_std::test]
     async fn parse_outlook_html_embedded_image() {
-        let context = dummy_context().await;
+        let context = TestContext::new().await;
         let raw = br##"From: Anonymous <anonymous@example.org>
 To: Anonymous <anonymous@example.org>
 Subject: Delta Chat is great stuff!

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -440,7 +440,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_dc_get_oauth2_addr() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
         let addr = "dignifiedquire@gmail.com";
         let code = "fail";
         let res = dc_get_oauth2_addr(&ctx.ctx, addr, code).await;
@@ -450,7 +450,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_dc_get_oauth2_url() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
         let addr = "dignifiedquire@gmail.com";
         let redirect_uri = "chat.delta:/com.b44t.messenger";
         let res = dc_get_oauth2_url(&ctx.ctx, addr, redirect_uri).await;
@@ -460,7 +460,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_dc_get_oauth2_token() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
         let addr = "dignifiedquire@gmail.com";
         let code = "fail";
         let res = dc_get_oauth2_access_token(&ctx.ctx, addr, code, false).await;

--- a/src/param.rs
+++ b/src/param.rs
@@ -414,7 +414,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_params_file_fs_path() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         if let ParamsFile::FsPath(p) = ParamsFile::from_param(&t.ctx, "/foo/bar/baz").unwrap() {
             assert_eq!(p, Path::new("/foo/bar/baz"));
         } else {
@@ -424,7 +424,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_params_file_blob() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         if let ParamsFile::Blob(b) = ParamsFile::from_param(&t.ctx, "$BLOBDIR/foo").unwrap() {
             assert_eq!(b.as_name(), "$BLOBDIR/foo");
         } else {
@@ -435,7 +435,7 @@ mod tests {
     // Tests for Params::get_file(), Params::get_path() and Params::get_blob().
     #[async_std::test]
     async fn test_params_get_fileparam() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let fname = t.dir.path().join("foo");
         let mut p = Params::new();
         p.set(Param::File, fname.to_str().unwrap());

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -473,7 +473,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_peerstate_save_to_db() {
-        let ctx = crate::test_utils::dummy_context().await;
+        let ctx = crate::test_utils::TestContext::new().await;
         let addr = "hello@mail.com";
 
         let pub_key = alice_keypair().public;
@@ -516,7 +516,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_peerstate_double_create() {
-        let ctx = crate::test_utils::dummy_context().await;
+        let ctx = crate::test_utils::TestContext::new().await;
         let addr = "hello@mail.com";
         let pub_key = alice_keypair().public;
 
@@ -549,7 +549,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_peerstate_with_empty_gossip_key_save_to_db() {
-        let ctx = crate::test_utils::dummy_context().await;
+        let ctx = crate::test_utils::TestContext::new().await;
         let addr = "hello@mail.com";
 
         let pub_key = alice_keypair().public;

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -383,11 +383,11 @@ fn normalize_address(addr: &str) -> Result<String, Error> {
 mod tests {
     use super::*;
 
-    use crate::test_utils::dummy_context;
+    use crate::test_utils::TestContext;
 
     #[async_std::test]
     async fn test_decode_http() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
 
         let res = check_qr(&ctx.ctx, "http://www.hello.com").await;
 
@@ -399,7 +399,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_decode_https() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
 
         let res = check_qr(&ctx.ctx, "https://www.hello.com").await;
 
@@ -411,7 +411,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_decode_text() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
 
         let res = check_qr(&ctx.ctx, "I am so cool").await;
 
@@ -423,7 +423,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_decode_vcard() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
 
         let res = check_qr(
             &ctx.ctx,
@@ -441,7 +441,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_decode_matmsg() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
 
         let res = check_qr(
             &ctx.ctx,
@@ -459,7 +459,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_decode_mailto() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
 
         let res = check_qr(
             &ctx.ctx,
@@ -485,7 +485,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_decode_smtp() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
 
         let res = check_qr(&ctx.ctx, "SMTP:stress@test.local:subjecthello:bodyworld").await;
 
@@ -499,7 +499,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_decode_openpgp_group() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
 
         let res = check_qr(
             &ctx.ctx,
@@ -528,7 +528,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_decode_openpgp_secure_join() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
 
         let res = check_qr(
             &ctx.ctx,
@@ -556,7 +556,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_decode_openpgp_without_addr() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
 
         let res = check_qr(
             &ctx.ctx,
@@ -591,7 +591,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_decode_account() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
 
         let res = check_qr(
             &ctx.ctx,
@@ -613,7 +613,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_decode_account_bad_scheme() {
-        let ctx = dummy_context().await;
+        let ctx = TestContext::new().await;
         let res = check_qr(
             &ctx.ctx,
             "DCACCOUNT:http://example.org/new_email?t=1w_7wDjgjelxeX884x96v3",

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -409,7 +409,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_set_stock_translation() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         t.ctx
             .set_stock_translation(StockMessage::NoMessages, "xyz".to_string())
             .await
@@ -419,7 +419,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_set_stock_translation_wrong_replacements() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         assert!(t
             .ctx
             .set_stock_translation(StockMessage::NoMessages, "xyz %1$s ".to_string())
@@ -434,7 +434,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_stock_str() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         assert_eq!(
             t.ctx.stock_str(StockMessage::NoMessages).await,
             "No messages."
@@ -443,7 +443,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_stock_string_repl_str() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         // uses %1$s substitution
         assert_eq!(
             t.ctx
@@ -456,7 +456,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_stock_string_repl_int() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         assert_eq!(
             t.ctx
                 .stock_string_repl_int(StockMessage::MsgAddMember, 42)
@@ -467,7 +467,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_stock_string_repl_str2() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         assert_eq!(
             t.ctx
                 .stock_string_repl_str2(StockMessage::ServerResponse, "foo", "bar")
@@ -478,7 +478,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_stock_system_msg_simple() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         assert_eq!(
             t.ctx
                 .stock_system_msg(StockMessage::MsgLocationEnabled, "", "", 0)
@@ -489,7 +489,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_stock_system_msg_add_member_by_me() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         assert_eq!(
             t.ctx
                 .stock_system_msg(
@@ -505,7 +505,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_stock_system_msg_add_member_by_me_with_displayname() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         Contact::create(&t.ctx, "Alice", "alice@example.com")
             .await
             .expect("failed to create contact");
@@ -524,7 +524,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_stock_system_msg_add_member_by_other_with_displayname() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let contact_id = {
             Contact::create(&t.ctx, "Alice", "alice@example.com")
                 .await
@@ -548,7 +548,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_stock_system_msg_grp_name() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         assert_eq!(
             t.ctx
                 .stock_system_msg(
@@ -564,7 +564,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_stock_system_msg_grp_name_other() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         let id = Contact::create(&t.ctx, "Alice", "alice@example.com")
             .await
             .expect("failed to create contact");
@@ -579,7 +579,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_update_device_chats() {
-        let t = dummy_context().await;
+        let t = TestContext::new().await;
         t.ctx.update_device_chats().await.ok();
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 2);


### PR DESCRIPTION
This tidies up our testing tools a little bit.  We had several
functions which through various changes ended up doing the same and
some more which did very similar stuff, so I merged them to have
things simpler.  Also moved towards methods on the TestContext struct
while cleaning this up anyway, seems like this structure is going to
stay around for a bit anyway.

The intersting change is in `test_utils.rs`, everything else is just
updating callers.  A few tests used example.org which I moved to
example.com to be able to re-use more configuration of the test
context.