### PR TITLE
print time needed to build chatlist in repl tool

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -488,6 +488,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
         }
         "listchats" | "listarchived" | "chats" => {
             let listflags = if arg0 == "listarchived" { 0x01 } else { 0 };
+            let time_start = std::time::SystemTime::now();
             let chatlist = Chatlist::try_load(
                 &context,
                 listflags,
@@ -495,6 +496,9 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                 None,
             )
             .await?;
+            let time_needed = std::time::SystemTime::now()
+                .duration_since(time_start)
+                .unwrap_or_default();
 
             let cnt = chatlist.len();
             if cnt > 0 {
@@ -553,6 +557,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                 println!("Location streaming enabled.");
             }
             println!("{} chats", cnt);
+            println!("{:?} to create this list", time_needed);
         }
         "chat" => {
             if sel_chat.is_none() && arg1.is_empty() {


### PR DESCRIPTION
the chatlist is the most complicated list to get from sql
and is also the most used list,
so it makes sense to keep an eye on the timing of that.

background:

i stopped some times while creating #1635 that uses `ORDER BY .. LIMIT` instead of `MAX` on a subselect that is executed for every chat in scope.

in fact, it does not change that much, on my pc and a >250 chats, chatlist creation takes now 43ms-64ms instead of 40ms-56ms (executing 10 times) - so, it is measurable, but still okay - and having a correctly ordered list is totally worth it :)