### PR TITLE
give correct "fresh" flag to calc_sort_timestamp()

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -45,13 +45,14 @@ pub async fn dc_receive_imf(
 ) -> Result<()> {
     info!(
         context,
-        "Receiving message {}/{}...",
+        "Receiving message {}/{}, seen={}...",
         if !server_folder.as_ref().is_empty() {
             server_folder.as_ref()
         } else {
             "?"
         },
         server_uid,
+        seen
     );
 
     if std::env::var(crate::DCC_MIME_DEBUG).unwrap_or_default() == "2" {
@@ -621,7 +622,13 @@ async fn add_parts(
     // correct message_timestamp, it should not be used before,
     // however, we cannot do this earlier as we need from_id to be set
     let rcvd_timestamp = time();
-    let sort_timestamp = calc_sort_timestamp(context, *sent_timestamp, *chat_id, !seen).await;
+    let sort_timestamp = calc_sort_timestamp(
+        context,
+        *sent_timestamp,
+        *chat_id,
+        state == MessageState::InFresh,
+    )
+    .await;
     *sent_timestamp = std::cmp::min(*sent_timestamp, rcvd_timestamp);
 
     // unarchive chat


### PR DESCRIPTION
for "fresh" messages, calc_sort_timestamp() makes sure,
the sorting timestamp is not less than the last-non-fresh message.

this commit fixes the "fresh" state we give to calc_sort_timestamp(),
it just uses the message-state we've already calculated.

the old assumption, that unseen messages are always fresh
is wrong as this "seen" flag just comes from an imap-flag
that is not set for self-sent messages.

therefore, in a multi-device-setup, the message-order was totally messed up.
(the bug was probably in there since a long time,
however did not came to light until the async-move)