### PR TITLE
prepare 1.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog 
 
+## 1.38.0
+
+- fix sorting, esp. for multi-device
+
+
 ## 1.37.0
 
 - improve ndn heuristics #1630

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,7 +814,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.37.0"
+version = "1.38.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -886,7 +886,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.37.0"
+version = "1.38.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.37.0"
+version = "1.38.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.37.0"
+version = "1.38.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"


### PR DESCRIPTION
this fixes a very visible error in a multi-device-setup that came to light with async, #1645, i think, this is worth another release.

i will do a new android release probably later today night or tomorrow, so, if there are more fixes, they an also come in :)

