### PR TITLE
remove config changes interrupt

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -268,11 +268,14 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  * - `mdns_enabled` = 0=do not send or request read receipts,
  *                    1=send and request read receipts (default)
  * - `inbox_watch`  = 1=watch `INBOX`-folder for changes (default),
- *                    0=do not watch the `INBOX`-folder
+ *                    0=do not watch the `INBOX`-folder,
+ *                    changes require restarting IO by calling dc_stop_io() and then dc_start_io().
  * - `sentbox_watch`= 1=watch `Sent`-folder for changes (default),
- *                    0=do not watch the `Sent`-folder
+ *                    0=do not watch the `Sent`-folder,
+ *                    changes require restarting IO by calling dc_stop_io() and then dc_start_io().
  * - `mvbox_watch`  = 1=watch `DeltaChat`-folder for changes (default),
- *                    0=do not watch the `DeltaChat`-folder
+ *                    0=do not watch the `DeltaChat`-folder,
+ *                    changes require restarting IO by calling dc_stop_io() and then dc_start_io().
  * - `mvbox_move`   = 1=heuristically detect chat-messages
  *                    and move them to the `DeltaChat`-folder,
  *                    0=do not move chat-messages

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ use crate::dc_tools::*;
 use crate::events::Event;
 use crate::message::MsgId;
 use crate::mimefactory::RECOMMENDED_FILE_SIZE;
-use crate::{scheduler::InterruptInfo, stock::StockMessage};
+use crate::stock::StockMessage;
 
 /// The available configuration keys.
 #[derive(
@@ -200,22 +200,6 @@ impl Context {
                     }
                     None => self.sql.set_raw_config(self, key, None).await,
                 }
-            }
-            Config::InboxWatch => {
-                let ret = self.sql.set_raw_config(self, key, value).await;
-                self.interrupt_inbox(InterruptInfo::new(false, None)).await;
-                ret
-            }
-            Config::SentboxWatch => {
-                let ret = self.sql.set_raw_config(self, key, value).await;
-                self.interrupt_sentbox(InterruptInfo::new(false, None))
-                    .await;
-                ret
-            }
-            Config::MvboxWatch => {
-                let ret = self.sql.set_raw_config(self, key, value).await;
-                self.interrupt_mvbox(InterruptInfo::new(false, None)).await;
-                ret
             }
             Config::Selfstatus => {
                 let def = self.stock_str(StockMessage::StatusLine).await;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -38,14 +38,6 @@ impl Context {
         self.scheduler.read().await.interrupt_inbox(info).await;
     }
 
-    pub(crate) async fn interrupt_sentbox(&self, info: InterruptInfo) {
-        self.scheduler.read().await.interrupt_sentbox(info).await;
-    }
-
-    pub(crate) async fn interrupt_mvbox(&self, info: InterruptInfo) {
-        self.scheduler.read().await.interrupt_mvbox(info).await;
-    }
-
     pub(crate) async fn interrupt_smtp(&self, info: InterruptInfo) {
         self.scheduler.read().await.interrupt_smtp(info).await;
     }


### PR DESCRIPTION
interrupts on changing `mvbox_watch` etc. are no longer needed; to take effect, `dc_stop_io()` followed by `dc_start_io()` is needed.

follow up of #1654 