### PR TITLE
Switch to sanitize-filename-reader-friendly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ dependencies = [
  "regex",
  "rusqlite",
  "rustyline",
- "sanitize-filename",
+ "sanitize-filename-reader-friendly",
  "serde",
  "serde_json",
  "sha2 0.9.0",
@@ -2687,14 +2687,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sanitize-filename"
-version = "0.2.1"
+name = "sanitize-filename-reader-friendly"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fd0fec94ec480abfd86bb8f4f6c57e0efb36dac5c852add176ea7b04c74801"
-dependencies = [
- "lazy_static",
- "regex",
-]
+checksum = "464ea3b205846bf746a75a3483d82027b05d157b0415788b7cea7cf0c4d36892"
 
 [[package]]
 name = "schannel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ image-meta = "0.1.0"
 quick-xml = "0.18.1"
 escaper = "0.1.0"
 bitflags = "1.1.0"
-sanitize-filename = "0.2.1"
+sanitize-filename-reader-friendly = "0.9.2"
 stop-token = { version = "0.1.1", features = ["unstable"] }
 mailparse = "0.12.1"
 encoded-words = { git = "https://github.com/async-email/encoded-words", branch="master" }

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -320,13 +320,8 @@ impl<'a> BlobObject<'a> {
                 break;
             }
         }
-        let opts = sanitize_filename::Options {
-            truncate: true,
-            windows: true,
-            replacement: "",
-        };
 
-        let clean = sanitize_filename::sanitize_with_options(name, opts);
+        let clean = sanitize_filename_reader_friendly::sanitize(&name);
         let mut iter = clean.splitn(2, '.');
         let stem: String = iter.next().unwrap_or_default().chars().take(64).collect();
         let ext: String = iter.next().unwrap_or_default().chars().take(32).collect();


### PR DESCRIPTION
One advantage is that it does not depend on any crates, so there is a
higher chance of dropping regex crate eventually.