### PR TITLE
sanitise sanitise

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -660,8 +660,19 @@ mod tests {
         assert_eq!(ext, ".txt");
         assert!(!stem.is_empty());
 
-        let (stem, ext) =
-            BlobObject::sanitise_name("path/ignored\\this: is* forbidden?.c");
+        let (stem, ext) = BlobObject::sanitise_name("wot.tar.gz");
+        assert_eq!(stem, "wot");
+        assert_eq!(ext, ".tar.gz");
+
+        let (stem, ext) = BlobObject::sanitise_name(".foo.bar");
+        assert_eq!(stem, "");
+        assert_eq!(ext, ".foo.bar");
+
+        let (stem, ext) = BlobObject::sanitise_name("no-extension");
+        assert_eq!(stem, "no-extension");
+        assert_eq!(ext, "");
+
+        let (stem, ext) = BlobObject::sanitise_name("path/ignored\\this: is* forbidden?.c");
         assert_eq!(ext, ".c");
         assert!(!stem.contains("path"));
         assert!(!stem.contains("ignored"));

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -321,10 +321,13 @@ impl<'a> BlobObject<'a> {
             }
         }
 
-        let clean = sanitize_filename_reader_friendly::sanitize(&name);
-        let mut iter = clean.splitn(2, '.');
+        let mut iter = name.splitn(2, '.');
         let stem: String = iter.next().unwrap_or_default().chars().take(64).collect();
         let ext: String = iter.next().unwrap_or_default().chars().take(32).collect();
+
+        let stem: String = sanitize_filename_reader_friendly::sanitize(&stem);
+        let ext: String = sanitize_filename_reader_friendly::sanitize(&ext);
+
         if ext.is_empty() {
             (stem, "".to_string())
         } else {

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -655,8 +655,22 @@ mod tests {
 
     #[test]
     fn test_sanitise_name() {
-        let (_, ext) =
+        let (stem, ext) =
             BlobObject::sanitise_name("Я ЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯЯ.txt");
         assert_eq!(ext, ".txt");
+        assert!(!stem.is_empty());
+
+        let (stem, ext) =
+            BlobObject::sanitise_name("path/ignored\\this: is* forbidden?.c");
+        assert_eq!(ext, ".c");
+        assert!(!stem.contains("path"));
+        assert!(!stem.contains("ignored"));
+        assert!(stem.contains("this"));
+        assert!(stem.contains("forbidden"));
+        assert!(!stem.contains("/"));
+        assert!(!stem.contains("\\"));
+        assert!(!stem.contains(":"));
+        assert!(!stem.contains("*"));
+        assert!(!stem.contains("?"));
     }
 }


### PR DESCRIPTION
targets https://github.com/deltachat/deltachat-core-rust/pull/1664#issuecomment-648215446

the issue with the new sanitizer is, that it ignores extensions (this is commented and by design) - wowever, we split into stem and exension _after_ sanitising - therefore, `foo=.bar` will be sanitized loosing the extension to `foo_bar` (whereas the old sanitizer keeps the extension)

a quick fix is just to call sanitize after splitting.