### PR TITLE
Revert "Switch to sanitize-filename-reader-friendly"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -869,7 +869,7 @@ dependencies = [
  "regex",
  "rusqlite",
  "rustyline",
- "sanitize-filename-reader-friendly",
+ "sanitize-filename",
  "serde",
  "serde_json",
  "sha2 0.9.0",
@@ -2687,10 +2687,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sanitize-filename-reader-friendly"
-version = "0.9.2"
+name = "sanitize-filename"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464ea3b205846bf746a75a3483d82027b05d157b0415788b7cea7cf0c4d36892"
+checksum = "23fd0fec94ec480abfd86bb8f4f6c57e0efb36dac5c852add176ea7b04c74801"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "schannel"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ image-meta = "0.1.0"
 quick-xml = "0.18.1"
 escaper = "0.1.0"
 bitflags = "1.1.0"
-sanitize-filename-reader-friendly = "0.9.2"
+sanitize-filename = "0.2.1"
 stop-token = { version = "0.1.1", features = ["unstable"] }
 mailparse = "0.12.1"
 encoded-words = { git = "https://github.com/async-email/encoded-words", branch="master" }

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -320,8 +320,13 @@ impl<'a> BlobObject<'a> {
                 break;
             }
         }
+        let opts = sanitize_filename::Options {
+            truncate: true,
+            windows: true,
+            replacement: "",
+        };
 
-        let clean = sanitize_filename_reader_friendly::sanitize(&name);
+        let clean = sanitize_filename::sanitize_with_options(name, opts);
         let mut iter = clean.splitn(2, '.');
         let stem: String = iter.next().unwrap_or_default().chars().take(64).collect();
         let ext: String = iter.next().unwrap_or_default().chars().take(32).collect();


### PR DESCRIPTION
Reverts deltachat/deltachat-core-rust#1664

reason is that the sanitize-filename-reader-friendly handles extensions only partly, eg. `foo=.bar` is converted to `foo_bar` - although the extension does not contain a bad character. `foo=x.bar` otoh preserves the extension.

see also recent discussion on irc.