### PR TITLE
[WIP] Fix  #1615 Too much IMAP/Fetch activity

### DIFF
--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -50,7 +50,7 @@ impl Imap {
 
         let session = self.session.take();
         let timeout = Duration::from_secs(23 * 60);
-        let mut info = Default::default();
+        let mut info = InterruptInfo::fetch();
 
         if let Some(session) = session {
             let mut handle = session.idle();
@@ -76,8 +76,10 @@ impl Imap {
             } else {
                 info!(context, "Idle entering wait-on-remote state");
                 let fut = idle_wait.map(|ev| ev.map(Event::IdleResponse)).race(
-                    self.idle_interrupt.recv().map(|probe_network| {
-                        Ok(Event::Interrupt(probe_network.unwrap_or_default()))
+                    self.idle_interrupt.recv().map(|info| {
+                        Ok(Event::Interrupt(
+                            info.unwrap_or_else(|_| InterruptInfo::fetch()),
+                        ))
                     }),
                 );
 
@@ -145,10 +147,14 @@ impl Imap {
 
         // Do not poll, just wait for an interrupt when no folder is passed in.
         if watch_folder.is_none() {
-            return self.idle_interrupt.recv().await.unwrap_or_default();
+            return self
+                .idle_interrupt
+                .recv()
+                .await
+                .unwrap_or_else(|_| InterruptInfo::fetch());
         }
 
-        let mut info: InterruptInfo = Default::default();
+        let mut info = InterruptInfo::fetch();
         if self.skip_next_idle_wait {
             // interrupt_idle has happened before we
             // provided self.interrupt
@@ -164,56 +170,55 @@ impl Imap {
                 Interrupt(InterruptInfo),
             }
             // loop until we are interrupted or if we fetched something
-            info =
-                loop {
-                    use futures::future::FutureExt;
-                    match interval
-                        .next()
-                        .map(|_| Event::Tick)
-                        .race(self.idle_interrupt.recv().map(|probe_network| {
-                            Event::Interrupt(probe_network.unwrap_or_default())
-                        }))
-                        .await
-                    {
-                        Event::Tick => {
-                            // try to connect with proper login params
-                            // (setup_handle_if_needed might not know about them if we
-                            // never successfully connected)
-                            if let Err(err) = self.connect_configured(context).await {
-                                warn!(context, "fake_idle: could not connect: {}", err);
-                                continue;
-                            }
-                            if self.config.can_idle {
-                                // we only fake-idled because network was gone during IDLE, probably
-                                break InterruptInfo::new(false, None);
-                            }
-                            info!(context, "fake_idle is connected");
-                            // we are connected, let's see if fetching messages results
-                            // in anything.  If so, we behave as if IDLE had data but
-                            // will have already fetched the messages so perform_*_fetch
-                            // will not find any new.
+            info = loop {
+                use futures::future::FutureExt;
+                match interval
+                    .next()
+                    .map(|_| Event::Tick)
+                    .race(self.idle_interrupt.recv().map(|info| {
+                        Event::Interrupt(info.unwrap_or_else(|_| InterruptInfo::fetch()))
+                    }))
+                    .await
+                {
+                    Event::Tick => {
+                        // try to connect with proper login params
+                        // (setup_handle_if_needed might not know about them if we
+                        // never successfully connected)
+                        if let Err(err) = self.connect_configured(context).await {
+                            warn!(context, "fake_idle: could not connect: {}", err);
+                            continue;
+                        }
+                        if self.config.can_idle {
+                            // we only fake-idled because network was gone during IDLE, probably
+                            break InterruptInfo::fetch();
+                        }
+                        info!(context, "fake_idle is connected");
+                        // we are connected, let's see if fetching messages results
+                        // in anything.  If so, we behave as if IDLE had data but
+                        // will have already fetched the messages so perform_*_fetch
+                        // will not find any new.
 
-                            if let Some(ref watch_folder) = watch_folder {
-                                match self.fetch_new_messages(context, watch_folder).await {
-                                    Ok(res) => {
-                                        info!(context, "fetch_new_messages returned {:?}", res);
-                                        if res {
-                                            break InterruptInfo::new(false, None);
-                                        }
+                        if let Some(ref watch_folder) = watch_folder {
+                            match self.fetch_new_messages(context, watch_folder).await {
+                                Ok(res) => {
+                                    info!(context, "fetch_new_messages returned {:?}", res);
+                                    if res {
+                                        break InterruptInfo::exec_due_jobs();
                                     }
-                                    Err(err) => {
-                                        error!(context, "could not fetch from folder: {}", err);
-                                        self.trigger_reconnect()
-                                    }
+                                }
+                                Err(err) => {
+                                    error!(context, "could not fetch from folder: {}", err);
+                                    self.trigger_reconnect()
                                 }
                             }
                         }
-                        Event::Interrupt(info) => {
-                            // Interrupt
-                            break info;
-                        }
                     }
-                };
+                    Event::Interrupt(info) => {
+                        // Interrupt
+                        break info;
+                    }
+                }
+            };
         }
 
         info!(

--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -44,6 +44,10 @@ impl Imap {
         if !self.can_idle() {
             return Err(Error::IdleAbilityMissing);
         }
+        if let Ok(info) = self.idle_interrupt.try_recv() {
+            return Ok(info); // We got an interrupt in the meantime, do not idle
+        }
+
         self.setup_handle_if_needed(context).await?;
 
         self.select_folder(context, watch_folder.clone()).await?;

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1402,8 +1402,9 @@ async fn precheck_imf(
 
         if old_server_folder != server_folder || old_server_uid != server_uid {
             update_server_uid(context, rfc724_mid, server_folder, server_uid).await;
+            // We now have a msg_id again now and might want to
             context
-                .interrupt_inbox(InterruptInfo::new(false, Some(msg_id)))
+                .interrupt_inbox(InterruptInfo::exec_one_job(msg_id))
                 .await;
             info!(context, "Updating server_uid and interrupting")
         }


### PR DESCRIPTION
I tried this and new problems arose:

- After a message was moved we do have to do a fetch to get the new msg_id. If we do not the server will probably directly interrupt the idle because the moved message is "new". Obviously we do not need to fetch after a `Markseen`. Also, maybe we could try to use the response in idle.rs:88 and not fetch if we are not interested.

- At least Testrun interrupts the idle when we got new msgs since the last fetch, so no risk of a race condition. If you want to see what I tried, have a look at the `fetch-less-race-condition-test` branch.

- Directly using the connected imap connection in `fetch_new_messages` and marking the message as read turned out to be possible but tricky (see the `fetch-less` branch if you are interested and really want to see some of the mess I produced, but I did not get too far)
- I chose to add a field to InterruptInfo, `fetch`, to indicate whether DC should fetch. This will do almost exactly the same thing as directly using the connected imap connection: Fetch, send the "move" command to the IMAP server, idle (currently it's Fetch, send the "move" command to the IMAP server, **fetch**, idle). It will only select the folder once more but we wanted to get rid of selecting folders anyway at some point.