### PR TITLE
Add timestamp to DayMarker

### DIFF
--- a/deltachat-ffi/src/dc_array.rs
+++ b/deltachat-ffi/src/dc_array.rs
@@ -39,6 +39,17 @@ impl dc_array_t {
         }
     }
 
+    pub(crate) fn get_marker(&self, index: usize) -> Option<&str> {
+        match self {
+            Self::MsgIds(_) => None,
+            Self::Chat(array) => None,
+            Self::Locations(array) => array
+                .get(index)
+                .and_then(|location| location.marker.as_deref()),
+            Self::Uint(_) => None,
+        }
+    }
+
     pub(crate) fn get_location(&self, index: usize) -> &Location {
         if let Self::Locations(array) = self {
             &array[index]

--- a/deltachat-ffi/src/dc_array.rs
+++ b/deltachat-ffi/src/dc_array.rs
@@ -19,10 +19,23 @@ impl dc_array_t {
             Self::Chat(array) => match array[index] {
                 ChatItem::Message { msg_id } => msg_id.to_u32(),
                 ChatItem::Marker1 => DC_MSG_ID_MARKER1,
-                ChatItem::DayMarker => DC_MSG_ID_DAYMARKER,
+                ChatItem::DayMarker { .. } => DC_MSG_ID_DAYMARKER,
             },
             Self::Locations(array) => array[index].location_id,
             Self::Uint(array) => array[index],
+        }
+    }
+
+    pub(crate) fn get_timestamp(&self, index: usize) -> Option<i64> {
+        match self {
+            Self::MsgIds(_) => None,
+            Self::Chat(array) => array.get(index).and_then(|item| match item {
+                ChatItem::Message { .. } => None,
+                ChatItem::Marker1 { .. } => None,
+                ChatItem::DayMarker { timestamp } => Some(*timestamp),
+            }),
+            Self::Locations(array) => array.get(index).map(|location| location.timestamp),
+            Self::Uint(_) => None,
         }
     }
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2021,7 +2021,7 @@ pub unsafe extern "C" fn dc_array_get_marker(
         return std::ptr::null_mut(); // NULL explicitly defined as "no markers"
     }
 
-    if let Some(s) = &(*array).get_location(index).marker {
+    if let Some(s) = (*array).get_marker(index) {
         s.strdup()
     } else {
         std::ptr::null_mut()

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1974,7 +1974,7 @@ pub unsafe extern "C" fn dc_array_get_timestamp(
         return 0;
     }
 
-    (*array).get_location(index).timestamp
+    (*array).get_timestamp(index).unwrap_or_default()
 }
 #[no_mangle]
 pub unsafe extern "C" fn dc_array_get_chat_id(

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -37,7 +37,10 @@ pub enum ChatItem {
 
     /// Day marker, separating messages that correspond to different
     /// days according to local time.
-    DayMarker,
+    DayMarker {
+        /// Marker timestamp, for day markers
+        timestamp: i64,
+    },
 }
 
 /// Chat ID, including reserved IDs.
@@ -1626,7 +1629,9 @@ pub async fn get_chat_msgs(
                 let curr_local_timestamp = ts + cnv_to_local;
                 let curr_day = curr_local_timestamp / 86400;
                 if curr_day != last_day {
-                    ret.push(ChatItem::DayMarker);
+                    ret.push(ChatItem::DayMarker {
+                        timestamp: curr_day,
+                    });
                     last_day = curr_day;
                 }
             }


### PR DESCRIPTION
With this change, API user does not need to look at the timestamp of
the next message to display the day marker, but can get the timestamp
directly from the marker. This way there is no database query and no
risk of error as a result of database being busy or message being deleted.