### PR TITLE
Add stock strings for ephemeral timer changes

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4480,8 +4480,15 @@ void dc_event_unref(dc_event_t* event);
 #define DC_STR_UNKNOWN_SENDER_FOR_CHAT    72
 #define DC_STR_SUBJECT_FOR_NEW_CONTACT    73
 #define DC_STR_FAILED_SENDING_TO          74
+#define DC_STR_EPHEMERAL_DISABLED         75
+#define DC_STR_EPHEMERAL_SECONDS          76
+#define DC_STR_EPHEMERAL_MINUTE           77
+#define DC_STR_EPHEMERAL_HOUR             78
+#define DC_STR_EPHEMERAL_DAY              79
+#define DC_STR_EPHEMERAL_WEEK             80
+#define DC_STR_EPHEMERAL_FOUR_WEEKS       81
 
-#define DC_STR_COUNT                      74
+#define DC_STR_COUNT                      81
 
 /*
  * @}

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -10,7 +10,7 @@ use crate::constants::*;
 use crate::contact::*;
 use crate::context::Context;
 use crate::dc_tools::*;
-use crate::ephemeral::Timer as EphemeralTimer;
+use crate::ephemeral::{stock_ephemeral_timer_changed, Timer as EphemeralTimer};
 use crate::error::{bail, ensure, format_err, Result};
 use crate::events::Event;
 use crate::headerdef::HeaderDef;
@@ -653,15 +653,12 @@ async fn add_parts(
     {
         match (*chat_id).inner_set_ephemeral_timer(context, timer).await {
             Ok(()) => {
-                let stock_str = context
-                    .stock_system_msg(
-                        StockMessage::MsgEphemeralTimerChanged,
-                        timer.to_string(),
-                        "",
-                        from_id,
-                    )
-                    .await;
-                chat::add_info_msg(context, *chat_id, stock_str).await;
+                chat::add_info_msg(
+                    context,
+                    *chat_id,
+                    stock_ephemeral_timer_changed(context, timer, from_id).await,
+                )
+                .await;
                 context.emit_event(Event::ChatEphemeralTimerModified {
                     chat_id: *chat_id,
                     timer: timer.to_u32(),

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -194,7 +194,7 @@ impl ChatId {
                     StockMessage::MsgEphemeralTimerChanged,
                     timer.to_string(),
                     "",
-                    0,
+                    DC_CONTACT_ID_SELF,
                 )
                 .await,
         );

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -186,8 +186,28 @@ pub enum StockMessage {
     #[strum(props(fallback = "Failed to send message to %1$s."))]
     FailedSendingTo = 74,
 
-    #[strum(props(fallback = "Ephemeral message timer changed to %1$s."))]
-    MsgEphemeralTimerChanged = 75,
+    #[strum(props(fallback = "Message deletion timer is disabled."))]
+    MsgEphemeralTimerDisabled = 75,
+
+    // A fallback message for unknown timer values.
+    // "s" stands for "second" SI unit here.
+    #[strum(props(fallback = "Message deletion timer is set to %1$s s."))]
+    MsgEphemeralTimerEnabled = 76,
+
+    #[strum(props(fallback = "Message deletion timer is set to 1 minute."))]
+    MsgEphemeralTimerMinute = 77,
+
+    #[strum(props(fallback = "Message deletion timer is set to 1 hour."))]
+    MsgEphemeralTimerHour = 78,
+
+    #[strum(props(fallback = "Message deletion timer is set to 1 day."))]
+    MsgEphemeralTimerDay = 79,
+
+    #[strum(props(fallback = "Message deletion timer is set to 1 week."))]
+    MsgEphemeralTimerWeek = 80,
+
+    #[strum(props(fallback = "Message deletion timer is set to 4 weeks."))]
+    MsgEphemeralTimerFourWeeks = 81,
 }
 
 /*


### PR DESCRIPTION
The message talks about "message deletion timer" instead of "ephemeral message timer".

Closes #1678 