### PR TITLE
Do not show an error on IMAP connection failure

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -122,7 +122,7 @@ async fn fetch_idle(ctx: &Context, connection: &mut Imap, folder: Config) -> Int
         Some(watch_folder) => {
             // connect and fake idle if unable to connect
             if let Err(err) = connection.connect_configured(&ctx).await {
-                error!(ctx, "imap connection failed: {}", err);
+                warn!(ctx, "imap connection failed: {}", err);
                 return connection.fake_idle(&ctx, None).await;
             }
 


### PR DESCRIPTION
It is annoying as it happens every time the server is rebooted.