### PR TITLE
imap: expunge folder before IDLE if needed

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1542,7 +1542,6 @@ class TestOnlineAccount:
         assert msg.is_encrypted(), "Message is not encrypted"
         assert msg.chat == ac2.create_chat(ac4)
 
-    @pytest.mark.xfail
     def test_immediate_autodelete(self, acfactory, lp):
         ac1 = acfactory.get_online_configuring_account()
         ac2 = acfactory.get_online_configuring_account(mvbox=False, move=False, sentbox=False)

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -74,6 +74,13 @@ async fn inbox_loop(ctx: Context, started: Sender<()>, inbox_handlers: ImapConne
                 }
                 None => {
                     jobs_loaded = 0;
+
+                    // Expunge folder if needed, e.g. if some jobs have
+                    // deleted messages on the server.
+                    if let Err(err) = connection.maybe_close_folder(&ctx).await {
+                        warn!(ctx, "failed to close folder: {:?}", err);
+                    }
+
                     info = if ctx.get_config_bool(Config::InboxWatch).await {
                         fetch_idle(&ctx, &mut connection, Config::ConfiguredInboxFolder).await
                     } else {


### PR DESCRIPTION
This ensures Inbox is expunged timely in setups that don't watch
DeltaChat folder.

Fixes #1614 