### PR TITLE
use time::SystemTime instead of time::Instant

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -247,7 +247,7 @@ async fn generate_keypair(context: &Context) -> Result<KeyPair> {
             secret: SignedSecretKey::from_slice(&sec_bytes)?,
         }),
         Err(sql::Error::Sql(rusqlite::Error::QueryReturnedNoRows)) => {
-            let start = std::time::Instant::now();
+            let start = std::time::SystemTime::now();
             let keytype = KeyGenType::from_i32(context.get_config_int(Config::KeyGenType).await)
                 .unwrap_or_default();
             info!(context, "Generating keypair with type {}", keytype);
@@ -258,7 +258,7 @@ async fn generate_keypair(context: &Context) -> Result<KeyPair> {
             info!(
                 context,
                 "Keypair generated in {:.3}s.",
-                start.elapsed().as_secs()
+                start.elapsed().unwrap_or_default().as_secs()
             );
             Ok(keypair)
         }

--- a/src/smtp/send.rs
+++ b/src/smtp/send.rs
@@ -53,7 +53,7 @@ impl Smtp {
                 "Message len={} was smtp-sent to {}",
                 message_len, recipients_display
             )));
-            self.last_success = Some(std::time::Instant::now());
+            self.last_success = Some(std::time::SystemTime::now());
 
             Ok(())
         } else {


### PR DESCRIPTION
time::Instant may use libc::clock_gettime(CLOCK_MONOTONIC) eg. on android and does not advance while being in deep sleep mode. therefore, time::Instant is not a reliable way for timeouts or stoping times.

we experienced that issue the first time when showing the "uptime" in info-dialog. see #1437 and https://users.rust-lang.org/t/std-now-with-android/41774 for some backgrounds.

closes #1437 
