### PR TITLE
sync encrypted avatars only

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -197,7 +197,14 @@ pub async fn dc_receive_imf(
     }
 
     if let Some(avatar_action) = &mime_parser.user_avatar {
-        match contact::set_profile_image(&context, from_id, avatar_action).await {
+        match contact::set_profile_image(
+            &context,
+            from_id,
+            avatar_action,
+            mime_parser.was_encrypted(),
+        )
+        .await
+        {
             Ok(()) => {
                 context.emit_event(Event::ChatModified(chat_id));
             }


### PR DESCRIPTION
this pr ignores selfavatar-syncing when it comes in an unencrypted message.

this way, syncing may take a bit longer (until an avatar is sent in an encrypted message), however, it is not possible to trick the user by passing a random avatar - that may happen also for other avatars, however, the other avatars are not re-sent on behalf of the user.

as said, at some point, we need a sync-message (that is always forced encrypted :)

successor of #1716 