### PR TITLE
add config value BasicWebRTCInstance

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -318,6 +318,10 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    The library uses the `media_quality` setting to use different defaults
  *                    for recoding images sent with type DC_MSG_IMAGE.
  *                    If needed, recoding other file types is up to the UI.
+ * - `basic_web_rtc_instance` = address and token to webrtc signaling server (https://github.com/cracker0dks/basicwebrtc)
+ *                    that should be used for calls
+ *                    Format: https://example.com/subdir?token=TOKEN
+ *                    The other properties that are needed for a call such as the roomname will be set in the anchor part of the url.
  *
  * If you want to retrieve a value, use dc_get_config().
  *

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -318,10 +318,11 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    The library uses the `media_quality` setting to use different defaults
  *                    for recoding images sent with type DC_MSG_IMAGE.
  *                    If needed, recoding other file types is up to the UI.
- * - `basic_web_rtc_instance` = address and token to webrtc signaling server (https://github.com/cracker0dks/basicwebrtc)
- *                    that should be used for calls
- *                    Format: https://example.com/subdir?token=TOKEN
- *                    The other properties that are needed for a call such as the roomname will be set in the anchor part of the url.
+ * - `basic_web_rtc_instance` = address to webrtc signaling server (https://github.com/cracker0dks/basicwebrtc)
+ *                    that should be used for opening video hangouts.
+ *                    This property is only used in the UIs not by the core itself.
+ *                    Format: https://example.com/subdir
+ *                    The other properties that are needed for a call such as the roomname will be set by the client in the anchor part of the url.
  *
  * If you want to retrieve a value, use dc_get_config().
  *

--- a/src/config.rs
+++ b/src/config.rs
@@ -122,6 +122,8 @@ pub enum Config {
     /// Whether we send a warning if the password is wrong (set to false when we send a warning
     /// because we do not want to send a second warning)
     NotifyAboutWrongPw,
+
+    BasicWebRTCInstance,
 }
 
 impl Context {

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,6 +123,9 @@ pub enum Config {
     /// because we do not want to send a second warning)
     NotifyAboutWrongPw,
 
+    /// webrtc signaling server (https://github.com/cracker0dks/basicwebrtc) that should be used for calls
+    /// Format: https://example.com/subdir?token=TOKEN
+    /// The other properties that are needed for a call such as the roomname will be set in the anchor part of the url.
     BasicWebRTCInstance,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,9 +123,11 @@ pub enum Config {
     /// because we do not want to send a second warning)
     NotifyAboutWrongPw,
 
-    /// webrtc signaling server (https://github.com/cracker0dks/basicwebrtc) that should be used for calls
-    /// Format: https://example.com/subdir?token=TOKEN
-    /// The other properties that are needed for a call such as the roomname will be set in the anchor part of the url.
+    /// address to webrtc signaling server (https://github.com/cracker0dks/basicwebrtc)
+    /// that should be used for opening video hangouts.
+    /// This property is only used in the UIs not by the core itself.
+    /// Format: https://example.com/subdir
+    /// The other properties that are needed for a call such as the roomname will be set by the client in the anchor part of the url.
     BasicWebRTCInstance,
 }
 


### PR DESCRIPTION
for the upcoming webrtc call feature in desktop.
We are currently implementing video hangouts into the desktop client and need this config property to store the server address that should be used for signaling to establish the p2p connections between the connected users of a video hangout room.
https://github.com/deltachat/deltachat-desktop/pull/1789