### PR TITLE
Fix hanging tests (stuck idle + details) and make python shutdown more robust

### DIFF
--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -609,10 +609,14 @@ class Account(object):
         self.log("remove dc_context references")
         # the dc_context_unref triggers get_next_event to return ffi.NULL
         # which in turns makes the event thread finish execution
+        self._event_thread.mark_shutdown()
         self._dc_context = None
 
-        self.log("wait for event thread to finish")
-        self._event_thread.wait()
+        # the following wait is left out for now because it can fail if
+        # a) python code holds an extra self._dc_context reference
+        # b) the core does not manage to send a NULL through get_next_event()
+        # self.log("wait for event thread to finish")
+        # self._event_thread.wait()
 
         self._shutdown_event.set()
 

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -615,8 +615,14 @@ class Account(object):
         # the following wait is left out for now because it can fail if
         # a) python code holds an extra self._dc_context reference
         # b) the core does not manage to send a NULL through get_next_event()
-        # self.log("wait for event thread to finish")
-        # self._event_thread.wait()
+        self.log("wait for event thread to finish")
+        try:
+            self._event_thread.wait(timeout=2)
+        except RuntimeError as e:
+            self.log("Could not wait for thread: {}".format(e))
+
+        if self._event_thread.is_alive():
+            self.log("WARN: event thread did not terminate")
 
         self._shutdown_event.set()
 

--- a/python/src/deltachat/direct_imap.py
+++ b/python/src/deltachat/direct_imap.py
@@ -162,6 +162,10 @@ class DirectImap:
             requested = [b'BODY.PEEK[HEADER]', FLAGS]
             for uid, data in self.conn.fetch(messages, requested).items():
                 body_bytes = data[b'BODY[HEADER]']
+                if not body_bytes:
+                    log("Message", uid, "has empty body")
+                    continue
+
                 flags = data[FLAGS]
                 path = pathlib.Path(str(dir)).joinpath("IMAP", self.logid, imapfolder)
                 path.mkdir(parents=True, exist_ok=True)

--- a/python/src/deltachat/direct_imap.py
+++ b/python/src/deltachat/direct_imap.py
@@ -196,6 +196,7 @@ class DirectImap:
             raise TimeoutError
         if terminate:
             self.idle_done()
+        self.account.log("imap-direct: idle_check returned {!r}".format(res))
         return res
 
     def idle_wait_for_seen(self):

--- a/python/src/deltachat/direct_imap.py
+++ b/python/src/deltachat/direct_imap.py
@@ -159,9 +159,9 @@ class DirectImap:
             log("---------", imapfolder, len(messages), "messages ---------")
             # get message content without auto-marking it as seen
             # fetching 'RFC822' would mark it as seen.
-            requested = [b'BODY.PEEK[HEADER]', FLAGS]
+            requested = [b'BODY.PEEK[]', FLAGS]
             for uid, data in self.conn.fetch(messages, requested).items():
-                body_bytes = data[b'BODY[HEADER]']
+                body_bytes = data[b'BODY[]']
                 if not body_bytes:
                     log("Message", uid, "has empty body")
                     continue

--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -86,11 +86,11 @@ class FFIEventTracker:
             if rex.match(ev.name):
                 return ev
 
-    def get_info_matching(self, regex):
-        rex = re.compile("(?:{}).*".format(regex))
+    def get_info_contains(self, regex):
+        rex = re.compile(regex)
         while 1:
             ev = self.get_matching("DC_EVENT_INFO")
-            if rex.match(ev.data2):
+            if rex.search(ev.data2):
                 return ev
 
     def ensure_event_not_queued(self, event_name_regex):

--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -151,12 +151,12 @@ class EventThread(threading.Thread):
     def mark_shutdown(self):
         self._marked_for_shutdown = True
 
-    def wait(self):
+    def wait(self, timeout=None):
         if self == threading.current_thread():
             # we are in the callback thread and thus cannot
             # wait for the thread-loop to finish.
             return
-        self.join()
+        self.join(timeout=timeout)
 
     def run(self):
         """ get and run events until shutdown. """

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -231,6 +231,7 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
         def make_account(self, path, logid, quiet=False):
             ac = Account(path, logging=self._logging)
             ac._evtracker = ac.add_account_plugin(FFIEventTracker(ac))
+            ac._evtracker.set_timeout(30)
             ac.addr = ac.get_self_contact().addr
             ac.set_config("displayname", logid)
             if not quiet:
@@ -246,9 +247,7 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
         def get_unconfigured_account(self):
             self.offline_count += 1
             tmpdb = tmpdir.join("offlinedb%d" % self.offline_count)
-            ac = self.make_account(tmpdb.strpath, logid="ac{}".format(self.offline_count))
-            ac._evtracker.set_timeout(2)
-            return ac
+            return self.make_account(tmpdb.strpath, logid="ac{}".format(self.offline_count))
 
         def _preconfigure_key(self, account, addr):
             # Only set a key if we haven't used it yet for another account.
@@ -291,8 +290,6 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
             ac = self.make_account(tmpdb.strpath, logid="ac{}".format(self.live_count), quiet=quiet)
             if pre_generated_key:
                 self._preconfigure_key(ac, configdict['addr'])
-            ac._evtracker.init_time = self.init_time
-            ac._evtracker.set_timeout(30)
             return ac, dict(configdict)
 
         def get_online_configuring_account(self, mvbox=False, sentbox=False, move=False,
@@ -333,8 +330,6 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
             ac = self.make_account(tmpdb.strpath, logid="ac{}".format(self.live_count))
             if pre_generated_key:
                 self._preconfigure_key(ac, account.get_config("addr"))
-            ac._evtracker.init_time = self.init_time
-            ac._evtracker.set_timeout(30)
             ac.update_config(dict(
                 addr=account.get_config("addr"),
                 mail_pw=account.get_config("mail_pw"),

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -234,7 +234,9 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
             ac.addr = ac.get_self_contact().addr
             ac.set_config("displayname", logid)
             if not quiet:
-                ac.add_account_plugin(FFIEventLogger(ac))
+                logger = FFIEventLogger(ac)
+                logger.init_time = self.init_time
+                ac.add_account_plugin(logger)
             self._accounts.append(ac)
             return ac
 
@@ -245,7 +247,6 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
             self.offline_count += 1
             tmpdb = tmpdir.join("offlinedb%d" % self.offline_count)
             ac = self.make_account(tmpdb.strpath, logid="ac{}".format(self.offline_count))
-            ac._evtracker.init_time = self.init_time
             ac._evtracker.set_timeout(2)
             return ac
 

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1577,8 +1577,6 @@ class TestOnlineAccount:
 
     def test_ephemeral_timer(self, acfactory, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()
-        ac1.set_config("e2ee_enabled", "0")
-        ac2.set_config("e2ee_enabled", "0")
 
         lp.sec("ac1: create chat with ac2")
         chat1 = ac1.create_chat(ac2)

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1551,21 +1551,23 @@ class TestOnlineAccount:
 
         acfactory.wait_configure_and_start_io()
 
-        imap = ac2.direct_imap
-        imap.idle_start()
+        imap2 = ac2.direct_imap
+        imap2.idle_start()
 
         lp.sec("ac1: create chat with ac2")
         chat1 = ac1.create_chat(ac2)
         ac2.create_chat(ac1)
 
         sent_msg = chat1.send_text("hello")
-        imap.idle_check(terminate=False)
+        imap2.idle_check(terminate=False)
 
         msg = ac2._evtracker.wait_next_incoming_message()
         assert msg.text == "hello"
 
-        imap.idle_check(terminate=True)
-        assert len(imap.get_all_messages()) == 0
+        imap2.idle_check(terminate=True)
+        ac2._evtracker.get_info_contains("close/expunge succeeded")
+
+        assert len(imap2.get_all_messages()) == 0
 
         # Mark deleted message as seen and check that read receipt arrives
         msg.mark_seen()

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1575,6 +1575,8 @@ class TestOnlineAccount:
 
     def test_ephemeral_timer(self, acfactory, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1.set_config("e2ee_enabled", "0")
+        ac2.set_config("e2ee_enabled", "0")
 
         lp.sec("ac1: create chat with ac2")
         chat1 = ac1.create_chat(ac2)

--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -1,6 +1,7 @@
 use super::Imap;
 
 use async_imap::extensions::idle::IdleResponse;
+use async_imap::types::UnsolicitedResponse;
 use async_std::prelude::*;
 use std::time::{Duration, SystemTime};
 
@@ -53,12 +54,21 @@ impl Imap {
 
         if let Some(session) = self.session.take() {
             // if we have unsolicited responses we directly return
-            if let Ok(res) = session.unsolicited_responses.try_recv() {
-                warn!(context, "skip idle, got unsolicited response {:?}", res);
+            let mut unsolicited_exists = false;
+            while let Ok(response) = session.unsolicited_responses.try_recv() {
+                match response {
+                    UnsolicitedResponse::Exists(_) => {
+                        warn!(context, "skip idle, got unsolicited EXISTS {:?}", response);
+                        unsolicited_exists = true;
+                    }
+                    _ => info!(context, "ignoring unsolicited response {:?}", response),
+                }
+            }
+
+            if unsolicited_exists {
                 self.session = Some(session);
                 return Ok(info);
             }
-
 
             let mut handle = session.idle();
             if let Err(err) = handle.init().await {

--- a/src/job.rs
+++ b/src/job.rs
@@ -976,10 +976,7 @@ async fn perform_job_action(
         }
     };
 
-    info!(
-        context,
-        "Finished immediate try {} of job {}", tries, job
-    );
+    info!(context, "Finished immediate try {} of job {}", tries, job);
 
     try_res
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -978,7 +978,7 @@ async fn perform_job_action(
 
     info!(
         context,
-        "Inbox finished immediate try {} of job {}", tries, job
+        "Finished immediate try {} of job {}", tries, job
     );
 
     try_res


### PR DESCRIPTION
fix #1720 -- don't wait for the daemon eventhread to terminate but count on it to eventually die
maybe help with #1639 -- we should now not get stuck in INBOX while a new message in fact arrived already. 
