### PR TITLE
prepare 1.40.0 python deltachat release

### DIFF
--- a/python/CHANGELOG
+++ b/python/CHANGELOG
@@ -1,5 +1,7 @@
-0.900.0 (DRAFT)
+1.40.0
 ---------------
+
+- uses latest 1.40+ Delta Chat core
 
 - refactored internals to use plugin-approach 
 
@@ -9,6 +11,7 @@
 
 - introduced two documented examples for an echo and a group-membership
   tracking plugin. 
+
 
 0.800.0
 -------


### PR DESCRIPTION
plan is to follow core-versions but inc/deviate in the micro version part (third part of version).
So the py version number is not semantic versioning for now. 