### PR TITLE
add APIs for videochats

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4596,8 +4596,10 @@ void dc_event_unref(dc_event_t* event);
 #define DC_STR_EPHEMERAL_DAY              79
 #define DC_STR_EPHEMERAL_WEEK             80
 #define DC_STR_EPHEMERAL_FOUR_WEEKS       81
+#define DC_STR_VIDEOCHAT_INVITATION       82
+#define DC_STR_VIDEOCHAT_INVITE_MSG_BODY  83
 
-#define DC_STR_COUNT                      81
+#define DC_STR_COUNT                      83
 
 /*
  * @}

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3291,11 +3291,11 @@ char* dc_msg_get_videochat_url (const dc_msg_t* msg);
 
 
 /**
- * Check if the videochat is a "basic webrtc" videochat.
+ * Get type of videochat.
  *
  * Calling this functions only makes sense for messages of type #DC_MSG_VIDEOCHAT_INVITATION,
  * in this case, if "basic webrtc" as of https://github.com/cracker0dks/basicwebrtc was used to initiate the videochat,
- * dc_msg_is_basic_videochat() returns true.
+ * dc_msg_get_videochat_type() returns DC_VIDEOCHATTYPE_BASICWEBRTC.
  * "basic webrtc" videochat may be processed natively by the app
  * whereas for other urls just the browser is opened.
  *
@@ -3303,13 +3303,12 @@ char* dc_msg_get_videochat_url (const dc_msg_t* msg);
  * To check if a message is a videochat invitation at all, check the message type for #DC_MSG_VIDEOCHAT_INVITATION.
  *
  * @param msg The message object.
- * @return 0=message is no "basic webrtc" videochat invitation
- *     1=message is a "basic webrtc" videochat invitation.
+ * @return Type of the videochat as of DC_VIDEOCHATTYPE_BASICWEBRTC or DC_VIDEOCHATTYPE_UNKNOWN.
  *
  * Example:
  * ~~~
  * if (dc_msg_get_viewtype(msg) == DC_MSG_VIDEOCHAT_INVITATION) {
- *   if (dc_msg_is_basic_videochat(msg)) {
+ *   if (dc_msg_get_videochat_type(msg) == DC_VIDEOCHATTYPE_BASICWEBRTC) {
  *       // videochat invitation that we ship a client for
  *   } else {
  *       // use browser for videochat, just open the url
@@ -3319,7 +3318,10 @@ char* dc_msg_get_videochat_url (const dc_msg_t* msg);
  * }
  * ~~~
  */
-int dc_msg_is_basic_videochat (const dc_msg_t* msg);
+int dc_msg_get_videochat_type (const dc_msg_t* msg);
+
+#define DC_VIDEOCHATTYPE_UNKNOWN     0
+#define DC_VIDEOCHATTYPE_BASICWEBRTC 1
 
 
 /**

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -318,9 +318,11 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    The library uses the `media_quality` setting to use different defaults
  *                    for recoding images sent with type DC_MSG_IMAGE.
  *                    If needed, recoding other file types is up to the UI.
- * - `webrtc_instance` = address to webrtc instance to use for videochats,
- *                    eg. a server as of https://github.com/cracker0dks/basicwebrtc.
- *                    Format: https://example.com/subdir#roomname=$ROOM
+ * - `webrtc_instance` = webrtc instance to use for videochats in the form
+ *                    `[basicwebrtc:]https://example.com/subdir#roomname=$ROOM`
+ *                    if the url is prefixed by `basicwebrtc`, the server is assumed to be of the type
+ *                    https://github.com/cracker0dks/basicwebrtc which some UIs have native support for.
+ *                    If no type is prefixed, the videochat is handled completely in a browser.
  *
  * If you want to retrieve a value, use dc_get_config().
  *

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -318,11 +318,9 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    The library uses the `media_quality` setting to use different defaults
  *                    for recoding images sent with type DC_MSG_IMAGE.
  *                    If needed, recoding other file types is up to the UI.
- * - `basic_webrtc_instance` = address to webrtc signaling server (https://github.com/cracker0dks/basicwebrtc)
- *                    that should be used for opening video hangouts.
- *                    This property is only used in the UIs not by the core itself.
- *                    Format: https://example.com/subdir
- *                    The other properties that are needed for a call such as the roomname will be set by the client in the anchor part of the url.
+ * - `webrtc_instance` = address to webrtc instance to use for videochats,
+ *                    eg. a server as of https://github.com/cracker0dks/basicwebrtc.
+ *                    Format: https://example.com/subdir#roomname=$ROOM
  *
  * If you want to retrieve a value, use dc_get_config().
  *
@@ -842,7 +840,7 @@ uint32_t        dc_send_text_msg             (dc_context_t* context, uint32_t ch
 /**
  * Send invitation to a videochat.
  *
- * This function reads the `basic_webrtc_instance` config value,
+ * This function reads the `webrtc_instance` config value,
  * may check that the server is working in some way
  * and creates a unique room for this chat, if needed doing a TOKEN roundtrip for that.
  *

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3291,9 +3291,11 @@ char* dc_msg_get_videochat_url (const dc_msg_t* msg);
 
 
 /**
- * Check if the videochat can be handled internally.
- * If "basic webrtc" as of https://github.com/cracker0dks/basicwebrtc is used to initiate the videochat,
- * this is returned by dc_msg_is_basic_videochat().
+ * Check if the videochat is a "basic webrtc" videochat.
+ *
+ * Calling this functions only makes sense for messages of type #DC_MSG_VIDEOCHAT_INVITATION,
+ * in this case, if "basic webrtc" as of https://github.com/cracker0dks/basicwebrtc was used to initiate the videochat,
+ * dc_msg_is_basic_videochat() returns true.
  * "basic webrtc" videochat may be processed natively by the app
  * whereas for other urls just the browser is opened.
  *
@@ -3301,8 +3303,21 @@ char* dc_msg_get_videochat_url (const dc_msg_t* msg);
  * To check if a message is a videochat invitation at all, check the message type for #DC_MSG_VIDEOCHAT_INVITATION.
  *
  * @param msg The message object.
- * @return 0=message is no videochat invitation or cannot be handled internally
- *     1=message is a videochat invitation that can be handled internally or by a supported browser.
+ * @return 0=message is no "basic webrtc" videochat invitation
+ *     1=message is a "basic webrtc" videochat invitation.
+ *
+ * Example:
+ * ~~~
+ * if (dc_msg_get_viewtype(msg) == DC_MSG_VIDEOCHAT_INVITATION) {
+ *   if (dc_msg_is_basic_videochat(msg)) {
+ *       // videochat invitation that we ship a client for
+ *   } else {
+ *       // use browser for videochat, just open the url
+ *   }
+ * } else {
+ *    // not a videochat invitation
+ * }
+ * ~~~
  */
 int dc_msg_is_basic_videochat (const dc_msg_t* msg);
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -318,7 +318,7 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    The library uses the `media_quality` setting to use different defaults
  *                    for recoding images sent with type DC_MSG_IMAGE.
  *                    If needed, recoding other file types is up to the UI.
- * - `basic_web_rtc_instance` = address to webrtc signaling server (https://github.com/cracker0dks/basicwebrtc)
+ * - `basic_webrtc_instance` = address to webrtc signaling server (https://github.com/cracker0dks/basicwebrtc)
  *                    that should be used for opening video hangouts.
  *                    This property is only used in the UIs not by the core itself.
  *                    Format: https://example.com/subdir
@@ -842,7 +842,7 @@ uint32_t        dc_send_text_msg             (dc_context_t* context, uint32_t ch
 /**
  * Send invitation to a videochat.
  *
- * This function reads the `basic_web_rtc_instance` config value,
+ * This function reads the `basic_webrtc_instance` config value,
  * may check that the server is working in some way
  * and creates a unique room for this chat, if needed doing a TOKEN roundtrip for that.
  *

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -854,7 +854,7 @@ uint32_t        dc_send_text_msg             (dc_context_t* context, uint32_t ch
  *
  * - delta-clients can get all information needed from
  *   the message object, using eg.
- *   dc_msg_is_videochat_invitation(), dc_msg_get_videochat_url()
+ *   dc_msg_get_videochat_url() and check dc_msg_get_viewtype() for DC_MSG_VIDEOCHAT_INVITATION
  *
  * dc_send_videochat_invitation() is blocking and may take a while,
  * so the UIs will typically call the function from within a thread.
@@ -864,8 +864,7 @@ uint32_t        dc_send_text_msg             (dc_context_t* context, uint32_t ch
  * As for other messages sent, this function
  * sends the event #DC_EVENT_MSGS_CHANGED on succcess, the message has a delivery state, and so on.
  * The recipient will get noticed by the call as usual by DC_EVENT_INCOMING_MSG or DC_EVENT_MSGS_CHANGED,
- * depending on dc_msg_is_videochat_invitation(), however, UIs might some things differently,
- * eg. play a different sound.
+ * However, UIs might some things differently, eg. play a different sound.
  *
  * @param context The context object.
  * @param chat_id The chat to start a videochat for.
@@ -3277,25 +3276,10 @@ char*           dc_msg_get_setupcodebegin     (const dc_msg_t* msg);
 
 
 /**
- * Check if the message is a videochat invitation.
- *
- * Typically, such messages are rendered differently by the UIs,
- * if so, they should contain a button to join the videochat.
- * The url for joining can be retrieved using dc_msg_get_videochat_url().
- *
- * @param msg The message object.
- * @return Tristate, 0=message is no videochat invitation,
- *     1=message is a videochat invitation that should be handled by a supported browser,
- *     2=message is a videochat invitation that can be handled internally or by a supported browser.
- */
-int dc_msg_is_videochat_invitation (const dc_msg_t* msg);
-
-
-/**
  * Get url of a videochat invitation.
  *
- * Videochat invitations are send out using dc_send_videochat_invitation()
- * and you can check the state of a message using dc_msg_is_videochat_invitation().
+ * Videochat invitations are sent out using dc_send_videochat_invitation()
+ * and dc_msg_get_viewtype() returns #DC_MSG_VIDEOCHAT_INVITATION for such invitations.
  *
  * @param msg The message object.
  * @return If the message contains a videochat invitation,
@@ -3304,6 +3288,23 @@ int dc_msg_is_videochat_invitation (const dc_msg_t* msg);
  *     Must be released using dc_str_unref() when done.
  */
 char* dc_msg_get_videochat_url (const dc_msg_t* msg);
+
+
+/**
+ * Check if the videochat can be handled internally.
+ * If "basic webrtc" as of https://github.com/cracker0dks/basicwebrtc is used to initiate the videochat,
+ * this is returned by dc_msg_is_basic_videochat().
+ * "basic webrtc" videochat may be processed natively by the app
+ * whereas for other urls just the browser is opened.
+ *
+ * The videochat-url can be retrieved using dc_msg_get_videochat_url().
+ * To check if a message is a videochat invitation at all, check the message type for #DC_MSG_VIDEOCHAT_INVITATION.
+ *
+ * @param msg The message object.
+ * @return 0=message is no videochat invitation or cannot be handled internally
+ *     1=message is a videochat invitation that can be handled internally or by a supported browser.
+ */
+int dc_msg_is_basic_videochat (const dc_msg_t* msg);
 
 
 /**
@@ -3840,6 +3841,18 @@ int64_t          dc_lot_get_timestamp     (const dc_lot_t* lot);
  * and retrieved via dc_msg_get_file().
  */
 #define DC_MSG_FILE      60
+
+
+/**
+ * Message indicating an incoming or outgoing videochat.
+ * The message was created via dc_send_videochat_invitation() on this or a remote device.
+ *
+ * Typically, such messages are rendered differently by the UIs,
+ * eg. contain a button to join the videochat.
+ * The url for joining can be retrieved using dc_msg_get_videochat_url().
+ */
+#define DC_MSG_VIDEOCHAT_INVITATION 70
+
 
 /**
  * @}

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2847,19 +2847,21 @@ pub unsafe extern "C" fn dc_msg_get_videochat_url(msg: *mut dc_msg_t) -> *mut li
     }
     let ffi_msg = &*msg;
 
-    block_on(ffi_msg.message.get_videochat_url())
+    ffi_msg
+        .message
+        .get_videochat_url()
         .unwrap_or_default()
         .strdup()
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_msg_is_basic_videochat(msg: *mut dc_msg_t) -> libc::c_int {
+pub unsafe extern "C" fn dc_msg_get_videochat_type(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
-        eprintln!("ignoring careless call to dc_msg_is_basic_videochat()");
+        eprintln!("ignoring careless call to dc_msg_get_videochat_type()");
         return 0;
     }
     let ffi_msg = &*msg;
-    ffi_msg.message.is_basic_videochat().into()
+    ffi_msg.message.get_videochat_type().unwrap_or_default() as i32
 }
 
 #[no_mangle]

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -725,7 +725,7 @@ pub unsafe extern "C" fn dc_send_videochat_invitation(
         chat::send_videochat_invitation(&ctx, ChatId::new(chat_id))
             .await
             .map(|msg_id| msg_id.to_u32())
-            .unwrap_or_log_default(&ctx, "Failed to send videochat invitation")
+            .unwrap_or_log_default(&ctx, "Failed to send video chat invitation")
     })
 }
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -711,6 +711,25 @@ pub unsafe extern "C" fn dc_send_text_msg(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_send_videochat_invitation(
+    context: *mut dc_context_t,
+    chat_id: u32,
+) -> u32 {
+    if context.is_null() {
+        eprintln!("ignoring careless call to dc_send_videochat_invitation()");
+        return 0;
+    }
+    let ctx = &*context;
+
+    block_on(async move {
+        chat::send_videochat_invitation(&ctx, ChatId::new(chat_id))
+            .await
+            .map(|msg_id| msg_id.to_u32())
+            .unwrap_or_log_default(&ctx, "Failed to send videochat invitation")
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_set_draft(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -2818,6 +2837,29 @@ pub unsafe extern "C" fn dc_msg_is_setupmessage(msg: *mut dc_msg_t) -> libc::c_i
     }
     let ffi_msg = &*msg;
     ffi_msg.message.is_setupmessage().into()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dc_msg_get_videochat_url(msg: *mut dc_msg_t) -> *mut libc::c_char {
+    if msg.is_null() {
+        eprintln!("ignoring careless call to dc_msg_get_videochat_url()");
+        return "".strdup();
+    }
+    let ffi_msg = &*msg;
+
+    block_on(ffi_msg.message.get_videochat_url())
+        .unwrap_or_default()
+        .strdup()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dc_msg_is_basic_videochat(msg: *mut dc_msg_t) -> libc::c_int {
+    if msg.is_null() {
+        eprintln!("ignoring careless call to dc_msg_is_basic_videochat()");
+        return 0;
+    }
+    let ffi_msg = &*msg;
+    ffi_msg.message.is_basic_videochat().into()
 }
 
 #[no_mangle]

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -204,9 +204,9 @@ async fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
         if msg.is_info() { "[INFO]" } else { "" },
         if msg.get_viewtype() == Viewtype::VideochatInvitation {
             format!(
-                "[VIDEOCHAT-INVITATION: {}, basic={}]",
-                msg.get_videochat_url().await.unwrap_or_default(),
-                msg.is_basic_videochat()
+                "[VIDEOCHAT-INVITATION: {}, type={}]",
+                msg.get_videochat_url().unwrap_or_default(),
+                msg.get_videochat_type().unwrap_or_default()
             )
         } else {
             "".to_string()

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -359,6 +359,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                  send-garbage\n\
                  sendimage <file> [<text>]\n\
                  sendfile <file> [<text>]\n\
+                 videochat\n\
                  draft [<text>]\n\
                  devicemsg <text>\n\
                  listmedia\n\
@@ -807,6 +808,10 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                 msg.set_text(Some(arg2.to_string()));
             }
             chat::send_msg(&context, sel_chat.as_ref().unwrap().get_id(), &mut msg).await?;
+        }
+        "videochat" => {
+            ensure!(sel_chat.is_some(), "No chat selected.");
+            chat::send_videochat_invitation(&context, sel_chat.as_ref().unwrap().get_id()).await?;
         }
         "listmsgs" => {
             ensure!(!arg1.is_empty(), "Argument <query> missing.");

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -183,7 +183,7 @@ async fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
     let temp2 = dc_timestamp_to_str(msg.get_timestamp());
     let msgtext = msg.get_text();
     println!(
-        "{}{}{}{}: {} (Contact#{}): {} {}{}{}{}{} [{}]",
+        "{}{}{}{}: {} (Contact#{}): {} {}{}{}{}{}{} [{}]",
         prefix.as_ref(),
         msg.get_id(),
         if msg.get_showpadlock() { "🔒" } else { "" },
@@ -202,6 +202,15 @@ async fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
             "[FRESH]"
         },
         if msg.is_info() { "[INFO]" } else { "" },
+        if msg.get_viewtype() == Viewtype::VideochatInvitation {
+            format!(
+                "[VIDEOCHAT-INVITATION: {}, basic={}]",
+                msg.get_videochat_url().await.unwrap_or_default(),
+                msg.is_basic_videochat()
+            )
+        } else {
+            "".to_string()
+        },
         if msg.is_forwarded() {
             "[FORWARDED]"
         } else {

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -158,7 +158,7 @@ const DB_COMMANDS: [&str; 9] = [
     "housekeeping",
 ];
 
-const CHAT_COMMANDS: [&str; 26] = [
+const CHAT_COMMANDS: [&str; 27] = [
     "listchats",
     "listarchived",
     "chat",
@@ -178,6 +178,7 @@ const CHAT_COMMANDS: [&str; 26] = [
     "send",
     "sendimage",
     "sendfile",
+    "videochat",
     "draft",
     "listmedia",
     "archive",

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1619,22 +1619,24 @@ pub async fn send_videochat_invitation(context: &Context, chat_id: ChatId) -> Re
         chat_id
     );
 
-    let url = if let Some(webrtc_instance) = context.get_config(Config::WebrtcInstance).await {
-        webrtc_instance
+    let instance = if let Some(instance) = context.get_config(Config::WebrtcInstance).await {
+        instance
     } else {
         bail!("webrtc_instance not set");
     };
 
     let room = dc_create_id();
 
-    let url = if url.contains("$ROOM") {
-        url.replace("$ROOM", &room)
+    let instance = if instance.contains("$ROOM") {
+        instance.replace("$ROOM", &room)
     } else {
-        format!("{}{}", url, room)
+        format!("{}{}", instance, room)
     };
 
+    let url = instance.replace("basicwebrtc:", "");
+
     let mut msg = Message::new(Viewtype::VideochatInvitation);
-    msg.param.set(Param::VideochatUrl, &url);
+    msg.param.set(Param::WebrtcInstance, &instance);
     msg.text = Some(
         context
             .stock_string_repl_str(StockMessage::VideochatInviteMsgBody, url)

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1633,13 +1633,14 @@ pub async fn send_videochat_invitation(context: &Context, chat_id: ChatId) -> Re
         format!("{}{}", instance, room)
     };
 
-    let url = instance.replace("basicwebrtc:", "");
-
     let mut msg = Message::new(Viewtype::VideochatInvitation);
     msg.param.set(Param::WebrtcInstance, &instance);
     msg.text = Some(
         context
-            .stock_string_repl_str(StockMessage::VideochatInviteMsgBody, url)
+            .stock_string_repl_str(
+                StockMessage::VideochatInviteMsgBody,
+                Message::parse_webrtc_instance(&instance).1,
+            )
             .await,
     );
     send_msg(context, chat_id, &mut msg).await

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1620,7 +1620,11 @@ pub async fn send_videochat_invitation(context: &Context, chat_id: ChatId) -> Re
     );
 
     let instance = if let Some(instance) = context.get_config(Config::WebrtcInstance).await {
-        instance
+        if !instance.is_empty() {
+            instance
+        } else {
+            bail!("webrtc_instance is empty");
+        }
     } else {
         bail!("webrtc_instance not set");
     };

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1619,12 +1619,10 @@ pub async fn send_videochat_invitation(context: &Context, chat_id: ChatId) -> Re
         chat_id
     );
 
-    let url = if let Some(basic_webrtc_instance) =
-        context.get_config(Config::BasicWebrtcInstance).await
-    {
-        basic_webrtc_instance
+    let url = if let Some(webrtc_instance) = context.get_config(Config::WebrtcInstance).await {
+        webrtc_instance
     } else {
-        bail!("basic_webrtc_instance not set");
+        bail!("webrtc_instance not set");
     };
 
     let room = dc_create_id();

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1636,6 +1636,7 @@ pub async fn send_videochat_invitation(context: &Context, chat_id: ChatId) -> Re
     };
 
     let mut msg = Message::new(Viewtype::VideochatInvitation);
+    msg.param.set(Param::VideochatUrl, &url);
     msg.text = Some(
         context
             .stock_string_repl_str(StockMessage::VideochatInviteMsgBody, url)

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1374,11 +1374,12 @@ pub(crate) fn msgtype_has_file(msgtype: Viewtype) -> bool {
         Viewtype::Voice => true,
         Viewtype::Video => true,
         Viewtype::File => true,
+        Viewtype::VideochatInvitation => false,
     }
 }
 
 async fn prepare_msg_blob(context: &Context, msg: &mut Message) -> Result<(), Error> {
-    if msg.viewtype == Viewtype::Text {
+    if msg.viewtype == Viewtype::Text || msg.viewtype == Viewtype::VideochatInvitation {
         // the caller should check if the message text is empty
     } else if msgtype_has_file(msg.viewtype) {
         let blob = msg
@@ -1634,7 +1635,7 @@ pub async fn send_videochat_invitation(context: &Context, chat_id: ChatId) -> Re
         format!("{}{}", url, room)
     };
 
-    let mut msg = Message::new(Viewtype::Text);
+    let mut msg = Message::new(Viewtype::VideochatInvitation);
     msg.text = Some(
         context
             .stock_string_repl_str(StockMessage::VideochatInviteMsgBody, url)

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1615,7 +1615,7 @@ pub async fn send_text_msg(
 pub async fn send_videochat_invitation(context: &Context, chat_id: ChatId) -> Result<MsgId, Error> {
     ensure!(
         !chat_id.is_special(),
-        "videochat invitation cannot be sent to special chat: {}",
+        "video chat invitation cannot be sent to special chat: {}",
         chat_id
     );
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1638,7 +1638,7 @@ pub async fn send_videochat_invitation(context: &Context, chat_id: ChatId) -> Re
     };
 
     let mut msg = Message::new(Viewtype::VideochatInvitation);
-    msg.param.set(Param::WebrtcInstance, &instance);
+    msg.param.set(Param::WebrtcRoom, &instance);
     msg.text = Some(
         context
             .stock_string_repl_str(

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,12 +123,8 @@ pub enum Config {
     /// because we do not want to send a second warning)
     NotifyAboutWrongPw,
 
-    /// address to webrtc signaling server (https://github.com/cracker0dks/basicwebrtc)
-    /// that should be used for opening video hangouts.
-    /// This property is only used in the UIs not by the core itself.
-    /// Format: https://example.com/subdir
-    /// The other properties that are needed for a call such as the roomname will be set by the client in the anchor part of the url.
-    BasicWebrtcInstance,
+    /// address to webrtc instance to use for videochats
+    WebrtcInstance,
 }
 
 impl Context {

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,7 +128,7 @@ pub enum Config {
     /// This property is only used in the UIs not by the core itself.
     /// Format: https://example.com/subdir
     /// The other properties that are needed for a call such as the roomname will be set by the client in the anchor part of the url.
-    BasicWebRTCInstance,
+    BasicWebrtcInstance,
 }
 
 impl Context {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -84,6 +84,19 @@ impl Default for KeyGenType {
     }
 }
 
+#[derive(Debug, Display, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive, FromSql, ToSql)]
+#[repr(i8)]
+pub enum VideochatType {
+    Unknown = 0,
+    BasicWebrtc = 1,
+}
+
+impl Default for VideochatType {
+    fn default() -> Self {
+        VideochatType::Unknown
+    }
+}
+
 pub const DC_HANDSHAKE_CONTINUE_NORMAL_PROCESSING: i32 = 0x01;
 pub const DC_HANDSHAKE_STOP_NORMAL_PROCESSING: i32 = 0x02;
 pub const DC_HANDSHAKE_ADD_DELETE_JOB: i32 = 0x04;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -296,6 +296,9 @@ pub enum Viewtype {
     /// The file is set via dc_msg_set_file()
     /// and retrieved via dc_msg_get_file().
     File = 60,
+
+    /// Message is an invitation to a videochat.
+    VideochatInvitation = 70,
 }
 
 impl Default for Viewtype {

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -35,6 +35,7 @@ pub enum HeaderDef {
     ChatContent,
     ChatDuration,
     ChatDispositionNotificationTo,
+    ChatVideochatUrl,
     Autocrypt,
     AutocryptSetupMessage,
     SecureJoin,

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -35,7 +35,7 @@ pub enum HeaderDef {
     ChatContent,
     ChatDuration,
     ChatDispositionNotificationTo,
-    ChatWebrtcInstance,
+    ChatWebrtcRoom,
     Autocrypt,
     AutocryptSetupMessage,
     SecureJoin,

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -35,7 +35,7 @@ pub enum HeaderDef {
     ChatContent,
     ChatDuration,
     ChatDispositionNotificationTo,
-    ChatVideochatUrl,
+    ChatWebrtcInstance,
     Autocrypt,
     AutocryptSetupMessage,
     SecureJoin,

--- a/src/message.rs
+++ b/src/message.rs
@@ -1249,6 +1249,13 @@ pub async fn get_summarytext_by_raw(
                 format!("{} – {}", label, file_name)
             }
         }
+        Viewtype::VideochatInvitation => {
+            append_text = false;
+            context
+                .stock_str(StockMessage::VideochatInvitation)
+                .await
+                .into_owned()
+        }
         _ => {
             if param.get_cmd() != SystemMessage::LocationOnly {
                 "".to_string()

--- a/src/message.rs
+++ b/src/message.rs
@@ -639,11 +639,17 @@ impl Message {
     }
 
     pub async fn get_videochat_url(&self) -> Option<String> {
-        None
+        if self.viewtype == Viewtype::VideochatInvitation {
+            self.param.get(Param::VideochatUrl).map(|s| s.to_string())
+        } else {
+            None
+        }
     }
 
     pub fn is_basic_videochat(&self) -> bool {
-        false
+        // currently, all videochat-urls are of type basic-webrtc
+        self.viewtype == Viewtype::VideochatInvitation
+            && self.param.get(Param::VideochatUrl).is_some()
     }
 
     pub fn set_text(&mut self, text: Option<String>) {

--- a/src/message.rs
+++ b/src/message.rs
@@ -640,16 +640,20 @@ impl Message {
 
     pub async fn get_videochat_url(&self) -> Option<String> {
         if self.viewtype == Viewtype::VideochatInvitation {
-            self.param.get(Param::VideochatUrl).map(|s| s.to_string())
-        } else {
-            None
+            if let Some(instance) = self.param.get(Param::WebrtcInstance) {
+                return Some(instance.replace("basicwebrtc:", ""));
+            }
         }
+        None
     }
 
     pub fn is_basic_videochat(&self) -> bool {
-        // currently, all videochat-urls are of type basic-webrtc
-        self.viewtype == Viewtype::VideochatInvitation
-            && self.param.get(Param::VideochatUrl).is_some()
+        if self.viewtype == Viewtype::VideochatInvitation {
+            if let Some(instance) = self.param.get(Param::WebrtcInstance) {
+                return instance.starts_with("basicwebrtc:");
+            }
+        }
+        false
     }
 
     pub fn set_text(&mut self, text: Option<String>) {

--- a/src/message.rs
+++ b/src/message.rs
@@ -638,22 +638,37 @@ impl Message {
         None
     }
 
-    pub async fn get_videochat_url(&self) -> Option<String> {
+    /// split a webrtc_instance as defined by the corresponding config-value into a type and a url
+    pub fn parse_webrtc_instance(instance: &str) -> (VideochatType, String) {
+        let mut split = instance.splitn(2, ':');
+        let type_str = split.next().unwrap_or_default().to_lowercase();
+        let url = split.next();
+        if type_str == "basicwebrtc" {
+            (
+                VideochatType::BasicWebrtc,
+                url.unwrap_or_default().to_string(),
+            )
+        } else {
+            (VideochatType::Unknown, instance.to_string())
+        }
+    }
+
+    pub fn get_videochat_url(&self) -> Option<String> {
         if self.viewtype == Viewtype::VideochatInvitation {
             if let Some(instance) = self.param.get(Param::WebrtcInstance) {
-                return Some(instance.replace("basicwebrtc:", ""));
+                return Some(Message::parse_webrtc_instance(instance).1);
             }
         }
         None
     }
 
-    pub fn is_basic_videochat(&self) -> bool {
+    pub fn get_videochat_type(&self) -> Option<VideochatType> {
         if self.viewtype == Viewtype::VideochatInvitation {
             if let Some(instance) = self.param.get(Param::WebrtcInstance) {
-                return instance.starts_with("basicwebrtc:");
+                return Some(Message::parse_webrtc_instance(instance).0);
             }
         }
-        false
+        None
     }
 
     pub fn set_text(&mut self, text: Option<String>) {
@@ -1823,5 +1838,20 @@ mod tests {
             get_summarytext_by_raw(Viewtype::File, no_text.as_ref(), &mut asm_file, 50, &ctx).await,
             "Autocrypt Setup Message" // file name is not added for autocrypt setup messages
         );
+    }
+
+    #[async_std::test]
+    async fn test_parse_webrtc_instance() {
+        let (webrtc_type, url) = Message::parse_webrtc_instance("basicwebrtc:https://foo/bar");
+        assert_eq!(webrtc_type, VideochatType::BasicWebrtc);
+        assert_eq!(url, "https://foo/bar");
+
+        let (webrtc_type, url) = Message::parse_webrtc_instance("bAsIcwEbrTc:url");
+        assert_eq!(webrtc_type, VideochatType::BasicWebrtc);
+        assert_eq!(url, "url");
+
+        let (webrtc_type, url) = Message::parse_webrtc_instance("https://foo/bar?key=val#key=val");
+        assert_eq!(webrtc_type, VideochatType::Unknown);
+        assert_eq!(url, "https://foo/bar?key=val#key=val");
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -655,7 +655,7 @@ impl Message {
 
     pub fn get_videochat_url(&self) -> Option<String> {
         if self.viewtype == Viewtype::VideochatInvitation {
-            if let Some(instance) = self.param.get(Param::WebrtcInstance) {
+            if let Some(instance) = self.param.get(Param::WebrtcRoom) {
                 return Some(Message::parse_webrtc_instance(instance).1);
             }
         }
@@ -664,7 +664,7 @@ impl Message {
 
     pub fn get_videochat_type(&self) -> Option<VideochatType> {
         if self.viewtype == Viewtype::VideochatInvitation {
-            if let Some(instance) = self.param.get(Param::WebrtcInstance) {
+            if let Some(instance) = self.param.get(Param::WebrtcRoom) {
                 return Some(Message::parse_webrtc_instance(instance).0);
             }
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -638,6 +638,14 @@ impl Message {
         None
     }
 
+    pub async fn get_videochat_url(&self) -> Option<String> {
+        None
+    }
+
+    pub fn is_basic_videochat(&self) -> bool {
+        false
+    }
+
     pub fn set_text(&mut self, text: Option<String>) {
         self.text = text;
     }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -881,10 +881,10 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                 "videochat-invitation".into(),
             ));
             protected_headers.push(Header::new(
-                "Chat-Webrtc-Instance".into(),
+                "Chat-Webrtc-Room".into(),
                 self.msg
                     .param
-                    .get(Param::WebrtcInstance)
+                    .get(Param::WebrtcRoom)
                     .unwrap_or_default()
                     .into(),
             ));

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -881,10 +881,10 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                 "videochat-invitation".into(),
             ));
             protected_headers.push(Header::new(
-                "Chat-Videochat-Url".into(),
+                "Chat-Webrtc-Instance".into(),
                 self.msg
                     .param
-                    .get(Param::VideochatUrl)
+                    .get(Param::WebrtcInstance)
                     .unwrap_or_default()
                     .into(),
             ));

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -875,6 +875,19 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
 
         if self.msg.viewtype == Viewtype::Sticker {
             protected_headers.push(Header::new("Chat-Content".into(), "sticker".into()));
+        } else if self.msg.viewtype == Viewtype::VideochatInvitation {
+            protected_headers.push(Header::new(
+                "Chat-Content".into(),
+                "videochat-invitation".into(),
+            ));
+            protected_headers.push(Header::new(
+                "Chat-Videochat-Url".into(),
+                self.msg
+                    .param
+                    .get(Param::VideochatUrl)
+                    .unwrap_or_default()
+                    .into(),
+            ));
         }
 
         if self.msg.viewtype == Viewtype::Voice

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -242,6 +242,18 @@ impl MimeMessage {
         }
     }
 
+    fn parse_videochat_headers(&mut self) {
+        if let Some(value) = self.get(HeaderDef::ChatContent).cloned() {
+            if value == "videochat-invitation" {
+                let url = self.get(HeaderDef::ChatVideochatUrl).cloned();
+                if let Some(part) = self.parts.first_mut() {
+                    part.typ = Viewtype::VideochatInvitation;
+                    part.param.set(Param::VideochatUrl, url.unwrap_or_default());
+                }
+            }
+        }
+    }
+
     /// Squashes mutlipart chat messages with attachment into single-part messages.
     ///
     /// Delta Chat sends attachments, such as images, in two-part messages, with the first message
@@ -314,6 +326,7 @@ impl MimeMessage {
     fn parse_headers(&mut self, context: &Context) -> Result<()> {
         self.parse_system_message_headers(context)?;
         self.parse_avatar_headers();
+        self.parse_videochat_headers();
         self.squash_attachment_parts();
 
         if let Some(ref subject) = self.get_subject() {
@@ -1447,6 +1460,28 @@ mod tests {
         assert_eq!(mimeparser.parts[0].typ, Viewtype::Image);
         assert_eq!(mimeparser.user_avatar, None);
         assert!(mimeparser.group_avatar.unwrap().is_change());
+    }
+
+    #[async_std::test]
+    async fn test_mimeparser_with_videochat() {
+        let t = TestContext::new().await;
+
+        let raw = include_bytes!("../test-data/message/videochat_invitation.eml");
+        let mimeparser = MimeMessage::from_bytes(&t.ctx, &raw[..]).await.unwrap();
+        assert_eq!(mimeparser.parts.len(), 1);
+        assert_eq!(mimeparser.parts[0].typ, Viewtype::VideochatInvitation);
+        assert_eq!(
+            mimeparser.parts[0]
+                .param
+                .get(Param::VideochatUrl)
+                .unwrap_or_default(),
+            "https://example.org/p2p/?roomname=6HiduoAn4xN"
+        );
+        assert!(mimeparser.parts[0]
+            .msg
+            .contains("https://example.org/p2p/?roomname=6HiduoAn4xN"));
+        assert_eq!(mimeparser.user_avatar, None);
+        assert_eq!(mimeparser.group_avatar, None);
     }
 
     #[async_std::test]

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -245,11 +245,11 @@ impl MimeMessage {
     fn parse_videochat_headers(&mut self) {
         if let Some(value) = self.get(HeaderDef::ChatContent).cloned() {
             if value == "videochat-invitation" {
-                let instance = self.get(HeaderDef::ChatWebrtcInstance).cloned();
+                let instance = self.get(HeaderDef::ChatWebrtcRoom).cloned();
                 if let Some(part) = self.parts.first_mut() {
                     part.typ = Viewtype::VideochatInvitation;
                     part.param
-                        .set(Param::WebrtcInstance, instance.unwrap_or_default());
+                        .set(Param::WebrtcRoom, instance.unwrap_or_default());
                 }
             }
         }
@@ -1474,7 +1474,7 @@ mod tests {
         assert_eq!(
             mimeparser.parts[0]
                 .param
-                .get(Param::WebrtcInstance)
+                .get(Param::WebrtcRoom)
                 .unwrap_or_default(),
             "https://example.org/p2p/?roomname=6HiduoAn4xN"
         );

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -245,10 +245,11 @@ impl MimeMessage {
     fn parse_videochat_headers(&mut self) {
         if let Some(value) = self.get(HeaderDef::ChatContent).cloned() {
             if value == "videochat-invitation" {
-                let url = self.get(HeaderDef::ChatVideochatUrl).cloned();
+                let instance = self.get(HeaderDef::ChatWebrtcInstance).cloned();
                 if let Some(part) = self.parts.first_mut() {
                     part.typ = Viewtype::VideochatInvitation;
-                    part.param.set(Param::VideochatUrl, url.unwrap_or_default());
+                    part.param
+                        .set(Param::WebrtcInstance, instance.unwrap_or_default());
                 }
             }
         }
@@ -1473,7 +1474,7 @@ mod tests {
         assert_eq!(
             mimeparser.parts[0]
                 .param
-                .get(Param::VideochatUrl)
+                .get(Param::WebrtcInstance)
                 .unwrap_or_default(),
             "https://example.org/p2p/?roomname=6HiduoAn4xN"
         );

--- a/src/param.rs
+++ b/src/param.rs
@@ -69,7 +69,7 @@ pub enum Param {
     AttachGroupImage = b'A',
 
     /// For Messages
-    VideochatUrl = b'V',
+    WebrtcInstance = b'V',
 
     /// For Messages: space-separated list of messaged IDs of forwarded copies.
     ///

--- a/src/param.rs
+++ b/src/param.rs
@@ -68,6 +68,9 @@ pub enum Param {
     /// For Messages
     AttachGroupImage = b'A',
 
+    /// For Messages
+    VideochatUrl = b'V',
+
     /// For Messages: space-separated list of messaged IDs of forwarded copies.
     ///
     /// This is used when a [crate::message::Message] is in the

--- a/src/param.rs
+++ b/src/param.rs
@@ -69,7 +69,7 @@ pub enum Param {
     AttachGroupImage = b'A',
 
     /// For Messages
-    WebrtcInstance = b'V',
+    WebrtcRoom = b'V',
 
     /// For Messages: space-separated list of messaged IDs of forwarded copies.
     ///

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -210,6 +210,12 @@ pub enum StockMessage {
 
     #[strum(props(fallback = "Message deletion timer is set to 4 weeks."))]
     MsgEphemeralTimerFourWeeks = 81,
+
+    #[strum(props(fallback = "Videochat invitation"))]
+    VideochatInvitation = 82,
+
+    #[strum(props(fallback = "You are invited to an videochat, click %1$s to join."))]
+    VideochatInviteMsgBody = 83,
 }
 
 /*

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -211,10 +211,10 @@ pub enum StockMessage {
     #[strum(props(fallback = "Message deletion timer is set to 4 weeks."))]
     MsgEphemeralTimerFourWeeks = 81,
 
-    #[strum(props(fallback = "Videochat invitation"))]
+    #[strum(props(fallback = "Video chat invitation"))]
     VideochatInvitation = 82,
 
-    #[strum(props(fallback = "You are invited to an videochat, click %1$s to join."))]
+    #[strum(props(fallback = "You are invited to a video chat, click %1$s to join."))]
     VideochatInviteMsgBody = 83,
 }
 

--- a/test-data/message/videochat_invitation.eml
+++ b/test-data/message/videochat_invitation.eml
@@ -1,0 +1,15 @@
+Content-Type: text/plain; charset=utf-8
+Subject: Message from user
+Message-ID: <Mr.f1O61111evx.ikocf333353@example.org>
+Date: Mon, 20 Jul 2020 14:28:30 +0000
+X-Mailer: Delta Chat Core 1.40.0/CLI
+Chat-Version: 1.0
+Chat-Content: videochat-invitation
+Chat-Videochat-Url: https://example.org/p2p/?roomname=6HiduoAn4xN
+To: <tunis3@example>
+From: "=?utf-8?q??=" <tunis4@example.org>
+
+You are invited to an videochat, click https://example.org/p2p/?roomname=6HiduoAn4xN to join.
+
+-- 
+Sent with my Delta Chat Messenger: https://delta.chat

--- a/test-data/message/videochat_invitation.eml
+++ b/test-data/message/videochat_invitation.eml
@@ -5,7 +5,7 @@ Date: Mon, 20 Jul 2020 14:28:30 +0000
 X-Mailer: Delta Chat Core 1.40.0/CLI
 Chat-Version: 1.0
 Chat-Content: videochat-invitation
-Chat-Webrtc-Instance: https://example.org/p2p/?roomname=6HiduoAn4xN
+Chat-Webrtc-Room: https://example.org/p2p/?roomname=6HiduoAn4xN
 To: <tunis3@example.org>
 From: "=?utf-8?q??=" <tunis4@example.org>
 

--- a/test-data/message/videochat_invitation.eml
+++ b/test-data/message/videochat_invitation.eml
@@ -6,7 +6,7 @@ X-Mailer: Delta Chat Core 1.40.0/CLI
 Chat-Version: 1.0
 Chat-Content: videochat-invitation
 Chat-Videochat-Url: https://example.org/p2p/?roomname=6HiduoAn4xN
-To: <tunis3@example>
+To: <tunis3@example.org>
 From: "=?utf-8?q??=" <tunis4@example.org>
 
 You are invited to an videochat, click https://example.org/p2p/?roomname=6HiduoAn4xN to join.

--- a/test-data/message/videochat_invitation.eml
+++ b/test-data/message/videochat_invitation.eml
@@ -5,7 +5,7 @@ Date: Mon, 20 Jul 2020 14:28:30 +0000
 X-Mailer: Delta Chat Core 1.40.0/CLI
 Chat-Version: 1.0
 Chat-Content: videochat-invitation
-Chat-Videochat-Url: https://example.org/p2p/?roomname=6HiduoAn4xN
+Chat-Webrtc-Instance: https://example.org/p2p/?roomname=6HiduoAn4xN
 To: <tunis3@example.org>
 From: "=?utf-8?q??=" <tunis4@example.org>
 


### PR DESCRIPTION
i first thought, that the invite-function should returns some more information about the url or so, however, as also the recipient will need these information, it seemed easier to attach them to the message object - as we've done also in some other case (eg. setup message, disappearing message info)

the invite-function is blocking, so it has to be called from within a thread - even if it will return fast in most cases.

for now i decided against special events or message-types - this seems not to be needed for now :)

next step would be to add some very basic implementation, so that the UIs are satisfied - wrt TOKEN etc. that can be refined in core, the UIs need not to take care about that. at least, this is the rough idea, of course, we can add additional apis as needed ;)