### PR TITLE
avoid popping up "IMAP Connect without configured params"

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4132,14 +4132,12 @@ void dc_event_unref(dc_event_t* event);
  * Network errors should be reported to users in a non-disturbing way,
  * however, as network errors may come in a sequence,
  * it is not useful to raise each an every error to the user.
- * For this purpose, data1 is set to 1 if the error is probably worth reporting.
  *
  * Moreover, if the UI detects that the device is offline,
  * it is probably more useful to report this to the user
  * instead of the string from data2.
  *
- * @param data1 (int) 1=first/new network error, should be reported the user;
- *     0=subsequent network error, should be logged only
+ * @param data1 0
  * @param data2 (char*) Error string, always set, never NULL.
  */
 #define DC_EVENT_ERROR_NETWORK            401

--- a/src/events.rs
+++ b/src/events.rs
@@ -140,7 +140,6 @@ pub enum Event {
     /// Network errors should be reported to users in a non-disturbing way,
     /// however, as network errors may come in a sequence,
     /// it is not useful to raise each an every error to the user.
-    /// For this purpose, data1 is set to 1 if the error is probably worth reporting.
     ///
     /// Moreover, if the UI detects that the device is offline,
     /// it is probably more useful to report this to the user

--- a/src/log.rs
+++ b/src/log.rs
@@ -42,6 +42,17 @@ macro_rules! error {
 }
 
 #[macro_export]
+macro_rules! error_network {
+    ($ctx:expr, $msg:expr) => {
+        error_network!($ctx, $msg,)
+    };
+    ($ctx:expr, $msg:expr, $($args:expr),* $(,)?) => {{
+        let formatted = format!($msg, $($args),*);
+        emit_event!($ctx, $crate::Event::ErrorNetwork(formatted));
+    }};
+}
+
+#[macro_export]
 macro_rules! emit_event {
     ($ctx:expr, $event:expr) => {
         $ctx.emit_event($event);

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -105,7 +105,7 @@ async fn fetch(ctx: &Context, connection: &mut Imap) {
     match ctx.get_config(Config::ConfiguredInboxFolder).await {
         Some(watch_folder) => {
             if let Err(err) = connection.connect_configured(&ctx).await {
-                error!(ctx, "{}", err);
+                error_network!(ctx, "{}", err);
                 return;
             }
 


### PR DESCRIPTION
the error "IMAP Connect without configured params" was emited as DC_EVENT_ERROR, these kind of errors are typically always show to the user eg. as a toast on android.

however, there is also the DC_EVENT_ERROR_NETWORK event, that is typically not reported in sequence to the user (following the docs ;) and also, when there is no network available, eg. android only shows a toast saying "Not network" instead of a random, unrelated error.

this pr changes the described error to DC_EVENT_ERROR_NETWORK and also updates the documentation (in fact, core does not handle tracking of subsequent errors as documented)

see also https://github.com/deltachat/deltachat-android/issues/1489 and https://github.com/deltachat/deltachat-android/issues/1490
