### PR TITLE
ci: allow nightly runs to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,22 @@ jobs:
   build_and_test:
     name: Build and test
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust: [nightly, 1.45.0]
+        rust: [1.45.0]
+        experimental: [false]
+        include:
+          - os: ubuntu-latest
+            rust: nightly
+            experimental: true
+          - os: windows-latest
+            rust: nightly
+            experimental: true
+          - os: macOS-latest
+            rust: nightly
+            experimental: true
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#example-including-new-combinations

Adding this because of the current nightly regression: https://github.com/rust-lang/rust/issues/74614