### PR TITLE
utf8-fix for backup import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ deltachat-ffi/html
 deltachat-ffi/xml
 
 .rsynclist
+
+# ignore backup files
+*.bak
+

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ deltachat-ffi/xml
 # ignore backup files
 *.bak
 
+# ignore test-data
+/test-data
+

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -28,6 +28,7 @@ use crate::message::{Message, MsgId};
 use crate::mimeparser::SystemMessage;
 use crate::param::*;
 use crate::pgp;
+use crate::rusqlite::types::ValueRef;
 use crate::sql::{self, Sql};
 use crate::stock::StockMessage;
 use async_tar::Archive;
@@ -601,7 +602,54 @@ async fn import_backup_old(context: &Context, backup_to_import: impl AsRef<Path>
             .query_row(
                 "SELECT file_name, file_content FROM backup_blobs WHERE id = ?",
                 paramsv![file_id],
-                |row| Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?)),
+                // cs: This is the affected line NOW for producing the error. But
+                // here get is awaiting for String or another type to come back?
+                // |row| Ok((row.get::<_, String>(0)?, row.get::<_, Vec<u8>>(1)?)),
+
+                // cs: this is the secure replacement code for |row| ...
+                |row| {
+                    // Statement  'let name: String = row.get(0)?;'  is an assumption!
+                    //
+                    // This assumption that data matches String type is only true with clean utf8!
+                    // This simple "row.get(0) only works when TEXT column is ok and String conversion
+                    // from clean utf8 encoding is possible.
+                    // Every bad utf8 encoded data in TEXT column crashes this assumption and
+                    // switches to Err(_) path.
+                    let name: String = match row.get(0) {
+                        Ok(name) => name, // good utf8 filename
+                        Err(_) => {
+                            // bad utf8 encoding in filename
+                            match row.get_raw(0) {
+                                ValueRef::Null => "Null Value".to_string(),
+                                ValueRef::Text(t) => {
+                                    // column type in db is TEXT
+                                    let name = String::from_utf8_lossy(t).to_string();
+                                    info!(
+                                        context,
+                                        "Err (_), ValueRef::Text(t), name: \"{}\"", name
+                                    );
+                                    name
+                                }
+                                ValueRef::Blob(b) => {
+                                    let name = String::from_utf8_lossy(b).to_string();
+                                    info!(
+                                        context,
+                                        "Err (_), ValueRef::Blob(b), name: \"{}\"", name
+                                    );
+                                    name
+                                }
+                                _ => "Other error determining type value".to_string(),
+                            }
+                        }
+                    };
+
+                    // this always works
+                    let blob: Vec<u8> = row.get(1)?;
+
+                    info!(context, "query_map |row| filename=\"{}\"", name);
+
+                    Ok((name, blob))
+                },
             )
             .await?;
 

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -619,8 +619,6 @@ async fn maybe_add_from_param(
         .query_map(
             query,
             paramsv![],
-            //|row| row.get::<_, String>(0), // <=== this crashes when non utf8 byte in column
-
             // cs: maybe the following could be done even more simple than here?
             |row| {
                 let value = match row.get_raw(0) {

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -624,16 +624,10 @@ async fn maybe_add_from_param(
             // cs: maybe the following could be done even more simple than here?
             |row| {
                 let value = match row.get_raw(0) {
-                    ValueRef::Text(t) => {
-                        // changed due to clippy complain
-                        //~let col_str = String::from_utf8_lossy(t).to_string();
-                        //~info!(context, "maybe_add_from_param() - col_str: \"{}\"", col_str);
-                        //~col_str
-                        String::from_utf8_lossy(t).to_string()
-                    }
+                    ValueRef::Text(t) => String::from_utf8_lossy(t).to_string(),
                     _ => {
                         let s_err = "maybe_add_from_param() - error - get_raw(0)".to_string();
-                        info!(context, "{}", s_err);
+                        warn!(context, "{}", s_err);
                         s_err
                     }
                 };

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -16,6 +16,7 @@ use crate::dc_tools::*;
 use crate::ephemeral::start_ephemeral_timers;
 use crate::param::*;
 use crate::peerstate::*;
+use crate::rusqlite::types::ValueRef; //cs
 
 #[macro_export]
 macro_rules! paramsv {
@@ -618,7 +619,26 @@ async fn maybe_add_from_param(
         .query_map(
             query,
             paramsv![],
-            |row| row.get::<_, String>(0),
+            //|row| row.get::<_, String>(0), // <=== this crashes when non utf8 byte in column
+
+            // cs: maybe the following could be done even more simple than here?
+            |row| {
+                let value = match row.get_raw(0) {
+                    ValueRef::Text(t) => {
+                        // changed due to clippy complain
+                        //~let col_str = String::from_utf8_lossy(t).to_string();
+                        //~info!(context, "maybe_add_from_param() - col_str: \"{}\"", col_str);
+                        //~col_str
+                        String::from_utf8_lossy(t).to_string()
+                    }
+                    _ => {
+                        let s_err = "maybe_add_from_param() - error - get_raw(0)".to_string();
+                        info!(context, "{}", s_err);
+                        s_err
+                    }
+                };
+                Ok(value)
+            },
             |rows| {
                 for row in rows {
                     let param: Params = row?.parse().unwrap_or_default();

--- a/test-db-run-repl.sh
+++ b/test-db-run-repl.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+#
+# command to run example cmd application
+#
+
+#cargo run --features="rustyline" --example repl -- test.db
+cargo run --example repl --features repl -- test.db
+


### PR DESCRIPTION
When non utf8 file names are in backup file import of backup crashes.

This is the PR related to this issue https://github.com/deltachat/deltachat-core-rust/issues/1640
