### PR TITLE
[WIP] Flexible timeouts for larger emails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,8 +216,7 @@ dependencies = [
 [[package]]
 name = "async-smtp"
 version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9720181a7d56bf3b4d0cfdcb6353df975125996bdd2958b4e639c8317fcaa68"
+source = "git+https://github.com/async-email/async-smtp?branch=smtptimeout#74f489f29f8cbd2650d69119e63bf9e35e36dc85"
 dependencies = [
  "async-native-tls",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ smallvec = "1.0.0"
 surf = { version = "2.0.0-alpha.4", default-features = false, features = ["h1-client"] }
 num-derive = "0.3.0"
 num-traits = "0.2.6"
-async-smtp = { version = "0.3" }
+async-smtp = { git = "https://github.com/async-email/async-smtp", branch = "smtptimeout" }
 email = { git = "https://github.com/deltachat/rust-email", branch = "master" }
 lettre_email = { git = "https://github.com/deltachat/lettre", branch = "master" }
 async-imap = "0.3.1"


### PR DESCRIPTION
Fix #1383, depends on https://github.com/async-email/async-smtp/pull/26.

The timeout is 60s + 180 extra seconds per MB now. This is about twice the amounts @hpk42 reported in the original issue.