### PR TITLE
Allow http scheme for DCACCOUNT URLs

### DIFF
--- a/src/qr.rs
+++ b/src/qr.rs
@@ -195,7 +195,7 @@ fn decode_account(_context: &Context, qr: &str) -> Lot {
     let mut lot = Lot::new();
 
     if let Ok(url) = url::Url::parse(payload) {
-        if url.scheme() == "https" {
+        if url.scheme() == "http" || url.scheme() == "https" {
             lot.state = LotState::QrAccount;
             lot.text1 = url.host_str().map(|x| x.to_string());
         } else {


### PR DESCRIPTION
It presents no security issue, because properly configured servers will
only serve passwords on HTTPS and distribute only HTTPS QR codes, but
makes testing easier when HTTPS is not easy to deploy.

If attacker can control the URL used, they can change the URL to another
HTTPS URL controlled by them and act as a proxy between the client and
original server anyway.