### PR TITLE
[WIP] Go back to standard async-smtp branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ smallvec = "1.0.0"
 surf = { version = "2.0.0-alpha.4", default-features = false, features = ["h1-client"] }
 num-derive = "0.3.0"
 num-traits = "0.2.6"
-async-smtp = { git = "https://github.com/async-email/async-smtp", branch = "smtptimeout" }
+async-smtp = { version = "0.3" }
 email = { git = "https://github.com/deltachat/rust-email", branch = "master" }
 lettre_email = { git = "https://github.com/deltachat/lettre", branch = "master" }
 async-imap = "0.3.1"


### PR DESCRIPTION
It was changed in https://github.com/deltachat/deltachat-core-rust/pull/1755/files#diff-80398c5faae3c069e4e6aa2ed11b28c0. 

Can be merged as soon as https://github.com/async-email/async-smtp/pull/26 is merged (and I maybe did cargo update once)