### PR TITLE
imap: always read all the responses

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1652,7 +1652,6 @@ class TestOnlineAccount:
         assert "Ephemeral timer: " not in system_message2.get_message_info()
         assert chat1.get_ephemeral_timer() == 0
 
-    @pytest.mark.xfail
     def test_delete_multiple_messages(self, acfactory, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()
         chat12 = acfactory.get_accepted_chat(ac1, ac2)

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1661,6 +1661,10 @@ class TestOnlineAccount:
         for text in texts:
             chat12.send_text(text)
 
+            # Ensure messages are delivered in exactly this order.
+            ac1._evtracker.get_matching("DC_EVENT_SMTP_MESSAGE_SENT")
+            ac1._evtracker.get_matching("DC_EVENT_MSG_DELIVERED")
+
         lp.sec("ac2: waiting for all messages on the other side")
         to_delete = []
         for text in texts:

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -970,7 +970,11 @@ impl Imap {
         if let Some(ref mut session) = &mut self.session {
             let query = format!("+FLAGS ({})", flag);
             match session.uid_store(uid_set, &query).await {
-                Ok(_) => {}
+                Ok(mut responses) => {
+                    while let Some(_response) = responses.next().await {
+                        // Read all the responses
+                    }
+                }
                 Err(err) => {
                     warn!(
                         context,

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1085,6 +1085,22 @@ impl Imap {
                         return ImapActionResult::AlreadyDone;
                     };
 
+                    if let Some(fetched_uid) = fetch.uid {
+                        if fetched_uid != uid {
+                            warn!(
+                                context,
+                                "IMAP bug: fetched UID {} is not equal to requested UID {}",
+                                fetched_uid,
+                                uid
+                            );
+                        }
+                    } else {
+                        warn!(
+                            context,
+                            "IMAP bug: fetch result doesn't contain requested UID {}", uid
+                        );
+                    }
+
                     let remote_message_id = get_fetch_headers(&fetch)
                         .and_then(|headers| prefetch_get_message_id(&headers))
                         .unwrap_or_default();


### PR DESCRIPTION
If some IMAP command responses are left unread, they, along with the `OK` or any other result, will be left in the socket, and reappear later as responses to the next command. async-imap library expects that user exhausts the stream before sending additional commands. 

Fixes #1796, fixes #1788 