### PR TITLE
peerstate: ignore invalid fingerprints in SQL

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1618,7 +1618,7 @@ async fn check_verified_properties(
     // this check is skipped for SELF as there is no proper SELF-peerstate
     // and results in group-splits otherwise.
     if from_id != DC_CONTACT_ID_SELF {
-        let peerstate = Peerstate::from_addr(context, contact.get_addr()).await;
+        let peerstate = Peerstate::from_addr(context, contact.get_addr()).await?;
 
         if peerstate.is_none()
             || contact.is_verified_ex(context, peerstate.as_ref()).await
@@ -1672,7 +1672,7 @@ async fn check_verified_properties(
             context.is_self_addr(&to_addr).await
         );
         let mut is_verified = _is_verified != 0;
-        let peerstate = Peerstate::from_addr(context, &to_addr).await;
+        let peerstate = Peerstate::from_addr(context, &to_addr).await?;
 
         // mark gossiped keys (if any) as verified
         if mimeparser.gossipped_addr.contains(&to_addr) {

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -140,7 +140,7 @@ pub async fn try_decrypt(
     let autocryptheader = Aheader::from_headers(context, &from, &mail.headers);
 
     if message_time > 0 {
-        peerstate = Peerstate::from_addr(context, &from).await;
+        peerstate = Peerstate::from_addr(context, &from).await?;
 
         if let Some(ref mut peerstate) = peerstate {
             if let Some(ref header) = autocryptheader {
@@ -163,7 +163,7 @@ pub async fn try_decrypt(
     let mut signatures = HashSet::default();
 
     if peerstate.as_ref().map(|p| p.last_seen).unwrap_or_else(|| 0) == 0 {
-        peerstate = Peerstate::from_addr(&context, &from).await;
+        peerstate = Peerstate::from_addr(&context, &from).await?;
     }
     if let Some(peerstate) = peerstate {
         if peerstate.degrade_event.is_some() {

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -221,7 +221,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             .filter(|(_, addr)| addr != &self_addr)
         {
             res.push((
-                Peerstate::from_addr(self.context, addr).await,
+                Peerstate::from_addr(self.context, addr).await?,
                 addr.as_str(),
             ));
         }

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1036,7 +1036,7 @@ async fn update_gossip_peerstates(
                 .iter()
                 .any(|info| info.addr == header.addr.to_lowercase())
             {
-                let mut peerstate = Peerstate::from_addr(context, &header.addr).await;
+                let mut peerstate = Peerstate::from_addr(context, &header.addr).await?;
                 if let Some(ref mut peerstate) = peerstate {
                     peerstate.apply_gossip(header, message_time);
                     peerstate.save_to_db(&context.sql, false).await?;

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -186,15 +186,18 @@ impl<'a> Peerstate<'a> {
                 res.public_key_fingerprint = row
                     .get::<_, Option<String>>(7)?
                     .map(|s| s.parse::<Fingerprint>())
-                    .transpose()?;
+                    .transpose()
+                    .unwrap_or_default();
                 res.gossip_key_fingerprint = row
                     .get::<_, Option<String>>(8)?
                     .map(|s| s.parse::<Fingerprint>())
-                    .transpose()?;
+                    .transpose()
+                    .unwrap_or_default();
                 res.verified_key_fingerprint = row
                     .get::<_, Option<String>>(10)?
                     .map(|s| s.parse::<Fingerprint>())
-                    .transpose()?;
+                    .transpose()
+                    .unwrap_or_default();
                 res.public_key = row
                     .get(4)
                     .ok()

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -403,21 +403,20 @@ impl<'a> Peerstate<'a> {
     }
 
     pub async fn save_to_db(&self, sql: &Sql, create: bool) -> crate::sql::Result<()> {
-        if create {
-            sql.execute(
-                "INSERT INTO acpeerstates (addr) VALUES(?);",
-                paramsv![self.addr],
-            )
-            .await?;
-        }
-
         if self.to_save == Some(ToSave::All) || create {
             sql.execute(
+                if create {
+                "INSERT INTO acpeerstates (last_seen, last_seen_autocrypt, prefer_encrypted, \
+                 public_key, gossip_timestamp, gossip_key, public_key_fingerprint, gossip_key_fingerprint, \
+                 verified_key, verified_key_fingerprint, addr \
+                ) VALUES(?,?,?,?,?,?,?,?,?,?,?)"
+                } else {
                 "UPDATE acpeerstates \
                  SET last_seen=?, last_seen_autocrypt=?, prefer_encrypted=?, \
                  public_key=?, gossip_timestamp=?, gossip_key=?, public_key_fingerprint=?, gossip_key_fingerprint=?, \
                  verified_key=?, verified_key_fingerprint=? \
-                 WHERE addr=?;",
+                 WHERE addr=?"
+                },
                 paramsv![
                     self.last_seen,
                     self.last_seen_autocrypt,

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -143,7 +143,10 @@ async fn decode_openpgp(context: &Context, qr: &str) -> Lot {
     let mut lot = Lot::new();
 
     // retrieve known state for this fingerprint
-    let peerstate = Peerstate::from_fingerprint(context, &context.sql, &fingerprint).await;
+    let peerstate = match Peerstate::from_fingerprint(context, &context.sql, &fingerprint).await {
+        Ok(peerstate) => peerstate,
+        Err(err) => return format_err!("Can't load peerstate: {}", err).into(),
+    };
 
     if invitenumber.is_none() || auth.is_none() {
         if let Some(peerstate) = peerstate {

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -366,7 +366,20 @@ async fn fingerprint_equals_sender(
 ) -> bool {
     if let [contact_id] = chat::get_chat_contacts(context, contact_chat_id).await[..] {
         if let Ok(contact) = Contact::load_from_db(context, contact_id).await {
-            if let Some(peerstate) = Peerstate::from_addr(context, contact.get_addr()).await {
+            let peerstate = match Peerstate::from_addr(context, contact.get_addr()).await {
+                Ok(peerstate) => peerstate,
+                Err(err) => {
+                    warn!(
+                        context,
+                        "Failed to sender peerstate for {}: {}",
+                        contact.get_addr(),
+                        err
+                    );
+                    return false;
+                }
+            };
+
+            if let Some(peerstate) = peerstate {
                 if peerstate.public_key_fingerprint.is_some()
                     && fingerprint == peerstate.public_key_fingerprint.as_ref().unwrap()
                 {

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -987,7 +987,7 @@ async fn could_not_establish_secure_connection(
 
 async fn mark_peer_as_verified(context: &Context, fingerprint: &Fingerprint) -> Result<(), Error> {
     if let Some(ref mut peerstate) =
-        Peerstate::from_fingerprint(context, &context.sql, fingerprint).await
+        Peerstate::from_fingerprint(context, &context.sql, fingerprint).await?
     {
         if peerstate.set_verified(
             PeerstateKeyType::PublicKey,

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1303,7 +1303,7 @@ async fn open(
                 )
                 .await?;
             for addr in &addrs {
-                if let Some(ref mut peerstate) = Peerstate::from_addr(context, addr).await {
+                if let Some(ref mut peerstate) = Peerstate::from_addr(context, addr).await? {
                     peerstate.recalc_fingerprint();
                     peerstate.save_to_db(sql, false).await?;
                 }


### PR DESCRIPTION
Normally NULL is used when there is no fingerprint, but default value
for fingerprint columns is an empty string.

In this case, loading should not fail with an "invalid length" error,
but treat the fingerprint as missing.

Strict check was introduced in commit ca95f25639e90dfa7d028b6ce89e3a81a0bf09dd

Fixes #1596 