### PR TITLE
dc_set_chat_mute_duration: avoid panic on overflow

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1286,7 +1286,9 @@ pub unsafe extern "C" fn dc_set_chat_mute_duration(
     let muteDuration = match duration {
         0 => MuteDuration::NotMuted,
         -1 => MuteDuration::Forever,
-        n if n > 0 => MuteDuration::Until(SystemTime::now() + Duration::from_secs(duration as u64)),
+        n if n > 0 => SystemTime::now()
+            .checked_add(Duration::from_secs(duration as u64))
+            .map_or(MuteDuration::Forever, MuteDuration::Until),
         _ => {
             warn!(
                 ctx,


### PR DESCRIPTION
A bug reported at https://support.delta.chat/t/app-crashes-suddenly/1031/26

Likely caused by this migration: https://github.com/deltachat/deltachat-android/blob/bdaf4df76455818c8a26e5a059f60df9291a62f7/src/org/thoughtcrime/securesms/connect/ApplicationDcContext.java#L88