### PR TITLE
adapt repl-tool to new peerstate api 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command:  check
-        args: --all --bins --examples --tests
+        args: --all --bins --examples --tests --features repl
 
     - name: tests
       uses: actions-rs/cargo@v1

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -284,13 +284,14 @@ async fn log_contactlist(context: &Context, contacts: &[u32]) {
                     "addr unset"
                 }
             );
-            if let Ok(peerstate) = Peerstate::from_addr(context, &addr).await {
-                if peerstate.is_some() && contact_id != 1 as libc::c_uint {
-                    line2 = format!(
-                        ", prefer-encrypt={}",
-                        peerstate.as_ref().unwrap().prefer_encrypt
-                    );
-                }
+            let peerstate = Peerstate::from_addr(context, &addr)
+                .await
+                .expect("peerstate error");
+            if peerstate.is_some() && contact_id != 1 as libc::c_uint {
+                line2 = format!(
+                    ", prefer-encrypt={}",
+                    peerstate.as_ref().unwrap().prefer_encrypt
+                );
             }
 
             println!("Contact#{}: {}{}", contact_id, line, line2);

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -284,12 +284,13 @@ async fn log_contactlist(context: &Context, contacts: &[u32]) {
                     "addr unset"
                 }
             );
-            let peerstate = Peerstate::from_addr(context, &addr).await;
-            if peerstate.is_some() && contact_id != 1 as libc::c_uint {
-                line2 = format!(
-                    ", prefer-encrypt={}",
-                    peerstate.as_ref().unwrap().prefer_encrypt
-                );
+            if let Ok(peerstate) = Peerstate::from_addr(context, &addr).await {
+                if peerstate.is_some() && contact_id != 1 as libc::c_uint {
+                    line2 = format!(
+                        ", prefer-encrypt={}",
+                        peerstate.as_ref().unwrap().prefer_encrypt
+                    );
+                }
             }
 
             println!("Contact#{}: {}{}", contact_id, line, line2);


### PR DESCRIPTION
the peerstate api was slightly changed in #1800, this pr adapts the repl-tool to the new api (without, repl does not even build)