### PR TITLE
add a higher-level test for dc_get_filemeta()

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1884,8 +1884,11 @@ mod tests {
                 if let Ok(msg) = Message::load_from_db(&t.ctx, msg_id.clone()).await {
                     if msg.get_viewtype() == Viewtype::Image {
                         has_image = true;
+                        // just check that width/height are inside some reasonable ranges
                         assert!(msg.get_width() > 100);
                         assert!(msg.get_height() > 100);
+                        assert!(msg.get_width() < 4000);
+                        assert!(msg.get_height() < 4000);
                     }
                 }
             }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1721,6 +1721,7 @@ pub async fn dc_empty_server(context: &Context, flags: u32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chat::ChatItem;
     use crate::test_utils as test;
 
     #[test]
@@ -1862,5 +1863,33 @@ mod tests {
         let (webrtc_type, url) = Message::parse_webrtc_instance("jitsi:https://j.si/foo");
         assert_eq!(webrtc_type, VideochatType::Jitsi);
         assert_eq!(url, "https://j.si/foo");
+    }
+
+    #[async_std::test]
+    async fn test_get_width_height() {
+        let t = test::TestContext::new().await;
+
+        // test that get_width() and get_height() are returning some dimensions for images;
+        // (as the device-chat contains a welcome-images, we check that)
+        t.ctx.update_device_chats().await.ok();
+        let (device_chat_id, _) =
+            chat::create_or_lookup_by_contact_id(&t.ctx, DC_CONTACT_ID_DEVICE, Blocked::Not)
+                .await
+                .unwrap();
+
+        let mut has_image = false;
+        let chatitems = chat::get_chat_msgs(&t.ctx, device_chat_id, 0, None).await;
+        for chatitem in chatitems {
+            if let ChatItem::Message { msg_id } = chatitem {
+                if let Ok(msg) = Message::load_from_db(&t.ctx, msg_id.clone()).await {
+                    if msg.get_viewtype() == Viewtype::Image {
+                        has_image = true;
+                        assert!(msg.get_width() > 100);
+                        assert!(msg.get_height() > 100);
+                    }
+                }
+            }
+        }
+        assert!(has_image);
     }
 }


### PR DESCRIPTION
this pr only adds a test.

test that, in general, msg.get_width() and msg.get_height()
return reasonable values.