### PR TITLE
Second attempt to fix flaky test

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1669,15 +1669,11 @@ class TestOnlineAccount:
         for text in texts:
             chat12.send_text(text)
 
-            # Ensure messages are delivered in exactly this order.
-            ac1._evtracker.get_matching("DC_EVENT_SMTP_MESSAGE_SENT")
-            ac1._evtracker.get_matching("DC_EVENT_MSG_DELIVERED")
-
         lp.sec("ac2: waiting for all messages on the other side")
         to_delete = []
         for text in texts:
             msg = ac2._evtracker.wait_next_incoming_message()
-            assert msg.text == text
+            assert msg.text in texts
             if text != "third":
                 to_delete.append(msg)
 


### PR DESCRIPTION
The server sometimes reorders the messages even if they were accepted
strictly in sequence.

Follow-up for #1795