### PR TITLE
python: fix more flaky tests

### DIFF
--- a/python/src/deltachat/direct_imap.py
+++ b/python/src/deltachat/direct_imap.py
@@ -108,6 +108,15 @@ class DirectImap:
 
     def get_all_messages(self):
         assert not self._idling
+
+        # Flush unsolicited responses. IMAPClient has problems
+        # dealing with them: https://github.com/mjs/imapclient/issues/334
+        # When this NOOP was introduced, next FETCH returned empty
+        # result instead of a single message, even though IMAP server
+        # can only return more untagged responses than required, not
+        # less.
+        self.conn.noop()
+
         return self.conn.fetch(ALL, [FLAGS])
 
     def get_unread_messages(self):

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1688,14 +1688,6 @@ class TestOnlineAccount:
         lp.sec("imap2: test that only one message is left")
         imap2 = ac2.direct_imap
 
-        # Flush unsolicited responses. IMAPClient has problems
-        # dealing with them: https://github.com/mjs/imapclient/issues/334
-        # When this NOOP was introduced, next FETCH returned empty
-        # result instead of a single message, even though IMAP server
-        # can only return more untagged responses than required, not
-        # less.
-        imap2.conn.noop()
-
         assert len(imap2.get_all_messages()) == 1
 
 


### PR DESCRIPTION
This change fixes `test_immediate_autodelete` and maybe other tests using
`DirectImap.get_all_messages()`.