### PR TITLE
Remove debug X-Mailer header

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -453,21 +453,6 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
 
         unprotected_headers.push(Header::new("Date".into(), date));
 
-        let os_name = &self.context.os_name;
-        let os_part = os_name
-            .as_ref()
-            .map(|s| format!("/{}", s))
-            .unwrap_or_default();
-        let version = get_version_str();
-
-        // Add a X-Mailer header.
-        // This is only informational for debugging and may be removed in the release.
-        // We do not rely on this header as it may be removed by MTAs.
-
-        unprotected_headers.push(Header::new(
-            "X-Mailer".into(),
-            format!("Delta Chat Core {}{}", version, os_part),
-        ));
         unprotected_headers.push(Header::new("Chat-Version".to_string(), "1.0".to_string()));
 
         if let Loaded::MDN { .. } = self.loaded {


### PR DESCRIPTION
Just stumbled about this code. Was there any reason it was there?

Or should we maybe set this header to something "unsuspicious" like "Firefox"? OTOH Thunderbird seems not to set this header, either, so probably not.