### PR TITLE
Recognize .tgs files as stickers

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1077,6 +1077,7 @@ pub fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)> {
         "png" => (Viewtype::Image, "image/png"),
         "spx" => (Viewtype::Audio, "audio/ogg"), // Ogg Speex Profile
         "svg" => (Viewtype::Image, "image/svg+xml"),
+        "tgs" => (Viewtype::Sticker, "application/x-tgsticker"),
         "vcard" => (Viewtype::File, "text/vcard"),
         "vcf" => (Viewtype::File, "text/vcard"),
         "webm" => (Viewtype::Video, "video/webm"),


### PR DESCRIPTION
.tgs files are Telegram stickers. Internally they are gzipped JSON files,
containing a single Lottie animation.

MIME type application/x-tgsticker is commonly used for telegram documents
containing such stickers.