### PR TITLE
be more tolerant on webrtc-servers set by the user

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1629,13 +1629,7 @@ pub async fn send_videochat_invitation(context: &Context, chat_id: ChatId) -> Re
         bail!("webrtc_instance not set");
     };
 
-    let room = dc_create_id();
-
-    let instance = if instance.contains("$ROOM") {
-        instance.replace("$ROOM", &room)
-    } else {
-        format!("{}{}", instance, room)
-    };
+    let instance = Message::create_webrtc_instance(&instance, &dc_create_id());
 
     let mut msg = Message::new(Viewtype::VideochatInvitation);
     msg.param.set(Param::WebrtcRoom, &instance);

--- a/src/message.rs
+++ b/src/message.rs
@@ -643,6 +643,16 @@ impl Message {
         None
     }
 
+    // add room to a webrtc_instance as defined by the corresponding config-value;
+    // the result may still be prefixed by the type
+    pub fn create_webrtc_instance(instance: &str, room: &str) -> String {
+        if instance.contains("$ROOM") {
+            instance.replace("$ROOM", &room)
+        } else {
+            format!("{}{}", instance, room)
+        }
+    }
+
     /// split a webrtc_instance as defined by the corresponding config-value into a type and a url
     pub fn parse_webrtc_instance(instance: &str) -> (VideochatType, String) {
         let mut split = instance.splitn(2, ':');

--- a/src/message.rs
+++ b/src/message.rs
@@ -649,7 +649,7 @@ impl Message {
         let (videochat_type, mut url) = Message::parse_webrtc_instance(instance);
 
         // make sure, there is a scheme in the url
-        if !url.contains(":") {
+        if !url.contains(':') {
             url = format!("https://{}", url);
         }
 
@@ -659,10 +659,10 @@ impl Message {
         } else {
             // if there nothing that would separate the room, add a slash as a separator;
             // this way, urls can be given as "https://meet.jit.si" as well as "https://meet.jit.si/"
-            let maybe_slash = if url.ends_with("/")
-                || url.ends_with("?")
-                || url.ends_with("#")
-                || url.ends_with("=")
+            let maybe_slash = if url.ends_with('/')
+                || url.ends_with('?')
+                || url.ends_with('#')
+                || url.ends_with('=')
             {
                 ""
             } else {

--- a/src/message.rs
+++ b/src/message.rs
@@ -681,6 +681,7 @@ impl Message {
 
     /// split a webrtc_instance as defined by the corresponding config-value into a type and a url
     pub fn parse_webrtc_instance(instance: &str) -> (VideochatType, String) {
+        let instance: String = instance.split_whitespace().collect();
         let mut split = instance.splitn(2, ':');
         let type_str = split.next().unwrap_or_default().to_lowercase();
         let url = split.next();
@@ -1914,6 +1915,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_create_webrtc_instance() {
+        // webrtc_instance may come from an input field of the ui, be pretty tolerant on input
         let instance = Message::create_webrtc_instance("https://meet.jit.si/", "123");
         assert_eq!(instance, "https://meet.jit.si/123");
 
@@ -1940,6 +1942,12 @@ mod tests {
 
         let instance = Message::create_webrtc_instance("bla.foo#room=$ROOM&after=cont", "234");
         assert_eq!(instance, "https://bla.foo#room=234&after=cont");
+
+        let instance = Message::create_webrtc_instance("  meet.jit .si ", "789");
+        assert_eq!(instance, "https://meet.jit.si/789");
+
+        let instance = Message::create_webrtc_instance(" basicwebrtc: basic . stuff\n ", "12345ab");
+        assert_eq!(instance, "basicwebrtc:https://basic.stuff/12345ab");
     }
 
     #[async_std::test]

--- a/src/message.rs
+++ b/src/message.rs
@@ -1887,6 +1887,36 @@ mod tests {
     }
 
     #[async_std::test]
+    async fn test_create_webrtc_instance() {
+        let instance = Message::create_webrtc_instance("https://meet.jit.si/", "123");
+        assert_eq!(instance, "https://meet.jit.si/123");
+
+        let instance = Message::create_webrtc_instance("https://meet.jit.si", "456");
+        assert_eq!(instance, "https://meet.jit.si/456");
+
+        let instance = Message::create_webrtc_instance("meet.jit.si", "789");
+        assert_eq!(instance, "https://meet.jit.si/789");
+
+        let instance = Message::create_webrtc_instance("bla.foo?", "123");
+        assert_eq!(instance, "https://bla.foo?123");
+
+        let instance = Message::create_webrtc_instance("jitsi:bla.foo#", "456");
+        assert_eq!(instance, "jitsi:https://bla.foo#456");
+
+        let instance = Message::create_webrtc_instance("bla.foo#room=", "789");
+        assert_eq!(instance, "https://bla.foo#room=789");
+
+        let instance = Message::create_webrtc_instance("https://bla.foo#room", "123");
+        assert_eq!(instance, "https://bla.foo#room/123");
+
+        let instance = Message::create_webrtc_instance("bla.foo#room$ROOM", "123");
+        assert_eq!(instance, "https://bla.foo#room123");
+
+        let instance = Message::create_webrtc_instance("bla.foo#room=$ROOM&after=cont", "234");
+        assert_eq!(instance, "https://bla.foo#room=234&after=cont");
+    }
+
+    #[async_std::test]
     async fn test_get_width_height() {
         let t = test::TestContext::new().await;
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -675,7 +675,7 @@ impl Message {
         match videochat_type {
             VideochatType::BasicWebrtc => format!("basicwebrtc:{}", url),
             VideochatType::Jitsi => format!("jitsi:{}", url),
-            _ => url,
+            VideochatType::Unknown => url,
         }
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -649,7 +649,18 @@ impl Message {
         if instance.contains("$ROOM") {
             instance.replace("$ROOM", &room)
         } else {
-            format!("{}{}", instance, room)
+            // if there nothing that would separate the room, add a slash as a separator
+            // this way, urls can be given as "https://meet.jit.si" as well as "https://meet.jit.si/"
+            let maybe_slash = if instance.ends_with("/")
+                || instance.ends_with("?")
+                || instance.ends_with("#")
+                || instance.ends_with("=")
+            {
+                ""
+            } else {
+                "/"
+            };
+            format!("{}{}{}", instance, maybe_slash, room)
         }
     }
 


### PR DESCRIPTION
this pr adds more tolerance to webrtc-servers as specified via set_config("webrtc_instance") - which is settable directly from the uis.

- if reasonable, missing slashes are added to the specified servers
- the protocol may be left out, in this case, https:// is added

so, you can use jitsi by just typing `meet.jit.si` instead of `https://meet.jit.si/`

fixes #1830 