### PR TITLE
greenify ci 💚💚

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,16 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         rust: [1.45.0]
         experimental: [false]
-        include:
-          - os: ubuntu-latest
-            rust: nightly
-            experimental: true
-          - os: windows-latest
-            rust: nightly
-            experimental: true
-          - os: macOS-latest
-            rust: nightly
-            experimental: true
+#        include:
+#          - os: ubuntu-latest
+#            rust: nightly
+#            experimental: true
+#          - os: windows-latest
+#            rust: nightly
+#            experimental: true
+#          - os: macOS-latest
+#            rust: nightly
+#            experimental: true
 
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
this pr comments-out the always-failing test with rust-nightly (see https://github.com/deltachat/deltachat-core-rust/pull/1835#issuecomment-674202818), building on rust.1.45 stays in place.

once, the nightlies work again on github-actions, we can revert this pr.