### PR TITLE
try harder to let all build processes die when ssh dies

### DIFF
--- a/ci_scripts/remote_python_packaging.sh
+++ b/ci_scripts/remote_python_packaging.sh
@@ -46,7 +46,7 @@ _HERE
 
 echo "--- Running $CIRCLE_JOB remotely"
 
-ssh -t $SSHTARGET bash "$BUILDDIR/exec_docker_run"
+ssh $SSHTARGET bash "$BUILDDIR/exec_docker_run"
 mkdir -p workspace 
 rsync -avz "$SSHTARGET:$BUILDDIR/python/.docker-tox/wheelhouse/*manylinux201*" workspace/wheelhouse/
 rsync -avz "$SSHTARGET:$BUILDDIR/python/.docker-tox/dist/*" workspace/wheelhouse/

--- a/ci_scripts/remote_tests_python.sh
+++ b/ci_scripts/remote_tests_python.sh
@@ -22,7 +22,7 @@ set +x
 
 echo "--- Running $CIRCLE_JOB remotely"
 
-ssh -t -t $SSHTARGET <<_HERE
+ssh $SSHTARGET <<_HERE
     set +x -e
 
     # make sure all processes exit when ssh dies

--- a/ci_scripts/remote_tests_rust.sh
+++ b/ci_scripts/remote_tests_rust.sh
@@ -18,7 +18,7 @@ rsync --delete --files-from=.rsynclist -az ./ "$SSHTARGET:$BUILDDIR"
 
 echo "--- Running $CIRCLE_JOB remotely"
 
-ssh -t -t $SSHTARGET <<_HERE
+ssh $SSHTARGET <<_HERE
     set +x -e
     # make sure all processes exit when ssh dies
     shopt -s huponexit


### PR DESCRIPTION
played around a bit to ensure that adding commits to a PR which has running CI properly kills the ongoing CI run, and starts the new.  I think the small changes of this PR improve the behaviour a little, but not sure.  Feel free to use this PR to test further before merging (i.e. change a random line, push, then change back, force-push etc.) and see if any build locks are held unwanted.   

I don't know what changed with Circle that the behaviour changed -- cancelling builds used to work fine for months with circleci->b1.delta.chat runs. 