### PR TITLE
Turn Bob::expects into an enum and add docs

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -202,10 +202,6 @@ pub const DC_LP_AUTH_NORMAL: i32 = 0x4;
 /// if none of these flags are set, the default is chosen
 pub const DC_LP_AUTH_FLAGS: i32 = DC_LP_AUTH_OAUTH2 | DC_LP_AUTH_NORMAL;
 
-// QR code scanning (view from Bob, the joiner)
-pub const DC_VC_AUTH_REQUIRED: i32 = 2;
-pub const DC_VC_CONTACT_CONFIRM: i32 = 6;
-
 // max. width/height of an avatar
 pub const AVATAR_SIZE: u32 = 192;
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -95,6 +95,12 @@ pub enum Param {
     Recipients = b'R',
 
     /// For Groups
+    ///
+    /// An unpromoted group has not had any messages sent to it and thus only exists on the
+    /// creator's device.  Any changes made to an unpromoted group do not need to send
+    /// system messages to the group members to update them of the changes.  Once a message
+    /// has been sent to a group it is promoted and group changes require sending system
+    /// messages to all members.
     Unpromoted = b'U',
 
     /// For Groups and Contacts

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -98,7 +98,7 @@ pub(crate) struct Bob {
 }
 
 /// The next message expected by [Bob] in the setup-contact/secure-join protocol.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum SecureJoinStep {
     /// No setup-contact protocol running.
     NotActive,
@@ -573,7 +573,7 @@ pub(crate) async fn handle_securejoin_handshake(
                 let bob = context.bob.read().await;
                 let scan = bob.qr_scan.as_ref();
                 scan.is_none()
-                    || !matches!(bob.expects, SecureJoinStep::AuthRequired)
+                    || bob.expects != SecureJoinStep::AuthRequired
                     || join_vg && scan.unwrap().state != LotState::QrAskVerifyGroup
             };
 
@@ -761,10 +761,7 @@ pub(crate) async fn handle_securejoin_handshake(
                 HandshakeMessage::Ignore
             };
 
-            if !matches!(
-                context.bob.read().await.expects,
-                SecureJoinStep::ContactConfirm
-            ) {
+            if context.bob.read().await.expects != SecureJoinStep::ContactConfirm {
                 info!(context, "Message belongs to a different handshake.",);
                 return Ok(abort_retval);
             }


### PR DESCRIPTION
This turns the Bob::expects field into an enum, removing the old
constants.  It also makes the field private, nothing outside the
securejoin module uses it.

Finally it documents stuff, including a seemingly-unrelated Param.
But that param is used by the securejoin module... It's nice to have
doc tooltips be helpful.