### PR TITLE
add an index to significantly speed up get_fresh_msg_cnt()

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -379,7 +379,7 @@ impl ChatId {
         // to make this as fast as possible, esp. on older devices, we added an combined index over the rows used for querying.
         // so if you alter the query here, you may want to alter the index over `(state, hidden, chat_id)` in `sql.rs`.
         //
-        // the impact if the index is significant once the database grows:
+        // the impact of the index is significant once the database grows:
         // - on an older android4 with 18k messages, query-time decreased from 110ms to 2ms
         // - on an mid-class moto-g or iphone7 with 50k messages, query-time decreased from 26ms or 6ms to 0-1ms
         // the times are average, no matter if there are fresh messages or not -

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -375,6 +375,16 @@ impl ChatId {
     }
 
     pub async fn get_fresh_msg_cnt(self, context: &Context) -> usize {
+        // this function is typically used to show a badge counter beside _each_ chatlist item.
+        // to make this as fast as possible, esp. on older devices, we added an combined index over the rows used for querying.
+        // so if you alter the query here, you may want to alter the index over `(state, hidden, chat_id)` in `sql.rs`.
+        //
+        // the impact if the index is significant once the database grows:
+        // - on an older android4 with 18k messages, query-time decreased from 110ms to 2ms
+        // - on an mid-class moto-g or iphone7 with 50k messages, query-time decreased from 26ms or 6ms to 0-1ms
+        // the times are average, no matter if there are fresh messages or not -
+        // and have to be multiplied by the number of items shown at once on the chatlist,
+        // so savings up to 2 seconds are possible on older devices - newer ones will feel "snappier" :)
         context
             .sql
             .query_get_value::<i32>(

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1315,6 +1315,16 @@ async fn open(
             }
             sql.set_raw_config_int(context, "dbversion", 67).await?;
         }
+        if dbversion < 68 {
+            info!(context, "[migration] v68");
+            // the index is used to speed up get_fresh_msg_cnt(), see comment there for more details
+            sql.execute(
+                "CREATE INDEX IF NOT EXISTS msgs_index7 ON msgs (state, hidden, chat_id);",
+                paramsv![],
+            )
+            .await?;
+            sql.set_raw_config_int(context, "dbversion", 68).await?;
+        }
 
         // (2) updates that require high-level objects
         // (the structure is complete now and all objects are usable)


### PR DESCRIPTION
thanks a lot to @csb0730 for endless trying to figure out a database bottleneck - where i was not even totally convinced that it even exist!

i tested the change on my 2yo motog and iphone7 with a database of 50k messages - and even here, saving was significant, see comments in the sourcecode. i added the comment also to ensure, we do not run into this issue again on changes.

fixes #1879