### PR TITLE
Do not reset peerstate on encrypted messages

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -842,12 +842,10 @@ impl Chat {
             /* check if we want to encrypt this message.  If yes and circumstances change
             so that E2EE is no longer available at a later point (reset, changed settings),
             we might not send the message out at all */
-            if msg
+            if !msg
                 .param
-                .get_int(Param::ForcePlaintext)
-                .and_then::<ForcePlaintext, _>(num_traits::FromPrimitive::from_i32)
+                .get_bool(Param::ForcePlaintext)
                 .unwrap_or_default()
-                == ForcePlaintext::Dont
             {
                 let mut can_encrypt = true;
                 let mut all_mutual = context.get_config_bool(Config::E2eeEnabled).await;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -842,7 +842,13 @@ impl Chat {
             /* check if we want to encrypt this message.  If yes and circumstances change
             so that E2EE is no longer available at a later point (reset, changed settings),
             we might not send the message out at all */
-            if msg.param.get_int(Param::ForcePlaintext).unwrap_or_default() == 0 {
+            if msg
+                .param
+                .get_int(Param::ForcePlaintext)
+                .and_then::<ForcePlaintext, _>(num_traits::FromPrimitive::from_i32)
+                .unwrap_or_default()
+                == ForcePlaintext::Dont
+            {
                 let mut can_encrypt = true;
                 let mut all_mutual = context.get_config_bool(Config::E2eeEnabled).await;
 

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -220,10 +220,8 @@ async fn do_initiate_key_transfer(context: &Context) -> Result<String> {
     msg.param
         .set(Param::MimeType, "application/autocrypt-setup");
     msg.param.set_cmd(SystemMessage::AutocryptSetupMessage);
-    msg.param.set_int(
-        Param::ForcePlaintext,
-        ForcePlaintext::NoAutocryptHeader as i32,
-    );
+    msg.param.set_int(Param::ForcePlaintext, 1);
+    msg.param.set_int(Param::SkipAutocrypt, 1);
 
     let msg_id = chat::send_msg(context, chat_id, &mut msg).await?;
     info!(context, "Wait for setup message being sent ...",);

--- a/src/param.rs
+++ b/src/param.rs
@@ -40,8 +40,7 @@ pub enum Param {
     /// 'c' nor 'e' are preset, the messages is only transport encrypted.
     ErroneousE2ee = b'e',
 
-    /// For Messages: force unencrypted message, either `ForcePlaintext::AddAutocryptHeader` (1),
-    /// `ForcePlaintext::NoAutocryptHeader` (2) or 0.
+    /// For Messages: force unencrypted message, a value from `ForcePlaintext` enum.
     ForcePlaintext = b'u',
 
     /// For Messages
@@ -132,8 +131,26 @@ pub enum Param {
 #[derive(PartialEq, Eq, Debug, Clone, Copy, FromPrimitive)]
 #[repr(u8)]
 pub enum ForcePlaintext {
+    /// Do not force plaintext
+    Dont = 0,
+
+    /// Force plaintext message with Autocrypt header
+    ///
+    /// Used for `vc-request` and `vg-request` messages in
+    /// Verified Contact Protocol and
+    /// Verified Group Protocol.
     AddAutocryptHeader = 1,
+
+    /// Force plaintext message without Autocrypt header
+    ///
+    /// Used for MDNs.
     NoAutocryptHeader = 2,
+}
+
+impl Default for ForcePlaintext {
+    fn default() -> Self {
+        Self::Dont
+    }
 }
 
 /// An object for handling key=value parameter lists.

--- a/src/param.rs
+++ b/src/param.rs
@@ -43,6 +43,9 @@ pub enum Param {
     /// For Messages: force unencrypted message, a value from `ForcePlaintext` enum.
     ForcePlaintext = b'u',
 
+    /// For Messages: do not include Autocrypt header.
+    SkipAutocrypt = b'o',
+
     /// For Messages
     WantsMdn = b'r',
 
@@ -125,32 +128,6 @@ pub enum Param {
 
     /// For MDN-sending job
     MsgId = b'I',
-}
-
-/// Possible values for `Param::ForcePlaintext`.
-#[derive(PartialEq, Eq, Debug, Clone, Copy, FromPrimitive)]
-#[repr(u8)]
-pub enum ForcePlaintext {
-    /// Do not force plaintext
-    Dont = 0,
-
-    /// Force plaintext message with Autocrypt header
-    ///
-    /// Used for `vc-request` and `vg-request` messages in
-    /// Verified Contact Protocol and
-    /// Verified Group Protocol.
-    AddAutocryptHeader = 1,
-
-    /// Force plaintext message without Autocrypt header
-    ///
-    /// Used for MDNs.
-    NoAutocryptHeader = 2,
-}
-
-impl Default for ForcePlaintext {
-    fn default() -> Self {
-        Self::Dont
-    }
 }
 
 /// An object for handling key=value parameter lists.

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -388,10 +388,7 @@ async fn send_handshake_msg(
         msg.param.set(Param::Arg4, grpid.as_ref());
     }
     if step == "vg-request" || step == "vc-request" {
-        msg.param.set_int(
-            Param::ForcePlaintext,
-            ForcePlaintext::AddAutocryptHeader as i32,
-        );
+        msg.param.set_int(Param::ForcePlaintext, 1);
     } else {
         msg.param.set_int(Param::GuaranteeE2ee, 1);
     }


### PR DESCRIPTION
If message does not contain Autocrypt header, but is encrypted, do not
change the peerstate.

Closes #1874 