### PR TITLE
add device-message on bad system clock or on outdated app

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4926,8 +4926,9 @@ void dc_event_unref(dc_event_t* event);
 #define DC_STR_VIDEOCHAT_INVITE_MSG_BODY  83
 #define DC_STR_CONFIGURATION_FAILED       84
 #define DC_STR_BAD_TIME_MSG_BODY          85
+#define DC_STR_UPDATE_REMINDER_MSG_BODY   86
 
-#define DC_STR_COUNT                      85
+#define DC_STR_COUNT                      86
 
 /*
  * @}

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4925,8 +4925,9 @@ void dc_event_unref(dc_event_t* event);
 #define DC_STR_VIDEOCHAT_INVITATION       82
 #define DC_STR_VIDEOCHAT_INVITE_MSG_BODY  83
 #define DC_STR_CONFIGURATION_FAILED       84
+#define DC_STR_BAD_TIME_MSG_BODY          85
 
-#define DC_STR_COUNT                      84
+#define DC_STR_COUNT                      85
 
 /*
  * @}

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -108,6 +108,12 @@ pub const DC_GCL_ADD_SELF: usize = 0x02;
 // unchanged user avatars are resent to the recipients every some days
 pub const DC_RESEND_USER_AVATAR_DAYS: i64 = 14;
 
+// warn about an outdated app after a given number of days.
+// as we use the "provider-db generation date" as reference (that might not be updated very often)
+// and as not all system get speedy updates,
+// do not use too small value that will annoy users checking for nonexistant updates.
+pub const DC_OUTDATED_WARNING_DAYS: i64 = 365;
+
 /// virtual chat showing all messages belonging to chats flagged with chats.blocked=2
 pub const DC_CHAT_ID_DEADDROP: u32 = 1;
 /// messages that should be deleted get this chat_id; the messages are deleted from the working thread later then. This is also needed as rfc724_mid should be preset as long as the message is not deleted on the server (otherwise it is downloaded again)

--- a/src/provider/data.rs
+++ b/src/provider/data.rs
@@ -807,4 +807,6 @@ lazy_static::lazy_static! {
         ("narod.ru", &*P_YANDEX_RU),
         ("ziggo.nl", &*P_ZIGGO_NL),
     ].iter().copied().collect();
+
+    pub static ref PROVIDER_UPDATED: chrono::NaiveDate = chrono::NaiveDate::from_ymd(2020, 9, 19);
 }

--- a/src/provider/update.py
+++ b/src/provider/update.py
@@ -4,6 +4,7 @@
 import sys
 import os
 import yaml
+import datetime
 
 out_all = ""
 out_domains = ""
@@ -169,6 +170,12 @@ if __name__ == "__main__":
 
     out_all += "    pub static ref PROVIDER_DATA: HashMap<&'static str, &'static Provider> = [\n"
     out_all += out_domains;
-    out_all += "    ].iter().copied().collect();\n}"
+    out_all += "    ].iter().copied().collect();\n\n"
+
+    now = datetime.datetime.utcnow()
+    out_all += "    pub static ref PROVIDER_UPDATED: chrono::NaiveDate = "\
+                        "chrono::NaiveDate::from_ymd("+str(now.year)+", "+str(now.month)+", "+str(now.day)+");\n"
+
+    out_all += "}"
 
     print(out_all)

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -3,6 +3,7 @@ use async_std::sync::{channel, Receiver, Sender};
 use async_std::task;
 
 use crate::context::Context;
+use crate::dc_tools::maybe_add_time_based_warnings;
 use crate::imap::Imap;
 use crate::job::{self, Thread};
 use crate::{config::Config, message::MsgId, smtp::Smtp};
@@ -80,6 +81,8 @@ async fn inbox_loop(ctx: Context, started: Sender<()>, inbox_handlers: ImapConne
                     if let Err(err) = connection.maybe_close_folder(&ctx).await {
                         warn!(ctx, "failed to close folder: {:?}", err);
                     }
+
+                    maybe_add_time_based_warnings(&ctx).await;
 
                     info = if ctx.get_config_bool(Config::InboxWatch).await {
                         fetch_idle(&ctx, &mut connection, Config::ConfiguredInboxFolder).await

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -225,6 +225,12 @@ pub enum StockMessage {
                     Adjust your clock ⏰🔧 to ensure your messages are received correctly."
     ))]
     BadTimeMsgBody = 85,
+
+    #[strum(props(fallback = "⚠️ Your Delta Chat version might be outdated.\n\n\
+                    This may cause problems because your chat partners use newer versions - \
+                    and you are missing the latest features 😳\n\
+                    Please check https://get.delta.chat or your app store for updates."))]
+    UpdateReminderMsgBody = 86,
 }
 
 /*

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -219,6 +219,12 @@ pub enum StockMessage {
 
     #[strum(props(fallback = "Configuration failed. Error: “%1$s”"))]
     ConfigurationFailed = 84,
+
+    #[strum(props(
+        fallback = "⚠️ Date or time of your device seem to be inaccurate (%1$s).\n\n\
+                    Adjust your clock ⏰🔧 to ensure your messages are received correctly."
+    ))]
+    BadTimeMsgBody = 85,
 }
 
 /*


### PR DESCRIPTION
as discussed several times offline and on other channels ([eg.](https://support.delta.chat/t/automatically-update-check/488)), this pr attempts to detect bad system dates and outdated apps and adds a device message in this case.

the bad system date is currently only detected when `time()` reports a date that is _older_ than some known date. however, this simple approach already handles a lot of typical errors we've seen several times in the past, eg.

- devices may fall back to "system compile time" easily - in theory, there is a timeserver and so on, however, this does not always sync or work - o/ @hpk42 :)
- the user may be wrong when setting the time by a whole year or month

to have a reference date, that is not too old - and to keep the option for reproducible builds and to not mess around with git - we just add an "update timestamp" to the provider-db that we generate anyway from time to time.

the error that is added to the device-chat is repeated every day until the clock is adjusted.

this is how it looks like on android - however, as no ui-parts are needed, it will look similar on ios/desktop :)

<img width=250 src=https://user-images.githubusercontent.com/9800740/93267793-781fb180-f7ac-11ea-9a61-56834d0058f7.png> <img width= 250 src=https://user-images.githubusercontent.com/9800740/93267807-7c4bcf00-f7ac-11ea-80b5-826f5b9c9abf.png> <img width= 250 src=https://user-images.githubusercontent.com/9800740/93267801-79e97500-f7ac-11ea-874b-4746f4a11bb8.png>

for detecting outdated apps, we use the same reference date, if that date gets too old, we assume the app is outdated. assuming that the app is not updated on all systems very quickly and that also the provider-db is not updated on every app-update, we are pretty generous and assume one year here.