### PR TITLE
Robust blob filename backup import/export

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -641,8 +641,12 @@ async fn maybe_add_from_param(
         paramsv![],
         |row| row.get::<_, String>(0),
         |rows| {
-            for row in rows {
-                let param: Params = row?.parse().unwrap_or_default();
+            // Rows that can't be parsed, for example if they are
+            // not UTF-8 strings, are ignored. It is possible
+            // when upgrading from C core to Rust core, which
+            // guarantees UTF-8 strings everywhere.
+            for row in rows.filter_map(|row| row.ok()) {
+                let param: Params = row.parse().unwrap_or_default();
                 if let Some(file) = param.get(param_id) {
                     maybe_add_file(files_in_use, file);
                 }


### PR DESCRIPTION
This ignores invalid UTF-8 filenames during import and export. Rust core
does not produce them, but it was possible to have such filenames with
C core.

Closes #1640 