### PR TITLE
[WIP] Peek receipients 2

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1610,6 +1610,7 @@ pub unsafe extern "C" fn dc_get_contacts(
     let query = to_opt_string_lossy(query);
 
     block_on(async move {
+        warn!(&ctx, "dbg flags {} query {:?}", flags, query);
         match Contact::get_all(&ctx, flags, query).await {
             Ok(contacts) => Box::into_raw(Box::new(dc_array_t::from(contacts))),
             Err(_) => ptr::null_mut(),

--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -21,6 +21,17 @@ class FFIEvent:
         return "{name} data1={data1} data2={data2}".format(**self.__dict__)
 
 
+class bcolors:
+    HEADER = '\033[95m'
+    OKBLUE = '\033[94m'
+    OKGREEN = '\033[92m'
+    WARN = '\033[93m'
+    ERROR = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
 class FFIEventLogger:
     """ If you register an instance of this logger with an Account
     you'll get all ffi-events printed.
@@ -48,6 +59,10 @@ class FFIEventLogger:
         if self.logid:
             locname += "-" + self.logid
         s = "{:2.2f} [{}] {}".format(elapsed, locname, message)
+        if message.startswith("DC_EVENT_WARNING"):
+            s = bcolors.WARN + s + bcolors.ENDC
+        if message.startswith("DC_EVENT_ERROR"):
+            s = bcolors.ERROR + s + bcolors.ENDC
         with self._loglock:
             print(s, flush=True)
 

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -10,7 +10,6 @@ use async_std::prelude::*;
 use async_std::task;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
-use crate::config::Config;
 use crate::constants::*;
 use crate::context::Context;
 use crate::dc_tools::*;
@@ -21,7 +20,12 @@ use crate::oauth2::*;
 use crate::provider::{Protocol, Socket, UsernamePattern};
 use crate::smtp::Smtp;
 use crate::stock::StockMessage;
-use crate::{chat, e2ee, provider};
+use crate::{
+    chat,
+    contact::{Contact, Modifier, Origin},
+    e2ee, provider, EventType,
+};
+use crate::{config::Config, contact::normalize_name};
 
 use auto_mozilla::moz_autoconfigure;
 use auto_outlook::outlk_autodiscover;
@@ -320,9 +324,8 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
         .await
         .context("could not read INBOX status")?;
 
-    drop(imap);
-
     progress!(ctx, 910);
+
     // configuration success - write back the configured parameters with the
     // "configured_" prefix; also write the "configured"-flag */
     // the trailing underscore is correct
@@ -333,6 +336,19 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
 
     e2ee::ensure_secret_key_exists(ctx).await?;
     info!(ctx, "key generation completed");
+
+    let ctx2 = ctx.clone();
+    async_std::task::spawn(async move {
+        let ctx = &ctx2;
+        // Read the receipients from old emails sent by the user user and add them as contacts.
+        // This way, we can already offer them some email addresses they can write to.
+        //
+        // This takes some time, so do it asynchronously and query the sentbox folder first because it
+        // is the most "promising" (has the highest amount of outgoing messages)
+        add_all_receipients_as_contacts(ctx, &mut imap, Config::ConfiguredSentboxFolder).await;
+        add_all_receipients_as_contacts(ctx, &mut imap, Config::ConfiguredMvboxFolder).await;
+        add_all_receipients_as_contacts(ctx, &mut imap, Config::ConfiguredInboxFolder).await;
+    });
 
     progress!(ctx, 940);
 
@@ -515,6 +531,51 @@ async fn try_smtp_one_param(
         smtp.disconnect().await;
         true
     }
+}
+
+async fn add_all_receipients_as_contacts(
+    ctx: &Context,
+    imap: &mut Imap,
+    folder: Config,
+) -> Option<()> {
+    let mailbox = ctx.get_config(folder).await?;
+    if let Err(e) = imap.select_with_uidvalidity(ctx, &mailbox).await {
+        warn!(ctx, "Could not select {}: {}", mailbox, e);
+        return None;
+    }
+    match imap.get_all_receipients(ctx).await {
+        Ok(contacts) => {
+            let mut any_modified = false;
+            for contact in contacts {
+                let display_name_normalized = contact
+                    .display_name
+                    .as_ref()
+                    .map(normalize_name)
+                    .unwrap_or_default();
+
+                match Contact::add_or_lookup(
+                    ctx,
+                    display_name_normalized,
+                    contact.addr,
+                    Origin::AddressBook, // TODO this should be OutgoingTo but this makes remote_tests_python fail on ci (for some reason not locally)
+                )
+                .await
+                {
+                    Ok((_, modified)) => {
+                        if modified != Modifier::None {
+                            any_modified = true;
+                        }
+                    }
+                    Err(e) => warn!(ctx, "Could not add receipient: {}", e),
+                }
+            }
+            if any_modified {
+                ctx.emit_event(EventType::ContactsChanged(None));
+            }
+        }
+        Err(e) => warn!(ctx, "Could not add receipients: {}", e),
+    };
+    None
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1204,7 +1204,7 @@ impl Context {
             .get_config(Config::ConfiguredAddr)
             .await
             .ok_or_else(|| format_err!("Not configured"))?;
-
+        // TODO what if ConfiguredAddr is only username, not username@domain.org?
         Ok(addr_cmp(self_addr, addr))
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -866,13 +866,18 @@ impl From<MessageState> for LotState {
 
 impl MessageState {
     pub fn can_fail(self) -> bool {
-        match self {
-            MessageState::OutPreparing
-            | MessageState::OutPending
-            | MessageState::OutDelivered
-            | MessageState::OutMdnRcvd => true, // OutMdnRcvd can still fail because it could be a group message and only some recipients failed.
-            _ => false,
-        }
+        use MessageState::*;
+        matches!(
+            self,
+            OutPreparing | OutPending | OutDelivered | OutMdnRcvd // OutMdnRcvd can still fail because it could be a group message and only some recipients failed.
+        )
+    }
+    pub fn is_outgoing(self) -> bool {
+        use MessageState::*;
+        matches!(
+            self,
+            OutPreparing | OutDraft | OutPending | OutFailed | OutDelivered | OutMdnRcvd
+        )
     }
 }
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1081,7 +1081,7 @@ async fn update_gossip_peerstates(
         let gossip_header = value.parse::<Aheader>();
 
         if let Ok(ref header) = gossip_header {
-            if get_recipients(&mail.headers)
+            if get_recipients(&mail.headers) // TODO is it a problem here that BCC addresses are now also returned?
                 .iter()
                 .any(|info| info.addr == header.addr.to_lowercase())
             {
@@ -1271,9 +1271,9 @@ fn get_attachment_filename(mail: &mailparse::ParsedMail) -> Result<Option<String
 }
 
 /// Returned addresses are normalized and lowercased.
-fn get_recipients(headers: &[MailHeader]) -> Vec<SingleInfo> {
+pub(crate) fn get_recipients(headers: &[MailHeader]) -> Vec<SingleInfo> {
     get_all_addresses_from_header(headers, |header_key| {
-        header_key == "to" || header_key == "cc"
+        header_key == "to" || header_key == "cc" || header_key == "bcc"
     })
 }
 


### PR DESCRIPTION
Read all of an e-mail accounts messages and extract all To/CC addresses if the From was from our own account.

Also, I fixed two other things:
- just by chance my test failed because of an completely unrelated bug.
The bug: bcc_self messages were not marked as read if mvbox_move was set
to true.
- add some color to the test output (minor change)

TODO:
- remove everything with `TODO` or `dbg`

Sorry for all the noise, I am having issues with the CI again, therefore I am creating so many PRs. The ci for this code failed in #1913 (it was my own newly-added test that failed), after squashing and opening a new pr (this one) it succeeded.