### PR TITLE
Maybe fix remote-tests-python problem (Blocking waiting for file lock on build directory)

### DIFF
--- a/ci_scripts/run-python-test.sh
+++ b/ci_scripts/run-python-test.sh
@@ -11,7 +11,7 @@ export DCC_RS_DEV=`pwd`
 
 cd python
 
-python install_python_bindings.py onlybuild
+python install_python_bindings.py onlybuild dontblock
 
 # remove and inhibit writing PYC files 
 rm -rf tests/__pycache__


### PR DESCRIPTION
If it realizes that the ci is blocking, then it makes a clean rebuild.

I pushed this commit to some pr's with blocking builds and it seems to work.