### PR TITLE
[WIP] Fetch old messages, ask the user about the "Show all emails" on start

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -352,9 +352,8 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    If no type is prefixed, the videochat is handled completely in a browser.
  * - `classic_emails_detected` = Check this when you receive DC_EVENT_CONFIGURE_PROGRESS(1000).
  *                    If this is "1", classical emails were detected in the mailbox.
- *                    You should ask the user whether they want to show classical emails in Delta Chat
+ *                    You could ask the user whether they want to show classical emails in Delta Chat
  *                    (and set show_emails to 2 if they say yes)
- *                    It might be a good idea to call dc_fetch_existing_msgs() afterwards.
  *
  * If you want to retrieve a value, use dc_get_config().
  *

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -350,6 +350,11 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    https://github.com/cracker0dks/basicwebrtc which some UIs have native support for.
  *                    The type `jitsi:` may be handled by external apps.
  *                    If no type is prefixed, the videochat is handled completely in a browser.
+ * - `classic_emails_detected` = Check this when you receive DC_EVENT_CONFIGURE_PROGRESS(1000).
+ *                    If this is "1", classical emails were detected in the mailbox.
+ *                    You should ask the user whether they want to show classical emails in Delta Chat
+ *                    (and set show_emails to 2 if they say yes)
+ *                    It might be a good idea to call dc_fetch_existing_msgs() afterwards.
  *
  * If you want to retrieve a value, use dc_get_config().
  *

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -372,9 +372,9 @@ pub unsafe extern "C" fn dc_event_get_data1_int(event: *mut dc_event_t) -> libc:
             let id = id.unwrap_or_default();
             id as libc::c_int
         }
-        EventType::ConfigureProgress { progress, .. }
-        | EventType::ImexProgress(progress)
-        | EventType::FetchExistingMsgsProgress(progress) => *progress as libc::c_int,
+        EventType::ConfigureProgress { progress, .. } | EventType::ImexProgress(progress) => {
+            *progress as libc::c_int
+        }
         EventType::ImexFileWritten(_) => 0,
         EventType::SecurejoinInviterProgress { contact_id, .. }
         | EventType::SecurejoinJoinerProgress { contact_id, .. } => *contact_id as libc::c_int,
@@ -408,7 +408,6 @@ pub unsafe extern "C" fn dc_event_get_data2_int(event: *mut dc_event_t) -> libc:
         | EventType::ConfigureProgress { .. }
         | EventType::ImexProgress(_)
         | EventType::ImexFileWritten(_)
-        | EventType::FetchExistingMsgsProgress(_)
         | EventType::ChatModified(_) => 0,
         EventType::MsgsChanged { msg_id, .. }
         | EventType::IncomingMsg { msg_id, .. }
@@ -457,7 +456,6 @@ pub unsafe extern "C" fn dc_event_get_data2_str(event: *mut dc_event_t) -> *mut 
         | EventType::ImexProgress(_)
         | EventType::SecurejoinInviterProgress { .. }
         | EventType::SecurejoinJoinerProgress { .. }
-        | EventType::FetchExistingMsgsProgress(_)
         | EventType::ChatEphemeralTimerModified { .. } => ptr::null_mut(),
         EventType::ConfigureProgress { comment, .. } => {
             if let Some(comment) = comment {

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -317,15 +317,6 @@ pub unsafe extern "C" fn dc_get_id(context: *mut dc_context_t) -> libc::c_int {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_fetch_existing_msgs(context: *mut dc_context_t) {
-    if context.is_null() {
-        eprintln!("ignoring careless call to dc_chat_get_info_json()");
-    }
-    let ctx = &*context;
-    spawn(async move { Context::fetch_existing_msgs(ctx, None) });
-}
-
-#[no_mangle]
 pub type dc_event_t = Event;
 
 #[no_mangle]

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,13 +121,22 @@ pub enum Config {
     #[strum(serialize = "sys.config_keys")]
     SysConfigKeys,
 
-    #[strum(props(default = "0"))]
     /// Whether we send a warning if the password is wrong (set to false when we send a warning
     /// because we do not want to send a second warning)
+    #[strum(props(default = "0"))]
     NotifyAboutWrongPw,
 
     /// address to webrtc instance to use for videochats
     WebrtcInstance,
+
+    /// Check this when you receive DC_EVENT_CONFIGURE_PROGRESS(1000).
+    /// If this is "1", classical emails were detected in the mailbox.
+    /// You should ask the user whether they want to show classical emails in Delta Chat
+    /// (and set show_emails to 2 if they say yes)
+    /// It might be a good idea to call dc_fetch_existing_msgs() afterwards.
+    #[strum(props(default = "0"))]
+    ClassicEmailsDetected,
+
 }
 
 impl Context {

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,7 +136,6 @@ pub enum Config {
     /// It might be a good idea to call dc_fetch_existing_msgs() afterwards.
     #[strum(props(default = "0"))]
     ClassicEmailsDetected,
-
 }
 
 impl Context {

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,9 +131,8 @@ pub enum Config {
 
     /// Check this when you receive DC_EVENT_CONFIGURE_PROGRESS(1000).
     /// If this is "1", classical emails were detected in the mailbox.
-    /// You should ask the user whether they want to show classical emails in Delta Chat
+    /// You could ask the user whether they want to show classical emails in Delta Chat
     /// (and set show_emails to 2 if they say yes)
-    /// It might be a good idea to call dc_fetch_existing_msgs() afterwards.
     #[strum(props(default = "0"))]
     ClassicEmailsDetected,
 }

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -337,18 +337,20 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
     e2ee::ensure_secret_key_exists(ctx).await?;
     info!(ctx, "key generation completed");
 
-    let ctx2 = ctx.clone();
-    async_std::task::spawn(async move {
-        let ctx = &ctx2;
-        // Read the receipients from old emails sent by the user user and add them as contacts.
-        // This way, we can already offer them some email addresses they can write to.
-        //
-        // This takes some time, so do it asynchronously and query the sentbox folder first because it
-        // is the most "promising" (has the highest amount of outgoing messages)
-        add_all_receipients_as_contacts(ctx, &mut imap, Config::ConfiguredSentboxFolder).await;
-        add_all_receipients_as_contacts(ctx, &mut imap, Config::ConfiguredMvboxFolder).await;
-        add_all_receipients_as_contacts(ctx, &mut imap, Config::ConfiguredInboxFolder).await;
-    });
+    // let ctx2 = ctx.clone();
+    // async_std::task::spawn(async move {
+    // let ctx = &ctx2;
+    // Read the receipients from old emails sent by the user user and add them as contacts.
+    // This way, we can already offer them some email addresses they can write to.
+    //
+    // This takes some time, so do it asynchronously and query the sentbox folder first because it
+    // is the most "promising" (has the highest amount of outgoing messages)
+    add_all_receipients_as_contacts(ctx, &mut imap, Config::ConfiguredSentboxFolder).await;
+    add_all_receipients_as_contacts(ctx, &mut imap, Config::ConfiguredMvboxFolder).await;
+    add_all_receipients_as_contacts(ctx, &mut imap, Config::ConfiguredInboxFolder).await;
+
+    imap.fetch_existing_messages(ctx).await;
+    // });
 
     progress!(ctx, 940);
 

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -10,6 +10,7 @@ use async_std::prelude::*;
 use async_std::task;
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
+use crate::constants::*;
 use crate::context::Context;
 use crate::dc_tools::*;
 use crate::imap::Imap;
@@ -25,7 +26,6 @@ use crate::{
     e2ee, provider, EventType,
 };
 use crate::{config::Config, contact::normalize_name};
-use crate::{constants::*};
 
 use auto_mozilla::moz_autoconfigure;
 use auto_outlook::outlk_autodiscover;
@@ -365,6 +365,8 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
 
     e2ee::ensure_secret_key_exists(ctx).await?;
     info!(ctx, "key generation completed");
+
+    imap.detect_classic_emails(ctx).await;
 
     // let ctx2 = ctx.clone();
     // async_std::task::spawn(async move {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -202,6 +202,9 @@ pub const DC_LP_AUTH_FLAGS: i32 = DC_LP_AUTH_OAUTH2 | DC_LP_AUTH_NORMAL;
 /// How many existing messages shall be fetched if this feature is enabled.
 pub const DC_FETCH_EXISTING_MSGS_COUNT: i32 = 100;
 
+/// How many emails have to be in the inbox so that Config::ClassicEmailsDetected is set to "1"
+pub const DC_DETECT_CLASSIC_EMAILS_THRESHOLT: usize = 5;
+
 // max. width/height of an avatar
 pub const AVATAR_SIZE: u32 = 192;
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -200,7 +200,7 @@ pub const DC_LP_AUTH_NORMAL: i32 = 0x4;
 pub const DC_LP_AUTH_FLAGS: i32 = DC_LP_AUTH_OAUTH2 | DC_LP_AUTH_NORMAL;
 
 /// How many existing messages shall be fetched if this feature is enabled.
-pub const DC_FETCH_EXISTING_MESSAGES_COUNT: i32 = 100;
+pub const DC_FETCH_EXISTING_MSGS_COUNT: i32 = 100;
 
 // max. width/height of an avatar
 pub const AVATAR_SIZE: u32 = 192;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -199,6 +199,9 @@ pub const DC_LP_AUTH_NORMAL: i32 = 0x4;
 /// if none of these flags are set, the default is chosen
 pub const DC_LP_AUTH_FLAGS: i32 = DC_LP_AUTH_OAUTH2 | DC_LP_AUTH_NORMAL;
 
+/// How many existing messages shall be fetched if this feature is enabled.
+pub const DC_FETCH_EXISTING_MESSAGES_COUNT: i32 = 100;
+
 // max. width/height of an avatar
 pub const AVATAR_SIZE: u32 = 192;
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -244,10 +244,6 @@ pub enum EventType {
         comment: Option<String>,
     },
 
-    /// Inform about the configuration progress started by dc_fetch_existing_msgs
-    #[strum(props(id = "2043"))]
-    FetchExistingMsgsProgress(usize),
-
     /// Inform about the import/export progress started by imex().
     ///
     /// @param data1 (usize) 0=error, 1-999=progress in permille, 1000=success and done

--- a/src/events.rs
+++ b/src/events.rs
@@ -244,6 +244,10 @@ pub enum EventType {
         comment: Option<String>,
     },
 
+    /// Inform about the configuration progress started by dc_fetch_existing_msgs
+    #[strum(props(id = "2043"))]
+    FetchExistingMsgsProgress(usize),
+
     /// Inform about the import/export progress started by imex().
     ///
     /// @param data1 (usize) 0=error, 1-999=progress in permille, 1000=success and done

--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -160,7 +160,7 @@ impl Imap {
                     // will not find any new.
 
                     if let Some(ref watch_folder) = watch_folder {
-                        match self.fetch_new_messages(context, watch_folder).await {
+                        match self.fetch_new_messages(context, watch_folder, false).await {
                             Ok(res) => {
                                 info!(context, "fetch_new_messages returned {:?}", res);
                                 if res {

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1433,6 +1433,7 @@ impl Imap {
         match self.detect_classic_emails_inner(context).await {
             Err(e) => warn!(context, "detect_classic_emails(): {:#}", e),
             Ok(count) => {
+                warn!(context, "dbg detected {}", count);
                 if count >= DC_DETECT_CLASSIC_EMAILS_THRESHOLT {
                     if let Err(e) = context.set_config(Config::ClassicEmailsDetected, Some("1")).await {
                         warn!(context, "detect_classic_emails() can't set config: {:#}", e);
@@ -1442,7 +1443,7 @@ impl Imap {
         }
     }
 
-    pub async fn detect_classic_emails_inner(&mut self, context: &Context) -> Result<usize> {
+    async fn detect_classic_emails_inner(&mut self, context: &Context) -> Result<usize> {
         let mut result = 0;
         for config in &[
             Config::ConfiguredInboxFolder,

--- a/src/job.rs
+++ b/src/job.rs
@@ -92,6 +92,7 @@ pub enum Action {
 
     // Jobs in the INBOX-thread, range from DC_IMAP_THREAD..DC_IMAP_THREAD+999
     Housekeeping = 105, // low priority ...
+    FetchExsistingMsgs = 110,
     MarkseenMsgOnImap = 130,
 
     // Moving message is prioritized lower than deletion so we don't
@@ -124,6 +125,7 @@ impl From<Action> for Thread {
             Unknown => Thread::Unknown,
 
             Housekeeping => Thread::Imap,
+            FetchExsistingMsgs => Thread::Imap,
             DeleteMsgOnImap => Thread::Imap,
             ResyncFolders => Thread::Imap,
             MarkseenMsgOnImap => Thread::Imap,


### PR DESCRIPTION
Fix https://github.com/deltachat/deltachat-android/issues/1516, During onboarding and after we scanned the history, we might ask the user something along the lines of
"oh, it appears you are using this e-mail account also with another email program. Do you want to a) see all your e-mails in Delta Chat or b) only see chat conversations from other Delta Chat users?"

The plan is to also fetch the last 100 messages from each folder and just show them. This will make it clearei to the user what they just decided and that they can really write EMAILS with DC.