### PR TITLE
split DC_EVENT_MSGS_NOTICED off DC_EVENT_MSGS_CHANGED, remove dc_marknoticed_all_chats()

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1123,7 +1123,7 @@ dc_array_t*     dc_get_fresh_msgs            (dc_context_t* context);
  * (IMAP/MDNs is not done for noticed messages).
  *
  * Calling this function usually results in the event #DC_EVENT_MSGS_NOTICED.
- * See also dc_marknoticed_all_chats(), dc_marknoticed_contact() and dc_markseen_msgs().
+ * See also dc_marknoticed_contact() and dc_markseen_msgs().
  *
  * @memberof dc_context_t
  * @param context The context object as returned from dc_context_new().
@@ -1131,16 +1131,6 @@ dc_array_t*     dc_get_fresh_msgs            (dc_context_t* context);
  * @return None.
  */
 void            dc_marknoticed_chat          (dc_context_t* context, uint32_t chat_id);
-
-
-/**
- * Same as dc_marknoticed_chat() but for _all_ chats.
- *
- * @memberof dc_context_t
- * @param context The context object as returned from dc_context_new().
- * @return None.
- */
-void            dc_marknoticed_all_chats     (dc_context_t* context);
 
 
 /**

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1503,11 +1503,13 @@ void            dc_forward_msgs              (dc_context_t* context, const uint3
 
 
 /**
- * Mark all messages sent by the given contact
- * as _noticed_.  See also dc_marknoticed_chat() and
- * dc_markseen_msgs()
+ * Mark all messages sent by the given contact as _noticed_.
+ * This function is typically used to ignore a user in the deaddrop temporarily ("Not now" button).
  *
- * Calling this function usually results in the event #DC_EVENT_MSGS_NOTICED.
+ * The contact is expected to belong to the deaddrop;
+ * only one #DC_EVENT_MSGS_NOTICED with chat_id=DC_CHAT_ID_DEADDROP may be emitted.
+ *
+ * See also dc_marknoticed_chat() and dc_markseen_msgs()
  *
  * @memberof dc_context_t
  * @param context The context object.
@@ -1526,7 +1528,8 @@ void            dc_marknoticed_contact       (dc_context_t* context, uint32_t co
  * Moreover, if messages belong to a chat with ephemeral messages enabled,
  * the ephemeral timer is started for these messages.
  *
- * Calling this function usually results in the event #DC_EVENT_MSGS_NOTICED.
+ * The given messages are expected to belong to the same chat or to the deaddrop;
+ * only one #DC_EVENT_MSGS_NOTICED event with this chat may be emitted.
  *
  * @memberof dc_context_t
  * @param context The context object.
@@ -4607,7 +4610,7 @@ void dc_event_unref(dc_event_t* event);
  * Do not try to derive the state of an item from just the fact you received the event;
  * use eg. dc_msg_get_state() or dc_get_fresh_msg_cnt() for this purpose.
  *
- * @param data1 (int) chat_id or 0 if the event affects multiple chats.
+ * @param data1 (int) chat_id
  * @param data2 0
  */
 #define DC_EVENT_MSGS_NOTICED             2008

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1122,7 +1122,7 @@ dc_array_t*     dc_get_fresh_msgs            (dc_context_t* context);
  * but are still waiting for being marked as "seen" using dc_markseen_msgs()
  * (IMAP/MDNs is not done for noticed messages).
  *
- * Calling this function usually results in the event #DC_EVENT_MSGS_CHANGED.
+ * Calling this function usually results in the event #DC_EVENT_MSGS_NOTICED.
  * See also dc_marknoticed_all_chats(), dc_marknoticed_contact() and dc_markseen_msgs().
  *
  * @memberof dc_context_t
@@ -1517,7 +1517,7 @@ void            dc_forward_msgs              (dc_context_t* context, const uint3
  * as _noticed_.  See also dc_marknoticed_chat() and
  * dc_markseen_msgs()
  *
- * Calling this function usually results in the event #DC_EVENT_MSGS_CHANGED.
+ * Calling this function usually results in the event #DC_EVENT_MSGS_NOTICED.
  *
  * @memberof dc_context_t
  * @param context The context object.
@@ -1535,6 +1535,8 @@ void            dc_marknoticed_contact       (dc_context_t* context, uint32_t co
  *
  * Moreover, if messages belong to a chat with ephemeral messages enabled,
  * the ephemeral timer is started for these messages.
+ *
+ * Calling this function usually results in the event #DC_EVENT_MSGS_NOTICED.
  *
  * @memberof dc_context_t
  * @param context The context object.
@@ -4605,6 +4607,20 @@ void dc_event_unref(dc_event_t* event);
  * @param data2 (int) msg_id
  */
 #define DC_EVENT_INCOMING_MSG             2005
+
+
+/**
+ * Messages were marked noticed or seen.
+ * The ui may update badge counters or stop showing a chatlist-item with a bold font.
+ *
+ * This event is emitted eg. when calling dc_markseen_msgs(), dc_marknoticed_chat() or dc_marknoticed_contact().
+ * Do not try to derive the state of an item from just the fact you received the event;
+ * use eg. dc_msg_get_state() or dc_get_fresh_msg_cnt() for this purpose.
+ *
+ * @param data1 (int) chat_id or 0 if the event affects multiple chats.
+ * @param data2 0
+ */
+#define DC_EVENT_MSGS_NOTICED             2008
 
 
 /**

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1528,8 +1528,7 @@ void            dc_marknoticed_contact       (dc_context_t* context, uint32_t co
  * Moreover, if messages belong to a chat with ephemeral messages enabled,
  * the ephemeral timer is started for these messages.
  *
- * The given messages are expected to belong to the same chat or to the deaddrop;
- * only one #DC_EVENT_MSGS_NOTICED event with this chat may be emitted.
+ * One #DC_EVENT_MSGS_NOTICED event is emitted per modified chat.
  *
  * @memberof dc_context_t
  * @param context The context object.

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -362,6 +362,7 @@ pub unsafe extern "C" fn dc_event_get_data1_int(event: *mut dc_event_t) -> libc:
         | EventType::ErrorSelfNotInGroup(_) => 0,
         EventType::MsgsChanged { chat_id, .. }
         | EventType::IncomingMsg { chat_id, .. }
+        | EventType::MsgsNoticed(chat_id)
         | EventType::MsgDelivered { chat_id, .. }
         | EventType::MsgFailed { chat_id, .. }
         | EventType::MsgRead { chat_id, .. }
@@ -407,6 +408,7 @@ pub unsafe extern "C" fn dc_event_get_data2_int(event: *mut dc_event_t) -> libc:
         | EventType::ConfigureProgress { .. }
         | EventType::ImexProgress(_)
         | EventType::ImexFileWritten(_)
+        | EventType::MsgsNoticed(_)
         | EventType::ChatModified(_) => 0,
         EventType::MsgsChanged { msg_id, .. }
         | EventType::IncomingMsg { msg_id, .. }
@@ -446,6 +448,7 @@ pub unsafe extern "C" fn dc_event_get_data2_str(event: *mut dc_event_t) -> *mut 
         }
         EventType::MsgsChanged { .. }
         | EventType::IncomingMsg { .. }
+        | EventType::MsgsNoticed(_)
         | EventType::MsgDelivered { .. }
         | EventType::MsgFailed { .. }
         | EventType::MsgRead { .. }

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -973,22 +973,6 @@ pub unsafe extern "C" fn dc_marknoticed_chat(context: *mut dc_context_t, chat_id
     })
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn dc_marknoticed_all_chats(context: *mut dc_context_t) {
-    if context.is_null() {
-        eprintln!("ignoring careless call to dc_marknoticed_all_chats()");
-        return;
-    }
-    let ctx = &*context;
-
-    block_on(async move {
-        chat::marknoticed_all_chats(&ctx)
-            .await
-            .log_err(ctx, "Failed marknoticed all chats")
-            .unwrap_or(())
-    })
-}
-
 fn from_prim<S, T>(s: S) -> Option<T>
 where
     T: FromPrimitive,

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -882,7 +882,13 @@ class TestOnlineAccount:
         lp.sec("mark messages as seen on ac2, wait for changes on ac1")
         ac2.direct_imap.idle_start()
         ac1.direct_imap.idle_start()
+
         ac2.mark_seen_messages([msg2, msg4])
+        ev = ac2._evtracker.get_matching("DC_EVENT_MSGS_NOTICED")
+        assert msg2.chat.id == msg4.chat.id
+        assert ev.data1 == msg2.chat.id
+        assert ev.data2 == 0
+
         ac2.direct_imap.idle_check(terminate=True)
         lp.step("1")
         for i in range(2):

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1800,35 +1800,6 @@ pub async fn marknoticed_chat(context: &Context, chat_id: ChatId) -> Result<(), 
     Ok(())
 }
 
-pub async fn marknoticed_all_chats(context: &Context) -> Result<(), Error> {
-    if !context
-        .sql
-        .exists(
-            "SELECT id
-           FROM msgs
-          WHERE state=10;",
-            paramsv![],
-        )
-        .await?
-    {
-        return Ok(());
-    }
-
-    context
-        .sql
-        .execute(
-            "UPDATE msgs
-            SET state=13
-          WHERE state=10;",
-            paramsv![],
-        )
-        .await?;
-
-    context.emit_event(EventType::MsgsNoticed(ChatId::new(0)));
-
-    Ok(())
-}
-
 pub async fn get_chat_media(
     context: &Context,
     chat_id: ChatId,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1795,10 +1795,7 @@ pub async fn marknoticed_chat(context: &Context, chat_id: ChatId) -> Result<(), 
         )
         .await?;
 
-    context.emit_event(EventType::MsgsChanged {
-        chat_id: ChatId::new(0),
-        msg_id: MsgId::new(0),
-    });
+    context.emit_event(EventType::MsgsNoticed(chat_id));
 
     Ok(())
 }
@@ -1827,10 +1824,7 @@ pub async fn marknoticed_all_chats(context: &Context) -> Result<(), Error> {
         )
         .await?;
 
-    context.emit_event(EventType::MsgsChanged {
-        msg_id: MsgId::new(0),
-        chat_id: ChatId::new(0),
-    });
+    context.emit_event(EventType::MsgsNoticed(ChatId::new(0)));
 
     Ok(())
 }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -260,10 +260,9 @@ impl Contact {
         Ok(contact_id)
     }
 
-    /// Mark all messages sent by the given contact
-    /// as *noticed*.  See also dc_marknoticed_chat() and dc_markseen_msgs()
-    ///
-    /// Calling this function usually results in the event `#DC_EVENT_MSGS_NOTICED`.
+    /// Mark messages from a contact as noticed.
+    /// The contact is expected to belong to the deaddrop,
+    /// therefore, DC_EVENT_MSGS_NOTICED(DC_CHAT_ID_DEADDROP) is emitted.
     pub async fn mark_noticed(context: &Context, id: u32) {
         if context
             .sql
@@ -274,7 +273,7 @@ impl Contact {
             .await
             .is_ok()
         {
-            context.emit_event(EventType::MsgsNoticed(ChatId::new(0)));
+            context.emit_event(EventType::MsgsNoticed(ChatId::new(DC_CHAT_ID_DEADDROP)));
         }
     }
 

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -16,7 +16,7 @@ use crate::error::{bail, ensure, format_err, Result};
 use crate::events::EventType;
 use crate::key::{DcKey, SignedPublicKey};
 use crate::login_param::LoginParam;
-use crate::message::{MessageState, MsgId};
+use crate::message::MessageState;
 use crate::mimeparser::AvatarAction;
 use crate::param::*;
 use crate::peerstate::*;
@@ -263,7 +263,7 @@ impl Contact {
     /// Mark all messages sent by the given contact
     /// as *noticed*.  See also dc_marknoticed_chat() and dc_markseen_msgs()
     ///
-    /// Calling this function usually results in the event `#DC_EVENT_MSGS_CHANGED`.
+    /// Calling this function usually results in the event `#DC_EVENT_MSGS_NOTICED`.
     pub async fn mark_noticed(context: &Context, id: u32) {
         if context
             .sql
@@ -274,10 +274,7 @@ impl Contact {
             .await
             .is_ok()
         {
-            context.emit_event(EventType::MsgsChanged {
-                chat_id: ChatId::new(0),
-                msg_id: MsgId::new(0),
-            });
+            context.emit_event(EventType::MsgsNoticed(ChatId::new(0)));
         }
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -186,6 +186,11 @@ pub enum EventType {
     #[strum(props(id = "2005"))]
     IncomingMsg { chat_id: ChatId, msg_id: MsgId },
 
+    /// Messages were seen or noticed.
+    /// If chat_id is 0, this affects multiple chats.
+    #[strum(props(id = "2008"))]
+    MsgsNoticed(ChatId),
+
     /// A single message is sent successfully. State changed from  DC_STATE_OUT_PENDING to
     /// DC_STATE_OUT_DELIVERED, see dc_msg_get_state().
     #[strum(props(id = "2010"))]

--- a/src/events.rs
+++ b/src/events.rs
@@ -187,7 +187,7 @@ pub enum EventType {
     IncomingMsg { chat_id: ChatId, msg_id: MsgId },
 
     /// Messages were seen or noticed.
-    /// If chat_id is 0, this affects multiple chats.
+    /// chat id is always set.
     #[strum(props(id = "2008"))]
     MsgsNoticed(ChatId),
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1285,7 +1285,7 @@ pub async fn markseen_msgs(context: &Context, msg_ids: Vec<MsgId>) -> bool {
         }
     }
 
-    for (updated_chat_id, _) in &updated_chat_ids {
+    for updated_chat_id in updated_chat_ids.keys() {
         context.emit_event(EventType::MsgsNoticed(*updated_chat_id));
     }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1283,10 +1283,7 @@ pub async fn markseen_msgs(context: &Context, msg_ids: Vec<MsgId>) -> bool {
     }
 
     if send_event {
-        context.emit_event(EventType::MsgsChanged {
-            chat_id: ChatId::new(0),
-            msg_id: MsgId::new(0),
-        });
+        context.emit_event(EventType::MsgsNoticed(ChatId::new(0)));
     }
 
     true


### PR DESCRIPTION
the new event can be used for updating the badge counter.
to get the old behavior, implementations can just do the same on both events.

this event is needed to make markseen-handling easier on ios (@cyBerta and me are doing currently a partly rewrite of the chatview), but will also mitigate flickering and needless redraws on android and possibly on desktop.

~~in a further improvement, we can set the correct chat_id in dc_markseen_msgs(), however, this won't affect implementation as a "broadcast" event is still needed for other functions. also, chat_id=0 is also needed for DC_EVENT_MSGS_CHANGED, so this new event does not add additional complexity here.~~ EDIT: done by recent commits, chat_id is now always set.