### PR TITLE
[WIP, help wanted] implement better second device setup

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -349,6 +349,8 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    https://github.com/cracker0dks/basicwebrtc which some UIs have native support for.
  *                    The type `jitsi:` may be handled by external apps.
  *                    If no type is prefixed, the videochat is handled completely in a browser.
+ * - `dc_was_used_before` = Set during the configure process. If true, DC was used with this email account before
+ *                    and the user re-installed DC or is setting up a second device.
  *
  * If you want to retrieve a value, use dc_get_config().
  *

--- a/src/config.rs
+++ b/src/config.rs
@@ -128,6 +128,8 @@ pub enum Config {
 
     /// address to webrtc instance to use for videochats
     WebrtcInstance,
+
+    DcWasUsedBefore,
 }
 
 impl Context {


### PR DESCRIPTION
I closed #1774 and made a copy-paste rebase.
- [x] Detect when this account already was in use with DC -> todo: tests
- [ ] (Show the QR scan activity, has to be done in UIs)
- [ ] (Send a message to self that opens the QR scan activity on the other device - we should probably leave out this step) 
- [ ] Somehow use the QR codes to establish a secure connection (I'll need help with this step)
- [ ] Transfer the backup
- [ ] set bcc_self to true because the user now uses multiple devices

cc @link2xt 