### PR TITLE
Call update_device_chats automatically during configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- breaking change: update_device_chats() was removed. This is now done automatically during configure.
+- breaking change: `dc_update_device_chats()` was removed. This is now done automatically during configure.
+
+- Added a `bot` config. Currently, it only prevents filling the device chats automatically.
 
 ## 1.46.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog 
 
+## Unreleased
+
+- breaking change: update_device_chats() was removed. This is now done automatically during configure.
+
 ## 1.46.0
 
 - breaking change: `dc_configure()` report errors in

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -984,27 +984,6 @@ void            dc_set_draft                 (dc_context_t* context, uint32_t ch
  */
 uint32_t        dc_add_device_msg            (dc_context_t* context, const char* label, dc_msg_t* msg);
 
-
-/**
- * DEPRECATED This is now done automatically while configuring.
- * There is no need to call this function anymore.
- *
- * Init device-messages and saved-messages chat.
- * This function adds the device-chat and saved-messages chat
- * and adds one or more welcome or update-messages.
- * The ui can add messages on its own using dc_add_device_msg() -
- * for ordering, either before or after or even without calling this function.
- *
- * Chat and message creation is done only once.
- * So if the user has manually deleted things, they won't be re-created
- * (however, not seen device messages are added and may re-create the device-chat).
- *
- * @memberof dc_context_t
- * @param context The context object.
- */
-void            dc_update_device_chats       (dc_context_t* context);
-
-
 /**
  * Check if a device-message with a given label was ever added.
  * Device-messages can be added dc_add_device_msg().

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -349,6 +349,7 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    https://github.com/cracker0dks/basicwebrtc which some UIs have native support for.
  *                    The type `jitsi:` may be handled by external apps.
  *                    If no type is prefixed, the videochat is handled completely in a browser.
+ * - `bot`          = Set to "1" if this is a bot. E.g. prevents adding the "Device messages" and "Saved messages" chats.
  *
  * If you want to retrieve a value, use dc_get_config().
  *

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -986,6 +986,9 @@ uint32_t        dc_add_device_msg            (dc_context_t* context, const char*
 
 
 /**
+ * DEPRECATED This is now done automatically while configuring.
+ * There is no need to call this function anymore.
+ *
  * Init device-messages and saved-messages chat.
  * This function adds the device-chat and saved-messages chat
  * and adds one or more welcome or update-messages.

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -808,21 +808,6 @@ pub unsafe extern "C" fn dc_add_device_msg(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_update_device_chats(context: *mut dc_context_t) {
-    if context.is_null() {
-        eprintln!("ignoring careless call to dc_update_device_chats()");
-        return;
-    }
-    let ctx = &mut *context;
-
-    block_on(async move {
-        ctx.update_device_chats()
-            .await
-            .unwrap_or_log_default(&ctx, "Failed to add device message")
-    })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn dc_was_device_msg_ever_added(
     context: *mut dc_context_t,
     label: *const libc::c_char,

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -881,9 +881,6 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             msg.set_text(Some(arg1.to_string()));
             chat::add_device_msg(&context, None, Some(&mut msg)).await?;
         }
-        "updatedevicechats" => {
-            context.update_device_chats().await?;
-        }
         "listmedia" => {
             ensure!(sel_chat.is_some(), "No chat selected.");
 

--- a/python/src/deltachat/__init__.py
+++ b/python/src/deltachat/__init__.py
@@ -77,6 +77,7 @@ def run_cmdline(argv=None, account_plugins=None):
         ac.set_config("mvbox_move", "0")
         ac.set_config("mvbox_watch", "0")
         ac.set_config("sentbox_watch", "0")
+        ac.set_config("bot", "1")
         configtracker = ac.configure()
         configtracker.wait_finish()
 

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -336,6 +336,9 @@ class Account(object):
     def get_deaddrop_chat(self):
         return Chat(self, const.DC_CHAT_ID_DEADDROP)
 
+    def get_device_chat(self):
+        return Chat(self, const.DC_CONTACT_ID_DEVICE)
+
     def get_message_by_id(self, msg_id):
         """ return Message instance.
         :param msg_id: integer id of this message.

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -337,7 +337,7 @@ class Account(object):
         return Chat(self, const.DC_CHAT_ID_DEADDROP)
 
     def get_device_chat(self):
-        return Chat(self, const.DC_CONTACT_ID_DEVICE)
+        return Contact(self, const.DC_CONTACT_ID_DEVICE).create_chat()
 
     def get_message_by_id(self, msg_id):
         """ return Message instance.

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -354,6 +354,8 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
             for acc in self._accounts:
                 if hasattr(acc, "_configtracker"):
                     acc._configtracker.wait_finish()
+                    acc._evtracker.consume_events()
+                    acc.get_device_chat().mark_noticed()
                     del acc._configtracker
                 acc.set_config("bcc_self", "0")
                 if acc.is_configured() and not acc.is_started():

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1259,10 +1259,12 @@ pub async fn create_by_contact_id(context: &Context, contact_id: u32) -> Result<
         }
     };
 
-    context.emit_event(EventType::MsgsChanged {
-        chat_id: ChatId::new(0),
-        msg_id: MsgId::new(0),
-    });
+    if context.is_configured().await {
+        context.emit_event(EventType::MsgsChanged {
+            chat_id: ChatId::new(0),
+            msg_id: MsgId::new(0),
+        });
+    }
 
     Ok(chat_id)
 }
@@ -2840,7 +2842,7 @@ pub async fn add_device_msg_with_importance(
             .await?;
     }
 
-    if !msg_id.is_unset() {
+    if !msg_id.is_unset() && context.is_configured().await {
         if important {
             context.emit_event(EventType::IncomingMsg { chat_id, msg_id });
         } else {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1259,12 +1259,10 @@ pub async fn create_by_contact_id(context: &Context, contact_id: u32) -> Result<
         }
     };
 
-    if context.is_configured().await {
-        context.emit_event(EventType::MsgsChanged {
-            chat_id: ChatId::new(0),
-            msg_id: MsgId::new(0),
-        });
-    }
+    context.emit_event(EventType::MsgsChanged {
+        chat_id: ChatId::new(0),
+        msg_id: MsgId::new(0),
+    });
 
     Ok(chat_id)
 }
@@ -2842,7 +2840,7 @@ pub async fn add_device_msg_with_importance(
             .await?;
     }
 
-    if !msg_id.is_unset() && context.is_configured().await {
+    if !msg_id.is_unset() {
         if important {
             context.emit_event(EventType::IncomingMsg { chat_id, msg_id });
         } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -121,6 +121,9 @@ pub enum Config {
     #[strum(serialize = "sys.config_keys")]
     SysConfigKeys,
 
+    Bot,
+
+    #[strum(props(default = "0"))]
     /// Whether we send a warning if the password is wrong (set to false when we send a warning
     /// because we do not want to send a second warning)
     #[strum(props(default = "0"))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,7 +123,6 @@ pub enum Config {
 
     Bot,
 
-    #[strum(props(default = "0"))]
     /// Whether we send a warning if the password is wrong (set to false when we send a warning
     /// because we do not want to send a second warning)
     #[strum(props(default = "0"))]

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -342,11 +342,6 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
     drop(imap);
 
     progress!(ctx, 910);
-
-    // Make sure update_device_chats is done before we set the "configured" config
-    // so that no DC_EVENT_MSGS_CHANGED is sent (this would confuse bots and python tests)
-    update_device_chats_handle.await?;
-
     // configuration success - write back the configured parameters with the
     // "configured_" prefix; also write the "configured"-flag */
     // the trailing underscore is correct
@@ -365,6 +360,7 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
     .await;
 
     progress!(ctx, 940);
+    update_device_chats_handle.await?;
 
     Ok(())
 }

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -358,6 +358,10 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
 
     progress!(ctx, 940);
 
+    ctx.update_device_chats().await?;
+
+    progress!(ctx, 950);
+
     Ok(())
 }
 

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -163,6 +163,9 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
         DC_LP_AUTH_NORMAL as i32
     };
 
+    let ctx2 = ctx.clone();
+    let update_device_chats_handle = task::spawn(async move { ctx2.update_device_chats().await });
+
     // Step 1: Load the parameters and check email-address and password
 
     if oauth2 {
@@ -357,10 +360,7 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
     .await;
 
     progress!(ctx, 940);
-
-    ctx.update_device_chats().await?;
-
-    progress!(ctx, 950);
+    update_device_chats_handle.await?;
 
     Ok(())
 }

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -342,6 +342,11 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
     drop(imap);
 
     progress!(ctx, 910);
+
+    // Make sure update_device_chats is done before we set the "configured" config
+    // so that no DC_EVENT_MSGS_CHANGED is sent (this would confuse bots and python tests)
+    update_device_chats_handle.await?;
+
     // configuration success - write back the configured parameters with the
     // "configured_" prefix; also write the "configured"-flag */
     // the trailing underscore is correct
@@ -360,7 +365,6 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
     .await;
 
     progress!(ctx, 940);
-    update_device_chats_handle.await?;
 
     Ok(())
 }

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use strum::EnumProperty;
 use strum_macros::EnumProperty;
 
-use crate::blob::BlobObject;
+use crate::{blob::BlobObject, config::Config};
 use crate::chat;
 use crate::chat::ProtectionStatus;
 use crate::constants::{Viewtype, DC_CONTACT_ID_SELF};
@@ -424,6 +424,10 @@ impl Context {
     }
 
     pub(crate) async fn update_device_chats(&self) -> Result<(), Error> {
+        if self.get_config_bool(Config::Bot).await {
+            return Ok(());
+        }
+
         // check for the LAST added device message - if it is present, we can skip message creation.
         // this is worthwhile as this function is typically called
         // by the UI on every program start or even on every opening of the chatlist.

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -423,7 +423,7 @@ impl Context {
         .await
     }
 
-    pub async fn update_device_chats(&self) -> Result<(), Error> {
+    pub(crate) async fn update_device_chats(&self) -> Result<(), Error> {
         // check for the LAST added device message - if it is present, we can skip message creation.
         // this is worthwhile as this function is typically called
         // by the UI on every program start or even on every opening of the chatlist.

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -428,15 +428,8 @@ impl Context {
             return Ok(());
         }
 
-        // check for the LAST added device message - if it is present, we can skip message creation.
-        // this is worthwhile as this function is typically called
-        // by the UI on every program start or even on every opening of the chatlist.
-        if chat::was_device_msg_ever_added(&self, "core-welcome").await? {
-            return Ok(());
-        }
-
-        // create saved-messages chat;
-        // we do this only once, if the user has deleted the chat, he can recreate it manually.
+        // create saved-messages chat; we do this only once, if the user has deleted the chat,
+        // he can recreate it manually (make sure we do not re-add it when configure() was called a second time)
         if !self.sql.get_raw_config_bool(&self, "self-chat-added").await {
             self.sql
                 .set_raw_config_bool(&self, "self-chat-added", true)

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -5,7 +5,6 @@ use std::borrow::Cow;
 use strum::EnumProperty;
 use strum_macros::EnumProperty;
 
-use crate::{blob::BlobObject, config::Config};
 use crate::chat;
 use crate::chat::ProtectionStatus;
 use crate::constants::{Viewtype, DC_CONTACT_ID_SELF};
@@ -15,6 +14,7 @@ use crate::error::{bail, Error};
 use crate::message::Message;
 use crate::param::Param;
 use crate::stock::StockMessage::{DeviceMessagesHint, WelcomeMessage};
+use crate::{blob::BlobObject, config::Config};
 
 /// Stock strings
 ///


### PR DESCRIPTION
update_device_chats() takes about 2 seconds on a modern device (Android) because the
welcome image file has to be written to the disk as a blob. The problem
was that this was done after the progress bar had vanished and before
anything else happened so that I thought that something had gone wrong
multiple times.

The UIs have to remove update_device_chats(), too..