### PR TITLE
prepare_msg: return Err if no address is configured

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1015,7 +1015,7 @@ impl Chat {
                         );
                     }
         } else {
-            error!(context, "Cannot send message, not configured.",);
+            bail!("Cannot prepare message for sending, address is not configured.");
         }
         schedule_ephemeral_task(context).await;
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -1833,6 +1833,23 @@ mod tests {
         assert_eq!(_msg2.get_filemime(), None);
     }
 
+    /// Tests that message cannot be prepared if account has no configured address.
+    #[async_std::test]
+    async fn test_prepare_not_configured() {
+        let d = test::TestContext::new().await;
+        let ctx = &d.ctx;
+
+        let contact = Contact::create(ctx, "", "dest@example.com")
+            .await
+            .expect("failed to create contact");
+
+        let chat = chat::create_by_contact_id(ctx, contact).await.unwrap();
+
+        let mut msg = Message::new(Viewtype::Text);
+
+        assert!(chat::prepare_msg(ctx, chat, &mut msg).await.is_err());
+    }
+
     #[async_std::test]
     async fn test_get_summarytext_by_raw() {
         let d = test::TestContext::new().await;


### PR DESCRIPTION
Address is used to generate `Message-Id`.

Previously error toast was shown, but `MsgId` was returned from `chat::prepare_msg` anyway. Now `chat::prepare_msg` returns an error.

`error!()` is removed, because FFI library shows errors via `.unwrap_or_log_default()`.