### PR TITLE
Quoting

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3676,6 +3676,63 @@ void            dc_msg_latefiling_mediasize   (dc_msg_t* msg, int width, int hei
 
 
 /**
+ * Set the message replying to.
+ * This allows optionally to reply to an explicit message
+ * instead of replying implicitly to the end of the chat.
+ *
+ * dc_msg_set_quote() copies some basic data from the quoted message object
+ * so that dc_msg_get_quoted_text() will always work.
+ * dc_msg_get_quoted_msg() gets back the quoted message only if it is _not_ deleted.
+ *
+ * @memberof dc_msg_t
+ * @param msg The message object to set the reply to.
+ * @param quote The quote to set for msg.
+ */
+void             dc_msg_set_quote             (dc_msg_t* msg, const dc_msg_t* quote);
+
+
+/**
+ * Get quoted text, if any.
+ * You can use this function also check if there is a quote for a message.
+ *
+ * The text is a summary of the original text,
+ * similar to what is shown in the chatlist.
+ *
+ * If available, you can get the whole quoted message object using dc_msg_get_quoted_msg().
+ *
+ * @memberof dc_msg_t
+ * @param msg The message object.
+ * @return The quoted text or NULL if there is no quote.
+ *     Returned strings must be released using dc_str_unref().
+ */
+char*           dc_msg_get_quoted_text        (const dc_msg_t* msg);
+
+
+/**
+ * Get quoted message, if available.
+ * UIs might use this information to offer "jumping back" to the quoted message
+ * or to enrich displaying the quote.
+ *
+ * If this function returns NULL,
+ * this does not mean there is no quote for the message -
+ * it might also mean that a quote exist but the quoted message is deleted meanwhile.
+ * Therefore, do not use this function to check if there is a quote for a message.
+ * To check if a message has a quote, use dc_msg_get_quoted_text().
+ *
+ * To display the quote in the chat, use dc_msg_get_quoted_text() as a primary source,
+ * however, one might add information from the message object (eg. an image).
+ *
+ * It is not guaranteed that the message belong to the same chat.
+ *
+ * @memberof dc_msg_t
+ * @param msg The message object.
+ * @return The quoted message or NULL.
+ *     Must be freed using dc_msg_unref() after usage.
+ */
+dc_msg_t*       dc_msg_get_quoted_msg         (const dc_msg_t* msg);
+
+
+/**
  * @class dc_contact_t
  *
  * An object representing a single contact in memory.

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2984,11 +2984,14 @@ pub unsafe extern "C" fn dc_msg_set_quote(msg: *mut dc_msg_t, quote: *const dc_m
     let ffi_msg = &mut *msg;
     let ffi_quote = &*quote;
 
-    ffi_msg
-        .message
-        .set_quote(&ffi_quote.message)
-        .log_err(&*ffi_msg.context, "failed to set quote")
-        .ok();
+    block_on(async move {
+        ffi_msg
+            .message
+            .set_quote(&*ffi_msg.context, &ffi_quote.message)
+            .await
+            .log_err(&*ffi_msg.context, "failed to set quote")
+            .ok();
+    });
 }
 
 #[no_mangle]

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -175,6 +175,27 @@ class Message(object):
         if ts:
             return datetime.utcfromtimestamp(ts)
 
+    @property
+    def quoted_text(self):
+        """Text inside the quote
+
+        :returns: Quoted text"""
+        return from_dc_charpointer(lib.dc_msg_get_quoted_text(self._dc_msg))
+
+    @property
+    def quote(self):
+        """Quote getter
+
+        :returns: Quoted message, if found in the database"""
+        msg = lib.dc_msg_get_quoted_msg(self._dc_msg)
+        if msg:
+            return Message(self.account, ffi.gc(msg, lib.dc_msg_unref))
+
+    @quote.setter
+    def quote(self, quoted_message):
+        """Quote setter"""
+        lib.dc_msg_set_quote(self._dc_msg, quoted_message._dc_msg)
+
     def get_mime_headers(self):
         """ return mime-header object for an incoming message.
 

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1067,6 +1067,7 @@ class TestOnlineAccount:
         # Majority prefers encryption now
         assert msg5.is_encrypted()
 
+    @pytest.mark.xfail(reason="Sticky encryption rule was removed")
     def test_reply_encrypted(self, acfactory, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()
 

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -476,6 +476,21 @@ class TestOfflineChat:
         assert not res.is_ask_verifygroup()
         assert res.contact_id == 10
 
+    def test_quote(self, chat1):
+        """Offline quoting test"""
+        msg = Message.new_empty(chat1.account, "text")
+        msg.set_text("message")
+        assert msg.quoted_text is None
+
+        # Prepare message to assign it a Message-Id.
+        # Messages without Message-Id cannot be quoted.
+        msg = chat1.prepare_message(msg)
+
+        reply_msg = Message.new_empty(chat1.account, "text")
+        reply_msg.set_text("reply")
+        reply_msg.quote = msg
+        assert reply_msg.quoted_text == "message"
+
     def test_group_chat_many_members_add_remove(self, ac1, lp):
         lp.sec("ac1: creating group chat with 10 other members")
         chat = ac1.create_group_chat(name="title1")
@@ -1067,8 +1082,8 @@ class TestOnlineAccount:
         # Majority prefers encryption now
         assert msg5.is_encrypted()
 
-    @pytest.mark.xfail(reason="Sticky encryption rule was removed")
     def test_reply_encrypted(self, acfactory, lp):
+        """Test that replies to encrypted messages are encrypted."""
         ac1, ac2 = acfactory.get_two_online_accounts()
 
         lp.sec("ac1: create chat with ac2")
@@ -1096,26 +1111,26 @@ class TestOnlineAccount:
         print("ac2: e2ee_enabled={}".format(ac2.get_config("e2ee_enabled")))
         ac1.set_config("e2ee_enabled", "0")
 
-        # Set unprepared and unencrypted draft to test that it is not
-        # taken into account when determining whether last message is
-        # encrypted.
-        msg_draft = Message.new_empty(ac1, "text")
-        msg_draft.set_text("message2 -- should be encrypted")
-        chat.set_draft(msg_draft)
+        for quoted_msg in msg1, msg3:
+            # Save the draft with a quote.
+            # It should be encrypted if quoted message is encrypted.
+            msg_draft = Message.new_empty(ac1, "text")
+            msg_draft.set_text("message reply")
+            msg_draft.quote = quoted_msg
+            chat.set_draft(msg_draft)
 
-        # Get the draft, prepare and send it.
-        msg_draft = chat.get_draft()
-        msg_out = chat.prepare_message(msg_draft)
-        chat.send_prepared(msg_out)
+            # Get the draft, prepare and send it.
+            msg_draft = chat.get_draft()
+            msg_out = chat.prepare_message(msg_draft)
+            chat.send_prepared(msg_out)
 
-        chat.set_draft(None)
-        assert chat.get_draft() is None
+            chat.set_draft(None)
+            assert chat.get_draft() is None
 
-        lp.sec("wait for ac2 to receive message")
-        ev = ac2._evtracker.get_matching("DC_EVENT_INCOMING_MSG")
-        msg_in = ac2.get_message_by_id(ev.data2)
-        assert msg_in.text == "message2 -- should be encrypted"
-        assert msg_in.is_encrypted()
+            msg_in = ac2._evtracker.wait_next_incoming_message()
+            assert msg_in.text == "message reply"
+            assert msg_in.quoted_text == quoted_msg.text
+            assert msg_in.is_encrypted() == quoted_msg.is_encrypted()
 
     def test_saved_mime_on_received_message(self, acfactory, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()
@@ -1868,6 +1883,45 @@ class TestOnlineAccount:
         else:
             # No renames should happen after explicit rename
             assert updated_name == "Renamed"
+
+    def test_group_quote(self, acfactory, lp):
+        """Test quoting in a group with a new member who have not seen the quoted message."""
+        ac1, ac2, ac3 = accounts = acfactory.get_many_online_accounts(3)
+        acfactory.introduce_each_other(accounts)
+        chat = ac1.create_group_chat(name="quote group")
+        chat.add_contact(ac2)
+
+        lp.sec("ac1: sending message")
+        out_msg = chat.send_text("hello")
+
+        lp.sec("ac2: receiving message")
+        msg = ac2._evtracker.wait_next_incoming_message()
+        assert msg.text == "hello"
+
+        chat.add_contact(ac3)
+        ac2._evtracker.wait_next_incoming_message()
+        ac3._evtracker.wait_next_incoming_message()
+
+        lp.sec("ac2: sending reply with a quote")
+        reply_msg = Message.new_empty(msg.chat.account, "text")
+        reply_msg.set_text("reply")
+        reply_msg.quote = msg
+        reply_msg = msg.chat.prepare_message(reply_msg)
+        assert reply_msg.quoted_text == "hello"
+        msg.chat.send_prepared(reply_msg)
+
+        lp.sec("ac3: receiving reply")
+        received_reply = ac3._evtracker.wait_next_incoming_message()
+        assert received_reply.text == "reply"
+        assert received_reply.quoted_text == "hello"
+        # ac3 was not in the group and has not received quoted message
+        assert received_reply.quote is None
+
+        lp.sec("ac1: receiving reply")
+        received_reply = ac1._evtracker.wait_next_incoming_message()
+        assert received_reply.text == "reply"
+        assert received_reply.quoted_text == "hello"
+        assert received_reply.quote.id == out_msg.id
 
 
 class TestGroupStressTests:

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -790,7 +790,11 @@ impl Chat {
             bail!("Cannot set message; self not in group.");
         }
 
-        if let Some(from) = context.get_config(Config::ConfiguredAddr).await {
+        let from = match context.get_config(Config::ConfiguredAddr).await {
+            Some(from) => from,
+            None => bail!("Cannot prepare message for sending, address is not configured."),
+        };
+
             let new_rfc724_mid = {
                 let grpid = match self.typ {
                     Chattype::Group | Chattype::VerifiedGroup => Some(self.grpid.as_str()),
@@ -1003,9 +1007,6 @@ impl Chat {
                             self.id,
                         );
                     }
-        } else {
-            bail!("Cannot prepare message for sending, address is not configured.");
-        }
         schedule_ephemeral_task(context).await;
 
         Ok(MsgId::new(msg_id))

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3,6 +3,7 @@
 use std::convert::TryFrom;
 use std::time::{Duration, SystemTime};
 
+use anyhow::Context as _;
 use async_std::path::{Path, PathBuf};
 use itertools::Itertools;
 use num_traits::FromPrimitive;
@@ -775,10 +776,10 @@ impl Chat {
             bail!("Cannot set message; self not in group.");
         }
 
-        let from = match context.get_config(Config::ConfiguredAddr).await {
-            Some(from) => from,
-            None => bail!("Cannot prepare message for sending, address is not configured."),
-        };
+        let from = context
+            .get_config(Config::ConfiguredAddr)
+            .await
+            .context("Cannot prepare message for sending, address is not configured.")?;
 
         let new_rfc724_mid = {
             let grpid = match self.typ {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -795,218 +795,236 @@ impl Chat {
             None => bail!("Cannot prepare message for sending, address is not configured."),
         };
 
-            let new_rfc724_mid = {
-                let grpid = match self.typ {
-                    Chattype::Group | Chattype::VerifiedGroup => Some(self.grpid.as_str()),
-                    _ => None,
-                };
-                dc_create_outgoing_rfc724_mid(grpid, &from)
+        let new_rfc724_mid = {
+            let grpid = match self.typ {
+                Chattype::Group | Chattype::VerifiedGroup => Some(self.grpid.as_str()),
+                _ => None,
             };
+            dc_create_outgoing_rfc724_mid(grpid, &from)
+        };
 
-            if self.typ == Chattype::Single {
-                if let Some(id) = context
-                    .sql
-                    .query_get_value(
-                        context,
-                        "SELECT contact_id FROM chats_contacts WHERE chat_id=?;",
-                        paramsv![self.id],
-                    )
-                    .await
-                {
-                    to_id = id;
-                } else {
-                    error!(
-                        context,
-                        "Cannot send message, contact for {} not found.", self.id,
-                    );
-                    bail!("Cannot set message, contact for {} not found.", self.id);
-                }
-            } else if (self.typ == Chattype::Group || self.typ == Chattype::VerifiedGroup)
-                && self.param.get_int(Param::Unpromoted).unwrap_or_default() == 1
+        if self.typ == Chattype::Single {
+            if let Some(id) = context
+                .sql
+                .query_get_value(
+                    context,
+                    "SELECT contact_id FROM chats_contacts WHERE chat_id=?;",
+                    paramsv![self.id],
+                )
+                .await
             {
-                msg.param.set_int(Param::AttachGroupImage, 1);
-                self.param.remove(Param::Unpromoted);
-                self.update_param(context).await?;
+                to_id = id;
+            } else {
+                error!(
+                    context,
+                    "Cannot send message, contact for {} not found.", self.id,
+                );
+                bail!("Cannot set message, contact for {} not found.", self.id);
             }
+        } else if (self.typ == Chattype::Group || self.typ == Chattype::VerifiedGroup)
+            && self.param.get_int(Param::Unpromoted).unwrap_or_default() == 1
+        {
+            msg.param.set_int(Param::AttachGroupImage, 1);
+            self.param.remove(Param::Unpromoted);
+            self.update_param(context).await?;
+        }
 
-            /* check if we want to encrypt this message.  If yes and circumstances change
-            so that E2EE is no longer available at a later point (reset, changed settings),
-            we might not send the message out at all */
-            if !msg
-                .param
-                .get_bool(Param::ForcePlaintext)
-                .unwrap_or_default()
-            {
-                let mut can_encrypt = true;
-                let mut all_mutual = context.get_config_bool(Config::E2eeEnabled).await;
+        /* check if we want to encrypt this message.  If yes and circumstances change
+        so that E2EE is no longer available at a later point (reset, changed settings),
+        we might not send the message out at all */
+        if !msg
+            .param
+            .get_bool(Param::ForcePlaintext)
+            .unwrap_or_default()
+        {
+            let mut can_encrypt = true;
+            let mut all_mutual = context.get_config_bool(Config::E2eeEnabled).await;
 
-                // take care that this statement returns NULL rows
-                // if there is no peerstates for a chat member!
-                // for DC_PARAM_SELFTALK this statement does not return any row
-                let res = context
-                    .sql
-                    .query_map(
-                        "SELECT ps.prefer_encrypted, c.addr \
+            // take care that this statement returns NULL rows
+            // if there is no peerstates for a chat member!
+            // for DC_PARAM_SELFTALK this statement does not return any row
+            let res = context
+                .sql
+                .query_map(
+                    "SELECT ps.prefer_encrypted, c.addr \
                      FROM chats_contacts cc  \
                      LEFT JOIN contacts c ON cc.contact_id=c.id  \
                      LEFT JOIN acpeerstates ps ON c.addr=ps.addr  \
                      WHERE cc.chat_id=?  AND cc.contact_id>9;",
-                        paramsv![self.id],
-                        |row| {
-                            let addr: String = row.get(1)?;
+                    paramsv![self.id],
+                    |row| {
+                        let addr: String = row.get(1)?;
 
-                            if let Some(prefer_encrypted) = row.get::<_, Option<i32>>(0)? {
-                                // the peerstate exist, so we have either public_key or gossip_key
-                                // and can encrypt potentially
-                                if prefer_encrypted != 1 {
-                                    info!(
-                                        context,
-                                        "[autocrypt] peerstate for {} is {}",
-                                        addr,
-                                        if prefer_encrypted == 0 {
-                                            "NOPREFERENCE"
-                                        } else {
-                                            "RESET"
-                                        },
-                                    );
-                                    all_mutual = false;
-                                }
-                            } else {
-                                info!(context, "[autocrypt] no peerstate for {}", addr,);
-                                can_encrypt = false;
+                        if let Some(prefer_encrypted) = row.get::<_, Option<i32>>(0)? {
+                            // the peerstate exist, so we have either public_key or gossip_key
+                            // and can encrypt potentially
+                            if prefer_encrypted != 1 {
+                                info!(
+                                    context,
+                                    "[autocrypt] peerstate for {} is {}",
+                                    addr,
+                                    if prefer_encrypted == 0 {
+                                        "NOPREFERENCE"
+                                    } else {
+                                        "RESET"
+                                    },
+                                );
                                 all_mutual = false;
                             }
-                            Ok(())
-                        },
-                        |rows| rows.collect::<Result<Vec<_>, _>>().map_err(Into::into),
-                    )
-                    .await;
-                match res {
-                    Ok(_) => {}
-                    Err(err) => {
-                        warn!(context, "chat: failed to load peerstates: {:?}", err);
-                    }
-                }
-
-                if can_encrypt && (all_mutual || self.id.parent_is_encrypted(context).await?) {
-                    msg.param.set_int(Param::GuaranteeE2ee, 1);
-                }
-            }
-            // reset encrypt error state eg. for forwarding
-            msg.param.remove(Param::ErroneousE2ee);
-
-            // set "In-Reply-To:" to identify the message to which the composed message is a reply;
-            // set "References:" to identify the "thread" of the conversation;
-            // both according to RFC 5322 3.6.4, page 25
-            //
-            // as self-talks are mainly used to transfer data between devices,
-            // we do not set In-Reply-To/References in this case.
-            if !self.is_self_talk() {
-                if let Some((parent_rfc724_mid, parent_in_reply_to, parent_references)) =
-                    self.id.get_parent_mime_headers(context).await
-                {
-                    if !parent_rfc724_mid.is_empty() {
-                        new_in_reply_to = parent_rfc724_mid.clone();
-                    }
-
-                    // the whole list of messages referenced may be huge;
-                    // only use the oldest and and the parent message
-                    let parent_references = parent_references
-                        .find(' ')
-                        .and_then(|n| parent_references.get(..n))
-                        .unwrap_or(&parent_references);
-
-                    if !parent_references.is_empty() && !parent_rfc724_mid.is_empty() {
-                        // angle brackets are added by the mimefactory later
-                        new_references = format!("{} {}", parent_references, parent_rfc724_mid);
-                    } else if !parent_references.is_empty() {
-                        new_references = parent_references.to_string();
-                    } else if !parent_in_reply_to.is_empty() && !parent_rfc724_mid.is_empty() {
-                        new_references = format!("{} {}", parent_in_reply_to, parent_rfc724_mid);
-                    } else if !parent_in_reply_to.is_empty() {
-                        new_references = parent_in_reply_to;
-                    }
+                        } else {
+                            info!(context, "[autocrypt] no peerstate for {}", addr,);
+                            can_encrypt = false;
+                            all_mutual = false;
+                        }
+                        Ok(())
+                    },
+                    |rows| rows.collect::<Result<Vec<_>, _>>().map_err(Into::into),
+                )
+                .await;
+            match res {
+                Ok(_) => {}
+                Err(err) => {
+                    warn!(context, "chat: failed to load peerstates: {:?}", err);
                 }
             }
 
-            // add independent location to database
+            if can_encrypt && (all_mutual || self.id.parent_is_encrypted(context).await?) {
+                msg.param.set_int(Param::GuaranteeE2ee, 1);
+            }
+        }
+        // reset encrypt error state eg. for forwarding
+        msg.param.remove(Param::ErroneousE2ee);
 
-            if msg.param.exists(Param::SetLatitude)
-                && context
-                    .sql
-                    .execute(
-                        "INSERT INTO locations \
+        // set "In-Reply-To:" to identify the message to which the composed message is a reply;
+        // set "References:" to identify the "thread" of the conversation;
+        // both according to RFC 5322 3.6.4, page 25
+        //
+        // as self-talks are mainly used to transfer data between devices,
+        // we do not set In-Reply-To/References in this case.
+        if !self.is_self_talk() {
+            if let Some((parent_rfc724_mid, parent_in_reply_to, parent_references)) =
+                self.id.get_parent_mime_headers(context).await
+            {
+                if !parent_rfc724_mid.is_empty() {
+                    new_in_reply_to = parent_rfc724_mid.clone();
+                }
+
+                // the whole list of messages referenced may be huge;
+                // only use the oldest and and the parent message
+                let parent_references = parent_references
+                    .find(' ')
+                    .and_then(|n| parent_references.get(..n))
+                    .unwrap_or(&parent_references);
+
+                if !parent_references.is_empty() && !parent_rfc724_mid.is_empty() {
+                    // angle brackets are added by the mimefactory later
+                    new_references = format!("{} {}", parent_references, parent_rfc724_mid);
+                } else if !parent_references.is_empty() {
+                    new_references = parent_references.to_string();
+                } else if !parent_in_reply_to.is_empty() && !parent_rfc724_mid.is_empty() {
+                    new_references = format!("{} {}", parent_in_reply_to, parent_rfc724_mid);
+                } else if !parent_in_reply_to.is_empty() {
+                    new_references = parent_in_reply_to;
+                }
+            }
+        }
+
+        // add independent location to database
+
+        if msg.param.exists(Param::SetLatitude)
+            && context
+                .sql
+                .execute(
+                    "INSERT INTO locations \
                      (timestamp,from_id,chat_id, latitude,longitude,independent)\
                      VALUES (?,?,?, ?,?,1);", // 1=DC_CONTACT_ID_SELF
-                        paramsv![
-                            timestamp,
-                            DC_CONTACT_ID_SELF,
-                            self.id,
-                            msg.param.get_float(Param::SetLatitude).unwrap_or_default(),
-                            msg.param.get_float(Param::SetLongitude).unwrap_or_default(),
-                        ],
-                    )
-                    .await
-                    .is_ok()
-            {
-                location_id = context
-                    .sql
-                    .get_rowid2(
-                        context,
-                        "locations",
-                        "timestamp",
+                    paramsv![
                         timestamp,
-                        "from_id",
-                        DC_CONTACT_ID_SELF as i32,
-                    )
-                    .await?;
-            }
+                        DC_CONTACT_ID_SELF,
+                        self.id,
+                        msg.param.get_float(Param::SetLatitude).unwrap_or_default(),
+                        msg.param.get_float(Param::SetLongitude).unwrap_or_default(),
+                    ],
+                )
+                .await
+                .is_ok()
+        {
+            location_id = context
+                .sql
+                .get_rowid2(
+                    context,
+                    "locations",
+                    "timestamp",
+                    timestamp,
+                    "from_id",
+                    DC_CONTACT_ID_SELF as i32,
+                )
+                .await?;
+        }
 
-            let ephemeral_timer = if msg.param.get_cmd() == SystemMessage::EphemeralTimerChanged {
-                EphemeralTimer::Disabled
-            } else {
-                self.id.get_ephemeral_timer(context).await?
-            };
-            let ephemeral_timestamp = match ephemeral_timer {
-                EphemeralTimer::Disabled => 0,
-                EphemeralTimer::Enabled { duration } => timestamp + i64::from(duration),
-            };
+        let ephemeral_timer = if msg.param.get_cmd() == SystemMessage::EphemeralTimerChanged {
+            EphemeralTimer::Disabled
+        } else {
+            self.id.get_ephemeral_timer(context).await?
+        };
+        let ephemeral_timestamp = match ephemeral_timer {
+            EphemeralTimer::Disabled => 0,
+            EphemeralTimer::Enabled { duration } => timestamp + i64::from(duration),
+        };
 
-            // add message to the database
+        // add message to the database
 
-            if context.sql.execute(
-                        "INSERT INTO msgs (rfc724_mid, chat_id, from_id, to_id, timestamp, type, state, txt, param, hidden, mime_in_reply_to, mime_references, location_id, ephemeral_timer, ephemeral_timestamp) VALUES (?,?,?,?,?, ?,?,?,?,?, ?,?,?,?,?);",
-                        paramsv![
-                            new_rfc724_mid,
-                            self.id,
-                            DC_CONTACT_ID_SELF,
-                            to_id as i32,
-                            timestamp,
-                            msg.viewtype,
-                            msg.state,
-                            msg.text.as_ref().cloned().unwrap_or_default(),
-                            msg.param.to_string(),
-                            msg.hidden,
-                            new_in_reply_to,
-                            new_references,
-                            location_id as i32,
-                            ephemeral_timer,
-                            ephemeral_timestamp
-                        ]
-                    ).await.is_ok() {
-                        msg_id = context.sql.get_rowid(
-                            context,
-                            "msgs",
-                            "rfc724_mid",
-                            new_rfc724_mid,
-                        ).await?;
-                    } else {
-                        error!(
-                            context,
-                            "Cannot send message, cannot insert to database ({}).",
-                            self.id,
-                        );
-                    }
+        if context
+            .sql
+            .execute(
+                "INSERT INTO msgs (
+                        rfc724_mid,
+                        chat_id,
+                        from_id,
+                        to_id,
+                        timestamp,
+                        type,
+                        state,
+                        txt,
+                        param,
+                        hidden,
+                        mime_in_reply_to,
+                        mime_references,
+                        location_id,
+                        ephemeral_timer,
+                        ephemeral_timestamp)
+                        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);",
+                paramsv![
+                    new_rfc724_mid,
+                    self.id,
+                    DC_CONTACT_ID_SELF,
+                    to_id as i32,
+                    timestamp,
+                    msg.viewtype,
+                    msg.state,
+                    msg.text.as_ref().cloned().unwrap_or_default(),
+                    msg.param.to_string(),
+                    msg.hidden,
+                    new_in_reply_to,
+                    new_references,
+                    location_id as i32,
+                    ephemeral_timer,
+                    ephemeral_timestamp
+                ],
+            )
+            .await
+            .is_ok()
+        {
+            msg_id = context
+                .sql
+                .get_rowid(context, "msgs", "rfc724_mid", new_rfc724_mid)
+                .await?;
+        } else {
+            error!(
+                context,
+                "Cannot send message, cannot insert to database ({}).", self.id,
+            );
+        }
         schedule_ephemeral_task(context).await;
 
         Ok(MsgId::new(msg_id))

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -335,8 +335,8 @@ impl ChatId {
         context
             .sql
             .execute(
-                "INSERT INTO msgs (chat_id, from_id, timestamp, type, state, txt, param, hidden)
-         VALUES (?,?,?, ?,?,?,?,?);",
+                "INSERT INTO msgs (chat_id, from_id, timestamp, type, state, txt, param, hidden, mime_in_reply_to)
+         VALUES (?,?,?, ?,?,?,?,?,?);",
                 paramsv![
                     self,
                     DC_CONTACT_ID_SELF,
@@ -346,6 +346,7 @@ impl ChatId {
                     msg.text.as_deref().unwrap_or(""),
                     msg.param.to_string(),
                     1,
+                    msg.in_reply_to,
                 ],
             )
             .await?;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -315,14 +315,11 @@ impl ChatId {
     async fn do_set_draft(self, context: &Context, msg: &mut Message) -> Result<(), Error> {
         match msg.viewtype {
             Viewtype::Unknown => bail!("Can not set draft of unknown type."),
-            Viewtype::Text => match msg.text.as_ref() {
-                Some(text) => {
-                    if text.is_empty() {
-                        bail!("No text in draft");
-                    }
+            Viewtype::Text => {
+                if msg.text.is_none_or_empty() && msg.in_reply_to.is_none_or_empty() {
+                    bail!("No text and no quote in draft");
                 }
-                None => bail!("No text in draft"),
-            },
+            }
             _ => {
                 let blob = msg
                     .param
@@ -346,7 +343,7 @@ impl ChatId {
                     msg.text.as_deref().unwrap_or(""),
                     msg.param.to_string(),
                     1,
-                    msg.in_reply_to,
+                    msg.in_reply_to.as_deref().unwrap_or_default(),
                 ],
             )
             .await?;

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -709,6 +709,21 @@ pub(crate) fn improve_single_line_input(input: impl AsRef<str>) -> String {
         .to_string()
 }
 
+pub(crate) trait IsNoneOrEmpty<T> {
+    fn is_none_or_empty(&self) -> bool;
+}
+impl<T> IsNoneOrEmpty<T> for Option<T>
+where
+    T: AsRef<str>,
+{
+    fn is_none_or_empty(&self) -> bool {
+        match self {
+            Some(s) if !s.as_ref().is_empty() => false,
+            _ => true,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #![allow(clippy::indexing_slicing)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -741,6 +741,55 @@ impl Message {
         self.update_param(context).await;
     }
 
+    /// Sets message quote.
+    ///
+    /// Message-Id is used to set Reply-To field, message text is used for quote.
+    ///
+    /// Encryption is required if quoted message was encrypted.
+    ///
+    /// The message itself is not required to exist in the database,
+    /// it may even be deleted from the database by the time the message is prepared.
+    pub fn set_quote(&mut self, quote: &Message) -> Result<(), Error> {
+        ensure!(
+            !quote.rfc724_mid.is_empty(),
+            "Message without Message-Id cannot be quoted"
+        );
+        self.in_reply_to = Some(quote.rfc724_mid.clone());
+
+        if quote
+            .param
+            .get_bool(Param::GuaranteeE2ee)
+            .unwrap_or_default()
+        {
+            self.param.set(Param::GuaranteeE2ee, "1");
+        }
+
+        self.param
+            .set(Param::Quote, quote.get_text().unwrap_or_default());
+
+        Ok(())
+    }
+
+    pub fn quoted_text(&self) -> Option<String> {
+        self.param.get(Param::Quote).map(|s| s.to_string())
+    }
+
+    pub async fn quoted_message(&self, context: &Context) -> Result<Option<Message>, Error> {
+        if self.param.get(Param::Quote).is_some() {
+            if let Some(in_reply_to) = &self.in_reply_to {
+                if let Some((_folder, _uid, msg_id)) = rfc724_mid_exists(
+                    context,
+                    in_reply_to.trim_start_matches('<').trim_end_matches('>'),
+                )
+                .await?
+                {
+                    return Ok(Some(Message::load_from_db(context, msg_id).await?));
+                }
+            }
+        }
+        Ok(None)
+    }
+
     pub async fn update_param(&mut self, context: &Context) -> bool {
         context
             .sql
@@ -2013,5 +2062,44 @@ mod tests {
             }
         }
         assert!(has_image);
+    }
+
+    #[async_std::test]
+    async fn test_quote() {
+        use crate::config::Config;
+
+        let d = test::TestContext::new().await;
+        let ctx = &d.ctx;
+
+        let contact = Contact::create(ctx, "", "dest@example.com")
+            .await
+            .expect("failed to create contact");
+
+        let res = ctx
+            .set_config(Config::ConfiguredAddr, Some("self@example.com"))
+            .await;
+        assert!(res.is_ok());
+
+        let chat = chat::create_by_contact_id(ctx, contact).await.unwrap();
+
+        let mut msg = Message::new(Viewtype::Text);
+        msg.set_text(Some("Quoted message".to_string()));
+
+        // Prepare message for sending, so it gets a Message-Id.
+        assert!(msg.rfc724_mid.is_empty());
+        let msg_id = chat::prepare_msg(ctx, chat, &mut msg).await.unwrap();
+        let msg = Message::load_from_db(ctx, msg_id).await.unwrap();
+        assert!(!msg.rfc724_mid.is_empty());
+
+        let mut msg2 = Message::new(Viewtype::Text);
+        msg2.set_quote(&msg).expect("can't set quote");
+        assert!(msg2.quoted_text() == msg.get_text());
+
+        let quoted_msg = msg2
+            .quoted_message(ctx)
+            .await
+            .expect("error while retrieving quoted message")
+            .expect("quoted message not found");
+        assert!(quoted_msg.get_text() == msg2.quoted_text());
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -749,7 +749,7 @@ impl Message {
     ///
     /// The message itself is not required to exist in the database,
     /// it may even be deleted from the database by the time the message is prepared.
-    pub fn set_quote(&mut self, quote: &Message) -> Result<(), Error> {
+    pub async fn set_quote(&mut self, context: &Context, quote: &Message) -> Result<(), Error> {
         ensure!(
             !quote.rfc724_mid.is_empty(),
             "Message without Message-Id cannot be quoted"
@@ -765,7 +765,7 @@ impl Message {
         }
 
         self.param
-            .set(Param::Quote, quote.get_text().unwrap_or_default());
+            .set(Param::Quote, quote.get_summarytext(context, 500).await);
 
         Ok(())
     }
@@ -2090,7 +2090,7 @@ mod tests {
         assert!(!msg.rfc724_mid.is_empty());
 
         let mut msg2 = Message::new(Viewtype::Text);
-        msg2.set_quote(&msg).expect("can't set quote");
+        msg2.set_quote(ctx, &msg).await.expect("can't set quote");
         assert!(msg2.quoted_text() == msg.get_text());
 
         let quoted_msg = msg2

--- a/src/message.rs
+++ b/src/message.rs
@@ -777,13 +777,11 @@ impl Message {
     pub async fn quoted_message(&self, context: &Context) -> Result<Option<Message>, Error> {
         if self.param.get(Param::Quote).is_some() {
             if let Some(in_reply_to) = &self.in_reply_to {
-                if let Some((_folder, _uid, msg_id)) = rfc724_mid_exists(
-                    context,
-                    in_reply_to.trim_start_matches('<').trim_end_matches('>'),
-                )
-                .await?
-                {
-                    return Ok(Some(Message::load_from_db(context, msg_id).await?));
+                let rfc724_mid = in_reply_to.trim_start_matches('<').trim_end_matches('>');
+                if !rfc724_mid.is_empty() {
+                    if let Some((_, _, msg_id)) = rfc724_mid_exists(context, rfc724_mid).await? {
+                        return Ok(Some(Message::load_from_db(context, msg_id).await?));
+                    }
                 }
             }
         }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -11,7 +11,7 @@ use crate::dc_tools::*;
 use crate::e2ee::*;
 use crate::ephemeral::Timer as EphemeralTimer;
 use crate::error::{bail, ensure, format_err, Error};
-use crate::format_flowed::format_flowed;
+use crate::format_flowed::{format_flowed, format_flowed_quote};
 use crate::location;
 use crate::message::{self, Message};
 use crate::mimeparser::SystemMessage;
@@ -917,12 +917,17 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
             }
         };
 
+        let quoted_text = self
+            .msg
+            .quoted_text()
+            .map(|quote| format_flowed_quote(&quote) + "\r\n");
         let flowed_text = format_flowed(final_text);
 
         let footer = &self.selfstatus;
         let message_text = format!(
-            "{}{}{}{}{}",
+            "{}{}{}{}{}{}",
             fwdhint.unwrap_or_default(),
+            quoted_text.unwrap_or_default(),
             escape_message_footer_marks(&flowed_text),
             if !final_text.is_empty() && !footer.is_empty() {
                 "\r\n\r\n"

--- a/src/param.rs
+++ b/src/param.rs
@@ -53,6 +53,9 @@ pub enum Param {
     /// For Messages
     Forwarded = b'a',
 
+    /// For Messages: quoted text.
+    Quote = b'q',
+
     /// For Messages
     Cmd = b'S',
 


### PR DESCRIPTION
This adds implementation for quote API from #1947

Encryption-related code is removed from message preparation code, it still used "veto" rule instead of "quorum" introduced in #1946.
"Sticky encryption" rule is replaced with a rule that requires messages with quotes replying to encrypted messages to be encrypted.

There is a huge `rustfmt` change in-between, so review commit-by-commit and do not squash (better, merge by rebasing).