### PR TITLE
basic DC_EVENT_MSGS_NOTICED multi-device-support

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4558,7 +4558,8 @@ void dc_event_unref(dc_event_t* event);
  * Messages were marked noticed or seen.
  * The ui may update badge counters or stop showing a chatlist-item with a bold font.
  *
- * This event is emitted eg. when calling dc_markseen_msgs(), dc_marknoticed_chat() or dc_marknoticed_contact().
+ * This event is emitted eg. when calling dc_markseen_msgs(), dc_marknoticed_chat() or dc_marknoticed_contact()
+ * or when a chat is answered on another device.
  * Do not try to derive the state of an item from just the fact you received the event;
  * use eg. dc_msg_get_state() or dc_get_fresh_msg_cnt() for this purpose.
  *

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1744,6 +1744,27 @@ pub async fn get_chat_msgs(
     }
 }
 
+pub(crate) async fn marknoticed_chat_if_older_than(
+    context: &Context,
+    chat_id: ChatId,
+    timestamp: i64,
+) -> Result<(), Error> {
+    if let Some(chat_timestamp) = context
+        .sql
+        .query_get_value(
+            context,
+            "SELECT MAX(timestamp) FROM msgs WHERE chat_id=?",
+            paramsv![chat_id],
+        )
+        .await
+    {
+        if timestamp > chat_timestamp {
+            marknoticed_chat(context, chat_id).await?;
+        }
+    }
+    Ok(())
+}
+
 pub async fn marknoticed_chat(context: &Context, chat_id: ChatId) -> Result<(), Error> {
     // "WHERE" below uses the index `(state, hidden, chat_id)`, see get_fresh_msg_cnt() for reasoning
     if !context

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -845,6 +845,11 @@ async fn add_parts(
         "Message has {} parts and is assigned to chat #{}.", icnt, chat_id,
     );
 
+    // new outgoing message from another device marks the chat as noticed.
+    if !incoming && !*hidden && !chat_id.is_special() {
+        chat::marknoticed_chat_if_older_than(context, chat_id, sort_timestamp).await?;
+    }
+
     // check event to send
     if chat_id.is_trash() || *hidden {
         *create_event_to_send = None;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1360,7 +1360,7 @@ CREATE INDEX devmsglabels_index1 ON devmsglabels (label);
         }
         if dbversion < 68 {
             info!(context, "[migration] v68");
-            // the index is used to speed up get_fresh_msg_cnt(), see comment there for more details
+            // the index is used to speed up get_fresh_msg_cnt() (see comment there for more details) and marknoticed_chat()
             sql.execute(
                 "CREATE INDEX IF NOT EXISTS msgs_index7 ON msgs (state, hidden, chat_id);",
                 paramsv![],


### PR DESCRIPTION
emit DC_EVENT_MSGS_NOTICED if new answers from other devices are seen and the chat was not yet noticed.

if UI use this event to update badge counters and notifications, this is now also updated when a chat is answered on another device. #1974 is about "best effort using current data", at some point, we can refine that, if needed and the effort is reasonable.

depending on how the events are currently used in the UIs, this pr might result in double-redrawing as DC_EVENT_MSGS_CHANGED with a concrete message-id is emitted anyway. however, as this affects only messages sent by the user one other devices and as DC_EVENT_MSGS_NOTICED is only emitted when _really_ things are changed, this is probably no big deal.

successor of #1942
closed #1974 
