### PR TITLE
fix recovering offline/lost connection situations (fixes background receive bug)

### DIFF
--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -113,12 +113,13 @@ impl Imap {
         // in this case, we're waiting for a configure job (and an interrupt).
 
         let fake_idle_start_time = SystemTime::now();
-        info!(context, "IMAP-fake-IDLEing...");
 
         // Do not poll, just wait for an interrupt when no folder is passed in.
         if watch_folder.is_none() {
+            info!(context, "IMAP-fake-IDLE: no folder, waiting for interrupt");
             return self.idle_interrupt.recv().await.unwrap_or_default();
         }
+        info!(context, "IMAP-fake-IDLEing folder={:?}", watch_folder);
 
         // check every minute if there are new messages
         // TODO: grow sleep durations / make them more flexible

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -131,7 +131,7 @@ async fn fetch_idle(ctx: &Context, connection: &mut Imap, folder: Config) -> Int
             // connect and fake idle if unable to connect
             if let Err(err) = connection.connect_configured(&ctx).await {
                 warn!(ctx, "imap connection failed: {}", err);
-                return connection.fake_idle(&ctx, None).await;
+                return connection.fake_idle(&ctx, Some(watch_folder)).await;
             }
 
             // fetch


### PR DESCRIPTION
If a configured account is disconnected/offline, and there is no "interrupt_idle" coming, fake_idle would wait indefinitely. 

The problem and fix can be reproduced/tested on linux using eg `sudo iptables -A OUTPUT -d imap.deltachat.de -j DROP` if using a deltachat.de account and then starting a desktop (or CLI) using the master core before this PR.  You can then wait some time and will see that fake-idle enters indefinite wait on interrupt_idle but there is no interrupt. When you remove the iptables-block with `sudo iptables -D OUTPUT -d imap.deltachat.de -j DROP` fake_idle will never recover. 

With this PR, we wake up every minute to retry connecting or if we get an interrupt-idle event.  This makes the above scenario work and message receiving recover. I think we can not solely rely on the operating systems' "maybe network" and the induced "interrupt_idle" event as there are many reasons and ways how network is broken. 

FWIW I guess we should separate the "retry-connection" logic from fake-idle so that fake-idle would only care for the situation where the imap-server does not support IDLE. But this is not part of this PR. 