### PR TITLE
Separate quote from reply with an empty line

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -920,7 +920,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
         let quoted_text = self
             .msg
             .quoted_text()
-            .map(|quote| format_flowed_quote(&quote) + "\r\n");
+            .map(|quote| format_flowed_quote(&quote) + "\r\n\r\n");
         let flowed_text = format_flowed(final_text);
 
         let footer = &self.selfstatus;


### PR DESCRIPTION
This makes quotes easier to read in previous DC versions and plaintext
MUAs.