### PR TITLE
name quote-only drafts as such in the summary

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5001,6 +5001,7 @@ void dc_event_unref(dc_event_t* event);
 #define DC_STR_ERROR_NO_NETWORK           87
 #define DC_STR_PROTECTION_ENABLED         88
 #define DC_STR_PROTECTION_DISABLED        89
+#define DC_STR_REPLY_NOUN                 90 /* eg. "Reply", used in summaries, a noun, not a verb (not: "to reply") */
 
 /*
  * @}

--- a/src/message.rs
+++ b/src/message.rs
@@ -998,16 +998,23 @@ impl Lot {
             }
         }
 
-        self.text2 = Some(
-            get_summarytext_by_raw(
-                msg.viewtype,
-                msg.text.as_ref(),
-                &msg.param,
-                SUMMARY_CHARACTERS,
-                context,
-            )
-            .await,
-        );
+        let mut text2 = get_summarytext_by_raw(
+            msg.viewtype,
+            msg.text.as_ref(),
+            &msg.param,
+            SUMMARY_CHARACTERS,
+            context,
+        )
+        .await;
+
+        if text2.is_empty() && msg.quoted_text().is_some() {
+            text2 = context
+                .stock_str(StockMessage::ReplyNoun)
+                .await
+                .into_owned()
+        }
+
+        self.text2 = Some(text2);
 
         self.timestamp = msg.get_timestamp();
         self.state = msg.state.into();

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -240,6 +240,10 @@ pub enum StockMessage {
 
     #[strum(props(fallback = "Chat protection disabled."))]
     ProtectionDisabled = 89,
+
+    // used in summaries, a noun, not a verb (not: "to reply")
+    #[strum(props(fallback = "Reply"))]
+    ReplyNoun = 90,
 }
 
 /*


### PR DESCRIPTION
a draft may contain only a quote,
without any text set yet.

these drafts cannot be sent, however, appear in the summary -
currently with the summary-text "", which results to sth.
as "Draft: " - which looks like an error or at least a bit weird.

this pr sets the summary text to "Reply" - similar to "Image", "Video" etc. -
the UI just expects some text here, not an empty string.

the result are summaries as "Draft: Reply" on all UIs -
which, btw. is also roughly the same what Signal does in this case.