### PR TITLE
Don't show HTML if there is no content and there is a file attached

### DIFF
--- a/src/dehtml.rs
+++ b/src/dehtml.rs
@@ -22,8 +22,8 @@ enum AddText {
     YesPreserveLineEnds,
 }
 
-/// dehtml() returns way too many newlines; however, an optimisation on this issue is not needed as
-/// the newlines are typically removed in further processing by the caller
+// dehtml() returns way too many newlines; however, an optimisation on this issue is not needed as
+// the newlines are typically removed in further processing by the caller
 pub fn dehtml(buf: &str) -> Option<String> {
     let s = dehtml_quick_xml(buf);
     if !s.trim().is_empty() {


### PR DESCRIPTION
Fixes probably https://github.com/deltachat/deltachat-core-rust/issues/1982 (I could not test it with the original emails because they were too big to fit in by inbox but the new rust test passes; I'll add `needs-retry`)