### PR TITLE
remove DC_STR_COUNT

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5002,8 +5002,6 @@ void dc_event_unref(dc_event_t* event);
 #define DC_STR_PROTECTION_ENABLED         88
 #define DC_STR_PROTECTION_DISABLED        89
 
-#define DC_STR_COUNT                      89
-
 /*
  * @}
  */


### PR DESCRIPTION
the constant comes from c-core
and was used to define the size of the string-array that time.

this is no longer needed in core
and also the UIs seems not to use it
(they will treat DC_STR* like an id,
there should be no need to know the max. DC_STR* value)

however, maintaining the value is annoying and error-prone, so i suggest to remove it :)

cc @Jikstra @Simon-Laux - can you please check if removal is fine for you? i did a grep, and at a first glance, desktop seems not to use it.