### PR TITLE
Mark all failed messages as failed when receiving an NDN

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1684,17 +1684,10 @@ async fn ndn_maybe_add_info_msg(
                 Contact::lookup_id_by_addr(context, failed_recipient, Origin::Unknown).await;
             let contact = Contact::load_from_db(context, contact_id).await?;
             // Tell the user which of the recipients failed if we know that (because in a group, this might otherwise be unclear)
-            chat::add_info_msg(
-                context,
-                chat_id,
-                context
-                    .stock_string_repl_str(
-                        StockMessage::FailedSendingTo,
-                        contact.get_display_name(),
-                    )
-                    .await,
-            )
-            .await;
+            let text = context
+                .stock_string_repl_str(StockMessage::FailedSendingTo, contact.get_display_name())
+                .await;
+            chat::add_info_msg(context, chat_id, text).await;
             context.emit_event(EventType::ChatModified(chat_id));
         }
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1630,12 +1630,12 @@ pub(crate) async fn handle_ndn(
     context: &Context,
     failed: &FailureReport,
     error: Option<impl AsRef<str>>,
-) {
+) -> anyhow::Result<()> {
     if failed.rfc724_mid.is_empty() {
         return;
     }
 
-    let res: Result<Vec<_>, _> = context
+    let msgs: Result<Vec<_>, _> = context
         .sql
         .query_map(
             concat!(
@@ -1656,23 +1656,20 @@ pub(crate) async fn handle_ndn(
             },
             |rows| Ok(rows.collect::<Vec<_>>()),
         )
-        .await;
+        .await?;
 
-    if let Err(ref err) = res {
-        info!(context, "Failed to select NDN {:?}", err);
+    for msg in msgs.iter() {
+        let (msg_id, chat_id, chat_type) = msg?;
+        set_msg_failed(context, *msg_id, error.as_ref()).await?;
     }
 
-    if let Ok(msgs) = res {
-        for msg in msgs.iter() {
-            match msg {
-                Ok((msg_id, chat_id, chat_type)) => {
-                    set_msg_failed(context, *msg_id, error.as_ref()).await;
-                    ndn_maybe_add_info_msg(context, failed, *chat_id, *chat_type).await;
-                }
-                Err(e) => warn!(context, "ndn error: {}", e),
-            }
-        }
+    if let Some(msg) = msgs.last() {
+        let (msg_id, chat_id, chat_type) = msg?;
+        // Add only one info msg for all failed messages
+        ndn_maybe_add_info_msg(context, failed, chat_id, chat_type).await?;
     }
+
+    Ok(())
 }
 
 async fn ndn_maybe_add_info_msg(
@@ -1680,28 +1677,28 @@ async fn ndn_maybe_add_info_msg(
     failed: &FailureReport,
     chat_id: ChatId,
     chat_type: Chattype,
-) {
+) -> anyhow::Result<()> {
     if chat_type == Chattype::Group {
         if let Some(failed_recipient) = &failed.failed_recipient {
             let contact_id =
                 Contact::lookup_id_by_addr(context, failed_recipient, Origin::Unknown).await;
-            if let Ok(contact) = Contact::load_from_db(context, contact_id).await {
-                // Tell the user which of the recipients failed if we know that (because in a group, this might otherwise be unclear)
-                chat::add_info_msg(
-                    context,
-                    chat_id,
-                    context
-                        .stock_string_repl_str(
-                            StockMessage::FailedSendingTo,
-                            contact.get_display_name(),
-                        )
-                        .await,
-                )
-                .await;
-                context.emit_event(EventType::ChatModified(chat_id));
-            }
+            let contact = Contact::load_from_db(context, contact_id).await?;
+            // Tell the user which of the recipients failed if we know that (because in a group, this might otherwise be unclear)
+            chat::add_info_msg(
+                context,
+                chat_id,
+                context
+                    .stock_string_repl_str(
+                        StockMessage::FailedSendingTo,
+                        contact.get_display_name(),
+                    )
+                    .await,
+            )
+            .await;
+            context.emit_event(EventType::ChatModified(chat_id));
         }
     }
+    Ok(())
 }
 
 /// The number of messages assigned to real chat (!=deaddrop, !=trash)

--- a/src/message.rs
+++ b/src/message.rs
@@ -1635,9 +1635,9 @@ pub(crate) async fn handle_ndn(
         return;
     }
 
-    let res = context
+    let res: Result<Vec<_>, _> = context
         .sql
-        .query_row(
+        .query_map(
             concat!(
                 "SELECT",
                 "    m.id AS msg_id,",
@@ -1654,34 +1654,51 @@ pub(crate) async fn handle_ndn(
                     row.get::<_, Chattype>("type")?,
                 ))
             },
+            |rows| Ok(rows.collect::<Vec<_>>()),
         )
         .await;
+
     if let Err(ref err) = res {
         info!(context, "Failed to select NDN {:?}", err);
     }
 
-    if let Ok((msg_id, chat_id, chat_type)) = res {
-        set_msg_failed(context, msg_id, error).await;
-
-        if chat_type == Chattype::Group {
-            if let Some(failed_recipient) = &failed.failed_recipient {
-                let contact_id =
-                    Contact::lookup_id_by_addr(context, failed_recipient, Origin::Unknown).await;
-                if let Ok(contact) = Contact::load_from_db(context, contact_id).await {
-                    // Tell the user which of the recipients failed if we know that (because in a group, this might otherwise be unclear)
-                    chat::add_info_msg(
-                        context,
-                        chat_id,
-                        context
-                            .stock_string_repl_str(
-                                StockMessage::FailedSendingTo,
-                                contact.get_display_name(),
-                            )
-                            .await,
-                    )
-                    .await;
-                    context.emit_event(EventType::ChatModified(chat_id));
+    if let Ok(msgs) = res {
+        for msg in msgs.iter() {
+            match msg {
+                Ok((msg_id, chat_id, chat_type)) => {
+                    set_msg_failed(context, *msg_id, error.as_ref()).await;
+                    ndn_maybe_add_info_msg(context, failed, *chat_id, *chat_type).await;
                 }
+                Err(e) => warn!(context, "ndn error: {}", e),
+            }
+        }
+    }
+}
+
+async fn ndn_maybe_add_info_msg(
+    context: &Context,
+    failed: &FailureReport,
+    chat_id: ChatId,
+    chat_type: Chattype,
+) {
+    if chat_type == Chattype::Group {
+        if let Some(failed_recipient) = &failed.failed_recipient {
+            let contact_id =
+                Contact::lookup_id_by_addr(context, failed_recipient, Origin::Unknown).await;
+            if let Ok(contact) = Contact::load_from_db(context, contact_id).await {
+                // Tell the user which of the recipients failed if we know that (because in a group, this might otherwise be unclear)
+                chat::add_info_msg(
+                    context,
+                    chat_id,
+                    context
+                        .stock_string_repl_str(
+                            StockMessage::FailedSendingTo,
+                            contact.get_display_name(),
+                        )
+                        .await,
+                )
+                .await;
+                context.emit_event(EventType::ChatModified(chat_id));
             }
         }
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1634,7 +1634,8 @@ pub(crate) async fn handle_ndn(
     if failed.rfc724_mid.is_empty() {
         return;
     }
-
+/// The NDN might be for a message-id that had attachments and was sent from a non-Delta Chat client.
+/// In this case we need to mark multiple "msgids" as failed that all refer to the same message-id. 
     let msgs: Result<Vec<_>, _> = context
         .sql
         .query_map(

--- a/src/message.rs
+++ b/src/message.rs
@@ -1632,11 +1632,12 @@ pub(crate) async fn handle_ndn(
     error: Option<impl AsRef<str>>,
 ) -> anyhow::Result<()> {
     if failed.rfc724_mid.is_empty() {
-        return;
+        return Ok(());
     }
-/// The NDN might be for a message-id that had attachments and was sent from a non-Delta Chat client.
-/// In this case we need to mark multiple "msgids" as failed that all refer to the same message-id. 
-    let msgs: Result<Vec<_>, _> = context
+
+    // The NDN might be for a message-id that had attachments and was sent from a non-Delta Chat client.
+    // In this case we need to mark multiple "msgids" as failed that all refer to the same message-id.
+    let msgs: Vec<_> = context
         .sql
         .query_map(
             concat!(
@@ -1659,15 +1660,13 @@ pub(crate) async fn handle_ndn(
         )
         .await?;
 
-    for msg in msgs.iter() {
+    for (i, msg) in msgs.into_iter().enumerate() {
         let (msg_id, chat_id, chat_type) = msg?;
-        set_msg_failed(context, *msg_id, error.as_ref()).await?;
-    }
-
-    if let Some(msg) = msgs.last() {
-        let (msg_id, chat_id, chat_type) = msg?;
-        // Add only one info msg for all failed messages
-        ndn_maybe_add_info_msg(context, failed, chat_id, chat_type).await?;
+        set_msg_failed(context, msg_id, error.as_ref()).await;
+        if i == 0 {
+            // Add only one info msg for all failed messages
+            ndn_maybe_add_info_msg(context, failed, chat_id, chat_type).await?;
+        }
     }
 
     Ok(())

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1056,7 +1056,9 @@ impl MimeMessage {
                 .iter()
                 .find(|p| p.typ == Viewtype::Text)
                 .map(|p| p.msg.clone());
-            message::handle_ndn(context, failure_report, error).await
+            if let Err(e) = message::handle_ndn(context, failure_report, error).await {
+                warn!(context, "Could not handle ndn: {}", e);
+            }
         }
     }
 


### PR DESCRIPTION
There may be multiple messages with the same `Message-Id`-header alias
rfc724_mid because an email with multiple attachments was split up.