### PR TITLE
workaround executer-blocking-handling bug

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -63,6 +63,12 @@ impl<'a> BlobObject<'a> {
                 blobname: name.clone(),
                 cause: err.into(),
             })?;
+
+        // workaround a bug in async-std
+        // (the executor does not handle blocking operation in Drop correctly,
+        // see https://github.com/async-rs/async-std/issues/900 )
+        let _ = file.flush().await;
+
         let blob = BlobObject {
             blobdir,
             name: format!("$BLOBDIR/{}", name),
@@ -151,6 +157,10 @@ impl<'a> BlobObject<'a> {
                 cause: err,
             });
         }
+
+        // workaround, see create() for details
+        let _ = dst_file.flush().await;
+
         let blob = BlobObject {
             blobdir: context.get_blobdir(),
             name: format!("$BLOBDIR/{}", name),


### PR DESCRIPTION
this works around the executer-blocking-handling bug as described at https://github.com/async-rs/async-std/issues/900

to make the android4.4 work again, only the flush() at create() is needed - however, create_and_copy() looks very similar to me, so i also added the flush() there. not sure if that is needed at other places as well.

closes #2021 
closes https://github.com/deltachat/deltachat-android/issues/1682