### PR TITLE
[wip] testing real-life providers 

### DIFF
--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -18,6 +18,8 @@ from .capi import lib
 from .events import FFIEventLogger, FFIEventTracker
 from _pytest._code import Source
 from deltachat import direct_imap
+from deltachat.account import parseaddr
+
 
 import deltachat
 
@@ -36,6 +38,9 @@ def pytest_addoption(parser):
         "--strict-tls", action="store_true",
         help="Never accept invalid TLS certificates for test accounts",
     )
+    parser.addoption(
+        "--provider-file", "-P", default=None,
+        help="file which contains config settings for real-world providers")
 
 
 def pytest_configure(config):
@@ -125,17 +130,30 @@ def pytest_report_header(config, startdir):
     return summary
 
 
+def parse_accountfile(fn):
+    if fn is None:
+        return []
+
+    for line in open(fn):
+        if line.strip() and not line.strip().startswith('#'):
+            config_dict = {}
+            for part in line.split():
+                name, value = part.split("=")
+                config_dict[name] = value
+            yield config_dict
+
+
+def pytest_generate_tests(metafunc):
+    if "real_provider_config" in metafunc.fixturenames:
+        account_configs = list(parse_accountfile(metafunc.config.getoption("--provider-file")))
+        ids = [parseaddr(cfg["addr"])[1] for cfg in account_configs]
+        metafunc.parametrize("real_provider_config", account_configs, ids=ids)
+
+
 class SessionLiveConfigFromFile:
     def __init__(self, fn):
         self.fn = fn
-        self.configlist = []
-        for line in open(fn):
-            if line.strip() and not line.strip().startswith('#'):
-                d = {}
-                for part in line.split():
-                    name, value = part.split("=")
-                    d[name] = value
-                self.configlist.append(d)
+        self.configlist = list(parse_accountfile(fn))
 
     def get(self, index):
         return self.configlist[index]
@@ -231,6 +249,15 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
                 acc.shutdown()
                 acc.disable_logging()
             deltachat.unregister_global_plugin(direct_imap)
+
+        def make_account_from_real_config(self, provider_config):
+            configdict = provider_config
+            addr = parseaddr(configdict["addr"])[1]
+            domain = addr.split("@")[1]
+            if "e2ee_enabled" not in configdict:
+                configdict["e2ee_enabled"] = "1"
+            tmpdb = tmpdir.join(domain)
+            return self.make_account(tmpdb.strpath, logid=domain)
 
         def make_account(self, path, logid, quiet=False):
             ac = Account(path, logging=self._logging)
@@ -361,6 +388,11 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
                 accounts = self._accounts[:]
             started_accounts = []
             for acc in accounts:
+                if hasattr(acc, "_configtracker"):
+                    acc._configtracker.wait_finish()
+                    acc._evtracker.consume_events()
+                    acc.get_device_chat().mark_noticed()
+                    del acc._configtracker
                 if acc not in started_accounts:
                     self.wait_configure(acc)
                     acc.set_config("bcc_self", "0")
@@ -369,6 +401,7 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
                         started_accounts.append(acc)
                     print("{}: {} account was started".format(
                         acc.get_config("displayname"), acc.get_config("addr")))
+
             for acc in started_accounts:
                 acc._evtracker.wait_all_initial_fetches()
 

--- a/python/tests/real_providers.py
+++ b/python/tests/real_providers.py
@@ -1,0 +1,72 @@
+import pytest
+
+
+@pytest.fixture
+def acprovider(acfactory, real_provider_config):
+    ac = acfactory.make_account_from_real_config(real_provider_config)
+    ac.update_config(real_provider_config)
+    ac._configtracker = ac.configure()
+    return ac
+
+
+@pytest.fixture
+def actest(acfactory):
+    return acfactory.get_online_configuring_account()
+
+
+def test_configure_success(acfactory, acprovider, lp):
+    lp.sec("waiting for successful configuration of provider account")
+    acfactory.wait_configure_and_start_io()
+
+    assert acprovider.is_configured()
+    for name in ("inbox", "mvbox", "sentbox"):
+        folder = acprovider.get_config("configured_" + name + "_folder")
+        if not folder:
+            lp.sec("found no {} folder".format(name))
+            continue
+
+        lp.sec("removing provider account IMAP folder {}".format(folder))
+        acprovider.direct_imap.select_folder(folder)
+        acprovider.direct_imap.delete("1:*")
+
+
+def test_basic_send_receive(acprovider, actest, acfactory, lp):
+    acfactory.wait_configure_and_start_io()
+
+    lp.sec("sending message from test account to provider account")
+    chat = actest.create_chat(acprovider)
+    chat.send_text("hello")
+
+    lp.sec("receiving message with the provider account")
+    msg = acprovider._evtracker.wait_next_messages_changed()
+    assert msg.chat.is_deaddrop() and not msg.is_encrypted()
+
+    lp.sec("sending message back from provider to test account")
+    back_chat = acprovider.create_chat(actest)
+    back_chat.send_text("world")
+
+    lp.sec("waiting with test account for provider mail")
+    msg = actest._evtracker.wait_next_incoming_message()
+    assert msg.text == "world"
+    assert msg.is_encrypted()
+
+
+def test_group_messages(acprovider, actest, acfactory, lp):
+    acfactory.wait_configure_and_start_io()
+
+    lp.sec("sending message from test account to provider account")
+    chat = actest.create_chat(acprovider)
+    chat.send_text("hello")
+
+    lp.sec("receiving message with the provider account")
+    msg = acprovider._evtracker.wait_next_messages_changed()
+    assert msg.chat.is_deaddrop() and not msg.is_encrypted()
+
+    lp.sec("sending message back from provider to test account")
+    back_chat = acprovider.create_chat(actest)
+    back_chat.send_text("world")
+
+    lp.sec("waiting with test account for provider mail")
+    msg = actest._evtracker.wait_next_incoming_message()
+    assert msg.text == "world"
+    assert msg.is_encrypted()

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -541,7 +541,7 @@ impl Contact {
             {
                 row_id = u32::try_from(new_row_id)?;
                 sth_modified = Modifier::Created;
-                info!(context, "added contact id={} addr={}", row_id, &addr);
+                info!(context, "added contact id={} addr={} origin={:?}", row_id, &addr, &origin);
             } else {
                 error!(context, "Cannot add contact.");
             }


### PR DESCRIPTION
two basic tests pass for me now with three providers.  Currently the test need to be run via: 

    pytest tests/real_providers.py --provider-file PATH

where PATH points to a text file where each non-empty, non-commented line specifies config-settings for a provider to connect to. 

The plan is to install this as a daily job.  Right now, during development i am hitting rate limits ... 