### PR TITLE
add hint about how to restore saved-messages chat

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4988,6 +4988,7 @@ void dc_event_unref(dc_event_t* event);
 #define DC_STR_PROTECTION_ENABLED         88
 #define DC_STR_PROTECTION_DISABLED        89
 #define DC_STR_REPLY_NOUN                 90 /* eg. "Reply", used in summaries, a noun, not a verb (not: "to reply") */
+#define DC_STR_SELF_DELETED_MSG_BODY      91
 
 /*
  * @}

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -244,6 +244,10 @@ pub enum StockMessage {
     // used in summaries, a noun, not a verb (not: "to reply")
     #[strum(props(fallback = "Reply"))]
     ReplyNoun = 90,
+
+    #[strum(props(fallback = "You deleted the \"Saved messages\" chat.\n\n\
+                    To use the \"Saved messages\" feature again, create a new chat with yourself."))]
+    SelfDeletedMsgBody = 91,
 }
 
 /*


### PR DESCRIPTION
the saved-messages can be deleted as any other chat;
if the feature is unneeded, this probably also makes some sense.

however, if saved-messages was deleted accidentally,
it is not intuitive to see how the saved-messages feature can be restored.

this pr just drops a note about how-to-restore to the device chat.

i've seen this issue in reality - and also, by recent android/ios cleanup of the saved-messages and device-chat profiles (removing unavailable things), the "delete" is even more outstanding ;)

we may think about not allowing deletion of saved-messages at all, however, even then, this not is useful, due to different uis.