### PR TITLE
fix mistakenly unarchive

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -772,9 +772,6 @@ async fn add_parts(
 
     *sent_timestamp = std::cmp::min(*sent_timestamp, rcvd_timestamp);
 
-    // unarchive chat
-    chat_id.unarchive(context).await?;
-
     // if the mime-headers should be saved, find out its size
     // (the mime-header ends with an empty line)
     let save_mime_headers = context.get_config_bool(Config::SaveMimeHeaders).await;
@@ -894,6 +891,10 @@ async fn add_parts(
 
     if let Some(id) = ids.iter().last() {
         *insert_msg_id = *id;
+    }
+
+    if !is_hidden {
+        chat_id.unarchive(context).await?;
     }
 
     *hidden = is_hidden;

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2227,7 +2227,7 @@ mod tests {
         let t = TestContext::new_alice().await;
 
         // create one-to-one with bob, archive one-to-one
-        let bob_id = Contact::create(&t.ctx, "bob", "bob@exampel.org")
+        let bob_id = Contact::create(&t.ctx, "bob", "bob@example.com")
             .await
             .unwrap();
         let one2one_id = chat::create_by_contact_id(&t.ctx, bob_id).await.unwrap();


### PR DESCRIPTION
there was a test, however, that was not working due to a typo :)

with that test fixed, the wrong unarchive-on-read-receipt is easily reproducible - it just does not check any state. i've moved the unarchive() call down a few line, where also secure-join-protocol-messages and kml are detected as hidden-messages, so that for none of these _hidden_ messages, chats get unarchived.

for normal messages, things should stay unchanged.

closes https://github.com/deltachat/deltachat-android/issues/1695
closes https://github.com/deltachat/deltachat-core-rust/issues/2054