### PR TITLE
Don't download ranges of messages (i.e. first:last)

### DIFF
--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1731,16 +1731,14 @@ fn build_sequence_sets(mut uids: Vec<u32>) -> Vec<String> {
     let mut result = vec![String::new()];
     for range in ranges {
         if let Some(last) = result.last_mut() {
+            if !last.is_empty() {
+                last.push(',');
+            }
             last.push_str(&range.to_string());
-            last.push(',');
+
             if last.len() > 990 {
                 result.push(String::new()); // Start a new uid set
             }
-        }
-    }
-    for set in &mut result {
-        if set.ends_with(',') {
-            set.pop();
         }
     }
 


### PR DESCRIPTION
fix #2031

@link2xt do you think any of these optimisations are worth implementing?

 - do not fetch emails in chunks of 100 but, like, 5000; only if this fails go back to chunks of 100, we could also remember this
- try to find consecutive ranges (`29:31` instead of `29,30,31`);
  - Use sequence numbers instead of uids as there will be more consecutive ranges
- Usually UIDs won't be 9-or 10-digit, so we currently are staying way below the 1000 chars limit

I tend not to think it's worth it because this will only be a real advantage if we download more than 100 messages at once, which is not very often.