### PR TITLE
smtp: do not use STARTTLS when PLAIN connection is requested

### DIFF
--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -192,7 +192,8 @@ impl Smtp {
         };
 
         let security = match lp.security {
-            Socket::STARTTLS | Socket::Plain => smtp::ClientSecurity::Opportunistic(tls_parameters),
+            Socket::Plain => smtp::ClientSecurity::None,
+            Socket::STARTTLS => smtp::ClientSecurity::Required(tls_parameters),
             _ => smtp::ClientSecurity::Wrapper(tls_parameters),
         };
 


### PR DESCRIPTION
Also do not allow downgrade if STARTTLS is not available
