### PR TITLE
let core carry a 1.50.0-alpha.0 version 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,7 +1003,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.49.0"
+version = "1.50.0-alpha.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.49.0"
+version = "1.50.0-alpha.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.49.0"
+version = "1.50.0-alpha.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.49.0"
+version = "1.50.0-alpha.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"

--- a/set_core_version.py
+++ b/set_core_version.py
@@ -63,13 +63,14 @@ def main():
     ffi_toml = read_toml_version("deltachat-ffi/Cargo.toml")
     assert core_toml == ffi_toml, (core_toml, ffi_toml)
 
-    for line in open("CHANGELOG.md"):
-        ## 1.25.0
-        if line.startswith("## "):
-            if line[2:].strip().startswith(newversion):
-                break
-    else:
-        raise SystemExit("CHANGELOG.md contains no entry for version: {}".format(newversion))
+    if "alpha" not in newversion:
+        for line in open("CHANGELOG.md"):
+            ## 1.25.0
+            if line.startswith("## "):
+                if line[2:].strip().startswith(newversion):
+                    break
+        else:
+            raise SystemExit("CHANGELOG.md contains no entry for version: {}".format(newversion))
 
     replace_toml_version("Cargo.toml", newversion)
     replace_toml_version("deltachat-ffi/Cargo.toml", newversion)


### PR DESCRIPTION
1.50.0-alpha.0 sits between 1.49.X and 1.50.0

This way we can better distinguish tagged from untagged core releases, also in logs etc.
We might, from time to time, increase the alpha.N "N" number if we are entering testing etc.