### PR TITLE
[CRITICAL] Don't fetch from INBOX if it is disabled

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -69,9 +69,11 @@ async fn inbox_loop(ctx: Context, started: Sender<()>, inbox_handlers: ImapConne
                 }
                 Some(job) => {
                     // Let the fetch run, but return back to the job afterwards.
-                    info!(ctx, "postponing imap-job {} to run fetch...", job);
                     jobs_loaded = 0;
-                    fetch(&ctx, &mut connection).await;
+                    if ctx.get_config_bool(Config::InboxWatch).await {
+                        info!(ctx, "postponing imap-job {} to run fetch...", job);
+                        fetch(&ctx, &mut connection).await;
+                    }
                 }
                 None => {
                     jobs_loaded = 0;


### PR DESCRIPTION
Before, if there were more than 20 jobs at once, we unconditionally
fetched from inbox

This small bug was probably the reason why all of Rene's emails were deleted.