### PR TITLE
improve dc_get_info()

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -12,7 +12,7 @@ use crate::chat::*;
 use crate::config::Config;
 use crate::constants::*;
 use crate::contact::*;
-use crate::dc_tools::{dc_get_filebytes, duration_to_str};
+use crate::dc_tools::{dc_get_dirbytes, dc_get_filebytes, duration_to_str};
 use crate::error::*;
 use crate::events::{Event, EventEmitter, EventType, Events};
 use crate::key::{DcKey, SignedPublicKey};
@@ -262,6 +262,9 @@ impl Context {
      ******************************************************************************/
 
     pub async fn get_info(&self) -> BTreeMap<&'static str, String> {
+        let blobdir = self.get_blobdir();
+        let (blobdir_files, blobdir_bytes) = dc_get_dirbytes(self, blobdir).await;
+
         let unset = "0";
         let l = LoginParam::from_database(self, "").await;
         let l2 = LoginParam::from_database(self, "configured_").await;
@@ -330,7 +333,9 @@ impl Context {
             dc_get_filebytes(self, self.get_dbfile()).await.to_string(),
         );
         res.insert("journal_mode", journal_mode);
-        res.insert("blobdir", self.get_blobdir().display().to_string());
+        res.insert("blobdir", blobdir.display().to_string());
+        res.insert("blobdir_files", blobdir_files.to_string());
+        res.insert("blobdir_bytes", blobdir_bytes.to_string());
         res.insert("display_name", displayname.unwrap_or_else(|| unset.into()));
         res.insert(
             "selfavatar",

--- a/src/context.rs
+++ b/src/context.rs
@@ -323,7 +323,7 @@ impl Context {
         res.insert("number_of_chat_messages", real_msgs.to_string());
         res.insert("messages_in_contact_requests", deaddrop_msgs.to_string());
         res.insert("number_of_contacts", contacts.to_string());
-        res.insert("database_dir", self.get_dbfile().display().to_string());
+        res.insert("database", self.get_dbfile().display().to_string());
         res.insert("database_version", dbversion.to_string());
         res.insert("journal_mode", journal_mode);
         res.insert("blobdir", self.get_blobdir().display().to_string());
@@ -595,14 +595,14 @@ mod tests {
         let t = TestContext::new().await;
 
         let info = t.ctx.get_info().await;
-        assert!(info.get("database_dir").is_some());
+        assert!(info.get("database").is_some());
     }
 
     #[test]
     fn test_get_info_no_context() {
         let info = get_info();
         assert!(info.get("deltachat_core_version").is_some());
-        assert!(info.get("database_dir").is_none());
+        assert!(info.get("database").is_none());
         assert_eq!(info.get("level").unwrap(), "awesome");
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -12,7 +12,7 @@ use crate::chat::*;
 use crate::config::Config;
 use crate::constants::*;
 use crate::contact::*;
-use crate::dc_tools::duration_to_str;
+use crate::dc_tools::{dc_get_filebytes, duration_to_str};
 use crate::error::*;
 use crate::events::{Event, EventEmitter, EventType, Events};
 use crate::key::{DcKey, SignedPublicKey};
@@ -325,6 +325,10 @@ impl Context {
         res.insert("number_of_contacts", contacts.to_string());
         res.insert("database", self.get_dbfile().display().to_string());
         res.insert("database_version", dbversion.to_string());
+        res.insert(
+            "database_bytes",
+            dc_get_filebytes(self, self.get_dbfile()).await.to_string(),
+        );
         res.insert("journal_mode", journal_mode);
         res.insert("blobdir", self.get_blobdir().display().to_string());
         res.insert("display_name", displayname.unwrap_or_else(|| unset.into()));
@@ -596,6 +600,7 @@ mod tests {
 
         let info = t.ctx.get_info().await;
         assert!(info.get("database").is_some());
+        assert!(info.get("database_bytes").unwrap().parse::<u64>().unwrap() > 1000);
     }
 
     #[test]
@@ -603,6 +608,7 @@ mod tests {
         let info = get_info();
         assert!(info.get("deltachat_core_version").is_some());
         assert!(info.get("database").is_none());
+        assert!(info.get("database_bytes").is_none());
         assert_eq!(info.get("level").unwrap(), "awesome");
     }
 }

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -339,6 +339,24 @@ pub(crate) async fn dc_get_filebytes(context: &Context, path: impl AsRef<Path>) 
     }
 }
 
+pub(crate) async fn dc_get_dirbytes(context: &Context, path: impl AsRef<Path>) -> (usize, u64) {
+    let path_abs = dc_get_abs_path(context, &path);
+    let mut files: usize = 0;
+    let mut bytes: u64 = 0;
+    if let Ok(mut read_dir) = async_std::fs::read_dir(path_abs).await {
+        while let Some(entry) = read_dir.next().await {
+            if let Ok(entry) = entry {
+                files += 1;
+                bytes += match entry.metadata().await {
+                    Ok(meta) => meta.len(),
+                    Err(_err) => 0,
+                }
+            }
+        }
+    }
+    (files, bytes)
+}
+
 pub(crate) async fn dc_delete_file(context: &Context, path: impl AsRef<Path>) -> bool {
     let path_abs = dc_get_abs_path(context, &path);
     if !path_abs.exists().await {


### PR DESCRIPTION
this was an attempt to add the number of bytes and files in blobdir to dc_get_info() to easier debug eg. https://github.com/deltachat/deltachat-android/issues/1742

however, it turns out that already on my delta chat desktopn installation (>1gb), getting these information takes 1-2 seconds, and on android that might be much longer.

so, this seems not to be worth the additional effort of handling this delay somehow in the ui.

leaving the pr closes for reference, however.