### PR TITLE
Reenable fetch existing msgs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -72,8 +72,7 @@ pub enum Config {
     /// If set to "1", on the first time `start_io()` is called after configuring,
     /// the newest existing messages are fetched.
     /// Existing recipients are added to the contact database regardless of this setting.
-    #[strum(props(default = "0"))]
-    // disabled for now, we'll set this back to "1" at some point
+    #[strum(props(default = "1"))]
     FetchExistingMsgs,
 
     #[strum(props(default = "0"))]

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -112,10 +112,13 @@ pub enum Origin {
     OutgoingTo = 0x4000,
 
     /// internal use
-    Internal = 0x40000,
+    Internal = 0x4_0000,
 
     /// address is in our address book
-    AddressBook = 0x80000,
+    AddressBook = 0x8_0000,
+
+    /// chat message sent by us (currently only used in add_all_recipients_as_contacts, to mark that a chat should be created when we get a message from this contact)
+    OutgoingChatMsg = 0x10_0000,
 
     /// set on Alice's side for contacts like Bob that have scanned the QR code offered by her. Only means the contact has once been established using the "securejoin" procedure in the past, getting the current key verification status requires calling dc_contact_is_verified() !
     SecurejoinInvited = 0x0100_0000,

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -452,12 +452,14 @@ async fn add_parts(
         if chat_id.is_unset() {
             // try to create a group
 
-            let create_blocked =
-                if !test_normal_chat_id.is_unset() && test_normal_chat_id_blocked == Blocked::Not {
-                    Blocked::Not
-                } else {
-                    Blocked::Deaddrop
-                };
+            let create_blocked = if (!test_normal_chat_id.is_unset()
+                && test_normal_chat_id_blocked == Blocked::Not)
+                || incoming_origin >= Origin::OutgoingChatMsg
+            {
+                Blocked::Not
+            } else {
+                Blocked::Deaddrop
+            };
 
             let (new_chat_id, new_chat_id_blocked) = create_or_lookup_group(
                 context,
@@ -493,11 +495,12 @@ async fn add_parts(
 
         if chat_id.is_unset() {
             // try to create a normal chat
-            let create_blocked = if from_id == to_id {
-                Blocked::Not
-            } else {
-                Blocked::Deaddrop
-            };
+            let create_blocked =
+                if from_id == DC_CONTACT_ID_SELF || incoming_origin >= Origin::OutgoingChatMsg {
+                    Blocked::Not
+                } else {
+                    Blocked::Deaddrop
+                };
 
             if !test_normal_chat_id.is_unset() {
                 *chat_id = test_normal_chat_id;


### PR DESCRIPTION
and fix https://github.com/deltachat/deltachat-core-rust/issues/2097 (because it was one of the reasons we disabled fetch-existing-msgs):

at peek-receipients (add_all_recipients_as_contacts()) we now also peek the Chat-Version header and if it's present, set the origin to sth. new between AddressBook and SecurejoinInvited. Then in dc_receive_imf(), we directly unblock the chat if the contact has this new origin. This will only fix this issue, not change the behavior in other cases.

Update: We can't do this exactly this way, see https://github.com/deltachat/deltachat-core-rust/issues/2097. So, this definitely needs some discussion before I continue coding.

Still needs a test but I wanted to ask first what y'all think in case we decide for a completely other way.