### PR TITLE
Compare ephemeral timer to parent message to deal with reordering better

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2724,7 +2724,7 @@ pub unsafe extern "C" fn dc_msg_get_ephemeral_timer(msg: *mut dc_msg_t) -> u32 {
         return 0;
     }
     let ffi_msg = &*msg;
-    ffi_msg.message.get_ephemeral_timer()
+    ffi_msg.message.get_ephemeral_timer().to_u32()
 }
 
 #[no_mangle]

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -684,6 +684,9 @@ async fn add_parts(
     if !*hidden
         && !location_kml_is
         && !is_mdn
+        && (is_dc_message != MessengerMessage::Yes
+            || parent.is_none()
+            || parent.unwrap().ephemeral_timer != ephemeral_timer)
         && (*chat_id).get_ephemeral_timer(context).await? != ephemeral_timer
     {
         if let Err(err) = (*chat_id)

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -460,6 +460,8 @@ pub(crate) async fn start_ephemeral_timers(context: &Context) -> sql::Result<()>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::chat;
+    use crate::contact::{Contact, Origin};
     use crate::test_utils::*;
 
     #[async_std::test]
@@ -524,5 +526,82 @@ mod tests {
             .await,
             "Message deletion timer is set to 4 weeks."
         );
+    }
+
+    #[async_std::test]
+    async fn test_ephemeral_timer() -> crate::error::Result<()> {
+        let alice = TestContext::new_alice().await;
+        let bob = TestContext::new_bob().await;
+
+        let (contact_alice_id, _modified) = Contact::add_or_lookup(
+            &bob.ctx,
+            "Alice",
+            "alice@example.com",
+            Origin::ManuallyCreated,
+        )
+        .await?;
+        let (contact_bob_id, _modified) = Contact::add_or_lookup(
+            &alice.ctx,
+            "Bob",
+            "bob@example.net",
+            Origin::ManuallyCreated,
+        )
+        .await?;
+
+        let chat_alice = chat::create_by_contact_id(&alice.ctx, contact_bob_id).await?;
+        let chat_bob = chat::create_by_contact_id(&bob.ctx, contact_alice_id).await?;
+
+        // Alice sends message to Bob
+        let mut msg = Message::new(Viewtype::Text);
+        chat::prepare_msg(&alice.ctx, chat_alice, &mut msg).await?;
+        chat::send_msg(&alice.ctx, chat_alice, &mut msg).await?;
+        let sent = alice.pop_sent_msg().await;
+        bob.recv_msg(&sent).await;
+
+        // Alice sends second message to Bob, with no timer
+        let mut msg = Message::new(Viewtype::Text);
+        chat::prepare_msg(&alice.ctx, chat_alice, &mut msg).await?;
+        chat::send_msg(&alice.ctx, chat_alice, &mut msg).await?;
+        let sent = alice.pop_sent_msg().await;
+
+        assert_eq!(
+            chat_bob.get_ephemeral_timer(&bob.ctx).await?,
+            Timer::Disabled
+        );
+
+        // Bob sets ephemeral timer and sends a message about timer change
+        chat_bob
+            .set_ephemeral_timer(&bob.ctx, Timer::Enabled { duration: 60 })
+            .await?;
+        let sent_timer_change = bob.pop_sent_msg().await;
+
+        assert_eq!(
+            chat_bob.get_ephemeral_timer(&bob.ctx).await?,
+            Timer::Enabled { duration: 60 }
+        );
+
+        // Bob receives message from Alice.
+        // Alice message has no timer. However, Bob should not disable timer,
+        // because Alice replies to old message.
+        bob.recv_msg(&sent).await;
+
+        assert_eq!(
+            chat_alice.get_ephemeral_timer(&alice.ctx).await?,
+            Timer::Disabled
+        );
+        assert_eq!(
+            chat_bob.get_ephemeral_timer(&bob.ctx).await?,
+            Timer::Enabled { duration: 60 }
+        );
+
+        // Alice receives message from Bob
+        alice.recv_msg(&sent_timer_change).await;
+
+        assert_eq!(
+            chat_alice.get_ephemeral_timer(&alice.ctx).await?,
+            Timer::Enabled { duration: 60 }
+        );
+
+        Ok(())
     }
 }

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -16,7 +16,7 @@ use num_traits::FromPrimitive;
 
 use crate::constants::*;
 use crate::context::Context;
-use crate::dc_receive_imf::{from_field_to_contact_id, is_msgrmsg_rfc724_mid_in_list};
+use crate::dc_receive_imf::{from_field_to_contact_id, get_prefetch_parent_message};
 use crate::error::{bail, format_err, Result};
 use crate::events::EventType;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
@@ -1556,25 +1556,6 @@ fn prefetch_get_message_id(headers: &[mailparse::MailHeader]) -> Result<String> 
     }
 }
 
-async fn prefetch_is_reply_to_chat_message(
-    context: &Context,
-    headers: &[mailparse::MailHeader<'_>],
-) -> bool {
-    if let Some(value) = headers.get_header_value(HeaderDef::InReplyTo) {
-        if is_msgrmsg_rfc724_mid_in_list(context, &value).await {
-            return true;
-        }
-    }
-
-    if let Some(value) = headers.get_header_value(HeaderDef::References) {
-        if is_msgrmsg_rfc724_mid_in_list(context, &value).await {
-            return true;
-        }
-    }
-
-    false
-}
-
 pub(crate) async fn prefetch_should_download(
     context: &Context,
     headers: &[mailparse::MailHeader<'_>],
@@ -1593,7 +1574,9 @@ pub(crate) async fn prefetch_should_download(
     }
 
     let is_chat_message = headers.get_header_value(HeaderDef::ChatVersion).is_some();
-    let is_reply_to_chat_message = prefetch_is_reply_to_chat_message(context, &headers).await;
+    let is_reply_to_chat_message = get_prefetch_parent_message(context, headers)
+        .await?
+        .is_some();
 
     let maybe_ndn = if let Some(from) = headers.get_header_value(HeaderDef::From_) {
         let from = from.to_ascii_lowercase();

--- a/src/message.rs
+++ b/src/message.rs
@@ -787,11 +787,8 @@ impl Message {
     pub async fn quoted_message(&self, context: &Context) -> Result<Option<Message>, Error> {
         if self.param.get(Param::Quote).is_some() {
             if let Some(in_reply_to) = &self.in_reply_to {
-                let rfc724_mid = in_reply_to.trim_start_matches('<').trim_end_matches('>');
-                if !rfc724_mid.is_empty() {
-                    if let Some((_, _, msg_id)) = rfc724_mid_exists(context, rfc724_mid).await? {
-                        return Ok(Some(Message::load_from_db(context, msg_id).await?));
-                    }
+                if let Some((_, _, msg_id)) = rfc724_mid_exists(context, in_reply_to).await? {
+                    return Ok(Some(Message::load_from_db(context, msg_id).await?));
                 }
             }
         }
@@ -1818,6 +1815,7 @@ pub(crate) async fn rfc724_mid_exists(
     context: &Context,
     rfc724_mid: &str,
 ) -> Result<Option<(String, u32, MsgId)>, Error> {
+    let rfc724_mid = rfc724_mid.trim_start_matches('<').trim_end_matches('>');
     if rfc724_mid.is_empty() {
         warn!(context, "Empty rfc724_mid passed to rfc724_mid_exists");
         return Ok(None);

--- a/src/message.rs
+++ b/src/message.rs
@@ -11,6 +11,7 @@ use crate::constants::*;
 use crate::contact::*;
 use crate::context::*;
 use crate::dc_tools::*;
+use crate::ephemeral::Timer as EphemeralTimer;
 use crate::error::{ensure, Error};
 use crate::events::EventType;
 use crate::job::{self, Action};
@@ -255,7 +256,7 @@ pub struct Message {
     pub(crate) timestamp_sort: i64,
     pub(crate) timestamp_sent: i64,
     pub(crate) timestamp_rcvd: i64,
-    pub(crate) ephemeral_timer: u32,
+    pub(crate) ephemeral_timer: EphemeralTimer,
     pub(crate) ephemeral_timestamp: i64,
     pub(crate) text: Option<String>,
     pub(crate) rfc724_mid: String,
@@ -523,7 +524,7 @@ impl Message {
         self.param.get_int(Param::GuaranteeE2ee).unwrap_or_default() != 0
     }
 
-    pub fn get_ephemeral_timer(&self) -> u32 {
+    pub fn get_ephemeral_timer(&self) -> EphemeralTimer {
         self.ephemeral_timer
     }
 
@@ -1065,8 +1066,8 @@ pub async fn get_msg_info(context: &Context, msg_id: MsgId) -> String {
         ret += "\n";
     }
 
-    if msg.ephemeral_timer != 0 {
-        ret += &format!("Ephemeral timer: {}\n", msg.ephemeral_timer);
+    if let EphemeralTimer::Enabled { duration } = msg.ephemeral_timer {
+        ret += &format!("Ephemeral timer: {}\n", duration);
     }
 
     if msg.ephemeral_timestamp != 0 {

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -1117,10 +1117,9 @@ mod tests {
             .unwrap();
 
         // Bob scans QR-code, sends vc-request
-        let bob_chatid = dc_join_securejoin(&bob.ctx, &qr).await.unwrap();
+        dc_join_securejoin(&bob.ctx, &qr).await.unwrap();
 
         let sent = bob.pop_sent_msg().await;
-        assert_eq!(sent.id(), bob_chatid);
         assert_eq!(sent.recipient(), "alice@example.com".parse().unwrap());
         let msg = alice.parse_msg(&sent).await;
         assert!(!msg.was_encrypted());


### PR DESCRIPTION
If user sends a message before receiving an ephemeral timer change, they will accidentally revert the timer setting.

To prevent this, compare the timer setting to the parent message and ignore the change if parent message had the same timer setting.