### PR TITLE
Nicer rust tests

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -536,36 +536,28 @@ mod tests {
     #[async_std::test]
     async fn test_lowercase_ext() {
         let t = TestContext::new().await;
-        let blob = BlobObject::create(&t, "foo.TXT", b"hello")
-            .await
-            .unwrap();
+        let blob = BlobObject::create(&t, "foo.TXT", b"hello").await.unwrap();
         assert_eq!(blob.as_name(), "$BLOBDIR/foo.txt");
     }
 
     #[async_std::test]
     async fn test_as_file_name() {
         let t = TestContext::new().await;
-        let blob = BlobObject::create(&t, "foo.txt", b"hello")
-            .await
-            .unwrap();
+        let blob = BlobObject::create(&t, "foo.txt", b"hello").await.unwrap();
         assert_eq!(blob.as_file_name(), "foo.txt");
     }
 
     #[async_std::test]
     async fn test_as_rel_path() {
         let t = TestContext::new().await;
-        let blob = BlobObject::create(&t, "foo.txt", b"hello")
-            .await
-            .unwrap();
+        let blob = BlobObject::create(&t, "foo.txt", b"hello").await.unwrap();
         assert_eq!(blob.as_rel_path(), Path::new("foo.txt"));
     }
 
     #[async_std::test]
     async fn test_suffix() {
         let t = TestContext::new().await;
-        let blob = BlobObject::create(&t, "foo.txt", b"hello")
-            .await
-            .unwrap();
+        let blob = BlobObject::create(&t, "foo.txt", b"hello").await.unwrap();
         assert_eq!(blob.suffix(), Some("txt"));
         let blob = BlobObject::create(&t, "bar", b"world").await.unwrap();
         assert_eq!(blob.suffix(), None);
@@ -574,14 +566,10 @@ mod tests {
     #[async_std::test]
     async fn test_create_dup() {
         let t = TestContext::new().await;
-        BlobObject::create(&t, "foo.txt", b"hello")
-            .await
-            .unwrap();
+        BlobObject::create(&t, "foo.txt", b"hello").await.unwrap();
         let foo_path = t.get_blobdir().join("foo.txt");
         assert!(foo_path.exists().await);
-        BlobObject::create(&t, "foo.txt", b"world")
-            .await
-            .unwrap();
+        BlobObject::create(&t, "foo.txt", b"world").await.unwrap();
         let mut dir = fs::read_dir(t.get_blobdir()).await.unwrap();
         while let Some(dirent) = dir.next().await {
             let fname = dirent.unwrap().file_name();

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -525,18 +525,18 @@ mod tests {
     #[async_std::test]
     async fn test_create() {
         let t = TestContext::new().await;
-        let blob = BlobObject::create(&t.ctx, "foo", b"hello").await.unwrap();
-        let fname = t.ctx.get_blobdir().join("foo");
+        let blob = BlobObject::create(&t, "foo", b"hello").await.unwrap();
+        let fname = t.get_blobdir().join("foo");
         let data = fs::read(fname).await.unwrap();
         assert_eq!(data, b"hello");
         assert_eq!(blob.as_name(), "$BLOBDIR/foo");
-        assert_eq!(blob.to_abs_path(), t.ctx.get_blobdir().join("foo"));
+        assert_eq!(blob.to_abs_path(), t.get_blobdir().join("foo"));
     }
 
     #[async_std::test]
     async fn test_lowercase_ext() {
         let t = TestContext::new().await;
-        let blob = BlobObject::create(&t.ctx, "foo.TXT", b"hello")
+        let blob = BlobObject::create(&t, "foo.TXT", b"hello")
             .await
             .unwrap();
         assert_eq!(blob.as_name(), "$BLOBDIR/foo.txt");
@@ -545,7 +545,7 @@ mod tests {
     #[async_std::test]
     async fn test_as_file_name() {
         let t = TestContext::new().await;
-        let blob = BlobObject::create(&t.ctx, "foo.txt", b"hello")
+        let blob = BlobObject::create(&t, "foo.txt", b"hello")
             .await
             .unwrap();
         assert_eq!(blob.as_file_name(), "foo.txt");
@@ -554,7 +554,7 @@ mod tests {
     #[async_std::test]
     async fn test_as_rel_path() {
         let t = TestContext::new().await;
-        let blob = BlobObject::create(&t.ctx, "foo.txt", b"hello")
+        let blob = BlobObject::create(&t, "foo.txt", b"hello")
             .await
             .unwrap();
         assert_eq!(blob.as_rel_path(), Path::new("foo.txt"));
@@ -563,26 +563,26 @@ mod tests {
     #[async_std::test]
     async fn test_suffix() {
         let t = TestContext::new().await;
-        let blob = BlobObject::create(&t.ctx, "foo.txt", b"hello")
+        let blob = BlobObject::create(&t, "foo.txt", b"hello")
             .await
             .unwrap();
         assert_eq!(blob.suffix(), Some("txt"));
-        let blob = BlobObject::create(&t.ctx, "bar", b"world").await.unwrap();
+        let blob = BlobObject::create(&t, "bar", b"world").await.unwrap();
         assert_eq!(blob.suffix(), None);
     }
 
     #[async_std::test]
     async fn test_create_dup() {
         let t = TestContext::new().await;
-        BlobObject::create(&t.ctx, "foo.txt", b"hello")
+        BlobObject::create(&t, "foo.txt", b"hello")
             .await
             .unwrap();
-        let foo_path = t.ctx.get_blobdir().join("foo.txt");
+        let foo_path = t.get_blobdir().join("foo.txt");
         assert!(foo_path.exists().await);
-        BlobObject::create(&t.ctx, "foo.txt", b"world")
+        BlobObject::create(&t, "foo.txt", b"world")
             .await
             .unwrap();
-        let mut dir = fs::read_dir(t.ctx.get_blobdir()).await.unwrap();
+        let mut dir = fs::read_dir(t.get_blobdir()).await.unwrap();
         while let Some(dirent) = dir.next().await {
             let fname = dirent.unwrap().file_name();
             if fname == foo_path.file_name().unwrap() {
@@ -598,15 +598,15 @@ mod tests {
     #[async_std::test]
     async fn test_double_ext_preserved() {
         let t = TestContext::new().await;
-        BlobObject::create(&t.ctx, "foo.tar.gz", b"hello")
+        BlobObject::create(&t, "foo.tar.gz", b"hello")
             .await
             .unwrap();
-        let foo_path = t.ctx.get_blobdir().join("foo.tar.gz");
+        let foo_path = t.get_blobdir().join("foo.tar.gz");
         assert!(foo_path.exists().await);
-        BlobObject::create(&t.ctx, "foo.tar.gz", b"world")
+        BlobObject::create(&t, "foo.tar.gz", b"world")
             .await
             .unwrap();
-        let mut dir = fs::read_dir(t.ctx.get_blobdir()).await.unwrap();
+        let mut dir = fs::read_dir(t.get_blobdir()).await.unwrap();
         while let Some(dirent) = dir.next().await {
             let fname = dirent.unwrap().file_name();
             if fname == foo_path.file_name().unwrap() {
@@ -624,7 +624,7 @@ mod tests {
     async fn test_create_long_names() {
         let t = TestContext::new().await;
         let s = "1".repeat(150);
-        let blob = BlobObject::create(&t.ctx, &s, b"data").await.unwrap();
+        let blob = BlobObject::create(&t, &s, b"data").await.unwrap();
         let blobname = blob.as_name().split('/').last().unwrap();
         assert!(blobname.len() < 128);
     }
@@ -634,14 +634,14 @@ mod tests {
         let t = TestContext::new().await;
         let src = t.dir.path().join("src");
         fs::write(&src, b"boo").await.unwrap();
-        let blob = BlobObject::create_and_copy(&t.ctx, &src).await.unwrap();
+        let blob = BlobObject::create_and_copy(&t, &src).await.unwrap();
         assert_eq!(blob.as_name(), "$BLOBDIR/src");
         let data = fs::read(blob.to_abs_path()).await.unwrap();
         assert_eq!(data, b"boo");
 
         let whoops = t.dir.path().join("whoops");
-        assert!(BlobObject::create_and_copy(&t.ctx, &whoops).await.is_err());
-        let whoops = t.ctx.get_blobdir().join("whoops");
+        assert!(BlobObject::create_and_copy(&t, &whoops).await.is_err());
+        let whoops = t.get_blobdir().join("whoops");
         assert!(!whoops.exists().await);
     }
 
@@ -651,14 +651,14 @@ mod tests {
 
         let src_ext = t.dir.path().join("external");
         fs::write(&src_ext, b"boo").await.unwrap();
-        let blob = BlobObject::new_from_path(&t.ctx, &src_ext).await.unwrap();
+        let blob = BlobObject::new_from_path(&t, &src_ext).await.unwrap();
         assert_eq!(blob.as_name(), "$BLOBDIR/external");
         let data = fs::read(blob.to_abs_path()).await.unwrap();
         assert_eq!(data, b"boo");
 
-        let src_int = t.ctx.get_blobdir().join("internal");
+        let src_int = t.get_blobdir().join("internal");
         fs::write(&src_int, b"boo").await.unwrap();
-        let blob = BlobObject::new_from_path(&t.ctx, &src_int).await.unwrap();
+        let blob = BlobObject::new_from_path(&t, &src_int).await.unwrap();
         assert_eq!(blob.as_name(), "$BLOBDIR/internal");
         let data = fs::read(blob.to_abs_path()).await.unwrap();
         assert_eq!(data, b"boo");
@@ -668,7 +668,7 @@ mod tests {
         let t = TestContext::new().await;
         let src_ext = t.dir.path().join("autocrypt-setup-message-4137848473.html");
         fs::write(&src_ext, b"boo").await.unwrap();
-        let blob = BlobObject::new_from_path(&t.ctx, &src_ext).await.unwrap();
+        let blob = BlobObject::new_from_path(&t, &src_ext).await.unwrap();
         assert_eq!(
             blob.as_name(),
             "$BLOBDIR/autocrypt-setup-message-4137848473.html"

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2976,11 +2976,7 @@ mod tests {
     #[async_std::test]
     async fn test_chat_info() {
         let t = TestContext::new().await;
-        let bob = Contact::create(&t.ctx, "bob", "bob@example.com")
-            .await
-            .unwrap();
-        let chat_id = create_by_contact_id(&t.ctx, bob).await.unwrap();
-        let chat = Chat::load_from_db(&t.ctx, chat_id).await.unwrap();
+        let chat = t.chat_with_contact("bob", "bob@example.com").await;
         let info = chat.get_info(&t.ctx).await.unwrap();
 
         // Ensure we can serialize this.
@@ -3011,10 +3007,8 @@ mod tests {
     #[async_std::test]
     async fn test_get_draft_no_draft() {
         let t = TestContext::new().await;
-        let chat_id = create_by_contact_id(&t.ctx, DC_CONTACT_ID_SELF)
-            .await
-            .unwrap();
-        let draft = chat_id.get_draft(&t.ctx).await.unwrap();
+        let chat = t.get_self_chat().await;
+        let draft = chat.id.get_draft(&t.ctx).await.unwrap();
         assert!(draft.is_none());
     }
 
@@ -3040,9 +3034,7 @@ mod tests {
     #[async_std::test]
     async fn test_get_draft() {
         let t = TestContext::new().await;
-        let chat_id = create_by_contact_id(&t.ctx, DC_CONTACT_ID_SELF)
-            .await
-            .unwrap();
+        let chat_id = &t.get_self_chat().await.id;
         let mut msg = Message::new(Viewtype::Text);
         msg.set_text(Some("hello".to_string()));
         chat_id.set_draft(&t.ctx, Some(&mut msg)).await;
@@ -3068,13 +3060,9 @@ mod tests {
     #[async_std::test]
     async fn test_self_talk() {
         let t = TestContext::new().await;
-        let chat_id = create_by_contact_id(&t.ctx, DC_CONTACT_ID_SELF)
-            .await
-            .unwrap();
+        let chat = &t.get_self_chat().await;
         assert_eq!(DC_CONTACT_ID_SELF, 1);
-        assert!(!chat_id.is_special());
-        let chat = Chat::load_from_db(&t.ctx, chat_id).await.unwrap();
-        assert_eq!(chat.id, chat_id);
+        assert!(!chat.id.is_special());
         assert!(chat.is_self_talk());
         assert!(chat.visibility == ChatVisibility::Normal);
         assert!(!chat.is_device_talk());
@@ -3321,9 +3309,7 @@ mod tests {
             .await
             .unwrap()
             .chat_id;
-        let chat_id2 = create_by_contact_id(&t.ctx, DC_CONTACT_ID_SELF)
-            .await
-            .unwrap();
+        let chat_id2 = t.get_self_chat().await.id;
         assert!(!chat_id1.is_special());
         assert!(!chat_id2.is_special());
         assert_eq!(get_chat_cnt(&t.ctx).await, 2);
@@ -3438,9 +3424,7 @@ mod tests {
             .unwrap()
             .chat_id;
         async_std::task::sleep(std::time::Duration::from_millis(1000)).await;
-        let chat_id2 = create_by_contact_id(&t.ctx, DC_CONTACT_ID_SELF)
-            .await
-            .unwrap();
+        let chat_id2 = t.get_self_chat().await.id;
         async_std::task::sleep(std::time::Duration::from_millis(1000)).await;
         let chat_id3 = create_group_chat(&t.ctx, ProtectionStatus::Unprotected, "foo")
             .await

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -463,9 +463,7 @@ mod tests {
         assert_eq!(chats.get_chat_id(0), chat_id2);
 
         // check chatlist query and archive functionality
-        let chats = Chatlist::try_load(&t, 0, Some("b"), None)
-            .await
-            .unwrap();
+        let chats = Chatlist::try_load(&t, 0, Some("b"), None).await.unwrap();
         assert_eq!(chats.len(), 1);
 
         let chats = Chatlist::try_load(&t, DC_GCL_ARCHIVED_ONLY, None, None)
@@ -522,8 +520,7 @@ mod tests {
             .unwrap();
         assert_eq!(chats.len(), 0);
 
-        t
-            .set_stock_translation(StockMessage::SavedMessages, "test-1234-save".to_string())
+        t.set_stock_translation(StockMessage::SavedMessages, "test-1234-save".to_string())
             .await
             .unwrap();
         let chats = Chatlist::try_load(&t, 0, Some("t-1234-s"), None)
@@ -531,8 +528,7 @@ mod tests {
             .unwrap();
         assert_eq!(chats.len(), 1);
 
-        t
-            .set_stock_translation(StockMessage::DeviceMessages, "test-5678-babbel".to_string())
+        t.set_stock_translation(StockMessage::DeviceMessages, "test-5678-babbel".to_string())
             .await
             .unwrap();
         let chats = Chatlist::try_load(&t, 0, Some("t-5678-b"), None)

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -438,18 +438,18 @@ mod tests {
     #[async_std::test]
     async fn test_try_load() {
         let t = TestContext::new().await;
-        let chat_id1 = create_group_chat(&t.ctx, ProtectionStatus::Unprotected, "a chat")
+        let chat_id1 = create_group_chat(&t, ProtectionStatus::Unprotected, "a chat")
             .await
             .unwrap();
-        let chat_id2 = create_group_chat(&t.ctx, ProtectionStatus::Unprotected, "b chat")
+        let chat_id2 = create_group_chat(&t, ProtectionStatus::Unprotected, "b chat")
             .await
             .unwrap();
-        let chat_id3 = create_group_chat(&t.ctx, ProtectionStatus::Unprotected, "c chat")
+        let chat_id3 = create_group_chat(&t, ProtectionStatus::Unprotected, "c chat")
             .await
             .unwrap();
 
         // check that the chatlist starts with the most recent message
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 3);
         assert_eq!(chats.get_chat_id(0), chat_id3);
         assert_eq!(chats.get_chat_id(1), chat_id2);
@@ -458,26 +458,26 @@ mod tests {
         // drafts are sorted to the top
         let mut msg = Message::new(Viewtype::Text);
         msg.set_text(Some("hello".to_string()));
-        chat_id2.set_draft(&t.ctx, Some(&mut msg)).await;
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        chat_id2.set_draft(&t, Some(&mut msg)).await;
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.get_chat_id(0), chat_id2);
 
         // check chatlist query and archive functionality
-        let chats = Chatlist::try_load(&t.ctx, 0, Some("b"), None)
+        let chats = Chatlist::try_load(&t, 0, Some("b"), None)
             .await
             .unwrap();
         assert_eq!(chats.len(), 1);
 
-        let chats = Chatlist::try_load(&t.ctx, DC_GCL_ARCHIVED_ONLY, None, None)
+        let chats = Chatlist::try_load(&t, DC_GCL_ARCHIVED_ONLY, None, None)
             .await
             .unwrap();
         assert_eq!(chats.len(), 0);
 
         chat_id1
-            .set_visibility(&t.ctx, ChatVisibility::Archived)
+            .set_visibility(&t, ChatVisibility::Archived)
             .await
             .ok();
-        let chats = Chatlist::try_load(&t.ctx, DC_GCL_ARCHIVED_ONLY, None, None)
+        let chats = Chatlist::try_load(&t, DC_GCL_ARCHIVED_ONLY, None, None)
             .await
             .unwrap();
         assert_eq!(chats.len(), 1);
@@ -486,23 +486,23 @@ mod tests {
     #[async_std::test]
     async fn test_sort_self_talk_up_on_forward() {
         let t = TestContext::new().await;
-        t.ctx.update_device_chats().await.unwrap();
-        create_group_chat(&t.ctx, ProtectionStatus::Unprotected, "a chat")
+        t.update_device_chats().await.unwrap();
+        create_group_chat(&t, ProtectionStatus::Unprotected, "a chat")
             .await
             .unwrap();
 
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert!(chats.len() == 3);
-        assert!(!Chat::load_from_db(&t.ctx, chats.get_chat_id(0))
+        assert!(!Chat::load_from_db(&t, chats.get_chat_id(0))
             .await
             .unwrap()
             .is_self_talk());
 
-        let chats = Chatlist::try_load(&t.ctx, DC_GCL_FOR_FORWARDING, None, None)
+        let chats = Chatlist::try_load(&t, DC_GCL_FOR_FORWARDING, None, None)
             .await
             .unwrap();
         assert!(chats.len() == 2); // device chat cannot be written and is skipped on forwarding
-        assert!(Chat::load_from_db(&t.ctx, chats.get_chat_id(0))
+        assert!(Chat::load_from_db(&t, chats.get_chat_id(0))
             .await
             .unwrap()
             .is_self_talk());
@@ -511,31 +511,31 @@ mod tests {
     #[async_std::test]
     async fn test_search_special_chat_names() {
         let t = TestContext::new().await;
-        t.ctx.update_device_chats().await.unwrap();
+        t.update_device_chats().await.unwrap();
 
-        let chats = Chatlist::try_load(&t.ctx, 0, Some("t-1234-s"), None)
+        let chats = Chatlist::try_load(&t, 0, Some("t-1234-s"), None)
             .await
             .unwrap();
         assert_eq!(chats.len(), 0);
-        let chats = Chatlist::try_load(&t.ctx, 0, Some("t-5678-b"), None)
+        let chats = Chatlist::try_load(&t, 0, Some("t-5678-b"), None)
             .await
             .unwrap();
         assert_eq!(chats.len(), 0);
 
-        t.ctx
+        t
             .set_stock_translation(StockMessage::SavedMessages, "test-1234-save".to_string())
             .await
             .unwrap();
-        let chats = Chatlist::try_load(&t.ctx, 0, Some("t-1234-s"), None)
+        let chats = Chatlist::try_load(&t, 0, Some("t-1234-s"), None)
             .await
             .unwrap();
         assert_eq!(chats.len(), 1);
 
-        t.ctx
+        t
             .set_stock_translation(StockMessage::DeviceMessages, "test-5678-babbel".to_string())
             .await
             .unwrap();
-        let chats = Chatlist::try_load(&t.ctx, 0, Some("t-5678-b"), None)
+        let chats = Chatlist::try_load(&t, 0, Some("t-5678-b"), None)
             .await
             .unwrap();
         assert_eq!(chats.len(), 1);
@@ -544,16 +544,16 @@ mod tests {
     #[async_std::test]
     async fn test_get_summary_unwrap() {
         let t = TestContext::new().await;
-        let chat_id1 = create_group_chat(&t.ctx, ProtectionStatus::Unprotected, "a chat")
+        let chat_id1 = create_group_chat(&t, ProtectionStatus::Unprotected, "a chat")
             .await
             .unwrap();
 
         let mut msg = Message::new(Viewtype::Text);
         msg.set_text(Some("foo:\nbar \r\n test".to_string()));
-        chat_id1.set_draft(&t.ctx, Some(&mut msg)).await;
+        chat_id1.set_draft(&t, Some(&mut msg)).await;
 
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
-        let summary = chats.get_summary(&t.ctx, 0, None).await;
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
+        let summary = chats.get_summary(&t, 0, None).await;
         assert_eq!(summary.get_text2().unwrap(), "foo: bar test"); // the linebreak should be removed from summary
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -321,8 +321,7 @@ mod tests {
             .unwrap();
         let avatar_blob = t.get_blobdir().join("avatar.jpg");
         assert!(!avatar_blob.exists().await);
-        t
-            .set_config(Config::Selfavatar, Some(&avatar_src.to_str().unwrap()))
+        t.set_config(Config::Selfavatar, Some(&avatar_src.to_str().unwrap()))
             .await
             .unwrap();
         assert!(avatar_blob.exists().await);
@@ -353,8 +352,7 @@ mod tests {
         assert_eq!(img.width(), 900);
         assert_eq!(img.height(), 900);
 
-        t
-            .set_config(Config::Selfavatar, Some(&avatar_src.to_str().unwrap()))
+        t.set_config(Config::Selfavatar, Some(&avatar_src.to_str().unwrap()))
             .await
             .unwrap();
         let avatar_cfg = t.get_config(Config::Selfavatar).await;
@@ -376,8 +374,7 @@ mod tests {
             .unwrap();
         let avatar_blob = t.get_blobdir().join("avatar.png");
         assert!(!avatar_blob.exists().await);
-        t
-            .set_config(Config::Selfavatar, Some(&avatar_src.to_str().unwrap()))
+        t.set_config(Config::Selfavatar, Some(&avatar_src.to_str().unwrap()))
             .await
             .unwrap();
         assert!(avatar_blob.exists().await);
@@ -397,10 +394,7 @@ mod tests {
         let media_quality = constants::MediaQuality::from_i32(media_quality).unwrap_or_default();
         assert_eq!(media_quality, constants::MediaQuality::Balanced);
 
-        t
-            .set_config(Config::MediaQuality, Some("1"))
-            .await
-            .unwrap();
+        t.set_config(Config::MediaQuality, Some("1")).await.unwrap();
 
         let media_quality = t.get_config_int(Config::MediaQuality).await;
         assert_eq!(media_quality, 1);

--- a/src/config.rs
+++ b/src/config.rs
@@ -319,15 +319,15 @@ mod tests {
             .unwrap()
             .write_all(avatar_bytes)
             .unwrap();
-        let avatar_blob = t.ctx.get_blobdir().join("avatar.jpg");
+        let avatar_blob = t.get_blobdir().join("avatar.jpg");
         assert!(!avatar_blob.exists().await);
-        t.ctx
+        t
             .set_config(Config::Selfavatar, Some(&avatar_src.to_str().unwrap()))
             .await
             .unwrap();
         assert!(avatar_blob.exists().await);
         assert!(std::fs::metadata(&avatar_blob).unwrap().len() < avatar_bytes.len() as u64);
-        let avatar_cfg = t.ctx.get_config(Config::Selfavatar).await;
+        let avatar_cfg = t.get_config(Config::Selfavatar).await;
         assert_eq!(avatar_cfg, avatar_blob.to_str().map(|s| s.to_string()));
 
         let img = image::open(avatar_src).unwrap();
@@ -342,7 +342,7 @@ mod tests {
     #[async_std::test]
     async fn test_selfavatar_in_blobdir() {
         let t = TestContext::new().await;
-        let avatar_src = t.ctx.get_blobdir().join("avatar.png");
+        let avatar_src = t.get_blobdir().join("avatar.png");
         let avatar_bytes = include_bytes!("../test-data/image/avatar900x900.png");
         File::create(&avatar_src)
             .unwrap()
@@ -353,11 +353,11 @@ mod tests {
         assert_eq!(img.width(), 900);
         assert_eq!(img.height(), 900);
 
-        t.ctx
+        t
             .set_config(Config::Selfavatar, Some(&avatar_src.to_str().unwrap()))
             .await
             .unwrap();
-        let avatar_cfg = t.ctx.get_config(Config::Selfavatar).await;
+        let avatar_cfg = t.get_config(Config::Selfavatar).await;
         assert_eq!(avatar_cfg, avatar_src.to_str().map(|s| s.to_string()));
 
         let img = image::open(avatar_src).unwrap();
@@ -374,9 +374,9 @@ mod tests {
             .unwrap()
             .write_all(avatar_bytes)
             .unwrap();
-        let avatar_blob = t.ctx.get_blobdir().join("avatar.png");
+        let avatar_blob = t.get_blobdir().join("avatar.png");
         assert!(!avatar_blob.exists().await);
-        t.ctx
+        t
             .set_config(Config::Selfavatar, Some(&avatar_src.to_str().unwrap()))
             .await
             .unwrap();
@@ -385,24 +385,24 @@ mod tests {
             std::fs::metadata(&avatar_blob).unwrap().len(),
             avatar_bytes.len() as u64
         );
-        let avatar_cfg = t.ctx.get_config(Config::Selfavatar).await;
+        let avatar_cfg = t.get_config(Config::Selfavatar).await;
         assert_eq!(avatar_cfg, avatar_blob.to_str().map(|s| s.to_string()));
     }
 
     #[async_std::test]
     async fn test_media_quality_config_option() {
         let t = TestContext::new().await;
-        let media_quality = t.ctx.get_config_int(Config::MediaQuality).await;
+        let media_quality = t.get_config_int(Config::MediaQuality).await;
         assert_eq!(media_quality, 0);
         let media_quality = constants::MediaQuality::from_i32(media_quality).unwrap_or_default();
         assert_eq!(media_quality, constants::MediaQuality::Balanced);
 
-        t.ctx
+        t
             .set_config(Config::MediaQuality, Some("1"))
             .await
             .unwrap();
 
-        let media_quality = t.ctx.get_config_int(Config::MediaQuality).await;
+        let media_quality = t.get_config_int(Config::MediaQuality).await;
         assert_eq!(media_quality, 1);
         assert_eq!(constants::MediaQuality::Worse as i32, 1);
         let media_quality = constants::MediaQuality::from_i32(media_quality).unwrap_or_default();

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -616,14 +616,10 @@ mod tests {
     #[async_std::test]
     async fn test_no_panic_on_bad_credentials() {
         let t = TestContext::new().await;
-        t
-            .set_config(Config::Addr, Some("probably@unexistant.addr"))
+        t.set_config(Config::Addr, Some("probably@unexistant.addr"))
             .await
             .unwrap();
-        t
-            .set_config(Config::MailPw, Some("123456"))
-            .await
-            .unwrap();
+        t.set_config(Config::MailPw, Some("123456")).await.unwrap();
         assert!(t.configure().await.is_err());
     }
 

--- a/src/configure/mod.rs
+++ b/src/configure/mod.rs
@@ -616,15 +616,15 @@ mod tests {
     #[async_std::test]
     async fn test_no_panic_on_bad_credentials() {
         let t = TestContext::new().await;
-        t.ctx
+        t
             .set_config(Config::Addr, Some("probably@unexistant.addr"))
             .await
             .unwrap();
-        t.ctx
+        t
             .set_config(Config::MailPw, Some("123456"))
             .await
             .unwrap();
-        assert!(t.ctx.configure().await.is_err());
+        assert!(t.configure().await.is_err());
     }
 
     #[async_std::test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -528,7 +528,7 @@ mod tests {
     #[async_std::test]
     async fn test_get_fresh_msgs() {
         let t = TestContext::new().await;
-        let fresh = t.ctx.get_fresh_msgs().await;
+        let fresh = t.get_fresh_msgs().await;
         assert!(fresh.is_empty())
     }
 
@@ -587,14 +587,14 @@ mod tests {
     #[async_std::test]
     async fn no_crashes_on_context_deref() {
         let t = TestContext::new().await;
-        std::mem::drop(t.ctx);
+        std::mem::drop(t);
     }
 
     #[async_std::test]
     async fn test_get_info() {
         let t = TestContext::new().await;
 
-        let info = t.ctx.get_info().await;
+        let info = t.get_info().await;
         assert!(info.get("database_dir").is_some());
     }
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2164,7 +2164,6 @@ mod tests {
         // create alice's account
         let t = TestContext::new_alice().await;
 
-        // create one-to-one with bob, archive one-to-one
         let bob_id = Contact::create(&t.ctx, "bob", "bob@example.com")
             .await
             .unwrap();

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2056,10 +2056,7 @@ mod tests {
     #[async_std::test]
     async fn test_adhoc_group_show_accepted_contact_unknown() {
         let t = TestContext::new_alice().await;
-        t
-            .set_config(Config::ShowEmails, Some("1"))
-            .await
-            .unwrap();
+        t.set_config(Config::ShowEmails, Some("1")).await.unwrap();
         dc_receive_imf(&t, GRP_MAIL, "INBOX", 1, false)
             .await
             .unwrap();
@@ -2072,13 +2069,8 @@ mod tests {
     #[async_std::test]
     async fn test_adhoc_group_show_accepted_contact_known() {
         let t = TestContext::new_alice().await;
-        t
-            .set_config(Config::ShowEmails, Some("1"))
-            .await
-            .unwrap();
-        Contact::create(&t, "Bob", "bob@example.com")
-            .await
-            .unwrap();
+        t.set_config(Config::ShowEmails, Some("1")).await.unwrap();
+        Contact::create(&t, "Bob", "bob@example.com").await.unwrap();
         dc_receive_imf(&t, GRP_MAIL, "INBOX", 1, false)
             .await
             .unwrap();
@@ -2092,10 +2084,7 @@ mod tests {
     #[async_std::test]
     async fn test_adhoc_group_show_accepted_contact_accepted() {
         let t = TestContext::new_alice().await;
-        t
-            .set_config(Config::ShowEmails, Some("1"))
-            .await
-            .unwrap();
+        t.set_config(Config::ShowEmails, Some("1")).await.unwrap();
 
         // accept Bob by accepting a delta-message from Bob
         dc_receive_imf(&t, MSGRMSG, "INBOX", 1, false)
@@ -2138,10 +2127,7 @@ mod tests {
     #[async_std::test]
     async fn test_adhoc_group_show_all() {
         let t = TestContext::new_alice().await;
-        t
-            .set_config(Config::ShowEmails, Some("2"))
-            .await
-            .unwrap();
+        t.set_config(Config::ShowEmails, Some("2")).await.unwrap();
         dc_receive_imf(&t, GRP_MAIL, "INBOX", 1, false)
             .await
             .unwrap();
@@ -2164,9 +2150,7 @@ mod tests {
         // create alice's account
         let t = TestContext::new_alice().await;
 
-        let bob_id = Contact::create(&t, "bob", "bob@example.com")
-            .await
-            .unwrap();
+        let bob_id = Contact::create(&t, "bob", "bob@example.com").await.unwrap();
         let one2one_id = chat::create_by_contact_id(&t, bob_id).await.unwrap();
         one2one_id
             .set_visibility(&t, ChatVisibility::Archived)
@@ -2180,10 +2164,7 @@ mod tests {
             .await
             .unwrap();
         chat::add_contact_to_chat(&t, group_id, bob_id).await;
-        assert_eq!(
-            chat::get_chat_msgs(&t, group_id, 0, None).await.len(),
-            0
-        );
+        assert_eq!(chat::get_chat_msgs(&t, group_id, 0, None).await.len(), 0);
         group_id
             .set_visibility(&t, ChatVisibility::Archived)
             .await
@@ -2231,9 +2212,7 @@ mod tests {
         } else {
             panic!("Wrong item type");
         };
-        let msg = message::Message::load_from_db(&t, *msg_id)
-            .await
-            .unwrap();
+        let msg = message::Message::load_from_db(&t, *msg_id).await.unwrap();
         assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
         assert_eq!(msg.text.unwrap(), "hello");
         assert_eq!(msg.state, MessageState::OutDelivered);
@@ -2278,13 +2257,8 @@ mod tests {
             false,
         )
         .await.unwrap();
-        assert_eq!(
-            chat::get_chat_msgs(&t, group_id, 0, None).await.len(),
-            1
-        );
-        let msg = message::Message::load_from_db(&t, *msg_id)
-            .await
-            .unwrap();
+        assert_eq!(chat::get_chat_msgs(&t, group_id, 0, None).await.len(), 1);
+        let msg = message::Message::load_from_db(&t, *msg_id).await.unwrap();
         assert_eq!(msg.state, MessageState::OutMdnRcvd);
 
         // check, the read-receipt has not unarchived the one2one
@@ -2338,9 +2312,7 @@ mod tests {
         let contact_id = Contact::create(&t, "foobar", "foobar@example.com")
             .await
             .unwrap();
-        let chat_id = chat::create_by_contact_id(&t, contact_id)
-            .await
-            .unwrap();
+        let chat_id = chat::create_by_contact_id(&t, contact_id).await.unwrap();
         dc_receive_imf(
             &t,
             b"From: =?UTF-8?B?0JjQvNGPLCDQpNCw0LzQuNC70LjRjw==?= <foobar@example.com>\n\
@@ -2370,9 +2342,7 @@ mod tests {
         } else {
             panic!("Wrong item type");
         };
-        let msg = message::Message::load_from_db(&t, *msg_id)
-            .await
-            .unwrap();
+        let msg = message::Message::load_from_db(&t, *msg_id).await.unwrap();
         assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
         assert_eq!(msg.text.unwrap(), "hello");
         assert_eq!(msg.param.get_int(Param::WantsMdn).unwrap(), 1);
@@ -2433,15 +2403,11 @@ mod tests {
             .await
             .unwrap();
 
-        let carl_contact_id = Contact::add_or_lookup(
-            &t,
-            "garabage",
-            "carl@host.tld",
-            Origin::IncomingUnknownFrom,
-        )
-        .await
-        .unwrap()
-        .0;
+        let carl_contact_id =
+            Contact::add_or_lookup(&t, "garabage", "carl@host.tld", Origin::IncomingUnknownFrom)
+                .await
+                .unwrap()
+                .0;
 
         dc_receive_imf(
             &t,
@@ -2624,9 +2590,7 @@ mod tests {
         let msg_id = chats.get_msg_id(0).unwrap();
 
         let raw = include_bytes!("../test-data/message/gmail_ndn_group.eml");
-        dc_receive_imf(&t, raw, "INBOX", 1, false)
-            .await
-            .unwrap();
+        dc_receive_imf(&t, raw, "INBOX", 1, false).await.unwrap();
 
         let msg = Message::load_from_db(&t, msg_id).await.unwrap();
 
@@ -2643,12 +2607,11 @@ mod tests {
         assert_eq!(
             last_msg.text,
             Some(
-                t
-                    .stock_string_repl_str(
-                        StockMessage::FailedSendingTo,
-                        "assidhfaaspocwaeofi@gmail.com",
-                    )
-                    .await,
+                t.stock_string_repl_str(
+                    StockMessage::FailedSendingTo,
+                    "assidhfaaspocwaeofi@gmail.com",
+                )
+                .await,
             )
         );
         assert_eq!(last_msg.from_id, DC_CONTACT_ID_INFO);
@@ -2670,11 +2633,7 @@ mod tests {
     #[async_std::test]
     async fn test_html_only_mail() {
         let t = TestContext::new_alice().await;
-        let msg = load_imf_email(
-            &t,
-            include_bytes!("../test-data/message/wrong-html.eml"),
-        )
-        .await;
+        let msg = load_imf_email(&t, include_bytes!("../test-data/message/wrong-html.eml")).await;
         assert_eq!(msg.text.unwrap(), "   Guten Abend,   \n\n   Lots of text   \n\n   text with Umlaut ä...   \n\n   MfG    [...]");
     }
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2029,134 +2029,134 @@ mod tests {
     #[async_std::test]
     async fn test_adhoc_group_show_chats_only() {
         let t = TestContext::new_alice().await;
-        assert_eq!(t.ctx.get_config_int(Config::ShowEmails).await, 0);
+        assert_eq!(t.get_config_int(Config::ShowEmails).await, 0);
 
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 0);
 
-        dc_receive_imf(&t.ctx, MSGRMSG, "INBOX", 1, false)
+        dc_receive_imf(&t, MSGRMSG, "INBOX", 1, false)
             .await
             .unwrap();
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
 
-        dc_receive_imf(&t.ctx, ONETOONE_NOREPLY_MAIL, "INBOX", 1, false)
+        dc_receive_imf(&t, ONETOONE_NOREPLY_MAIL, "INBOX", 1, false)
             .await
             .unwrap();
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
 
-        dc_receive_imf(&t.ctx, GRP_MAIL, "INBOX", 1, false)
+        dc_receive_imf(&t, GRP_MAIL, "INBOX", 1, false)
             .await
             .unwrap();
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
     }
 
     #[async_std::test]
     async fn test_adhoc_group_show_accepted_contact_unknown() {
         let t = TestContext::new_alice().await;
-        t.ctx
+        t
             .set_config(Config::ShowEmails, Some("1"))
             .await
             .unwrap();
-        dc_receive_imf(&t.ctx, GRP_MAIL, "INBOX", 1, false)
+        dc_receive_imf(&t, GRP_MAIL, "INBOX", 1, false)
             .await
             .unwrap();
 
         // adhoc-group with unknown contacts with show_emails=accepted is ignored for unknown contacts
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 0);
     }
 
     #[async_std::test]
     async fn test_adhoc_group_show_accepted_contact_known() {
         let t = TestContext::new_alice().await;
-        t.ctx
+        t
             .set_config(Config::ShowEmails, Some("1"))
             .await
             .unwrap();
-        Contact::create(&t.ctx, "Bob", "bob@example.com")
+        Contact::create(&t, "Bob", "bob@example.com")
             .await
             .unwrap();
-        dc_receive_imf(&t.ctx, GRP_MAIL, "INBOX", 1, false)
+        dc_receive_imf(&t, GRP_MAIL, "INBOX", 1, false)
             .await
             .unwrap();
 
         // adhoc-group with known contacts with show_emails=accepted is still ignored for known contacts
         // (and existent chat is required)
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 0);
     }
 
     #[async_std::test]
     async fn test_adhoc_group_show_accepted_contact_accepted() {
         let t = TestContext::new_alice().await;
-        t.ctx
+        t
             .set_config(Config::ShowEmails, Some("1"))
             .await
             .unwrap();
 
         // accept Bob by accepting a delta-message from Bob
-        dc_receive_imf(&t.ctx, MSGRMSG, "INBOX", 1, false)
+        dc_receive_imf(&t, MSGRMSG, "INBOX", 1, false)
             .await
             .unwrap();
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         assert!(chats.get_chat_id(0).is_deaddrop());
-        let chat_id = chat::create_by_msg_id(&t.ctx, chats.get_msg_id(0).unwrap())
+        let chat_id = chat::create_by_msg_id(&t, chats.get_msg_id(0).unwrap())
             .await
             .unwrap();
         assert!(!chat_id.is_special());
-        let chat = chat::Chat::load_from_db(&t.ctx, chat_id).await.unwrap();
+        let chat = chat::Chat::load_from_db(&t, chat_id).await.unwrap();
         assert_eq!(chat.typ, Chattype::Single);
         assert_eq!(chat.name, "Bob");
-        assert_eq!(chat::get_chat_contacts(&t.ctx, chat_id).await.len(), 1);
-        assert_eq!(chat::get_chat_msgs(&t.ctx, chat_id, 0, None).await.len(), 1);
+        assert_eq!(chat::get_chat_contacts(&t, chat_id).await.len(), 1);
+        assert_eq!(chat::get_chat_msgs(&t, chat_id, 0, None).await.len(), 1);
 
         // receive a non-delta-message from Bob, shows up because of the show_emails setting
-        dc_receive_imf(&t.ctx, ONETOONE_NOREPLY_MAIL, "INBOX", 2, false)
+        dc_receive_imf(&t, ONETOONE_NOREPLY_MAIL, "INBOX", 2, false)
             .await
             .unwrap();
-        assert_eq!(chat::get_chat_msgs(&t.ctx, chat_id, 0, None).await.len(), 2);
+        assert_eq!(chat::get_chat_msgs(&t, chat_id, 0, None).await.len(), 2);
 
         // let Bob create an adhoc-group by a non-delta-message, shows up because of the show_emails setting
-        dc_receive_imf(&t.ctx, GRP_MAIL, "INBOX", 3, false)
+        dc_receive_imf(&t, GRP_MAIL, "INBOX", 3, false)
             .await
             .unwrap();
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 2);
-        let chat_id = chat::create_by_msg_id(&t.ctx, chats.get_msg_id(0).unwrap())
+        let chat_id = chat::create_by_msg_id(&t, chats.get_msg_id(0).unwrap())
             .await
             .unwrap();
-        let chat = chat::Chat::load_from_db(&t.ctx, chat_id).await.unwrap();
+        let chat = chat::Chat::load_from_db(&t, chat_id).await.unwrap();
         assert_eq!(chat.typ, Chattype::Group);
         assert_eq!(chat.name, "group with Alice, Bob and Claire");
-        assert_eq!(chat::get_chat_contacts(&t.ctx, chat_id).await.len(), 3);
+        assert_eq!(chat::get_chat_contacts(&t, chat_id).await.len(), 3);
     }
 
     #[async_std::test]
     async fn test_adhoc_group_show_all() {
         let t = TestContext::new_alice().await;
-        t.ctx
+        t
             .set_config(Config::ShowEmails, Some("2"))
             .await
             .unwrap();
-        dc_receive_imf(&t.ctx, GRP_MAIL, "INBOX", 1, false)
+        dc_receive_imf(&t, GRP_MAIL, "INBOX", 1, false)
             .await
             .unwrap();
 
         // adhoc-group with unknown contacts with show_emails=all will show up in the deaddrop
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         assert!(chats.get_chat_id(0).is_deaddrop());
-        let chat_id = chat::create_by_msg_id(&t.ctx, chats.get_msg_id(0).unwrap())
+        let chat_id = chat::create_by_msg_id(&t, chats.get_msg_id(0).unwrap())
             .await
             .unwrap();
-        let chat = chat::Chat::load_from_db(&t.ctx, chat_id).await.unwrap();
+        let chat = chat::Chat::load_from_db(&t, chat_id).await.unwrap();
         assert_eq!(chat.typ, Chattype::Group);
         assert_eq!(chat.name, "group with Alice, Bob and Claire");
-        assert_eq!(chat::get_chat_contacts(&t.ctx, chat_id).await.len(), 3);
+        assert_eq!(chat::get_chat_contacts(&t, chat_id).await.len(), 3);
     }
 
     #[async_std::test]
@@ -2164,36 +2164,36 @@ mod tests {
         // create alice's account
         let t = TestContext::new_alice().await;
 
-        let bob_id = Contact::create(&t.ctx, "bob", "bob@example.com")
+        let bob_id = Contact::create(&t, "bob", "bob@example.com")
             .await
             .unwrap();
-        let one2one_id = chat::create_by_contact_id(&t.ctx, bob_id).await.unwrap();
+        let one2one_id = chat::create_by_contact_id(&t, bob_id).await.unwrap();
         one2one_id
-            .set_visibility(&t.ctx, ChatVisibility::Archived)
+            .set_visibility(&t, ChatVisibility::Archived)
             .await
             .unwrap();
-        let one2one = Chat::load_from_db(&t.ctx, one2one_id).await.unwrap();
+        let one2one = Chat::load_from_db(&t, one2one_id).await.unwrap();
         assert!(one2one.get_visibility() == ChatVisibility::Archived);
 
         // create a group with bob, archive group
-        let group_id = chat::create_group_chat(&t.ctx, ProtectionStatus::Unprotected, "foo")
+        let group_id = chat::create_group_chat(&t, ProtectionStatus::Unprotected, "foo")
             .await
             .unwrap();
-        chat::add_contact_to_chat(&t.ctx, group_id, bob_id).await;
+        chat::add_contact_to_chat(&t, group_id, bob_id).await;
         assert_eq!(
-            chat::get_chat_msgs(&t.ctx, group_id, 0, None).await.len(),
+            chat::get_chat_msgs(&t, group_id, 0, None).await.len(),
             0
         );
         group_id
-            .set_visibility(&t.ctx, ChatVisibility::Archived)
+            .set_visibility(&t, ChatVisibility::Archived)
             .await
             .unwrap();
-        let group = Chat::load_from_db(&t.ctx, group_id).await.unwrap();
+        let group = Chat::load_from_db(&t, group_id).await.unwrap();
         assert!(group.get_visibility() == ChatVisibility::Archived);
 
         // everything archived, chatlist should be empty
         assert_eq!(
-            Chatlist::try_load(&t.ctx, DC_GCL_NO_SPECIALS, None, None)
+            Chatlist::try_load(&t, DC_GCL_NO_SPECIALS, None, None)
                 .await
                 .unwrap()
                 .len(),
@@ -2202,7 +2202,7 @@ mod tests {
 
         // send a message to group with bob
         dc_receive_imf(
-            &t.ctx,
+            &t,
             format!(
                 "From: alice@example.com\n\
                  To: bob@example.com\n\
@@ -2224,25 +2224,25 @@ mod tests {
         )
         .await
         .unwrap();
-        let msgs = chat::get_chat_msgs(&t.ctx, group_id, 0, None).await;
+        let msgs = chat::get_chat_msgs(&t, group_id, 0, None).await;
         assert_eq!(msgs.len(), 1);
         let msg_id = if let ChatItem::Message { msg_id } = msgs.first().unwrap() {
             msg_id
         } else {
             panic!("Wrong item type");
         };
-        let msg = message::Message::load_from_db(&t.ctx, *msg_id)
+        let msg = message::Message::load_from_db(&t, *msg_id)
             .await
             .unwrap();
         assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
         assert_eq!(msg.text.unwrap(), "hello");
         assert_eq!(msg.state, MessageState::OutDelivered);
-        let group = Chat::load_from_db(&t.ctx, group_id).await.unwrap();
+        let group = Chat::load_from_db(&t, group_id).await.unwrap();
         assert!(group.get_visibility() == ChatVisibility::Normal);
 
         // bob sends a read receipt to the group
         dc_receive_imf(
-            &t.ctx,
+            &t,
             format!(
                 "From: bob@example.com\n\
                  To: alice@example.com\n\
@@ -2279,23 +2279,23 @@ mod tests {
         )
         .await.unwrap();
         assert_eq!(
-            chat::get_chat_msgs(&t.ctx, group_id, 0, None).await.len(),
+            chat::get_chat_msgs(&t, group_id, 0, None).await.len(),
             1
         );
-        let msg = message::Message::load_from_db(&t.ctx, *msg_id)
+        let msg = message::Message::load_from_db(&t, *msg_id)
             .await
             .unwrap();
         assert_eq!(msg.state, MessageState::OutMdnRcvd);
 
         // check, the read-receipt has not unarchived the one2one
         assert_eq!(
-            Chatlist::try_load(&t.ctx, DC_GCL_NO_SPECIALS, None, None)
+            Chatlist::try_load(&t, DC_GCL_NO_SPECIALS, None, None)
                 .await
                 .unwrap()
                 .len(),
             1
         );
-        let one2one = Chat::load_from_db(&t.ctx, one2one_id).await.unwrap();
+        let one2one = Chat::load_from_db(&t, one2one_id).await.unwrap();
         assert!(one2one.get_visibility() == ChatVisibility::Archived);
     }
 
@@ -2306,9 +2306,9 @@ mod tests {
         // "deaddrop" chat) to avoid a re-download from the server. See also [**]
 
         let t = TestContext::new_alice().await;
-        let context = &t.ctx;
+        let context = &t;
 
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert!(chats.get_msg_id(0).is_err());
 
         dc_receive_imf(
@@ -2327,7 +2327,7 @@ mod tests {
         .await
         .unwrap();
 
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         // Check that the message was added to the database:
         assert!(chats.get_msg_id(0).is_ok());
     }
@@ -2335,14 +2335,14 @@ mod tests {
     #[async_std::test]
     async fn test_escaped_from() {
         let t = TestContext::new_alice().await;
-        let contact_id = Contact::create(&t.ctx, "foobar", "foobar@example.com")
+        let contact_id = Contact::create(&t, "foobar", "foobar@example.com")
             .await
             .unwrap();
-        let chat_id = chat::create_by_contact_id(&t.ctx, contact_id)
+        let chat_id = chat::create_by_contact_id(&t, contact_id)
             .await
             .unwrap();
         dc_receive_imf(
-            &t.ctx,
+            &t,
             b"From: =?UTF-8?B?0JjQvNGPLCDQpNCw0LzQuNC70LjRjw==?= <foobar@example.com>\n\
                  To: alice@example.com\n\
                  Subject: foo\n\
@@ -2357,20 +2357,20 @@ mod tests {
             false,
         ).await.unwrap();
         assert_eq!(
-            Contact::load_from_db(&t.ctx, contact_id)
+            Contact::load_from_db(&t, contact_id)
                 .await
                 .unwrap()
                 .get_authname(),
             "Имя, Фамилия",
         );
-        let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0, None).await;
+        let msgs = chat::get_chat_msgs(&t, chat_id, 0, None).await;
         assert_eq!(msgs.len(), 1);
         let msg_id = if let ChatItem::Message { msg_id } = msgs.first().unwrap() {
             msg_id
         } else {
             panic!("Wrong item type");
         };
-        let msg = message::Message::load_from_db(&t.ctx, *msg_id)
+        let msg = message::Message::load_from_db(&t, *msg_id)
             .await
             .unwrap();
         assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
@@ -2381,18 +2381,18 @@ mod tests {
     #[async_std::test]
     async fn test_escaped_recipients() {
         let t = TestContext::new_alice().await;
-        Contact::create(&t.ctx, "foobar", "foobar@example.com")
+        Contact::create(&t, "foobar", "foobar@example.com")
             .await
             .unwrap();
 
         let carl_contact_id =
-            Contact::add_or_lookup(&t.ctx, "Carl", "carl@host.tld", Origin::IncomingUnknownFrom)
+            Contact::add_or_lookup(&t, "Carl", "carl@host.tld", Origin::IncomingUnknownFrom)
                 .await
                 .unwrap()
                 .0;
 
         dc_receive_imf(
-            &t.ctx,
+            &t,
             b"From: Foobar <foobar@example.com>\n\
                  To: =?UTF-8?B?0JjQvNGPLCDQpNCw0LzQuNC70LjRjw==?= alice@example.com\n\
                  Cc: =?utf-8?q?=3Ch2=3E?= <carl@host.tld>\n\
@@ -2410,15 +2410,15 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            Contact::load_from_db(&t.ctx, carl_contact_id)
+            Contact::load_from_db(&t, carl_contact_id)
                 .await
                 .unwrap()
                 .get_name(),
             "h2"
         );
 
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
-        let msg = Message::load_from_db(&t.ctx, chats.get_msg_id(0).unwrap())
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
+        let msg = Message::load_from_db(&t, chats.get_msg_id(0).unwrap())
             .await
             .unwrap();
         assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
@@ -2429,12 +2429,12 @@ mod tests {
     #[async_std::test]
     async fn test_cc_to_contact() {
         let t = TestContext::new_alice().await;
-        Contact::create(&t.ctx, "foobar", "foobar@example.com")
+        Contact::create(&t, "foobar", "foobar@example.com")
             .await
             .unwrap();
 
         let carl_contact_id = Contact::add_or_lookup(
-            &t.ctx,
+            &t,
             "garabage",
             "carl@host.tld",
             Origin::IncomingUnknownFrom,
@@ -2444,7 +2444,7 @@ mod tests {
         .0;
 
         dc_receive_imf(
-            &t.ctx,
+            &t,
             b"From: Foobar <foobar@example.com>\n\
                  To: alice@example.com\n\
                  Cc: Carl <carl@host.tld>\n\
@@ -2462,7 +2462,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            Contact::load_from_db(&t.ctx, carl_contact_id)
+            Contact::load_from_db(&t, carl_contact_id)
                 .await
                 .unwrap()
                 .get_name(),
@@ -2554,7 +2554,7 @@ mod tests {
         t.configure_addr(self_addr).await;
 
         dc_receive_imf(
-            &t.ctx,
+            &t,
             format!(
                 "From: {}\n\
                 To: {}\n\
@@ -2574,21 +2574,21 @@ mod tests {
         .await
         .unwrap();
 
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         let msg_id = chats.get_msg_id(0).unwrap();
 
         // Check that the ndn would be downloaded:
         let headers = mailparse::parse_mail(raw_ndn).unwrap().headers;
         assert!(
-            crate::imap::prefetch_should_download(&t.ctx, &headers, ShowEmails::Off)
+            crate::imap::prefetch_should_download(&t, &headers, ShowEmails::Off)
                 .await
                 .unwrap()
         );
 
-        dc_receive_imf(&t.ctx, raw_ndn, "INBOX", 1, false)
+        dc_receive_imf(&t, raw_ndn, "INBOX", 1, false)
             .await
             .unwrap();
-        let msg = Message::load_from_db(&t.ctx, msg_id).await.unwrap();
+        let msg = Message::load_from_db(&t, msg_id).await.unwrap();
 
         assert_eq!(msg.state, MessageState::OutFailed);
 
@@ -2601,7 +2601,7 @@ mod tests {
         t.configure_addr("alice@gmail.com").await;
 
         dc_receive_imf(
-            &t.ctx,
+            &t,
             b"From: alice@gmail.com\n\
                  To: bob@example.com, assidhfaaspocwaeofi@gmail.com\n\
                  Subject: foo\n\
@@ -2620,30 +2620,30 @@ mod tests {
         .await
         .unwrap();
 
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         let msg_id = chats.get_msg_id(0).unwrap();
 
         let raw = include_bytes!("../test-data/message/gmail_ndn_group.eml");
-        dc_receive_imf(&t.ctx, raw, "INBOX", 1, false)
+        dc_receive_imf(&t, raw, "INBOX", 1, false)
             .await
             .unwrap();
 
-        let msg = Message::load_from_db(&t.ctx, msg_id).await.unwrap();
+        let msg = Message::load_from_db(&t, msg_id).await.unwrap();
 
         assert_eq!(msg.state, MessageState::OutFailed);
 
-        let msgs = chat::get_chat_msgs(&t.ctx, msg.chat_id, 0, None).await;
+        let msgs = chat::get_chat_msgs(&t, msg.chat_id, 0, None).await;
         let msg_id = if let ChatItem::Message { msg_id } = msgs.last().unwrap() {
             msg_id
         } else {
             panic!("Wrong item type");
         };
-        let last_msg = Message::load_from_db(&t.ctx, *msg_id).await.unwrap();
+        let last_msg = Message::load_from_db(&t, *msg_id).await.unwrap();
 
         assert_eq!(
             last_msg.text,
             Some(
-                t.ctx
+                t
                     .stock_string_repl_str(
                         StockMessage::FailedSendingTo,
                         "assidhfaaspocwaeofi@gmail.com",
@@ -2671,7 +2671,7 @@ mod tests {
     async fn test_html_only_mail() {
         let t = TestContext::new_alice().await;
         let msg = load_imf_email(
-            &t.ctx,
+            &t,
             include_bytes!("../test-data/message/wrong-html.eml"),
         )
         .await;
@@ -2682,7 +2682,7 @@ mod tests {
     async fn test_pdf_filename_simple() {
         let t = TestContext::new_alice().await;
         let msg = load_imf_email(
-            &t.ctx,
+            &t,
             include_bytes!("../test-data/message/pdf_filename_simple.eml"),
         )
         .await;
@@ -2696,7 +2696,7 @@ mod tests {
         // test filenames split across multiple header lines, see rfc 2231
         let t = TestContext::new_alice().await;
         let msg = load_imf_email(
-            &t.ctx,
+            &t,
             include_bytes!("../test-data/message/pdf_filename_continuation.eml"),
         )
         .await;

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -357,13 +357,13 @@ mod tests {
         async fn test_prexisting() {
             let t = TestContext::new().await;
             let test_addr = t.configure_alice().await;
-            assert_eq!(ensure_secret_key_exists(&t.ctx).await.unwrap(), test_addr);
+            assert_eq!(ensure_secret_key_exists(&t).await.unwrap(), test_addr);
         }
 
         #[async_std::test]
         async fn test_not_configured() {
             let t = TestContext::new().await;
-            assert!(ensure_secret_key_exists(&t.ctx).await.is_err());
+            assert!(ensure_secret_key_exists(&t).await.is_err());
         }
     }
 
@@ -526,28 +526,28 @@ Sent with my Delta Chat Messenger: https://delta.chat";
     #[async_std::test]
     async fn test_should_encrypt() {
         let t = TestContext::new_alice().await;
-        let encrypt_helper = EncryptHelper::new(&t.ctx).await.unwrap();
+        let encrypt_helper = EncryptHelper::new(&t).await.unwrap();
 
         // test with EncryptPreference::NoPreference:
         // if e2ee_eguaranteed is unset, there is no encryption as not more than half of peers want encryption
-        let ps = new_peerstates(&t.ctx, EncryptPreference::NoPreference);
-        assert!(encrypt_helper.should_encrypt(&t.ctx, true, &ps).unwrap());
-        assert!(!encrypt_helper.should_encrypt(&t.ctx, false, &ps).unwrap());
+        let ps = new_peerstates(&t, EncryptPreference::NoPreference);
+        assert!(encrypt_helper.should_encrypt(&t, true, &ps).unwrap());
+        assert!(!encrypt_helper.should_encrypt(&t, false, &ps).unwrap());
 
         // test with EncryptPreference::Reset
-        let ps = new_peerstates(&t.ctx, EncryptPreference::Reset);
-        assert!(encrypt_helper.should_encrypt(&t.ctx, true, &ps).unwrap());
-        assert!(!encrypt_helper.should_encrypt(&t.ctx, false, &ps).unwrap());
+        let ps = new_peerstates(&t, EncryptPreference::Reset);
+        assert!(encrypt_helper.should_encrypt(&t, true, &ps).unwrap());
+        assert!(!encrypt_helper.should_encrypt(&t, false, &ps).unwrap());
 
         // test with EncryptPreference::Mutual (self is also Mutual)
-        let ps = new_peerstates(&t.ctx, EncryptPreference::Mutual);
-        assert!(encrypt_helper.should_encrypt(&t.ctx, true, &ps).unwrap());
-        assert!(encrypt_helper.should_encrypt(&t.ctx, false, &ps).unwrap());
+        let ps = new_peerstates(&t, EncryptPreference::Mutual);
+        assert!(encrypt_helper.should_encrypt(&t, true, &ps).unwrap());
+        assert!(encrypt_helper.should_encrypt(&t, false, &ps).unwrap());
 
         // test with missing peerstate
         let mut ps = Vec::new();
         ps.push((None, "bob@foo.bar"));
-        assert!(encrypt_helper.should_encrypt(&t.ctx, true, &ps).is_err());
-        assert!(!encrypt_helper.should_encrypt(&t.ctx, false, &ps).unwrap());
+        assert!(encrypt_helper.should_encrypt(&t, true, &ps).is_err());
+        assert!(!encrypt_helper.should_encrypt(&t, false, &ps).unwrap());
     }
 }

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -346,7 +346,6 @@ mod tests {
 
     use crate::chat;
     use crate::constants::Viewtype;
-    use crate::contact::{Contact, Origin};
     use crate::message::Message;
     use crate::param::Param;
     use crate::test_utils::*;
@@ -415,23 +414,8 @@ Sent with my Delta Chat Messenger: https://delta.chat";
         let alice = TestContext::new_alice().await;
         let bob = TestContext::new_bob().await;
 
-        let (contact_alice_id, _modified) = Contact::add_or_lookup(
-            &bob.ctx,
-            "Alice",
-            "alice@example.com",
-            Origin::ManuallyCreated,
-        )
-        .await?;
-        let (contact_bob_id, _modified) = Contact::add_or_lookup(
-            &alice.ctx,
-            "Bob",
-            "bob@example.net",
-            Origin::ManuallyCreated,
-        )
-        .await?;
-
-        let chat_alice = chat::create_by_contact_id(&alice.ctx, contact_bob_id).await?;
-        let chat_bob = chat::create_by_contact_id(&bob.ctx, contact_alice_id).await?;
+        let chat_alice = alice.create_chat(&bob).await.id;
+        let chat_bob = bob.create_chat(&alice).await.id;
 
         // Alice sends unencrypted message to Bob
         let mut msg = Message::new(Viewtype::Text);

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -461,7 +461,6 @@ pub(crate) async fn start_ephemeral_timers(context: &Context) -> sql::Result<()>
 mod tests {
     use super::*;
     use crate::chat;
-    use crate::contact::{Contact, Origin};
     use crate::test_utils::*;
 
     #[async_std::test]
@@ -533,23 +532,8 @@ mod tests {
         let alice = TestContext::new_alice().await;
         let bob = TestContext::new_bob().await;
 
-        let (contact_alice_id, _modified) = Contact::add_or_lookup(
-            &bob.ctx,
-            "Alice",
-            "alice@example.com",
-            Origin::ManuallyCreated,
-        )
-        .await?;
-        let (contact_bob_id, _modified) = Contact::add_or_lookup(
-            &alice.ctx,
-            "Bob",
-            "bob@example.net",
-            Origin::ManuallyCreated,
-        )
-        .await?;
-
-        let chat_alice = chat::create_by_contact_id(&alice.ctx, contact_bob_id).await?;
-        let chat_bob = chat::create_by_contact_id(&bob.ctx, contact_alice_id).await?;
+        let chat_alice = alice.create_chat(&bob).await.id;
+        let chat_bob = bob.create_chat(&alice).await.id;
 
         // Alice sends message to Bob
         let mut msg = Message::new(Viewtype::Text);

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -909,7 +909,7 @@ mod tests {
         let t = TestContext::new().await;
 
         t.configure_alice().await;
-        let msg = render_setup_file(&t.ctx, "hello").await.unwrap();
+        let msg = render_setup_file(&t, "hello").await.unwrap();
         println!("{}", &msg);
         // Check some substrings, indicating things got substituted.
         // In particular note the mixing of `\r\n` and `\n` depending
@@ -926,12 +926,11 @@ mod tests {
     #[async_std::test]
     async fn test_render_setup_file_newline_replace() {
         let t = TestContext::new().await;
-        t.ctx
-            .set_stock_translation(StockMessage::AcSetupMsgBody, "hello\r\nthere".to_string())
+        t.set_stock_translation(StockMessage::AcSetupMsgBody, "hello\r\nthere".to_string())
             .await
             .unwrap();
         t.configure_alice().await;
-        let msg = render_setup_file(&t.ctx, "pw").await.unwrap();
+        let msg = render_setup_file(&t, "pw").await.unwrap();
         println!("{}", &msg);
         assert!(msg.contains("<p>hello<br>there</p>"));
     }
@@ -939,7 +938,7 @@ mod tests {
     #[async_std::test]
     async fn test_create_setup_code() {
         let t = TestContext::new().await;
-        let setupcode = create_setup_code(&t.ctx);
+        let setupcode = create_setup_code(&t);
         assert_eq!(setupcode.len(), 44);
         assert_eq!(setupcode.chars().nth(4).unwrap(), '-');
         assert_eq!(setupcode.chars().nth(9).unwrap(), '-');

--- a/src/job.rs
+++ b/src/job.rs
@@ -1372,18 +1372,18 @@ mod tests {
         // fails to load from the database instead of failing to load
         // all jobs.
         let t = TestContext::new().await;
-        insert_job(&t.ctx, -1).await; // This can not be loaded into Job struct.
+        insert_job(&t, -1).await; // This can not be loaded into Job struct.
         let jobs = load_next(
-            &t.ctx,
+            &t,
             Thread::from(Action::MoveMsg),
             &InterruptInfo::new(false, None),
         )
         .await;
         assert!(jobs.is_none());
 
-        insert_job(&t.ctx, 1).await;
+        insert_job(&t, 1).await;
         let jobs = load_next(
-            &t.ctx,
+            &t,
             Thread::from(Action::MoveMsg),
             &InterruptInfo::new(false, None),
         )
@@ -1395,10 +1395,10 @@ mod tests {
     async fn test_load_next_job_one() {
         let t = TestContext::new().await;
 
-        insert_job(&t.ctx, 1).await;
+        insert_job(&t, 1).await;
 
         let jobs = load_next(
-            &t.ctx,
+            &t,
             Thread::from(Action::MoveMsg),
             &InterruptInfo::new(false, None),
         )

--- a/src/key.rs
+++ b/src/key.rs
@@ -558,31 +558,31 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
         let alice = alice_keypair();
         let t = TestContext::new().await;
         t.configure_alice().await;
-        let pubkey = SignedPublicKey::load_self(&t.ctx).await.unwrap();
+        let pubkey = SignedPublicKey::load_self(&t).await.unwrap();
         assert_eq!(alice.public, pubkey);
-        let seckey = SignedSecretKey::load_self(&t.ctx).await.unwrap();
+        let seckey = SignedSecretKey::load_self(&t).await.unwrap();
         assert_eq!(alice.secret, seckey);
     }
 
     #[async_std::test]
     async fn test_load_self_generate_public() {
         let t = TestContext::new().await;
-        t.ctx
+        t
             .set_config(Config::ConfiguredAddr, Some("alice@example.com"))
             .await
             .unwrap();
-        let key = SignedPublicKey::load_self(&t.ctx).await;
+        let key = SignedPublicKey::load_self(&t).await;
         assert!(key.is_ok());
     }
 
     #[async_std::test]
     async fn test_load_self_generate_secret() {
         let t = TestContext::new().await;
-        t.ctx
+        t
             .set_config(Config::ConfiguredAddr, Some("alice@example.com"))
             .await
             .unwrap();
-        let key = SignedSecretKey::load_self(&t.ctx).await;
+        let key = SignedSecretKey::load_self(&t).await;
         assert!(key.is_ok());
     }
 
@@ -591,11 +591,11 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
         use std::thread;
 
         let t = TestContext::new().await;
-        t.ctx
+        t
             .set_config(Config::ConfiguredAddr, Some("alice@example.com"))
             .await
             .unwrap();
-        let ctx = t.ctx.clone();
+        let ctx = t.clone();
         let ctx0 = ctx.clone();
         let thr0 =
             thread::spawn(move || async_std::task::block_on(SignedPublicKey::load_self(&ctx0)));
@@ -618,7 +618,7 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
         // Saving the same key twice should result in only one row in
         // the keypairs table.
         let t = TestContext::new().await;
-        let ctx = Arc::new(t.ctx);
+        let ctx = Arc::new(t);
 
         let ctx1 = ctx.clone();
         let nrows = || async {

--- a/src/key.rs
+++ b/src/key.rs
@@ -567,8 +567,7 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
     #[async_std::test]
     async fn test_load_self_generate_public() {
         let t = TestContext::new().await;
-        t
-            .set_config(Config::ConfiguredAddr, Some("alice@example.com"))
+        t.set_config(Config::ConfiguredAddr, Some("alice@example.com"))
             .await
             .unwrap();
         let key = SignedPublicKey::load_self(&t).await;
@@ -578,8 +577,7 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
     #[async_std::test]
     async fn test_load_self_generate_secret() {
         let t = TestContext::new().await;
-        t
-            .set_config(Config::ConfiguredAddr, Some("alice@example.com"))
+        t.set_config(Config::ConfiguredAddr, Some("alice@example.com"))
             .await
             .unwrap();
         let key = SignedSecretKey::load_self(&t).await;
@@ -591,8 +589,7 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
         use std::thread;
 
         let t = TestContext::new().await;
-        t
-            .set_config(Config::ConfiguredAddr, Some("alice@example.com"))
+        t.set_config(Config::ConfiguredAddr, Some("alice@example.com"))
             .await
             .unwrap();
         let ctx = t.clone();

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -83,10 +83,10 @@ mod tests {
         t.configure_alice().await;
         let alice = alice_keypair();
 
-        let pub_ring: Keyring<SignedPublicKey> = Keyring::new_self(&t.ctx).await.unwrap();
+        let pub_ring: Keyring<SignedPublicKey> = Keyring::new_self(&t).await.unwrap();
         assert_eq!(pub_ring.keys(), [alice.public]);
 
-        let sec_ring: Keyring<SignedSecretKey> = Keyring::new_self(&t.ctx).await.unwrap();
+        let sec_ring: Keyring<SignedSecretKey> = Keyring::new_self(&t).await.unwrap();
         assert_eq!(sec_ring.keys(), [alice.secret]);
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -2057,17 +2057,17 @@ mod tests {
 
         // test that get_width() and get_height() are returning some dimensions for images;
         // (as the device-chat contains a welcome-images, we check that)
-        t.ctx.update_device_chats().await.ok();
+        t.update_device_chats().await.ok();
         let (device_chat_id, _) =
-            chat::create_or_lookup_by_contact_id(&t.ctx, DC_CONTACT_ID_DEVICE, Blocked::Not)
+            chat::create_or_lookup_by_contact_id(&t, DC_CONTACT_ID_DEVICE, Blocked::Not)
                 .await
                 .unwrap();
 
         let mut has_image = false;
-        let chatitems = chat::get_chat_msgs(&t.ctx, device_chat_id, 0, None).await;
+        let chatitems = chat::get_chat_msgs(&t, device_chat_id, 0, None).await;
         for chatitem in chatitems {
             if let ChatItem::Message { msg_id } = chatitem {
-                if let Ok(msg) = Message::load_from_db(&t.ctx, msg_id).await {
+                if let Ok(msg) = Message::load_from_db(&t, msg_id).await {
                     if msg.get_viewtype() == Viewtype::Image {
                         has_image = true;
                         // just check that width/height are inside some reasonable ranges

--- a/src/message.rs
+++ b/src/message.rs
@@ -1883,20 +1883,15 @@ mod tests {
         let d = test::TestContext::new().await;
         let ctx = &d.ctx;
 
-        let contact = Contact::create(ctx, "", "dest@example.com")
+        ctx.set_config(Config::ConfiguredAddr, Some("self@example.com"))
             .await
-            .expect("failed to create contact");
+            .unwrap();
 
-        let res = ctx
-            .set_config(Config::ConfiguredAddr, Some("self@example.com"))
-            .await;
-        assert!(res.is_ok());
-
-        let chat = chat::create_by_contact_id(ctx, contact).await.unwrap();
+        let chat = d.chat_with_contact("", "dest@example.com").await;
 
         let mut msg = Message::new(Viewtype::Text);
 
-        let msg_id = chat::prepare_msg(ctx, chat, &mut msg).await.unwrap();
+        let msg_id = chat::prepare_msg(ctx, chat.id, &mut msg).await.unwrap();
 
         let _msg2 = Message::load_from_db(ctx, msg_id).await.unwrap();
         assert_eq!(_msg2.get_filemime(), None);
@@ -1908,15 +1903,11 @@ mod tests {
         let d = test::TestContext::new().await;
         let ctx = &d.ctx;
 
-        let contact = Contact::create(ctx, "", "dest@example.com")
-            .await
-            .expect("failed to create contact");
-
-        let chat = chat::create_by_contact_id(ctx, contact).await.unwrap();
+        let chat = d.chat_with_contact("", "dest@example.com").await;
 
         let mut msg = Message::new(Viewtype::Text);
 
-        assert!(chat::prepare_msg(ctx, chat, &mut msg).await.is_err());
+        assert!(chat::prepare_msg(ctx, chat.id, &mut msg).await.is_err());
     }
 
     #[async_std::test]
@@ -2098,23 +2089,18 @@ mod tests {
         let d = test::TestContext::new().await;
         let ctx = &d.ctx;
 
-        let contact = Contact::create(ctx, "", "dest@example.com")
+        ctx.set_config(Config::ConfiguredAddr, Some("self@example.com"))
             .await
-            .expect("failed to create contact");
+            .unwrap();
 
-        let res = ctx
-            .set_config(Config::ConfiguredAddr, Some("self@example.com"))
-            .await;
-        assert!(res.is_ok());
-
-        let chat = chat::create_by_contact_id(ctx, contact).await.unwrap();
+        let chat = d.chat_with_contact("", "dest@example.com").await;
 
         let mut msg = Message::new(Viewtype::Text);
         msg.set_text(Some("Quoted message".to_string()));
 
         // Prepare message for sending, so it gets a Message-Id.
         assert!(msg.rfc724_mid.is_empty());
-        let msg_id = chat::prepare_msg(ctx, chat, &mut msg).await.unwrap();
+        let msg_id = chat::prepare_msg(ctx, chat.id, &mut msg).await.unwrap();
         let msg = Message::load_from_db(ctx, msg_id).await.unwrap();
         assert!(!msg.rfc724_mid.is_empty());
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1417,8 +1417,7 @@ mod tests {
         assert_eq!(first_subject_str(t).await, "Message from alice@example.com");
 
         let t = TestContext::new_alice().await;
-        t
-            .set_config(Config::Displayname, Some("Alice"))
+        t.set_config(Config::Displayname, Some("Alice"))
             .await
             .unwrap();
         assert_eq!(first_subject_str(t).await, "Message from Alice");
@@ -1492,9 +1491,7 @@ mod tests {
                  Original-Message-ID: <2893@example.com>\n\
                  Disposition: manual-action/MDN-sent-automatically; displayed\n\
                  \n", &t).await;
-        let mf = MimeFactory::from_msg(&t, &new_msg, false)
-            .await
-            .unwrap();
+        let mf = MimeFactory::from_msg(&t, &new_msg, false).await.unwrap();
         // The subject string should not be "Re: message opened"
         assert_eq!("Re: Hello, Charlie", mf.subject_str().await);
     }
@@ -1506,20 +1503,14 @@ mod tests {
                 .unwrap()
                 .0;
 
-        let chat_id = chat::create_by_contact_id(&t, contact_id)
-            .await
-            .unwrap();
+        let chat_id = chat::create_by_contact_id(&t, contact_id).await.unwrap();
 
         let mut new_msg = Message::new(Viewtype::Text);
         new_msg.set_text(Some("Hi".to_string()));
         new_msg.chat_id = chat_id;
-        chat::prepare_msg(&t, chat_id, &mut new_msg)
-            .await
-            .unwrap();
+        chat::prepare_msg(&t, chat_id, &mut new_msg).await.unwrap();
 
-        let mf = MimeFactory::from_msg(&t, &new_msg, false)
-            .await
-            .unwrap();
+        let mf = MimeFactory::from_msg(&t, &new_msg, false).await.unwrap();
 
         mf.subject_str().await
     }
@@ -1527,9 +1518,7 @@ mod tests {
     async fn msg_to_subject_str(imf_raw: &[u8]) -> String {
         let t = TestContext::new_alice().await;
         let new_msg = incoming_msg_to_reply_msg(imf_raw, &t).await;
-        let mf = MimeFactory::from_msg(&t, &new_msg, false)
-            .await
-            .unwrap();
+        let mf = MimeFactory::from_msg(&t, &new_msg, false).await.unwrap();
         mf.subject_str().await
     }
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1417,7 +1417,7 @@ mod tests {
         assert_eq!(first_subject_str(t).await, "Message from alice@example.com");
 
         let t = TestContext::new_alice().await;
-        t.ctx
+        t
             .set_config(Config::Displayname, Some("Alice"))
             .await
             .unwrap();
@@ -1453,7 +1453,7 @@ mod tests {
         // 5. Receive an mdn (read receipt) and make sure the mdn's subject is not used
         let t = TestContext::new_alice().await;
         dc_receive_imf(
-            &t.ctx,
+            &t,
             b"From: alice@example.com\n\
             To: Charlie <charlie@example.com>\n\
             Subject: Hello, Charlie\n\
@@ -1491,8 +1491,8 @@ mod tests {
                  Final-Recipient: rfc822;charlie@example.com\n\
                  Original-Message-ID: <2893@example.com>\n\
                  Disposition: manual-action/MDN-sent-automatically; displayed\n\
-                 \n", &t.ctx).await;
-        let mf = MimeFactory::from_msg(&t.ctx, &new_msg, false)
+                 \n", &t).await;
+        let mf = MimeFactory::from_msg(&t, &new_msg, false)
             .await
             .unwrap();
         // The subject string should not be "Re: message opened"
@@ -1501,23 +1501,23 @@ mod tests {
 
     async fn first_subject_str(t: TestContext) -> String {
         let contact_id =
-            Contact::add_or_lookup(&t.ctx, "Dave", "dave@example.com", Origin::ManuallyCreated)
+            Contact::add_or_lookup(&t, "Dave", "dave@example.com", Origin::ManuallyCreated)
                 .await
                 .unwrap()
                 .0;
 
-        let chat_id = chat::create_by_contact_id(&t.ctx, contact_id)
+        let chat_id = chat::create_by_contact_id(&t, contact_id)
             .await
             .unwrap();
 
         let mut new_msg = Message::new(Viewtype::Text);
         new_msg.set_text(Some("Hi".to_string()));
         new_msg.chat_id = chat_id;
-        chat::prepare_msg(&t.ctx, chat_id, &mut new_msg)
+        chat::prepare_msg(&t, chat_id, &mut new_msg)
             .await
             .unwrap();
 
-        let mf = MimeFactory::from_msg(&t.ctx, &new_msg, false)
+        let mf = MimeFactory::from_msg(&t, &new_msg, false)
             .await
             .unwrap();
 
@@ -1526,8 +1526,8 @@ mod tests {
 
     async fn msg_to_subject_str(imf_raw: &[u8]) -> String {
         let t = TestContext::new_alice().await;
-        let new_msg = incoming_msg_to_reply_msg(imf_raw, &t.ctx).await;
-        let mf = MimeFactory::from_msg(&t.ctx, &new_msg, false)
+        let new_msg = incoming_msg_to_reply_msg(imf_raw, &t).await;
+        let mf = MimeFactory::from_msg(&t, &new_msg, false)
             .await
             .unwrap();
         mf.subject_str().await
@@ -1564,7 +1564,7 @@ mod tests {
     // This test could still be extended
     async fn test_render_reply() {
         let t = TestContext::new_alice().await;
-        let context = &t.ctx;
+        let context = &t;
 
         let msg = incoming_msg_to_reply_msg(
             b"From: Charlie <charlie@example.com>\n\
@@ -1579,7 +1579,7 @@ mod tests {
         )
         .await;
 
-        let mimefactory = MimeFactory::from_msg(&t.ctx, &msg, false).await.unwrap();
+        let mimefactory = MimeFactory::from_msg(&t, &msg, false).await.unwrap();
 
         let recipients = mimefactory.recipients();
         assert_eq!(recipients, vec!["charlie@example.com"]);

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1493,8 +1493,8 @@ mod tests {
 
     fn load_mail_with_attachment<'a>(t: &'a TestContext, raw: &'a [u8]) -> ParsedMail<'a> {
         let mail = mailparse::parse_mail(raw).unwrap();
-        assert!(get_attachment_filename(&t.ctx, &mail).unwrap().is_none());
-        assert!(get_attachment_filename(&t.ctx, &mail.subparts[0])
+        assert!(get_attachment_filename(&t, &mail).unwrap().is_none());
+        assert!(get_attachment_filename(&t, &mail.subparts[0])
             .unwrap()
             .is_none());
         mail
@@ -1507,7 +1507,7 @@ mod tests {
             &t,
             include_bytes!("../test-data/message/attach_filename_simple.eml"),
         );
-        let filename = get_attachment_filename(&t.ctx, &mail.subparts[1]).unwrap();
+        let filename = get_attachment_filename(&t, &mail.subparts[1]).unwrap();
         assert_eq!(filename, Some("test.html".to_string()))
     }
 
@@ -1518,7 +1518,7 @@ mod tests {
             &t,
             include_bytes!("../test-data/message/attach_filename_encoded_words.eml"),
         );
-        let filename = get_attachment_filename(&t.ctx, &mail.subparts[1]).unwrap();
+        let filename = get_attachment_filename(&t, &mail.subparts[1]).unwrap();
         assert_eq!(filename, Some("Maßnahmen Okt. 2020.html".to_string()))
     }
 
@@ -1529,7 +1529,7 @@ mod tests {
             &t,
             include_bytes!("../test-data/message/attach_filename_encoded_words_binary.eml"),
         );
-        let filename = get_attachment_filename(&t.ctx, &mail.subparts[1]).unwrap();
+        let filename = get_attachment_filename(&t, &mail.subparts[1]).unwrap();
         assert_eq!(filename, Some(" § 165 Abs".to_string()))
     }
 
@@ -1540,7 +1540,7 @@ mod tests {
             &t,
             include_bytes!("../test-data/message/attach_filename_encoded_words_windows1251.eml"),
         );
-        let filename = get_attachment_filename(&t.ctx, &mail.subparts[1]).unwrap();
+        let filename = get_attachment_filename(&t, &mail.subparts[1]).unwrap();
         assert_eq!(filename, Some("file Что нового 2020.pdf".to_string()))
     }
 
@@ -1552,7 +1552,7 @@ mod tests {
             &t,
             include_bytes!("../test-data/message/attach_filename_encoded_words_cont.eml"),
         );
-        let filename = get_attachment_filename(&t.ctx, &mail.subparts[1]).unwrap();
+        let filename = get_attachment_filename(&t, &mail.subparts[1]).unwrap();
         assert_eq!(filename, Some("Maßn'ah'men Okt. 2020.html".to_string()))
     }
 
@@ -1563,7 +1563,7 @@ mod tests {
             &t,
             include_bytes!("../test-data/message/attach_filename_encoded_words_bad_delimiter.eml"),
         );
-        let filename = get_attachment_filename(&t.ctx, &mail.subparts[1]).unwrap();
+        let filename = get_attachment_filename(&t, &mail.subparts[1]).unwrap();
         // not decoded as a space is missing after encoded-words part
         assert_eq!(filename, Some("=?utf-8?q?foo?=.bar".to_string()))
     }
@@ -1575,7 +1575,7 @@ mod tests {
             &t,
             include_bytes!("../test-data/message/attach_filename_apostrophed.eml"),
         );
-        let filename = get_attachment_filename(&t.ctx, &mail.subparts[1]).unwrap();
+        let filename = get_attachment_filename(&t, &mail.subparts[1]).unwrap();
         assert_eq!(filename, Some("Maßnahmen Okt. 2021.html".to_string()))
     }
 
@@ -1586,7 +1586,7 @@ mod tests {
             &t,
             include_bytes!("../test-data/message/attach_filename_apostrophed_cont.eml"),
         );
-        let filename = get_attachment_filename(&t.ctx, &mail.subparts[1]).unwrap();
+        let filename = get_attachment_filename(&t, &mail.subparts[1]).unwrap();
         assert_eq!(filename, Some("Maßnahmen März 2022.html".to_string()))
     }
 
@@ -1597,7 +1597,7 @@ mod tests {
             &t,
             include_bytes!("../test-data/message/attach_filename_apostrophed_windows1251.eml"),
         );
-        let filename = get_attachment_filename(&t.ctx, &mail.subparts[1]).unwrap();
+        let filename = get_attachment_filename(&t, &mail.subparts[1]).unwrap();
         assert_eq!(filename, Some("программирование.HTM".to_string()))
     }
 
@@ -1608,7 +1608,7 @@ mod tests {
             &t,
             include_bytes!("../test-data/message/attach_filename_apostrophed_cp1252.eml"),
         );
-        let filename = get_attachment_filename(&t.ctx, &mail.subparts[1]).unwrap();
+        let filename = get_attachment_filename(&t, &mail.subparts[1]).unwrap();
         assert_eq!(filename, Some("Auftragsbestätigung.pdf".to_string()))
     }
 
@@ -1619,7 +1619,7 @@ mod tests {
             &t,
             include_bytes!("../test-data/message/attach_filename_apostrophed_invalid.eml"),
         );
-        let filename = get_attachment_filename(&t.ctx, &mail.subparts[1]).unwrap();
+        let filename = get_attachment_filename(&t, &mail.subparts[1]).unwrap();
         assert_eq!(filename, Some("somedäüta.html.zip".to_string()))
     }
 
@@ -1631,7 +1631,7 @@ mod tests {
             &t,
             include_bytes!("../test-data/message/attach_filename_combined.eml"),
         );
-        let filename = get_attachment_filename(&t.ctx, &mail.subparts[1]).unwrap();
+        let filename = get_attachment_filename(&t, &mail.subparts[1]).unwrap();
         assert_eq!(filename, Some("Maßnahmen Okt. 2020.html".to_string()))
     }
 
@@ -1764,26 +1764,26 @@ mod tests {
         let t = TestContext::new().await;
 
         let raw = include_bytes!("../test-data/message/mail_attach_txt.eml");
-        let mimeparser = MimeMessage::from_bytes(&t.ctx, &raw[..]).await.unwrap();
+        let mimeparser = MimeMessage::from_bytes(&t, &raw[..]).await.unwrap();
         assert_eq!(mimeparser.user_avatar, None);
         assert_eq!(mimeparser.group_avatar, None);
 
         let raw = include_bytes!("../test-data/message/mail_with_user_avatar.eml");
-        let mimeparser = MimeMessage::from_bytes(&t.ctx, &raw[..]).await.unwrap();
+        let mimeparser = MimeMessage::from_bytes(&t, &raw[..]).await.unwrap();
         assert_eq!(mimeparser.parts.len(), 1);
         assert_eq!(mimeparser.parts[0].typ, Viewtype::Text);
         assert!(mimeparser.user_avatar.unwrap().is_change());
         assert_eq!(mimeparser.group_avatar, None);
 
         let raw = include_bytes!("../test-data/message/mail_with_user_avatar_deleted.eml");
-        let mimeparser = MimeMessage::from_bytes(&t.ctx, &raw[..]).await.unwrap();
+        let mimeparser = MimeMessage::from_bytes(&t, &raw[..]).await.unwrap();
         assert_eq!(mimeparser.parts.len(), 1);
         assert_eq!(mimeparser.parts[0].typ, Viewtype::Text);
         assert_eq!(mimeparser.user_avatar, Some(AvatarAction::Delete));
         assert_eq!(mimeparser.group_avatar, None);
 
         let raw = include_bytes!("../test-data/message/mail_with_user_and_group_avatars.eml");
-        let mimeparser = MimeMessage::from_bytes(&t.ctx, &raw[..]).await.unwrap();
+        let mimeparser = MimeMessage::from_bytes(&t, &raw[..]).await.unwrap();
         assert_eq!(mimeparser.parts.len(), 1);
         assert_eq!(mimeparser.parts[0].typ, Viewtype::Text);
         assert!(mimeparser.user_avatar.unwrap().is_change());
@@ -1793,7 +1793,7 @@ mod tests {
         let raw = include_bytes!("../test-data/message/mail_with_user_and_group_avatars.eml");
         let raw = String::from_utf8_lossy(raw).to_string();
         let raw = raw.replace("Chat-User-Avatar:", "Xhat-Xser-Xvatar:");
-        let mimeparser = MimeMessage::from_bytes(&t.ctx, raw.as_bytes())
+        let mimeparser = MimeMessage::from_bytes(&t, raw.as_bytes())
             .await
             .unwrap();
         assert_eq!(mimeparser.parts.len(), 1);
@@ -1807,7 +1807,7 @@ mod tests {
         let t = TestContext::new().await;
 
         let raw = include_bytes!("../test-data/message/videochat_invitation.eml");
-        let mimeparser = MimeMessage::from_bytes(&t.ctx, &raw[..]).await.unwrap();
+        let mimeparser = MimeMessage::from_bytes(&t, &raw[..]).await.unwrap();
         assert_eq!(mimeparser.parts.len(), 1);
         assert_eq!(mimeparser.parts[0].typ, Viewtype::VideochatInvitation);
         assert_eq!(
@@ -2121,7 +2121,7 @@ MDYyMDYxNTE1RTlDOEE4Cj4+CnN0YXJ0eHJlZgo4Mjc4CiUlRU9GCg==
 ------=_Part_25_46172632.1581201680436--
 "#;
 
-        let message = MimeMessage::from_bytes(&t.ctx, &raw[..]).await.unwrap();
+        let message = MimeMessage::from_bytes(&t, &raw[..]).await.unwrap();
 
         assert_eq!(message.parts.len(), 1);
         assert_eq!(message.parts[0].typ, Viewtype::File);
@@ -2130,7 +2130,7 @@ MDYyMDYxNTE1RTlDOEE4Cj4+CnN0YXJ0eHJlZgo4Mjc4CiUlRU9GCg==
         // Make sure the file is there even though the html is wrong:
         let param = &message.parts[0].param;
         let blob: BlobObject = param
-            .get_blob(Param::File, &t.ctx, false)
+            .get_blob(Param::File, &t, false)
             .await
             .unwrap()
             .unwrap();
@@ -2518,7 +2518,7 @@ On 2020-10-25, Bob wrote:
     async fn test_quote_div() {
         let t = TestContext::new().await;
         let raw = include_bytes!("../test-data/message/gmx-quote.eml");
-        let mimeparser = MimeMessage::from_bytes(&t.ctx, raw).await.unwrap();
+        let mimeparser = MimeMessage::from_bytes(&t, raw).await.unwrap();
         assert_eq!(mimeparser.parts[0].msg, "YIPPEEEEEE\n\nMulti-line");
         assert_eq!(mimeparser.parts[0].param.get(Param::Quote).unwrap(), "Now?");
     }

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1793,9 +1793,7 @@ mod tests {
         let raw = include_bytes!("../test-data/message/mail_with_user_and_group_avatars.eml");
         let raw = String::from_utf8_lossy(raw).to_string();
         let raw = raw.replace("Chat-User-Avatar:", "Xhat-Xser-Xvatar:");
-        let mimeparser = MimeMessage::from_bytes(&t, raw.as_bytes())
-            .await
-            .unwrap();
+        let mimeparser = MimeMessage::from_bytes(&t, raw.as_bytes()).await.unwrap();
         assert_eq!(mimeparser.parts.len(), 1);
         assert_eq!(mimeparser.parts[0].typ, Viewtype::Image);
         assert_eq!(mimeparser.user_avatar, None);

--- a/src/param.rs
+++ b/src/param.rs
@@ -436,7 +436,7 @@ mod tests {
     #[async_std::test]
     async fn test_params_file_fs_path() {
         let t = TestContext::new().await;
-        if let ParamsFile::FsPath(p) = ParamsFile::from_param(&t.ctx, "/foo/bar/baz").unwrap() {
+        if let ParamsFile::FsPath(p) = ParamsFile::from_param(&t, "/foo/bar/baz").unwrap() {
             assert_eq!(p, Path::new("/foo/bar/baz"));
         } else {
             panic!("Wrong enum variant");
@@ -446,7 +446,7 @@ mod tests {
     #[async_std::test]
     async fn test_params_file_blob() {
         let t = TestContext::new().await;
-        if let ParamsFile::Blob(b) = ParamsFile::from_param(&t.ctx, "$BLOBDIR/foo").unwrap() {
+        if let ParamsFile::Blob(b) = ParamsFile::from_param(&t, "$BLOBDIR/foo").unwrap() {
             assert_eq!(b.as_name(), "$BLOBDIR/foo");
         } else {
             panic!("Wrong enum variant");
@@ -461,15 +461,15 @@ mod tests {
         let mut p = Params::new();
         p.set(Param::File, fname.to_str().unwrap());
 
-        let file = p.get_file(Param::File, &t.ctx).unwrap().unwrap();
+        let file = p.get_file(Param::File, &t).unwrap().unwrap();
         assert_eq!(file, ParamsFile::FsPath(fname.clone().into()));
 
-        let path: PathBuf = p.get_path(Param::File, &t.ctx).unwrap().unwrap();
+        let path: PathBuf = p.get_path(Param::File, &t).unwrap().unwrap();
         let fname: PathBuf = fname.into();
         assert_eq!(path, fname);
 
         // Blob does not exist yet, expect BlobError.
-        let err = p.get_blob(Param::File, &t.ctx, false).await.unwrap_err();
+        let err = p.get_blob(Param::File, &t, false).await.unwrap_err();
         match err {
             BlobError::WrongBlobdir { .. } => (),
             _ => panic!("wrong error type/variant: {:?}", err),
@@ -477,33 +477,33 @@ mod tests {
 
         fs::write(fname, b"boo").await.unwrap();
         let blob = p
-            .get_blob(Param::File, &t.ctx, true)
+            .get_blob(Param::File, &t, true)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(
             blob,
-            BlobObject::from_name(&t.ctx, "foo".to_string()).unwrap()
+            BlobObject::from_name(&t, "foo".to_string()).unwrap()
         );
 
         // Blob in blobdir, expect blob.
-        let bar_path = t.ctx.get_blobdir().join("bar");
+        let bar_path = t.get_blobdir().join("bar");
         p.set(Param::File, bar_path.to_str().unwrap());
         let blob = p
-            .get_blob(Param::File, &t.ctx, false)
+            .get_blob(Param::File, &t, false)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(
             blob,
-            BlobObject::from_name(&t.ctx, "bar".to_string()).unwrap()
+            BlobObject::from_name(&t, "bar".to_string()).unwrap()
         );
 
         p.remove(Param::File);
-        assert!(p.get_file(Param::File, &t.ctx).unwrap().is_none());
-        assert!(p.get_path(Param::File, &t.ctx).unwrap().is_none());
+        assert!(p.get_file(Param::File, &t).unwrap().is_none());
+        assert!(p.get_path(Param::File, &t).unwrap().is_none());
         assert!(p
-            .get_blob(Param::File, &t.ctx, false)
+            .get_blob(Param::File, &t, false)
             .await
             .unwrap()
             .is_none());

--- a/src/param.rs
+++ b/src/param.rs
@@ -476,36 +476,18 @@ mod tests {
         }
 
         fs::write(fname, b"boo").await.unwrap();
-        let blob = p
-            .get_blob(Param::File, &t, true)
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            blob,
-            BlobObject::from_name(&t, "foo".to_string()).unwrap()
-        );
+        let blob = p.get_blob(Param::File, &t, true).await.unwrap().unwrap();
+        assert_eq!(blob, BlobObject::from_name(&t, "foo".to_string()).unwrap());
 
         // Blob in blobdir, expect blob.
         let bar_path = t.get_blobdir().join("bar");
         p.set(Param::File, bar_path.to_str().unwrap());
-        let blob = p
-            .get_blob(Param::File, &t, false)
-            .await
-            .unwrap()
-            .unwrap();
-        assert_eq!(
-            blob,
-            BlobObject::from_name(&t, "bar".to_string()).unwrap()
-        );
+        let blob = p.get_blob(Param::File, &t, false).await.unwrap().unwrap();
+        assert_eq!(blob, BlobObject::from_name(&t, "bar".to_string()).unwrap());
 
         p.remove(Param::File);
         assert!(p.get_file(Param::File, &t).unwrap().is_none());
         assert!(p.get_path(Param::File, &t).unwrap().is_none());
-        assert!(p
-            .get_blob(Param::File, &t, false)
-            .await
-            .unwrap()
-            .is_none());
+        assert!(p.get_blob(Param::File, &t, false).await.unwrap().is_none());
     }
 }

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -485,11 +485,10 @@ mod tests {
     #[async_std::test]
     async fn test_set_stock_translation() {
         let t = TestContext::new().await;
-        t.ctx
-            .set_stock_translation(StockMessage::NoMessages, "xyz".to_string())
+        t.set_stock_translation(StockMessage::NoMessages, "xyz".to_string())
             .await
             .unwrap();
-        assert_eq!(t.ctx.stock_str(StockMessage::NoMessages).await, "xyz")
+        assert_eq!(t.stock_str(StockMessage::NoMessages).await, "xyz")
     }
 
     #[async_std::test]
@@ -510,10 +509,7 @@ mod tests {
     #[async_std::test]
     async fn test_stock_str() {
         let t = TestContext::new().await;
-        assert_eq!(
-            t.ctx.stock_str(StockMessage::NoMessages).await,
-            "No messages."
-        );
+        assert_eq!(t.stock_str(StockMessage::NoMessages).await, "No messages.");
     }
 
     #[async_std::test]
@@ -521,8 +517,7 @@ mod tests {
         let t = TestContext::new().await;
         // uses %1$s substitution
         assert_eq!(
-            t.ctx
-                .stock_string_repl_str(StockMessage::MsgAddMember, "Foo")
+            t.stock_string_repl_str(StockMessage::MsgAddMember, "Foo")
                 .await,
             "Member Foo added."
         );
@@ -533,8 +528,7 @@ mod tests {
     async fn test_stock_string_repl_int() {
         let t = TestContext::new().await;
         assert_eq!(
-            t.ctx
-                .stock_string_repl_int(StockMessage::MsgAddMember, 42)
+            t.stock_string_repl_int(StockMessage::MsgAddMember, 42)
                 .await,
             "Member 42 added."
         );
@@ -544,8 +538,7 @@ mod tests {
     async fn test_stock_string_repl_str2() {
         let t = TestContext::new().await;
         assert_eq!(
-            t.ctx
-                .stock_string_repl_str2(StockMessage::ServerResponse, "foo", "bar")
+            t.stock_string_repl_str2(StockMessage::ServerResponse, "foo", "bar")
                 .await,
             "Could not connect to foo: bar"
         );
@@ -555,8 +548,7 @@ mod tests {
     async fn test_stock_system_msg_simple() {
         let t = TestContext::new().await;
         assert_eq!(
-            t.ctx
-                .stock_system_msg(StockMessage::MsgLocationEnabled, "", "", 0)
+            t.stock_system_msg(StockMessage::MsgLocationEnabled, "", "", 0)
                 .await,
             "Location streaming enabled."
         )
@@ -566,14 +558,13 @@ mod tests {
     async fn test_stock_system_msg_add_member_by_me() {
         let t = TestContext::new().await;
         assert_eq!(
-            t.ctx
-                .stock_system_msg(
-                    StockMessage::MsgAddMember,
-                    "alice@example.com",
-                    "",
-                    DC_CONTACT_ID_SELF
-                )
-                .await,
+            t.stock_system_msg(
+                StockMessage::MsgAddMember,
+                "alice@example.com",
+                "",
+                DC_CONTACT_ID_SELF
+            )
+            .await,
             "Member alice@example.com added by me."
         )
     }
@@ -581,18 +572,17 @@ mod tests {
     #[async_std::test]
     async fn test_stock_system_msg_add_member_by_me_with_displayname() {
         let t = TestContext::new().await;
-        Contact::create(&t.ctx, "Alice", "alice@example.com")
+        Contact::create(&t, "Alice", "alice@example.com")
             .await
             .expect("failed to create contact");
         assert_eq!(
-            t.ctx
-                .stock_system_msg(
-                    StockMessage::MsgAddMember,
-                    "alice@example.com",
-                    "",
-                    DC_CONTACT_ID_SELF
-                )
-                .await,
+            t.stock_system_msg(
+                StockMessage::MsgAddMember,
+                "alice@example.com",
+                "",
+                DC_CONTACT_ID_SELF
+            )
+            .await,
             "Member Alice (alice@example.com) added by me."
         );
     }
@@ -601,22 +591,21 @@ mod tests {
     async fn test_stock_system_msg_add_member_by_other_with_displayname() {
         let t = TestContext::new().await;
         let contact_id = {
-            Contact::create(&t.ctx, "Alice", "alice@example.com")
+            Contact::create(&t, "Alice", "alice@example.com")
                 .await
                 .expect("Failed to create contact Alice");
-            Contact::create(&t.ctx, "Bob", "bob@example.com")
+            Contact::create(&t, "Bob", "bob@example.com")
                 .await
                 .expect("failed to create bob")
         };
         assert_eq!(
-            t.ctx
-                .stock_system_msg(
-                    StockMessage::MsgAddMember,
-                    "alice@example.com",
-                    "",
-                    contact_id,
-                )
-                .await,
+            t.stock_system_msg(
+                StockMessage::MsgAddMember,
+                "alice@example.com",
+                "",
+                contact_id,
+            )
+            .await,
             "Member Alice (alice@example.com) added by Bob (bob@example.com)."
         );
     }
@@ -625,14 +614,13 @@ mod tests {
     async fn test_stock_system_msg_grp_name() {
         let t = TestContext::new().await;
         assert_eq!(
-            t.ctx
-                .stock_system_msg(
-                    StockMessage::MsgGrpName,
-                    "Some chat",
-                    "Other chat",
-                    DC_CONTACT_ID_SELF
-                )
-                .await,
+            t.stock_system_msg(
+                StockMessage::MsgGrpName,
+                "Some chat",
+                "Other chat",
+                DC_CONTACT_ID_SELF
+            )
+            .await,
             "Group name changed from \"Some chat\" to \"Other chat\" by me."
         )
     }
@@ -640,13 +628,12 @@ mod tests {
     #[async_std::test]
     async fn test_stock_system_msg_grp_name_other() {
         let t = TestContext::new().await;
-        let id = Contact::create(&t.ctx, "Alice", "alice@example.com")
+        let id = Contact::create(&t, "Alice", "alice@example.com")
             .await
             .expect("failed to create contact");
 
         assert_eq!(
-            t.ctx
-                .stock_system_msg(StockMessage::MsgGrpName, "Some chat", "Other chat", id)
+            t.stock_system_msg(StockMessage::MsgGrpName, "Some chat", "Other chat", id)
                 .await,
             "Group name changed from \"Some chat\" to \"Other chat\" by Alice (alice@example.com)."
         )
@@ -655,13 +642,11 @@ mod tests {
     #[async_std::test]
     async fn test_update_device_chats() {
         let t = TestContext::new().await;
-        t.ctx.update_device_chats().await.ok();
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        t.update_device_chats().await.ok();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 2);
 
-        let chat0 = Chat::load_from_db(&t.ctx, chats.get_chat_id(0))
-            .await
-            .unwrap();
+        let chat0 = Chat::load_from_db(&t, chats.get_chat_id(0)).await.unwrap();
         let (self_talk_id, device_chat_id) = if chat0.is_self_talk() {
             (chats.get_chat_id(0), chats.get_chat_id(1))
         } else {
@@ -669,27 +654,23 @@ mod tests {
         };
 
         // delete self-talk first; this adds a message to device-chat about how self-talk can be restored
-        let device_chat_msgs_before = chat::get_chat_msgs(&t.ctx, device_chat_id, 0, None)
-            .await
-            .len();
-        self_talk_id.delete(&t.ctx).await.ok();
+        let device_chat_msgs_before = chat::get_chat_msgs(&t, device_chat_id, 0, None).await.len();
+        self_talk_id.delete(&t).await.ok();
         assert_eq!(
-            chat::get_chat_msgs(&t.ctx, device_chat_id, 0, None)
-                .await
-                .len(),
+            chat::get_chat_msgs(&t, device_chat_id, 0, None).await.len(),
             device_chat_msgs_before + 1
         );
 
         // delete device chat
-        device_chat_id.delete(&t.ctx).await.ok();
+        device_chat_id.delete(&t).await.ok();
 
         // check, that the chatlist is empty
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 0);
 
         // a subsequent call to update_device_chats() must not re-add manally deleted messages or chats
-        t.ctx.update_device_chats().await.ok();
-        let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
+        t.update_device_chats().await.ok();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 0);
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -77,7 +77,7 @@ impl TestContext {
         let t = Self::new().await;
         let keypair = bob_keypair();
         t.configure_addr(&keypair.addr.to_string()).await;
-        key::store_self_keypair(&t.ctx, &keypair, key::KeyPairUse::Default)
+        key::store_self_keypair(&t, &keypair, key::KeyPairUse::Default)
             .await
             .expect("Failed to save Bob's key");
         t


### PR DESCRIPTION
- Create and use some test helper functions
- make TestContext deref to Context so that we don't have to write `.ctx` all the time
- Replace all t.ctx with t (bulk rename)
Not sure if that's the way to go because, you know, merge conflicts (at least it's in the tests, which don't change as often as the rest of the code base) (the rename is all in one commit so no problem to revert this), but we could do this now.