### PR TITLE
Remove strict domain checks for EmailAddress::from_str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - Do not process names, avatars, location XMLs, message signature
 etc. for duplicate messages. #2513
 - Fix `can_send` for users not in group #2479
+- Allow email addresses without dot in the domain part #2112
 
 ## 1.56.0
 

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1390,12 +1390,12 @@ mod tests {
         assert_eq!(may_be_valid_addr("user@domain.tld"), true);
         assert_eq!(may_be_valid_addr("uuu"), false);
         assert_eq!(may_be_valid_addr("dd.tt"), false);
-        assert_eq!(may_be_valid_addr("tt.dd@uu"), false);
-        assert_eq!(may_be_valid_addr("u@d"), false);
-        assert_eq!(may_be_valid_addr("u@d."), false);
-        assert_eq!(may_be_valid_addr("u@d.t"), false);
+        assert_eq!(may_be_valid_addr("tt.dd@uu"), true);
+        assert_eq!(may_be_valid_addr("u@d"), true);
+        assert_eq!(may_be_valid_addr("u@d."), true);
+        assert_eq!(may_be_valid_addr("u@d.t"), true);
         assert_eq!(may_be_valid_addr("u@d.tt"), true);
-        assert_eq!(may_be_valid_addr("u@.tt"), false);
+        assert_eq!(may_be_valid_addr("u@.tt"), true);
         assert_eq!(may_be_valid_addr("@d.tt"), false);
         assert_eq!(may_be_valid_addr("<da@d.tt"), false);
         assert_eq!(may_be_valid_addr("sk <@d.tt>"), false);
@@ -1837,9 +1837,6 @@ mod tests {
             .is_err());
         assert!(Contact::create(&t, "", "dskjfdslksadklj.dk").await.is_err());
         assert!(Contact::create(&t, "", "dskjfdslk@sadklj.dk>")
-            .await
-            .is_err());
-        assert!(Contact::create(&t, "", "dskjf@dslk@sadkljdk")
             .await
             .is_err());
         assert!(Contact::create(&t, "", "dskjf dslk@d.e").await.is_err());

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -608,19 +608,8 @@ impl FromStr for EmailAddress {
                 if local.is_empty() {
                     return err("empty string is not valid for local part");
                 }
-                if domain.len() <= 3 {
-                    return err("domain is too short");
-                }
-                let dot = domain.find('.');
-                match dot {
-                    None => {
-                        return err("invalid domain");
-                    }
-                    Some(dot_idx) => {
-                        if dot_idx >= domain.len() - 2 {
-                            return err("invalid domain");
-                        }
-                    }
+                if domain.is_empty() {
+                    return err("missing domain after '@'");
                 }
                 Ok(EmailAddress {
                     local: (*local).to_string(),
@@ -825,12 +814,19 @@ mod tests {
                 domain: "domain.tld".into(),
             }
         );
+        assert_eq!(
+            "user@localhost".parse::<EmailAddress>().unwrap(),
+            EmailAddress {
+                local: "user".into(),
+                domain: "localhost".into()
+            }
+        );
         assert_eq!("uuu".parse::<EmailAddress>().is_ok(), false);
         assert_eq!("dd.tt".parse::<EmailAddress>().is_ok(), false);
-        assert_eq!("tt.dd@uu".parse::<EmailAddress>().is_ok(), false);
-        assert_eq!("u@d".parse::<EmailAddress>().is_ok(), false);
-        assert_eq!("u@d.".parse::<EmailAddress>().is_ok(), false);
-        assert_eq!("u@d.t".parse::<EmailAddress>().is_ok(), false);
+        assert!("tt.dd@uu".parse::<EmailAddress>().is_ok());
+        assert!("u@d".parse::<EmailAddress>().is_ok());
+        assert!("u@d.".parse::<EmailAddress>().is_ok());
+        assert!("u@d.t".parse::<EmailAddress>().is_ok());
         assert_eq!(
             "u@d.tt".parse::<EmailAddress>().unwrap(),
             EmailAddress {
@@ -838,7 +834,7 @@ mod tests {
                 domain: "d.tt".into(),
             }
         );
-        assert_eq!("u@tt".parse::<EmailAddress>().is_ok(), false);
+        assert!("u@tt".parse::<EmailAddress>().is_ok());
         assert_eq!("@d.tt".parse::<EmailAddress>().is_ok(), false);
     }
 


### PR DESCRIPTION
They prevent "user@localhost" addresses from being parsed, which are
useful for running online tests against local server.
