### PR TITLE
Fix marking read receipts as seen

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -836,7 +836,7 @@ async fn add_parts(
 
                 if is_mdn || is_location_kml {
                     is_hidden = true;
-                    if state == MessageState::InFresh || state == MessageState::InNoticed {
+                    if incoming {
                         state = MessageState::InSeen; // Set the state to InSeen so that precheck_imf() adds a markseen job after we moved the message
                     }
                 }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -836,8 +836,8 @@ async fn add_parts(
 
                 if is_mdn || is_location_kml {
                     is_hidden = true;
-                    if state == MessageState::InFresh {
-                        state = MessageState::InNoticed;
+                    if state == MessageState::InFresh || state == MessageState::InNoticed {
+                        state = MessageState::InSeen; // Set the state to InSeen so that precheck_imf() adds a markseen job after we moved the message
                     }
                 }
 

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1521,6 +1521,7 @@ async fn precheck_imf(
         }
 
         if old_server_folder != server_folder || old_server_uid != server_uid {
+            info!(context, "Updating server uid");
             update_server_uid(context, rfc724_mid, server_folder, server_uid).await;
             if let Ok(message_state) = msg_id.get_state(context).await {
                 if message_state == MessageState::InSeen || message_state.is_outgoing() {
@@ -1531,7 +1532,6 @@ async fn precheck_imf(
                     .await;
                 }
             }
-            info!(context, "Updating server_uid and adding markseen job");
         }
         Ok(true)
     } else {


### PR DESCRIPTION
If mvbox_move was on and an mdn was received, it was not marked as read.

Also remove a confusing log that said that we are adding a markseen job, even if we weren't. As job::save() logs itself, there is no need to log this again.