### PR TITLE
Resolve MX domain only once per OAuth2 provider

### DIFF
--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -297,16 +297,16 @@ impl Oauth2 {
         )
         .await
         {
-            for provider in OAUTH2_PROVIDERS.iter() {
-                if let Some(pattern) = provider.mx_pattern {
-                    let re = Regex::new(pattern).unwrap();
+            let mut fqdn: String = String::from(domain.as_ref());
+            if !fqdn.ends_with('.') {
+                fqdn.push('.');
+            }
 
-                    let mut fqdn: String = String::from(domain.as_ref());
-                    if !fqdn.ends_with('.') {
-                        fqdn.push('.');
-                    }
+            if let Ok(res) = resolver.mx_lookup(fqdn).await {
+                for provider in OAUTH2_PROVIDERS.iter() {
+                    if let Some(pattern) = provider.mx_pattern {
+                        let re = Regex::new(pattern).unwrap();
 
-                    if let Ok(res) = resolver.mx_lookup(fqdn).await {
                         for rr in res.iter() {
                             if re.is_match(&rr.exchange().to_lowercase().to_utf8()) {
                                 return Some(provider.clone());


### PR DESCRIPTION
Currently we have only one provider in the list, so there is no
difference, but more providers (e.g. Yandex.Connect) may be added later.