### PR TITLE
add flag to get only info/system messages of chat

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1000,7 +1000,7 @@ dc_msg_t*       dc_get_draft                 (dc_context_t* context, uint32_t ch
 
 
 #define         DC_GCM_ADDDAYMARKER          0x01
-#define         DC_GCM_INFO_ONLY           0x02
+#define         DC_GCM_INFO_ONLY             0x02
 
 
 /**

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1000,7 +1000,7 @@ dc_msg_t*       dc_get_draft                 (dc_context_t* context, uint32_t ch
 
 
 #define         DC_GCM_ADDDAYMARKER          0x01
-#define         DC_GCM_SYSTEM_ONLY           0x02
+#define         DC_GCM_INFO_ONLY           0x02
 
 
 /**
@@ -1019,7 +1019,7 @@ dc_msg_t*       dc_get_draft                 (dc_context_t* context, uint32_t ch
  * @param flags If set to DC_GCM_ADDDAYMARKER, the marker DC_MSG_ID_DAYMARKER will
  *     be added before each day (regarding the local timezone).  Set this to 0 if you do not want this behaviour.
  *     To get the concrete time of the marker, use dc_array_get_timestamp().
- *     If set to DC_GCM_SYSTEM_ONLY, only system messages will be returned, can be combined with DC_GCM_ADDDAYMARKER.
+ *     If set to DC_GCM_INFO_ONLY, only system messages will be returned, can be combined with DC_GCM_ADDDAYMARKER.
  * @param marker1before An optional message ID.  If set, the id DC_MSG_ID_MARKER1 will be added just
  *   before the given ID in the returned array.  Set this to 0 if you do not want this behaviour.
  * @return Array of message IDs, must be dc_array_unref()'d when no longer used.

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1000,6 +1000,7 @@ dc_msg_t*       dc_get_draft                 (dc_context_t* context, uint32_t ch
 
 
 #define         DC_GCM_ADDDAYMARKER          0x01
+#define         DC_GCM_SYSTEM_ONLY           0x02
 
 
 /**
@@ -1018,6 +1019,7 @@ dc_msg_t*       dc_get_draft                 (dc_context_t* context, uint32_t ch
  * @param flags If set to DC_GCM_ADDDAYMARKER, the marker DC_MSG_ID_DAYMARKER will
  *     be added before each day (regarding the local timezone).  Set this to 0 if you do not want this behaviour.
  *     To get the concrete time of the marker, use dc_array_get_timestamp().
+ *     If set to DC_GCM_SYSTEM_ONLY, only system messages will be returned, can be combined with DC_GCM_ADDDAYMARKER.
  * @param marker1before An optional message ID.  If set, the id DC_MSG_ID_MARKER1 will be added just
  *   before the given ID in the returned array.  Set this to 0 if you do not want this behaviour.
  * @return Array of message IDs, must be dc_array_unref()'d when no longer used.

--- a/python/src/deltachat/_build.py
+++ b/python/src/deltachat/_build.py
@@ -145,7 +145,7 @@ def extract_defines(flags):
                 | DC_STR
                 | DC_CONTACT_ID
                 | DC_GCL
-                | DC_GCM 
+                | DC_GCM
                 | DC_SOCKET
                 | DC_CHAT
                 | DC_PROVIDER

--- a/python/src/deltachat/_build.py
+++ b/python/src/deltachat/_build.py
@@ -145,6 +145,7 @@ def extract_defines(flags):
                 | DC_STR
                 | DC_CONTACT_ID
                 | DC_GCL
+                | DC_GCM 
                 | DC_SOCKET
                 | DC_CHAT
                 | DC_PROVIDER

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -614,7 +614,7 @@ class TestOfflineChat:
 
         lp.sec("check message count of only system messages (without daymarkers)")
         dc_array = ffi.gc(
-            lib.dc_get_chat_msgs(ac1._dc_context, chat.id, const.DC_GCM_SYSTEM_ONLY, 0),
+            lib.dc_get_chat_msgs(ac1._dc_context, chat.id, const.DC_GCM_INFO_ONLY, 0),
             lib.dc_array_unref
         )
         assert len(list(iter_array(dc_array, lambda x: x))) == 2

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -614,7 +614,7 @@ class TestOfflineChat:
 
         lp.sec("check message count of only system messages (without daymarkers)")
         dc_array = ffi.gc(
-            lib.dc_get_chat_msgs(ac1._dc_context, chat.id, 2, 0),  # todo replace `2` with const.DC_GCM_SYSTEM_ONLY
+            lib.dc_get_chat_msgs(ac1._dc_context, chat.id, const.DC_GCM_SYSTEM_ONLY, 0),
             lib.dc_array_unref
         )
         assert len(list(iter_array(dc_array, lambda x: x))) == 2

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -597,7 +597,7 @@ class TestOfflineChat:
         assert in_list[1][1] == chat
         assert in_list[1][2] == contacts[3]
 
-    def test_audit_log_view(self, ac1, lp):
+    def test_audit_log_view_without_daymarker(self, ac1, lp):
         lp.sec("ac1: test audit log (show only system messages)")
         chat = ac1.create_group_chat(name="audit log sample data")
         # promote chat

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -18,7 +18,7 @@ use crate::constants::{
     Blocked, Chattype, ShowEmails, Viewtype, DC_CHAT_ID_ALLDONE_HINT, DC_CHAT_ID_ARCHIVED_LINK,
     DC_CHAT_ID_DEADDROP, DC_CHAT_ID_LAST_SPECIAL, DC_CHAT_ID_TRASH, DC_CONTACT_ID_DEVICE,
     DC_CONTACT_ID_INFO, DC_CONTACT_ID_LAST_SPECIAL, DC_CONTACT_ID_SELF, DC_GCM_ADDDAYMARKER,
-    DC_RESEND_USER_AVATAR_DAYS,
+    DC_GCM_INFO_ONLY, DC_RESEND_USER_AVATAR_DAYS,
 };
 use crate::contact::{addr_cmp, Contact, Origin, VerifiedStatus};
 use crate::context::Context;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -99,6 +99,7 @@ pub const DC_GCL_ADD_ALLDONE_HINT: usize = 0x04;
 pub const DC_GCL_FOR_FORWARDING: usize = 0x08;
 
 pub const DC_GCM_ADDDAYMARKER: u32 = 0x01;
+pub const DC_GCM_SYSTEM_ONLY: u32 = 0x02;
 
 pub const DC_GCL_VERIFIED_ONLY: usize = 0x01;
 pub const DC_GCL_ADD_SELF: usize = 0x02;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -99,7 +99,7 @@ pub const DC_GCL_ADD_ALLDONE_HINT: usize = 0x04;
 pub const DC_GCL_FOR_FORWARDING: usize = 0x08;
 
 pub const DC_GCM_ADDDAYMARKER: u32 = 0x01;
-pub const DC_GCM_SYSTEM_ONLY: u32 = 0x02;
+pub const DC_GCM_INFO_ONLY: u32 = 0x02;
 
 pub const DC_GCL_VERIFIED_ONLY: usize = 0x01;
 pub const DC_GCL_ADD_SELF: usize = 0x02;


### PR DESCRIPTION
useful for creating an "audit log" view of a chat that helps to find
actions like who added/removed who quickly and without endless scrolling.