### PR TITLE
use dbversion=71 for updating ConfiguredProvider

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1396,8 +1396,8 @@ CREATE INDEX devmsglabels_index1 ON devmsglabels (label);
             .await?;
             sql.set_raw_config_int(context, "dbversion", 69).await?;
         }
-        if dbversion < 70 {
-            info!(context, "[migration] v70");
+        if dbversion < 71 {
+            info!(context, "[migration] v71");
             if let Some(addr) = context.get_config(Config::ConfiguredAddr).await {
                 if let Ok(domain) = addr.parse::<EmailAddress>().map(|email| email.domain) {
                     context
@@ -1411,7 +1411,7 @@ CREATE INDEX devmsglabels_index1 ON devmsglabels (label);
                 }
             }
 
-            sql.set_raw_config_int(context, "dbversion", 70).await?;
+            sql.set_raw_config_int(context, "dbversion", 71).await?;
         }
 
         // (2) updates that require high-level objects


### PR DESCRIPTION
in addition to merged pr #2123,
dbversion=70 was also used by pr #2125.

pr #2125 is not yet merged, however beta-versions were shipped with
that pr, so, dbversion=70 is already in use on some systems and on these
systems ConfiguredProvider won't be set.

the other way round, that ConfiguredProvider is set twice on some systems
affects only dev-installations and should not harm.

once this pr is merged, #2125 needs a rebase and will use dbversion=72 for
its changes to add the new column also n the dev-installations :)
(we need to check that the column to add does not exist, however)