### PR TITLE
ffi: remove dc_is_io_running()

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -532,7 +532,6 @@ int             dc_is_configured   (const dc_context_t* context);
 /**
  * Start job and IMAP/SMTP tasks.
  * If IO is already running, nothing happens.
- * To check the current IO state, use dc_is_io_running().
  *
  * If the context was created by the dc_accounts_t account manager,
  * use dc_accounts_start_io() instead of this function.
@@ -543,19 +542,9 @@ int             dc_is_configured   (const dc_context_t* context);
 void            dc_start_io     (dc_context_t* context);
 
 /**
- * Check if IO (SMTP/IMAP/Jobs) has been started.
- *
- * @memberof dc_context_t
- * @param context The context object.
- * @return 1=IO is running; 
- *   0=IO is not running.
- */
-int             dc_is_io_running(const dc_context_t* context);
-
-/**
  * Stop job, IMAP, SMTP and other tasks and return when they
  * are finished.
- * To check the current IO state, use dc_is_io_running().
+ *
  * Even if IO is not running, there may be pending tasks,
  * so this function should always be called before releasing
  * context to ensure clean termination of event loop.

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -297,16 +297,6 @@ pub unsafe extern "C" fn dc_start_io(context: *mut dc_context_t) {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_is_io_running(context: *mut dc_context_t) -> libc::c_int {
-    if context.is_null() {
-        return 0;
-    }
-    let ctx = &*context;
-
-    block_on(ctx.is_io_running()) as libc::c_int
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn dc_get_id(context: *mut dc_context_t) -> libc::c_int {
     if context.is_null() {
         return 0;

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -459,8 +459,6 @@ class Account(object):
         If sending out was unsuccessful, a RuntimeError is raised.
         """
         self.check_is_configured()
-        if not self.is_started():
-            raise RuntimeError("IO not running, can not send out")
         res = lib.dc_initiate_key_transfer(self._dc_context)
         if res == ffi.NULL:
             raise RuntimeError("could not send out autocrypt setup message")
@@ -592,9 +590,6 @@ class Account(object):
         lib.dc_configure(self._dc_context)
         return configtracker
 
-    def is_started(self):
-        return self._event_thread.is_alive() and bool(lib.dc_is_io_running(self._dc_context))
-
     def wait_shutdown(self):
         """ wait until shutdown of this account has completed. """
         self._shutdown_event.wait()
@@ -604,11 +599,8 @@ class Account(object):
         self.log("stop_ongoing")
         self.stop_ongoing()
 
-        if bool(lib.dc_is_io_running(self._dc_context)):
-            self.log("dc_stop_io (stop core IO scheduler)")
-            lib.dc_stop_io(self._dc_context)
-        else:
-            self.log("stop_scheduler called on non-running context")
+        self.log("dc_stop_io (stop core IO scheduler)")
+        lib.dc_stop_io(self._dc_context)
 
     def shutdown(self):
         """ shutdown and destroy account (stop callback thread, close and remove

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -365,7 +365,7 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
                     acc.get_device_chat().mark_noticed()
                     del acc._configtracker
                 acc.set_config("bcc_self", "0")
-                if acc.is_configured() and not acc.is_started():
+                if acc.is_configured() and acc not in started_accounts:
                     acc.start_io()
                     started_accounts.append(acc)
                 print("{}: {} account was successfully setup".format(

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -488,10 +488,6 @@ class TestOfflineChat:
         assert messages[0].text == "msg1"
         assert os.path.exists(messages[1].filename)
 
-    def test_ac_setup_message_fails(self, ac1):
-        with pytest.raises(RuntimeError):
-            ac1.initiate_key_transfer()
-
     def test_set_get_draft(self, chat1):
         msg = Message.new_empty(chat1.account, "text")
         msg1 = chat1.prepare_message(msg)

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1620,10 +1620,6 @@ pub async fn send_msg_sync(
     chat_id: ChatId,
     msg: &mut Message,
 ) -> Result<MsgId, Error> {
-    if context.is_io_running().await {
-        return send_msg(context, chat_id, msg).await;
-    }
-
     if let Some(mut job) = prepare_send_msg(context, chat_id, msg).await? {
         let mut smtp = crate::smtp::Smtp::new();
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -144,7 +144,7 @@ impl Context {
     /// Starts the IO scheduler.
     pub async fn start_io(&self) {
         info!(self, "starting IO");
-        if self.is_io_running().await {
+        if self.inner.is_io_running().await {
             info!(self, "IO is already running");
             return;
         }
@@ -153,11 +153,6 @@ impl Context {
             let l = &mut *self.inner.scheduler.write().await;
             l.start(self.clone()).await;
         }
-    }
-
-    /// Returns if the IO scheduler is running.
-    pub async fn is_io_running(&self) -> bool {
-        self.inner.is_io_running().await
     }
 
     /// Stops the IO scheduler.


### PR DESCRIPTION
It is misleading and should never be checked.

dc_stop_io() also stops pending ephemeral message deletion tasks, so it
should be called in any case before releasing context.

Closes #2052 