### PR TITLE
word-encode Chat-Group-Name-Changed

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1177,13 +1177,12 @@ async fn create_or_lookup_group(
                 .await;
             X_MrAddToGrp = Some(optional_field);
         } else {
-            let field = mime_parser.get(HeaderDef::ChatGroupNameChanged);
-            if let Some(field) = field {
+            if let Some(old_name) = mime_parser.get(HeaderDef::ChatGroupNameChanged) {
                 X_MrGrpNameChanged = true;
                 better_msg = context
                     .stock_system_msg(
                         StockMessage::MsgGrpName,
-                        field,
+                        old_name,
                         if let Some(ref name) = grpname {
                             name
                         } else {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1176,41 +1176,38 @@ async fn create_or_lookup_group(
                 )
                 .await;
             X_MrAddToGrp = Some(optional_field);
-        } else {
-            if let Some(old_name) = mime_parser.get(HeaderDef::ChatGroupNameChanged) {
-                X_MrGrpNameChanged = true;
-                better_msg = context
-                    .stock_system_msg(
-                        StockMessage::MsgGrpName,
-                        old_name,
-                        if let Some(ref name) = grpname {
-                            name
-                        } else {
-                            ""
-                        },
-                        from_id as u32,
-                    )
-                    .await;
-
-                mime_parser.is_system_message = SystemMessage::GroupNameChanged;
-            } else if let Some(value) = mime_parser.get(HeaderDef::ChatContent) {
-                if value == "group-avatar-changed" {
-                    if let Some(avatar_action) = &mime_parser.group_avatar {
-                        // this is just an explicit message containing the group-avatar,
-                        // apart from that, the group-avatar is send along with various other messages
-                        mime_parser.is_system_message = SystemMessage::GroupImageChanged;
-                        better_msg = context
-                            .stock_system_msg(
-                                match avatar_action {
-                                    AvatarAction::Delete => StockMessage::MsgGrpImgDeleted,
-                                    AvatarAction::Change(_) => StockMessage::MsgGrpImgChanged,
-                                },
-                                "",
-                                "",
-                                from_id as u32,
-                            )
-                            .await
-                    }
+        } else if let Some(old_name) = mime_parser.get(HeaderDef::ChatGroupNameChanged) {
+            X_MrGrpNameChanged = true;
+            better_msg = context
+                .stock_system_msg(
+                    StockMessage::MsgGrpName,
+                    old_name,
+                    if let Some(ref name) = grpname {
+                        name
+                    } else {
+                        ""
+                    },
+                    from_id as u32,
+                )
+                .await;
+            mime_parser.is_system_message = SystemMessage::GroupNameChanged;
+        } else if let Some(value) = mime_parser.get(HeaderDef::ChatContent) {
+            if value == "group-avatar-changed" {
+                if let Some(avatar_action) = &mime_parser.group_avatar {
+                    // this is just an explicit message containing the group-avatar,
+                    // apart from that, the group-avatar is send along with various other messages
+                    mime_parser.is_system_message = SystemMessage::GroupImageChanged;
+                    better_msg = context
+                        .stock_system_msg(
+                            match avatar_action {
+                                AvatarAction::Delete => StockMessage::MsgGrpImgDeleted,
+                                AvatarAction::Change(_) => StockMessage::MsgGrpImgChanged,
+                            },
+                            "",
+                            "",
+                            from_id as u32,
+                        )
+                        .await
                 }
             }
         }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -756,7 +756,7 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                     let old_name = self.msg.param.get(Param::Arg).unwrap_or_default();
                     protected_headers.push(Header::new(
                         "Chat-Group-Name-Changed".into(),
-                        maybe_encode_words(old_name.into()),
+                        maybe_encode_words(old_name),
                     ));
                 }
                 SystemMessage::GroupImageChanged => {

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -753,11 +753,10 @@ impl<'a, 'b> MimeFactory<'a, 'b> {
                     }
                 }
                 SystemMessage::GroupNameChanged => {
-                    let value_to_add = self.msg.param.get(Param::Arg).unwrap_or_default();
-
+                    let old_name = self.msg.param.get(Param::Arg).unwrap_or_default();
                     protected_headers.push(Header::new(
                         "Chat-Group-Name-Changed".into(),
-                        value_to_add.into(),
+                        maybe_encode_words(old_name.into()),
                     ));
                 }
                 SystemMessage::GroupImageChanged => {


### PR DESCRIPTION
for easier handling, this pr also adds a helper function `maybe_encode_words()` and uses that for the filename.

fixes #2124

nb: for the `needs_encoding()` check - i am pretty sure that this check is too restrictive and encodes more than needed, eg. spaces, that already prevented usage at https://github.com/deltachat/deltachat-core-rust/pull/1702. but that can be changed later, there is not much waste currently :)

