### PR TITLE
fix internal link in README.rst

### DIFF
--- a/python/README.rst
+++ b/python/README.rst
@@ -11,8 +11,8 @@ Installing pre-built packages (Linux-only)
 ========================================================
 
 If you have a Linux system you may try to install the ``deltachat`` binary "wheel" packages
-without any "build-from-source" steps. Otherwise you need to `compile the Delta Chat bindings
-yourself <sourceinstall>`_.
+without any "build-from-source" steps.
+Otherwise you need to `compile the Delta Chat bindings yourself <#sourceinstall>`_.
 
 We recommend to first `install virtualenv <https://virtualenv.pypa.io/en/stable/installation/>`_,
 then create a fresh Python virtual environment and activate it in your shell::


### PR DESCRIPTION
~~there must not be a space between link text and the link in angle brackets:
https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html~~
~~did not try that out, not sure if i understand that correctly, however.~~ 

EDIT: this is about sphinx (that also defines :ref:  and so on), so, just adding the `#` should do the trick, i could test that at least locally with the rst-plugin of CLion.

closes https://github.com/deltachat/deltachat-core-rust/issues/2145