### PR TITLE
Add more detail to securejoin tests

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -64,7 +64,10 @@ pub struct InnerContext {
 
     pub(crate) last_full_folder_scan: Mutex<Option<Instant>>,
 
-    /// Id for this context on the current device.
+    /// ID for this `Context` in the current process.
+    ///
+    /// This allows for multiple `Context`s open in a single process where each context can
+    /// be identified by this ID.
     pub(crate) id: u32,
 
     creation_time: SystemTime,

--- a/src/events.rs
+++ b/src/events.rs
@@ -73,9 +73,25 @@ impl async_std::stream::Stream for EventEmitter {
     }
 }
 
+/// The event emitted by a [`Context`] from an [`EventEmitter`].
+///
+/// Events are documented on the C/FFI API in `deltachat.h` as `DC_EVENT_*` contants.  The
+/// context emits them in relation to various operations happening, a lot of these are again
+/// documented in `deltachat.h`.
+///
+/// This struct [`Deref`]s to the [`EventType`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Event {
+    /// The ID of the [`Context`] which emitted this event.
+    ///
+    /// This allows using multiple [`Context`]s in a single process as they are identified
+    /// by this ID.
+    ///
+    /// [`Context`]: crate::context::Context
     pub id: u32,
+    /// The event payload.
+    ///
+    /// These are documented in `deltachat.h` as the `DC_EVENT_*` constants.
     pub typ: EventType,
 }
 
@@ -88,7 +104,9 @@ impl Deref for Event {
 }
 
 impl EventType {
-    /// Returns the corresponding Event id.
+    /// Returns the corresponding Event ID.
+    ///
+    /// These are the IDs used in the `DC_EVENT_*` constants in `deltachat.h`.
     pub fn as_id(&self) -> i32 {
         self.get_str("id")
             .expect("missing id")

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -461,48 +461,28 @@ fn receive_event(event: Event) {
     let red = Color::Red.normal();
 
     let msg = match event.typ {
-        EventType::Info(msg) => {
-            format!("INFO: {}", msg)
-        }
-        EventType::SmtpConnected(msg) => {
-            format!("[SMTP_CONNECTED] {}", msg)
-        }
-        EventType::ImapConnected(msg) => {
-            format!("[IMAP_CONNECTED] {}", msg)
-        }
-        EventType::SmtpMessageSent(msg) => {
-            format!("[SMTP_MESSAGE_SENT] {}", msg)
-        }
-        EventType::Warning(msg) => {
-            format!("WARN: {}", yellow.paint(msg))
-        }
-        EventType::Error(msg) => {
-            format!("ERROR: {}", red.paint(msg))
-        }
-        EventType::ErrorNetwork(msg) => {
-            format!("{}", red.paint(format!("[NETWORK] msg={}", msg)))
-        }
+        EventType::Info(msg) => format!("INFO: {}", msg),
+        EventType::SmtpConnected(msg) => format!("[SMTP_CONNECTED] {}", msg),
+        EventType::ImapConnected(msg) => format!("[IMAP_CONNECTED] {}", msg),
+        EventType::SmtpMessageSent(msg) => format!("[SMTP_MESSAGE_SENT] {}", msg),
+        EventType::Warning(msg) => format!("WARN: {}", yellow.paint(msg)),
+        EventType::Error(msg) => format!("ERROR: {}", red.paint(msg)),
+        EventType::ErrorNetwork(msg) => format!("{}", red.paint(format!("[NETWORK] msg={}", msg))),
         EventType::ErrorSelfNotInGroup(msg) => {
             format!("{}", red.paint(format!("[SELF_NOT_IN_GROUP] {}", msg)))
         }
-        EventType::MsgsChanged { chat_id, msg_id } => {
-            format!(
-                "{}",
-                green.paint(format!(
-                    "Received MSGS_CHANGED(chat_id={}, msg_id={})",
-                    chat_id, msg_id,
-                ))
-            )
-        }
-        EventType::ContactsChanged(_) => {
-            format!("{}", green.paint("Received CONTACTS_CHANGED()"))
-        }
-        EventType::LocationChanged(contact) => {
-            format!(
-                "{}",
-                green.paint(format!("Received LOCATION_CHANGED(contact={:?})", contact))
-            )
-        }
+        EventType::MsgsChanged { chat_id, msg_id } => format!(
+            "{}",
+            green.paint(format!(
+                "Received MSGS_CHANGED(chat_id={}, msg_id={})",
+                chat_id, msg_id,
+            ))
+        ),
+        EventType::ContactsChanged(_) => format!("{}", green.paint("Received CONTACTS_CHANGED()")),
+        EventType::LocationChanged(contact) => format!(
+            "{}",
+            green.paint(format!("Received LOCATION_CHANGED(contact={:?})", contact))
+        ),
         EventType::ConfigureProgress { progress, comment } => {
             if let Some(comment) = comment {
                 format!(
@@ -519,27 +499,19 @@ fn receive_event(event: Event) {
                 )
             }
         }
-        EventType::ImexProgress(progress) => {
-            format!(
-                "{}",
-                green.paint(format!("Received IMEX_PROGRESS({} ‰)", progress))
-            )
-        }
-        EventType::ImexFileWritten(file) => {
-            format!(
-                "{}",
-                green.paint(format!("Received IMEX_FILE_WRITTEN({})", file.display()))
-            )
-        }
-        EventType::ChatModified(chat) => {
-            format!(
-                "{}",
-                green.paint(format!("Received CHAT_MODIFIED({})", chat))
-            )
-        }
-        _ => {
-            format!("Received {:?}", event)
-        }
+        EventType::ImexProgress(progress) => format!(
+            "{}",
+            green.paint(format!("Received IMEX_PROGRESS({} ‰)", progress))
+        ),
+        EventType::ImexFileWritten(file) => format!(
+            "{}",
+            green.paint(format!("Received IMEX_FILE_WRITTEN({})", file.display()))
+        ),
+        EventType::ChatModified(chat) => format!(
+            "{}",
+            green.paint(format!("Received CHAT_MODIFIED({})", chat))
+        ),
+        _ => format!("Received {:?}", event),
     };
     let context_names = CONTEXT_NAMES.read().unwrap();
     match context_names.get(&event.id) {


### PR DESCRIPTION
This also checks that some of the correct user interactions happen,
checking we get a joiner event and the verified chat messages.

It also extends the test utils with the ability to distinguish the
different context logs by having them named.

I'm mostly trying to reduce the diff of an upcoming securejoin PR...