### PR TITLE
Refactor securejoin QR-code and bob state handling

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3063,7 +3063,7 @@ mod tests {
     #[async_std::test]
     async fn test_chat_info() {
         let t = TestContext::new().await;
-        let chat = t.chat_with_contact("bob", "bob@example.com").await;
+        let chat = t.create_chat_with_contact("bob", "bob@example.com").await;
         let info = chat.get_info(&t).await.unwrap();
 
         // Ensure we can serialize this.

--- a/src/context.rs
+++ b/src/context.rs
@@ -47,7 +47,7 @@ pub struct InnerContext {
     pub(crate) blobdir: PathBuf,
     pub(crate) sql: Sql,
     pub(crate) os_name: Option<String>,
-    pub(crate) bob: RwLock<Bob>,
+    pub(crate) bob: Bob,
     pub(crate) last_smeared_timestamp: RwLock<i64>,
     pub(crate) running_state: RwLock<RunningState>,
     /// Mutex to avoid generating the key for the user more than once.
@@ -129,7 +129,7 @@ impl Context {
             os_name: Some(os_name),
             running_state: RwLock::new(Default::default()),
             sql: Sql::new(),
-            bob: RwLock::new(Default::default()),
+            bob: Default::default(),
             last_smeared_timestamp: RwLock::new(0),
             generating_key_mutex: Mutex::new(()),
             oauth2_mutex: Mutex::new(()),
@@ -197,7 +197,10 @@ impl Context {
         });
     }
 
-    /// Get the next queued event.
+    /// Returns a receiver for emitted events.
+    ///
+    /// Multiple emitters can be created, but note that in this case each emitted event will
+    /// only be received by one of the emitters, not by all of them.
     pub fn get_event_emitter(&self) -> EventEmitter {
         self.events.get_emitter()
     }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -440,7 +440,6 @@ async fn add_parts(
                 }
                 Err(err) => {
                     *hidden = true;
-                    context.stop_ongoing().await;
                     warn!(context, "Error in Secure-Join message handling: {}", err);
                     return Ok(());
                 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -47,6 +47,17 @@ impl Events {
     }
 }
 
+/// A receiver of events from a [`Context`].
+///
+/// See [`Context::get_event_emitter`] to create an instance.  If multiple instances are
+/// created events emitted by the [`Context`] will only be delivered to one of the
+/// `EventEmitter`s.
+///
+/// The `EventEmitter` is also a [`Stream`], so a typical usage is in a `while let` loop.
+///
+/// [`Context`]: crate::context::Context
+/// [`Context::get_event_emitter`]: crate::context::Context::get_event_emitter
+/// [`Stream`]: async_std::stream::Stream
 #[derive(Debug, Clone)]
 pub struct EventEmitter(Receiver<Event>);
 
@@ -120,8 +131,9 @@ impl EventType {
 #[derive(Debug, Clone, PartialEq, Eq, EnumProperty)]
 pub enum EventType {
     /// The library-user may write an informational string to the log.
-    /// Passed to the callback given to dc_context_new().
-    /// This event should not be reported to the end-user using a popup or something like that.
+    ///
+    /// This event should *not* be reported to the end-user using a popup or something like
+    /// that.
     #[strum(props(id = "100"))]
     Info(String),
 
@@ -154,14 +166,13 @@ pub enum EventType {
     DeletedBlobFile(String),
 
     /// The library-user should write a warning string to the log.
-    /// Passed to the callback given to dc_context_new().
     ///
-    /// This event should not be reported to the end-user using a popup or something like that.
+    /// This event should *not* be reported to the end-user using a popup or something like
+    /// that.
     #[strum(props(id = "300"))]
     Warning(String),
 
     /// The library-user should report an error to the end-user.
-    /// Passed to the callback given to dc_context_new().
     ///
     /// As most things are asynchronous, things may go wrong at any time and the user
     /// should not be disturbed by a dialog or so.  Instead, use a bubble or so.

--- a/src/html.rs
+++ b/src/html.rs
@@ -451,7 +451,9 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         // alice receives a non-delta html-message
         let alice = TestContext::new_alice().await;
         alice.set_config(Config::ShowEmails, Some("2")).await.ok();
-        let chat = alice.chat_with_contact("", "sender@testrun.org").await;
+        let chat = alice
+            .create_chat_with_contact("", "sender@testrun.org")
+            .await;
         let raw = include_bytes!("../test-data/message/text_alt_plain_html.eml");
         dc_receive_imf(&alice, raw, "INBOX", 1, false)
             .await
@@ -466,7 +468,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         assert!(html.find("this is <b>html</b>").is_some());
 
         // alice: create chat with bob and forward received html-message there
-        let chat = alice.chat_with_contact("", "bob@example.net").await;
+        let chat = alice.create_chat_with_contact("", "bob@example.net").await;
         forward_msgs(&alice, &[msg.get_id()], chat.get_id())
             .await
             .unwrap();
@@ -481,7 +483,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
 
         // bob: check that bob also got the html-part of the forwarded message
         let bob = TestContext::new_bob().await;
-        let chat = bob.chat_with_contact("", "alice@example.com").await;
+        let chat = bob.create_chat_with_contact("", "alice@example.com").await;
         bob.recv_msg(&alice.pop_sent_msg().await).await;
         let msg = bob.get_last_msg_in(chat.get_id()).await;
         assert_ne!(msg.get_from_id(), DC_CONTACT_ID_SELF);
@@ -500,7 +502,9 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         // the contact is marked as known by creating a chat using `chat_with_contact()`)
         let alice = TestContext::new_alice().await;
         alice.set_config(Config::ShowEmails, Some("1")).await.ok();
-        let chat = alice.chat_with_contact("", "sender@testrun.org").await;
+        let chat = alice
+            .create_chat_with_contact("", "sender@testrun.org")
+            .await;
         let raw = include_bytes!("../test-data/message/text_alt_plain_html.eml");
         dc_receive_imf(&alice, raw, "INBOX", 1, false)
             .await

--- a/src/message.rs
+++ b/src/message.rs
@@ -2125,7 +2125,7 @@ mod tests {
             .await
             .unwrap();
 
-        let chat = d.chat_with_contact("", "dest@example.com").await;
+        let chat = d.create_chat_with_contact("", "dest@example.com").await;
 
         let mut msg = Message::new(Viewtype::Text);
 
@@ -2141,7 +2141,7 @@ mod tests {
         let d = test::TestContext::new().await;
         let ctx = &d.ctx;
 
-        let chat = d.chat_with_contact("", "dest@example.com").await;
+        let chat = d.create_chat_with_contact("", "dest@example.com").await;
 
         let mut msg = Message::new(Viewtype::Text);
 
@@ -2331,7 +2331,7 @@ mod tests {
             .await
             .unwrap();
 
-        let chat = d.chat_with_contact("", "dest@example.com").await;
+        let chat = d.create_chat_with_contact("", "dest@example.com").await;
 
         let mut msg = Message::new(Viewtype::Text);
         msg.set_text(Some("Quoted message".to_string()));

--- a/src/securejoin/bobstate.rs
+++ b/src/securejoin/bobstate.rs
@@ -135,6 +135,8 @@ impl<'a> BobStateHandle<'a> {
 impl<'a> Drop for BobStateHandle<'a> {
     fn drop(&mut self) {
         if self.clear_state_on_drop {
+            // The Option should already be empty because we take it out in the ctor,
+            // however the typesystem doesn't guarantee this so do it again anyway.
             self.guard.take();
         } else {
             // Make sure to put back the BobState into the Option of the Mutex, it was taken

--- a/src/securejoin/bobstate.rs
+++ b/src/securejoin/bobstate.rs
@@ -1,0 +1,532 @@
+//! Secure-Join protocol state machine for Bob, the joiner-side.
+//!
+//! This module contains the state machine to run the Secure-Join handshake for Bob and does
+//! not do any user interaction required by the protocol.  Instead the state machine
+//! provides all the information to the driver of them to perform the correct interactions.
+//!
+//! The [`BobState`] is only directly used to initially create it when starting the
+//! protocol.  Afterwards it must be stored in a mutex and the [`BobStateHandle`] should be
+//! used to work with the state.
+
+use anyhow::{Error, Result};
+use async_std::sync::MutexGuard;
+
+use crate::chat::{self, ChatId};
+use crate::constants::{Blocked, Viewtype};
+use crate::contact::{Contact, Origin};
+use crate::context::Context;
+use crate::events::EventType;
+use crate::headerdef::HeaderDef;
+use crate::key::{DcKey, SignedPublicKey};
+use crate::message::Message;
+use crate::mimeparser::{MimeMessage, SystemMessage};
+use crate::param::Param;
+
+use super::qrinvite::QrInvite;
+use super::{
+    encrypted_and_signed, fingerprint_equals_sender, mark_peer_as_verified, JoinError, SendMsgError,
+};
+
+/// The stage of the [`BobState`] securejoin handshake protocol state machine.
+///
+/// This does not concern itself with user interactions, only represents what happened to
+/// the protocol state machine from handling this message.
+#[derive(Clone, Copy, Debug, Display)]
+pub enum BobHandshakeStage {
+    /// Step 2 completed: (vc|vg)-request message sent.
+    ///
+    /// Note that this is only ever returned by [`BobState::start_protocol`] and never by
+    /// [`BobState::handle_message`].
+    RequestSent,
+    /// Step 4 completed: (vc|vg)-request-with-auth message sent.
+    RequestWithAuthSent,
+    /// The protocol completed successfully.
+    Completed,
+    /// The protocol prematurely terminated with given reason.
+    Terminated(&'static str),
+}
+
+/// A handle to work with the [`BobState`] of Bob's securejoin protocol.
+///
+/// This handle can only be created for when an underlying [`BobState`] exists.  It keeps
+/// open a lock which guarantees unique access to the state and this struct must be dropped
+/// to return the lock.
+pub struct BobStateHandle<'a> {
+    guard: MutexGuard<'a, Option<BobState>>,
+    clear_state_on_drop: bool,
+}
+
+impl<'a> BobStateHandle<'a> {
+    /// Creates a new instance, upholding the guarantee that [`BobState`] must exist.
+    pub fn from_guard(guard: MutexGuard<'a, Option<BobState>>) -> Option<Self> {
+        match *guard {
+            Some(_) => Some(Self {
+                guard,
+                clear_state_on_drop: false,
+            }),
+            None => None,
+        }
+    }
+
+    /// Returns the [`ChatId`] of the 1:1 chat with the inviter (Alice).
+    ///
+    /// # Safety
+    ///
+    /// [`BobStateHandle::from_guard`] guarantees this struct is only created with a valid
+    /// state available.
+    pub fn chat_id(&self) -> ChatId {
+        match *self.guard {
+            Some(ref bobstate) => bobstate.chat_id,
+            None => unreachable!(),
+        }
+    }
+
+    /// Returns a reference to the [`QrInvite`] of the joiner process.
+    ///
+    /// # Safety
+    ///
+    /// [`BobStateHandle::from_guard`] guarantees this struct is only created with a valid
+    /// state available.
+    pub fn invite(&self) -> &QrInvite {
+        match *self.guard {
+            Some(ref bobstate) => &bobstate.invite,
+            None => unreachable!(),
+        }
+    }
+
+    /// Handles the given message for the securejoin handshake for Bob.
+    ///
+    /// This proxies to [`BobState::handle_message`] and makes sure to clear the state when
+    /// the protocol state is terminal.  It returns `Some` if the message successfully
+    /// advanced the state of the protocol state machine, `None` otherwise.
+    pub async fn handle_message(
+        &mut self,
+        context: &Context,
+        mime_message: &MimeMessage,
+    ) -> Option<BobHandshakeStage> {
+        info!(context, "Handling securejoin message for BobStateHandle");
+        match *self.guard {
+            Some(ref mut bobstate) => match bobstate.handle_message(context, mime_message).await {
+                Ok(Some(stage)) => {
+                    if matches!(stage,
+                                BobHandshakeStage::Completed
+                                | BobHandshakeStage::Terminated(_))
+                    {
+                        self.finish_protocol(context).await;
+                    }
+                    Some(stage)
+                }
+                Ok(None) => None,
+                Err(_) => {
+                    self.finish_protocol(context).await;
+                    None
+                }
+            },
+            None => None, // also unreachable!()
+        }
+    }
+
+    /// Marks the bob handshake as finished.
+    ///
+    /// This will clear the state on [`InnerContext::bob`] once this handle is dropped,
+    /// allowing a new handshake to be started from [`Bob`].
+    ///
+    /// Note that the state is only cleared on Drop since otherwise the invariant that the
+    /// state is always cosistent is violated.  However the "ongoing" prococess is released
+    /// here a little bit earlier as this requires access to the Context, which we do not
+    /// have on Drop (Drop can not run asynchronous code).
+    ///
+    /// [`InnerContext::bob`]: crate::context::InnerContext::bob
+    /// [`Bob`]: super::Bob
+    async fn finish_protocol(&mut self, context: &Context) {
+        info!(context, "Finishing securejoin handshake protocol for Bob");
+        self.clear_state_on_drop = true;
+        if let Some(ref bobstate) = *self.guard {
+            if let QrInvite::Group { .. } = bobstate.invite {
+                context.stop_ongoing().await;
+            }
+        }
+    }
+}
+
+impl<'a> Drop for BobStateHandle<'a> {
+    fn drop(&mut self) {
+        if self.clear_state_on_drop {
+            self.guard.take();
+        }
+    }
+}
+
+/// The securejoin state kept in-memory while Bob is joining.
+///
+/// This is currently stored in [`Bob`] which is stored on the [`Context`], thus Bob can
+/// only run one securejoin joiner protocol at a time.
+///
+/// This purposefully has nothing optional, the state is always fully valid.  See
+/// [`Bob::state`] to get access to this state.
+///
+/// # Conducing the securejoin handshake
+///
+/// The methods on this struct allow you to interact with the state and thus conduct the
+/// securejoin handshake for Bob.  The methods **only concern themselves** with the protocol
+/// state and explicitly avoid doing performing any user interactions required by
+/// securejoin.  This simplifies the concerns and logic required in both the callers and in
+/// the state management.  The return values can be used to understand what user
+/// interactions need to happen.
+///
+/// [`Bob`]: super::Bob
+/// [`Bob::state`]: super::Bob::state
+#[derive(Debug)]
+pub struct BobState {
+    /// The QR Invite code.
+    invite: QrInvite,
+    /// The next expected message from Alice.
+    next: SecureJoinStep,
+    /// The [`ChatId`] of the 1:1 chat with Alice, matching [`QrInvite::contact_id`].
+    chat_id: ChatId,
+}
+
+impl BobState {
+    /// Starts the securejoin protocol and creates a new [`BobState`].
+    ///
+    /// # Bob - the joiner's side
+    /// ## Step 2 in the "Setup Contact protocol", section 2.1 of countermitm 0.10.0
+    pub async fn start_protocol(
+        context: &Context,
+        invite: QrInvite,
+    ) -> Result<(Self, BobHandshakeStage), JoinError> {
+        let chat_id = chat::create_by_contact_id(context, invite.contact_id())
+            .await
+            .map_err(JoinError::UnknownContact)?;
+        if fingerprint_equals_sender(context, invite.fingerprint(), chat_id).await {
+            // The scanned fingerprint matches Alice's key, we can proceed to step 4b.
+            info!(context, "Taking securejoin protocol shortcut");
+            let state = Self {
+                invite,
+                next: SecureJoinStep::ContactConfirm,
+                chat_id,
+            };
+            state
+                .send_handshake_message(context, BobHandshakeMsg::RequestWithAuth)
+                .await?;
+            Ok((state, BobHandshakeStage::RequestWithAuthSent))
+        } else {
+            let state = Self {
+                invite,
+                next: SecureJoinStep::AuthRequired,
+                chat_id,
+            };
+            state
+                .send_handshake_message(context, BobHandshakeMsg::Request)
+                .await?;
+            Ok((state, BobHandshakeStage::RequestSent))
+        }
+    }
+
+    /// Returns the [`QrInvite`] use to create this [`BobState`].
+    pub fn invite(&self) -> &QrInvite {
+        &self.invite
+    }
+
+    /// Handles the given message for the securejoin handshake for Bob.
+    ///
+    /// If the message was not used for this handshake `None` is returned, otherwise the new
+    /// stage is returned.  Once [`BobHandshakeStage::Completed`] or
+    /// [`BobHandshakeStage::Terminated`] are reached this [`BobState`] should be destroyed,
+    /// further calling it will just result in the messages being unused by this handshake.
+    ///
+    /// # Errors
+    ///
+    /// Under normal operation this should never return an error, regardless of what kind of
+    /// message it is called with.  Any errors therefore should be treated as fatal internal
+    /// errors and this entire [`BobState`] should be thrown away as the state machine can
+    /// no longer be considered consistent.
+    async fn handle_message(
+        &mut self,
+        context: &Context,
+        mime_message: &MimeMessage,
+    ) -> Result<Option<BobHandshakeStage>> {
+        let step = match mime_message.get(HeaderDef::SecureJoin) {
+            Some(step) => step,
+            None => {
+                warn!(
+                    context,
+                    "Message has no Secure-Join header: {}",
+                    mime_message.get_rfc724_mid().unwrap_or_default()
+                );
+                return Ok(None);
+            }
+        };
+        if !self.is_msg_expected(context, step.as_str()) {
+            info!(context, "{} message out of sync for BobState", step);
+            return Ok(None);
+        }
+        match step.as_str() {
+            "vg-auth-required" | "vc-auth-required" => {
+                self.step_auth_required(context, mime_message).await
+            }
+            "vg-member-added" | "vc-contact-confirm" => {
+                self.step_contact_confirm(context, mime_message).await
+            }
+            _ => {
+                warn!(context, "Invalid step for BobState: {}", step);
+                Ok(None)
+            }
+        }
+    }
+
+    /// Returns `true` if the message is expected according to the protocol.
+    fn is_msg_expected(&self, context: &Context, step: &str) -> bool {
+        let variant_matches = match self.invite {
+            QrInvite::Contact { .. } => step.starts_with("vc-"),
+            QrInvite::Group { .. } => step.starts_with("vg-"),
+        };
+        let step_matches = self.next.matches(context, step);
+        variant_matches && step_matches
+    }
+
+    /// Handles a *vc-auth-required* or *vg-auth-required* message.
+    ///
+    /// # Bob - the joiner's side
+    /// ## Step 4 in the "Setup Contact protocol", section 2.1 of countermitm 0.10.0
+    async fn step_auth_required(
+        &mut self,
+        context: &Context,
+        mime_message: &MimeMessage,
+    ) -> Result<Option<BobHandshakeStage>> {
+        info!(
+            context,
+            "Bob Step 4 - handling vc-auth-require/vg-auth-required message"
+        );
+        if !encrypted_and_signed(context, mime_message, Some(self.invite.fingerprint())) {
+            let reason = if mime_message.was_encrypted() {
+                "Valid signature missing"
+            } else {
+                "Required encryption missing"
+            };
+            self.next = SecureJoinStep::Terminated;
+            return Ok(Some(BobHandshakeStage::Terminated(reason)));
+        }
+        if !fingerprint_equals_sender(context, self.invite.fingerprint(), self.chat_id).await {
+            self.next = SecureJoinStep::Terminated;
+            return Ok(Some(BobHandshakeStage::Terminated("Fingerprint mismatch")));
+        }
+        info!(context, "Fingerprint verified.",);
+        self.next = SecureJoinStep::ContactConfirm;
+        self.send_handshake_message(context, BobHandshakeMsg::RequestWithAuth)
+            .await?;
+        Ok(Some(BobHandshakeStage::RequestWithAuthSent))
+    }
+
+    /// Handles a *vc-contact-confirm* or *vg-member-added* message.
+    ///
+    /// # Bob - the joiner's side
+    /// ## Step 7 in the "Setup Contact protocol", section 2.1 of countermitm 0.10.0
+    ///
+    /// This deviates from the protocol by also sending a confirmation message in response
+    /// to the *vc-contact-confirm* message.  This has no specific value to the protocol and
+    /// is only done out of symmerty with *vg-member-added* handling.
+    async fn step_contact_confirm(
+        &mut self,
+        context: &Context,
+        mime_message: &MimeMessage,
+    ) -> Result<Option<BobHandshakeStage>> {
+        info!(
+            context,
+            "Bob Step 7 - handling vc-contact-confirm/vg-member-added message"
+        );
+        let vg_expect_encrypted = match self.invite {
+            QrInvite::Contact { .. } => {
+                // setup-contact is always encrypted
+                true
+            }
+            QrInvite::Group { ref grpid, .. } => {
+                // This is buggy, is_verified_group will always be
+                // false since the group is created by receive_imf for
+                // the very handshake message we're handling now.  But
+                // only after we have returned.  It does not impact
+                // the security invariants of secure-join however.
+                let (_, is_verified_group, _) = chat::get_chat_id_by_grpid(context, grpid)
+                    .await
+                    .unwrap_or((ChatId::new(0), false, Blocked::Not));
+                // when joining a non-verified group
+                // the vg-member-added message may be unencrypted
+                // when not all group members have keys or prefer encryption.
+                // So only expect encryption if this is a verified group
+                is_verified_group
+            }
+        };
+        if vg_expect_encrypted
+            && !encrypted_and_signed(context, mime_message, Some(self.invite.fingerprint()))
+        {
+            self.next = SecureJoinStep::Terminated;
+            return Ok(Some(BobHandshakeStage::Terminated(
+                "Contact confirm message not encrypted",
+            )));
+        }
+        mark_peer_as_verified(context, self.invite.fingerprint()).await?;
+        Contact::scaleup_origin_by_id(context, self.invite.contact_id(), Origin::SecurejoinJoined)
+            .await;
+        emit_event!(context, EventType::ContactsChanged(None));
+
+        if let QrInvite::Group { .. } = self.invite {
+            let member_added = mime_message
+                .get(HeaderDef::ChatGroupMemberAdded)
+                .map(|s| s.as_str())
+                .ok_or_else(|| Error::msg("Missing Chat-Group-Member-Added header"))?;
+            if !context.is_self_addr(member_added).await? {
+                info!(context, "Message belongs to a different handshake (scaled up contact anyway to allow creation of group).");
+                return Ok(None);
+            }
+        }
+
+        self.send_handshake_message(context, BobHandshakeMsg::ContactConfirmReceived)
+            .await
+            .map_err(|_| {
+                warn!(
+                    context,
+                    "Failed to send vc-contact-confirm-received/vg-member-added-received"
+                );
+            })
+            // This is not an error affecting the protocol outcome.
+            .ok();
+
+        self.next = SecureJoinStep::Completed;
+        Ok(Some(BobHandshakeStage::Completed))
+    }
+
+    /// Sends the requested handshake message to Alice.
+    ///
+    /// This takes care of adding the required headers for the step.
+    async fn send_handshake_message(
+        &self,
+        context: &Context,
+        step: BobHandshakeMsg,
+    ) -> Result<(), SendMsgError> {
+        let mut msg = Message {
+            viewtype: Viewtype::Text,
+            text: Some(step.body_text(&self.invite)),
+            hidden: true,
+            ..Default::default()
+        };
+        msg.param.set_cmd(SystemMessage::SecurejoinMessage);
+
+        // Sends the step in Secure-Join header.
+        msg.param
+            .set(Param::Arg, step.securejoin_header(&self.invite));
+
+        match step {
+            BobHandshakeMsg::Request => {
+                // Sends the Secure-Join-Invitenumber header in mimefactory.rs.
+                msg.param.set(Param::Arg2, self.invite.invitenumber());
+                msg.param.set_int(Param::ForcePlaintext, 1);
+            }
+            BobHandshakeMsg::RequestWithAuth => {
+                // Sends the Secure-Join-Auth header in mimefactory.rs.
+                msg.param.set(Param::Arg2, self.invite.authcode());
+                msg.param.set_int(Param::GuaranteeE2ee, 1);
+            }
+            BobHandshakeMsg::ContactConfirmReceived => {
+                msg.param.set_int(Param::GuaranteeE2ee, 1);
+            }
+        };
+
+        // Sends our own fingerprint in the Secure-Join-Fingerprint header.
+        let bob_fp = SignedPublicKey::load_self(context).await?.fingerprint();
+        msg.param.set(Param::Arg3, bob_fp.hex());
+
+        // Sends the grpid in the Secure-Join-Group header.
+        if let QrInvite::Group { ref grpid, .. } = self.invite {
+            msg.param.set(Param::Arg4, grpid);
+        }
+
+        chat::send_msg(context, self.chat_id, &mut msg).await?;
+        Ok(())
+    }
+}
+
+/// Identifies the SecureJoin handshake messages Bob can send.
+enum BobHandshakeMsg {
+    /// vc-request or vg-request
+    Request,
+    /// vc-request-with-auth or vg-request-with-auth
+    RequestWithAuth,
+    /// vc-contact-confirm-received or vg-member-added-received
+    ContactConfirmReceived,
+}
+
+impl BobHandshakeMsg {
+    /// Returns the text to send in the body of the handshake message.
+    ///
+    /// This text has no significance to the protocol, but would be visible if users see
+    /// this email message directly, e.g. when accessing their email without using
+    /// DeltaChat.
+    fn body_text(&self, invite: &QrInvite) -> String {
+        format!("Secure-Join: {}", self.securejoin_header(invite))
+    }
+
+    /// Returns the `Secure-Join` header value.
+    ///
+    /// This identifies the step this message is sending information about.  Most protocol
+    /// steps include additional information into other headers, see
+    /// [`BobState::send_handshake_message`] for these.
+    fn securejoin_header(&self, invite: &QrInvite) -> &'static str {
+        match self {
+            Self::Request => match invite {
+                QrInvite::Contact { .. } => "vc-request",
+                QrInvite::Group { .. } => "vg-request",
+            },
+            Self::RequestWithAuth => match invite {
+                QrInvite::Contact { .. } => "vc-request-with-auth",
+                QrInvite::Group { .. } => "vg-request-with-auth",
+            },
+            Self::ContactConfirmReceived => match invite {
+                QrInvite::Contact { .. } => "vc-contact-confirm-received",
+                QrInvite::Group { .. } => "vg-member-added-received",
+            },
+        }
+    }
+}
+
+/// The next message expected by [`BobState`] in the setup-contact/secure-join protocol.
+#[derive(Debug, PartialEq)]
+enum SecureJoinStep {
+    /// Expecting the auth-required message.
+    ///
+    /// This corresponds to the `vc-auth-required` or `vg-auth-required` message of step 3d.
+    AuthRequired,
+    /// Expecting the contact-confirm message.
+    ///
+    /// This corresponds to the `vc-contact-confirm` or `vg-member-added` message of step
+    /// 6b.
+    ContactConfirm,
+    /// The protocol terminated because of an error.
+    ///
+    /// The securejoin protocol terminated, this exists to ensure [`BobState`] can detect
+    /// when it earlier signalled that is should be terminated.  It is an error to call with
+    /// this state.
+    Terminated,
+    /// The protocol completed.
+    ///
+    /// This exists to ensure [`BobState`] can detect when it earlier signalled that it is
+    /// complete.  It is an error to call with this state.
+    Completed,
+}
+
+impl SecureJoinStep {
+    /// Compares the legacy string representation of a step to a [`SecureJoinStep`] variant.
+    fn matches(&self, context: &Context, step: &str) -> bool {
+        match self {
+            Self::AuthRequired => step == "vc-auth-required" || step == "vg-auth-required",
+            Self::ContactConfirm => step == "vc-contact-confirm" || step == "vg-member-added",
+            SecureJoinStep::Terminated => {
+                warn!(context, "Terminated state for next securejoin step");
+                false
+            }
+            SecureJoinStep::Completed => {
+                warn!(context, "Complted state for next securejoin step");
+                false
+            }
+        }
+    }
+}

--- a/src/securejoin/mod.rs
+++ b/src/securejoin/mod.rs
@@ -824,7 +824,7 @@ async fn secure_connection_established(context: &Context, contact_chat_id: ChatI
         .await;
     chat::add_info_msg(context, contact_chat_id, &msg).await;
     emit_event!(context, EventType::ChatModified(contact_chat_id));
-    info!(context, "{}", msg);
+    info!(context, "StockMessage::ContactVerified posted to 1:1 chat");
 }
 
 async fn could_not_establish_secure_connection(
@@ -846,7 +846,10 @@ async fn could_not_establish_secure_connection(
         .await;
 
     chat::add_info_msg(context, contact_chat_id, &msg).await;
-    error!(context, "{} ({})", &msg, details);
+    error!(
+        context,
+        "StockMessage::ContactNotVerified posted to 1:1 chat ({})", details
+    );
 }
 
 async fn mark_peer_as_verified(context: &Context, fingerprint: &Fingerprint) -> Result<(), Error> {

--- a/src/securejoin/mod.rs
+++ b/src/securejoin/mod.rs
@@ -4,7 +4,7 @@ use std::convert::TryFrom;
 use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context as _, Error, Result};
-use async_std::sync::{Mutex, MutexGuard};
+use async_std::sync::Mutex;
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 
 use crate::aheader::EncryptPreference;
@@ -26,8 +26,10 @@ use crate::sql;
 use crate::stock::StockMessage;
 use crate::token;
 
+mod bobstate;
 mod qrinvite;
 
+use bobstate::{BobHandshakeStage, BobState, BobStateHandle};
 use qrinvite::{QrError, QrInvite};
 
 pub const NON_ALPHANUMERIC_WITHOUT_DOT: &AsciiSet = &NON_ALPHANUMERIC.remove(b'.');
@@ -62,7 +64,7 @@ macro_rules! inviter_progress {
 ///
 /// The setup-contact protocol needs to carry state for both the inviter (Alice) and the
 /// joiner/invitee (Bob).  For Alice this state is minimal and in the `tokens` table in the
-/// database.  For Bob this state is only carried live on the [Context] in this struct.
+/// database.  For Bob this state is only carried live on the [`Context`] in this struct.
 #[derive(Debug, Default)]
 pub(crate) struct Bob {
     inner: Mutex<Option<BobState>>,
@@ -91,7 +93,7 @@ impl Bob {
         match BobState::start_protocol(context, invite).await {
             Ok((state, stage)) => {
                 if matches!(stage, BobHandshakeStage::RequestWithAuthSent) {
-                    joiner_progress!(context, state.invite.contact_id(), 400);
+                    joiner_progress!(context, state.invite().contact_id(), 400);
                 }
                 *guard = Some(state);
                 Ok(())
@@ -121,487 +123,6 @@ impl Bob {
             info!(context, "No active BobState found for securejoin handshake");
         }
         ret
-    }
-}
-
-/// A handle to work with the [`BobState`] of Bob's securejoin protocol.
-///
-/// This handle can only be created for when an underlying [`BobState`] exists.  It keeps
-/// open a lock which guarantees unique access to the state and this struct must be dropped
-/// to return the lock.
-struct BobStateHandle<'a> {
-    guard: MutexGuard<'a, Option<BobState>>,
-    clear_state_on_drop: bool,
-}
-
-impl<'a> BobStateHandle<'a> {
-    /// Creates a new instance, upholding the guarantee that [`BobState`] must exist.
-    fn from_guard(guard: MutexGuard<'a, Option<BobState>>) -> Option<Self> {
-        match *guard {
-            Some(_) => Some(Self {
-                guard,
-                clear_state_on_drop: false,
-            }),
-            None => None,
-        }
-    }
-
-    /// Returns the [`ChatId`] of the 1:1 chat with the inviter (Alice).
-    pub fn chat_id(&self) -> Result<ChatId> {
-        match *self.guard {
-            Some(ref bobstate) => Ok(bobstate.chat_id),
-            None => Err(Error::msg("Invalid BobStateHandle state")),
-        }
-    }
-
-    /// Returns a reference to the [`QrInvite`] of the joiner process.
-    pub fn invite(&self) -> Result<&QrInvite> {
-        match *self.guard {
-            Some(ref bobstate) => Ok(&bobstate.invite),
-            None => Err(Error::msg("Invalid BobStateHandle state")),
-        }
-    }
-
-    /// Handles the given message for the securejoin handshake for Bob.
-    ///
-    /// This proxies to [`BobState::handle_message`] and makes sure to clear the state when
-    /// the protocol state is terminal.  It returns `Some` if the message successfully
-    /// advanced the state of the protocol state machine, `None` otherwise.
-    pub async fn handle_message(
-        &mut self,
-        context: &Context,
-        mime_message: &MimeMessage,
-    ) -> Option<BobHandshakeStage> {
-        info!(context, "Handling securejoin message for BobStateHandle");
-        match *self.guard {
-            Some(ref mut bobstate) => match bobstate.handle_message(context, mime_message).await {
-                Ok(Some(stage)) => {
-                    if matches!(stage,
-                                BobHandshakeStage::Completed
-                                | BobHandshakeStage::Terminated(_))
-                    {
-                        self.finish_protocol(context).await;
-                    }
-                    Some(stage)
-                }
-                Ok(None) => None,
-                Err(_) => {
-                    self.finish_protocol(context).await;
-                    None
-                }
-            },
-            None => None,
-        }
-    }
-
-    /// Marks the bob handshake as finished.
-    ///
-    /// This will clear the state on [`Context::bob`] once this handle is dropped, allowing
-    /// a new handshake to be started from [`Bob`].
-    ///
-    /// Note that the state is only cleared on Drop since otherwise the invariant that the
-    /// state is always cosistent is violated.  However the "ongoing" prococess is released
-    /// here a little bit earlier as this requires access to the Context, which we do not
-    /// have on Drop (Drop can not run asynchronous code).
-    async fn finish_protocol(&mut self, context: &Context) {
-        info!(context, "Finishing securejoin handshake protocol for Bob");
-        self.clear_state_on_drop = true;
-        if let Some(ref bobstate) = *self.guard {
-            if let QrInvite::Group { .. } = bobstate.invite {
-                context.stop_ongoing().await;
-            }
-        }
-    }
-}
-
-impl<'a> Drop for BobStateHandle<'a> {
-    fn drop(&mut self) {
-        if self.clear_state_on_drop {
-            self.guard.take();
-        }
-    }
-}
-
-/// The securejoin state kept in-memory while Bob is joining.
-///
-/// This is currently stored in [`Bob`] which is stored on the [`Context`], thus Bob can
-/// only run one securejoin joiner protocol at a time.
-///
-/// This purposefully has nothing optional, the state is always fully valid.  See
-/// [`Bob::state`] to get access to this state.
-///
-/// # Conducing the securejoin handshake
-///
-/// The methods on this struct allow you to interact with the state and thus conduct the
-/// securejoin handshake for Bob.  The methods **only concern themselves** with the protocol
-/// state and explicitly avoid doing performing any user interactions required by
-/// securejoin.  This simplifies the concerns and logic required in both the callers and in
-/// the state management.  The return values can be used to understand what user
-/// interactions need to happen.
-#[derive(Debug)]
-struct BobState {
-    /// The QR Invite code.
-    invite: QrInvite,
-    /// The next expected message from Alice.
-    next: SecureJoinStep,
-    /// The [ChatId] of the 1:1 chat with Alice, matching [QrInvite::contact].
-    chat_id: ChatId,
-}
-
-impl BobState {
-    /// Starts the securejoin protocol and creates a new [`BobState`].
-    ///
-    /// # Bob - the joiner's side
-    /// ## Step 2 in the "Setup Contact protocol", section 2.1 of countermitm 0.10.0
-    async fn start_protocol(
-        context: &Context,
-        invite: QrInvite,
-    ) -> Result<(Self, BobHandshakeStage), JoinError> {
-        let chat_id = chat::create_by_contact_id(context, invite.contact_id())
-            .await
-            .map_err(JoinError::UnknownContact)?;
-        if fingerprint_equals_sender(context, invite.fingerprint(), chat_id).await {
-            // The scanned fingerprint matches Alice's key, we can proceed to step 4b.
-            info!(context, "Taking securejoin protocol shortcut");
-            let state = Self {
-                invite,
-                next: SecureJoinStep::ContactConfirm,
-                chat_id,
-            };
-            state
-                .send_handshake_message(context, BobHandshakeMsg::RequestWithAuth)
-                .await?;
-            Ok((state, BobHandshakeStage::RequestWithAuthSent))
-        } else {
-            let state = Self {
-                invite,
-                next: SecureJoinStep::AuthRequired,
-                chat_id,
-            };
-            state
-                .send_handshake_message(context, BobHandshakeMsg::Request)
-                .await?;
-            Ok((state, BobHandshakeStage::RequestSent))
-        }
-    }
-
-    /// Handles the given message for the securejoin handshake for Bob.
-    ///
-    /// If the message was not used for this handshake `None` is returned, otherwise the new
-    /// stage is returned.  Once [`BobHandshakeStage::Completed`] or
-    /// [`BobHandshakeStage::Terminated`] are reached this [`BobState`] should be destroyed,
-    /// further calling it will just result in the messages being unused by this handshake.
-    ///
-    /// # Errors
-    ///
-    /// Under normal operation this should never return an error, regardless of what kind of
-    /// message it is called with.  Any errors therefore should be treated as fatal internal
-    /// errors and this entire [`BobState`] should be thrown away as the state machine can
-    /// no longer be considered consistent.
-    async fn handle_message(
-        &mut self,
-        context: &Context,
-        mime_message: &MimeMessage,
-    ) -> Result<Option<BobHandshakeStage>> {
-        let step = match mime_message.get(HeaderDef::SecureJoin) {
-            Some(step) => step,
-            None => {
-                warn!(
-                    context,
-                    "Message has no Secure-Join header: {}",
-                    mime_message.get_rfc724_mid().unwrap_or_default()
-                );
-                return Ok(None);
-            }
-        };
-        if !self.is_msg_expected(context, step.as_str()) {
-            info!(context, "{} message out of sync for BobState", step);
-            return Ok(None);
-        }
-        match step.as_str() {
-            "vg-auth-required" | "vc-auth-required" => {
-                self.step_auth_required(context, mime_message).await
-            }
-            "vg-member-added" | "vc-contact-confirm" => {
-                self.step_contact_confirm(context, mime_message).await
-            }
-            _ => {
-                warn!(context, "Invalid step for BobState: {}", step);
-                Ok(None)
-            }
-        }
-    }
-
-    /// Returns `true` if the message is expected according to the protocol.
-    fn is_msg_expected(&self, context: &Context, step: &str) -> bool {
-        let variant_matches = match self.invite {
-            QrInvite::Contact { .. } => step.starts_with("vc-"),
-            QrInvite::Group { .. } => step.starts_with("vg-"),
-        };
-        let step_matches = self.next.matches(context, step);
-        variant_matches && step_matches
-    }
-
-    /// Handles a *vc-auth-required* or *vg-auth-required* message.
-    ///
-    /// # Bob - the joiner's side
-    /// ## Step 4 in the "Setup Contact protocol", section 2.1 of countermitm 0.10.0
-    async fn step_auth_required(
-        &mut self,
-        context: &Context,
-        mime_message: &MimeMessage,
-    ) -> Result<Option<BobHandshakeStage>> {
-        info!(
-            context,
-            "Bob Step 4 - handling vc-auth-require/vg-auth-required message"
-        );
-        if !encrypted_and_signed(context, mime_message, Some(self.invite.fingerprint())) {
-            let reason = if mime_message.was_encrypted() {
-                "Valid signature missing"
-            } else {
-                "Required encryption missing"
-            };
-            self.next = SecureJoinStep::Terminated;
-            return Ok(Some(BobHandshakeStage::Terminated(reason)));
-        }
-        if !fingerprint_equals_sender(context, self.invite.fingerprint(), self.chat_id).await {
-            self.next = SecureJoinStep::Terminated;
-            return Ok(Some(BobHandshakeStage::Terminated("Fingerprint mismatch")));
-        }
-        info!(context, "Fingerprint verified.",);
-        self.next = SecureJoinStep::ContactConfirm;
-        self.send_handshake_message(context, BobHandshakeMsg::RequestWithAuth)
-            .await?;
-        Ok(Some(BobHandshakeStage::RequestWithAuthSent))
-    }
-
-    /// Handles a *vc-contact-confirm* or *vg-member-added* message.
-    ///
-    /// # Bob - the joiner's side
-    /// ## Step 7 in the "Setup Contact protocol", section 2.1 of countermitm 0.10.0
-    ///
-    /// This deviates from the protocol by also sending a confirmation message in response
-    /// to the *vc-contact-confirm* message.  This has no specific value to the protocol and
-    /// is only done out of symmerty with *vg-member-added* handling.
-    async fn step_contact_confirm(
-        &mut self,
-        context: &Context,
-        mime_message: &MimeMessage,
-    ) -> Result<Option<BobHandshakeStage>> {
-        info!(
-            context,
-            "Bob Step 7 - handling vc-contact-confirm/vg-member-added message"
-        );
-        let vg_expect_encrypted = match self.invite {
-            QrInvite::Contact { .. } => {
-                // setup-contact is always encrypted
-                true
-            }
-            QrInvite::Group { ref grpid, .. } => {
-                // This is buggy, is_verified_group will always be
-                // false since the group is created by receive_imf for
-                // the very handshake message we're handling now.  But
-                // only after we have returned.  It does not impact
-                // the security invariants of secure-join however.
-                let (_, is_verified_group, _) = chat::get_chat_id_by_grpid(context, grpid)
-                    .await
-                    .unwrap_or((ChatId::new(0), false, Blocked::Not));
-                // when joining a non-verified group
-                // the vg-member-added message may be unencrypted
-                // when not all group members have keys or prefer encryption.
-                // So only expect encryption if this is a verified group
-                is_verified_group
-            }
-        };
-        if vg_expect_encrypted
-            && !encrypted_and_signed(context, mime_message, Some(self.invite.fingerprint()))
-        {
-            self.next = SecureJoinStep::Terminated;
-            return Ok(Some(BobHandshakeStage::Terminated(
-                "Contact confirm message not encrypted",
-            )));
-        }
-        mark_peer_as_verified(context, self.invite.fingerprint()).await?;
-        Contact::scaleup_origin_by_id(context, self.invite.contact_id(), Origin::SecurejoinJoined)
-            .await;
-        emit_event!(context, EventType::ContactsChanged(None));
-
-        if let QrInvite::Group { .. } = self.invite {
-            let member_added = mime_message
-                .get(HeaderDef::ChatGroupMemberAdded)
-                .map(|s| s.as_str())
-                .ok_or_else(|| Error::msg("Missing Chat-Group-Member-Added header"))?;
-            if !context.is_self_addr(member_added).await? {
-                info!(context, "Message belongs to a different handshake (scaled up contact anyway to allow creation of group).");
-                return Ok(None);
-            }
-        }
-
-        self.send_handshake_message(context, BobHandshakeMsg::ContactConfirmReceived)
-            .await
-            .map_err(|_| {
-                warn!(
-                    context,
-                    "Failed to send vc-contact-confirm-received/vg-member-added-received"
-                );
-            })
-            // This is not an error affecting the protocol outcome.
-            .ok();
-
-        self.next = SecureJoinStep::Completed;
-        Ok(Some(BobHandshakeStage::Completed))
-    }
-
-    /// Sends the requested handshake message to Alice.
-    ///
-    /// This takes care of adding the required headers for the step.
-    async fn send_handshake_message(
-        &self,
-        context: &Context,
-        step: BobHandshakeMsg,
-    ) -> Result<(), SendMsgError> {
-        let mut msg = Message::default();
-        msg.viewtype = Viewtype::Text;
-        msg.text = Some(step.body_text(&self.invite));
-        msg.hidden = true;
-        msg.param.set_cmd(SystemMessage::SecurejoinMessage);
-
-        // Sends the step in Secure-Join header.
-        msg.param
-            .set(Param::Arg, step.securejoin_header(&self.invite));
-
-        match step {
-            BobHandshakeMsg::Request => {
-                // Sends the Secure-Join-Invitenumber header in mimefactory.rs.
-                msg.param.set(Param::Arg2, self.invite.invitenumber());
-                msg.param.set_int(Param::ForcePlaintext, 1);
-            }
-            BobHandshakeMsg::RequestWithAuth => {
-                // Sends the Secure-Join-Auth header in mimefactory.rs.
-                msg.param.set(Param::Arg2, self.invite.authcode());
-                msg.param.set_int(Param::GuaranteeE2ee, 1);
-            }
-            BobHandshakeMsg::ContactConfirmReceived => {
-                msg.param.set_int(Param::GuaranteeE2ee, 1);
-            }
-        };
-
-        // Sends our own fingerprint in the Secure-Join-Fingerprint header.
-        let bob_fp = SignedPublicKey::load_self(context).await?.fingerprint();
-        msg.param.set(Param::Arg3, bob_fp.hex());
-
-        // Sends the grpid in the Secure-Join-Group header.
-        if let QrInvite::Group { ref grpid, .. } = self.invite {
-            msg.param.set(Param::Arg4, grpid);
-        }
-
-        chat::send_msg(context, self.chat_id, &mut msg).await?;
-        Ok(())
-    }
-}
-
-/// The stage of the [`BobState`] securejoin handshake protocol state machine.
-///
-/// This does not concern itself with user interactions, only represents what happened to
-/// the protocol state machine from handling this message.
-#[derive(Clone, Copy, Debug, Display)]
-enum BobHandshakeStage {
-    /// Step 2 completed: (vc|vg)-request message sent.
-    ///
-    /// Note that this is only ever returned by [`BobState::start_protocol`] and never by
-    /// [`BobState::handle_message`].
-    RequestSent,
-    /// Step 4 completed: (vc|vg)-request-with-auth message sent.
-    RequestWithAuthSent,
-    /// The protocol completed successfully.
-    Completed,
-    /// The protocol prematurely terminated with given reason.
-    Terminated(&'static str),
-}
-
-/// Identifies the SecureJoin handshake messages Bob can send.
-enum BobHandshakeMsg {
-    /// vc-request or vg-request
-    Request,
-    /// vc-request-with-auth or vg-request-with-auth
-    RequestWithAuth,
-    /// vc-contact-confirm-received or vg-member-added-received
-    ContactConfirmReceived,
-}
-
-impl BobHandshakeMsg {
-    /// Returns the text to send in the body of the handshake message.
-    ///
-    /// This text has no significance to the protocol, but would be visible if users see
-    /// this email message directly, e.g. when accessing their email without using
-    /// DeltaChat.
-    fn body_text(&self, invite: &QrInvite) -> String {
-        format!("Secure-Join: {}", self.securejoin_header(invite))
-    }
-
-    /// Returns the `Secure-Join` header value.
-    ///
-    /// This identifies the step this message is sending information about.  Most protocol
-    /// steps include additional information into other headers, see
-    /// [`BobState::send_handshake_message`] for these.
-    fn securejoin_header(&self, invite: &QrInvite) -> &'static str {
-        match self {
-            Self::Request => match invite {
-                QrInvite::Contact { .. } => "vc-request",
-                QrInvite::Group { .. } => "vg-request",
-            },
-            Self::RequestWithAuth => match invite {
-                QrInvite::Contact { .. } => "vc-request-with-auth",
-                QrInvite::Group { .. } => "vg-request-with-auth",
-            },
-            Self::ContactConfirmReceived => match invite {
-                QrInvite::Contact { .. } => "vc-contact-confirm-received",
-                QrInvite::Group { .. } => "vg-member-added-received",
-            },
-        }
-    }
-}
-
-/// The next message expected by [`BobState`] in the setup-contact/secure-join protocol.
-#[derive(Debug, PartialEq)]
-enum SecureJoinStep {
-    /// Expecting the auth-required message.
-    ///
-    /// This corresponds to the `vc-auth-required` or `vg-auth-required` message of step 3d.
-    AuthRequired,
-    /// Expecting the contact-confirm message.
-    ///
-    /// This corresponds to the `vc-contact-confirm` or `vg-member-added` message of step
-    /// 6b.
-    ContactConfirm,
-    /// The protocol terminated because of an error.
-    ///
-    /// The securejoin protocol terminated, this exists to ensure [`BobState`] can detect
-    /// when it earlier signalled that is should be terminated.  It is an error to call with
-    /// this state.
-    Terminated,
-    /// The protocol completed.
-    ///
-    /// This exists to ensure [`BobState`] can detect when it earlier signalled that it is
-    /// complete.  It is an error to call with this state.
-    Completed,
-}
-
-impl SecureJoinStep {
-    /// Compares the legacy string representation of a step to a [`SecureJoinStep`] variant.
-    fn matches(&self, context: &Context, step: &str) -> bool {
-        match self {
-            Self::AuthRequired => step == "vc-auth-required" || step == "vg-auth-required",
-            Self::ContactConfirm => step == "vc-contact-confirm" || step == "vg-member-added",
-            SecureJoinStep::Terminated => {
-                warn!(context, "Terminated state for next securejoin step");
-                false
-            }
-            SecureJoinStep::Completed => {
-                warn!(context, "Complted state for next securejoin step");
-                false
-            }
-        }
     }
 }
 
@@ -874,6 +395,8 @@ async fn fingerprint_equals_sender(
 ///
 /// This status is returned to [`dc_receive_imf`] which will use it to decide what to do
 /// next with this incoming setup-contact/secure-join handshake message.
+///
+/// [`dc_receive_imf`]: crate::dc_receive_imf::dc_receive_imf
 pub(crate) enum HandshakeMessage {
     /// The message has been fully handled and should be removed/delete.
     ///
@@ -989,12 +512,12 @@ pub(crate) async fn handle_securejoin_handshake(
             match context.bob.state(context).await {
                 Some(mut bobstate) => match bobstate.handle_message(context, mime_message).await {
                     Some(BobHandshakeStage::Terminated(why)) => {
-                        could_not_establish_secure_connection(context, bobstate.chat_id()?, why)
+                        could_not_establish_secure_connection(context, bobstate.chat_id(), why)
                             .await;
                         Ok(HandshakeMessage::Done)
                     }
                     Some(_stage) => {
-                        joiner_progress!(context, bobstate.invite()?.contact_id(), 400);
+                        joiner_progress!(context, bobstate.invite().contact_id(), 400);
                         Ok(HandshakeMessage::Done)
                     }
                     None => Ok(HandshakeMessage::Ignore),
@@ -1130,13 +653,13 @@ pub(crate) async fn handle_securejoin_handshake(
             match context.bob.state(context).await {
                 Some(mut bobstate) => match bobstate.handle_message(context, mime_message).await {
                     Some(BobHandshakeStage::Terminated(why)) => {
-                        could_not_establish_secure_connection(context, bobstate.chat_id()?, why)
+                        could_not_establish_secure_connection(context, bobstate.chat_id(), why)
                             .await;
                         Ok(HandshakeMessage::Done)
                     }
                     Some(_stage) => {
                         // Can only be BobHandshakeStage::Completed
-                        secure_connection_established(context, bobstate.chat_id()?).await;
+                        secure_connection_established(context, bobstate.chat_id()).await;
                         Ok(retval)
                     }
                     None => Ok(retval),
@@ -1379,7 +902,7 @@ mod tests {
     use crate::chat::ProtectionStatus;
     use crate::events::Event;
     use crate::peerstate::Peerstate;
-    use crate::test_utils::{LogSink, TestContext};
+    use crate::test_utils::TestContext;
 
     #[async_std::test]
     async fn test_setup_contact() {

--- a/src/securejoin/qrinvite.rs
+++ b/src/securejoin/qrinvite.rs
@@ -1,0 +1,115 @@
+//! Supporting code for the QR-code invite.
+//!
+//! QR-codes are decoded into a more general-purpose [`Lot`] struct normally, this struct is
+//! so general it is not even specific to QR-codes.  This makes working with it rather hard,
+//! so here we have a wrapper type that specifically deals weith Secure-Join QR-codes so
+//! that the Secure-Join code can have many more guarantees when dealing with this.
+
+use std::convert::TryFrom;
+
+use anyhow::Result;
+
+use crate::key::{Fingerprint, FingerprintError};
+use crate::lot::{Lot, LotState};
+
+/// Represents the data from a QR-code scan.
+///
+/// There are methods to conveniently access fields present in both variants.
+#[derive(Debug, Clone)]
+pub enum QrInvite {
+    Contact {
+        contact_id: u32,
+        fingerprint: Fingerprint,
+        invitenumber: String,
+        authcode: String,
+    },
+    Group {
+        contact_id: u32,
+        fingerprint: Fingerprint,
+        name: String,
+        grpid: String,
+        invitenumber: String,
+        authcode: String,
+    },
+}
+
+impl QrInvite {
+    /// The contact ID of the inviter.
+    ///
+    /// The actual QR-code contains a URL-encoded email address, but upon scanning this is
+    /// currently translated to a contact ID.
+    pub fn contact_id(&self) -> u32 {
+        match self {
+            Self::Contact { contact_id, .. } | Self::Group { contact_id, .. } => *contact_id,
+        }
+    }
+
+    /// The fingerprint of the inviter.
+    pub fn fingerprint(&self) -> &Fingerprint {
+        match self {
+            Self::Contact { fingerprint, .. } | Self::Group { fingerprint, .. } => &fingerprint,
+        }
+    }
+
+    /// The `INVITENUMBER` of the setup-contact/secure-join protocol.
+    pub fn invitenumber(&self) -> &str {
+        match self {
+            Self::Contact { invitenumber, .. } | Self::Group { invitenumber, .. } => &invitenumber,
+        }
+    }
+
+    /// The `AUTH` code of the setup-contact/secure-join protocol.
+    pub fn authcode(&self) -> &str {
+        match self {
+            Self::Contact { authcode, .. } | Self::Group { authcode, .. } => &authcode,
+        }
+    }
+}
+
+impl TryFrom<Lot> for QrInvite {
+    type Error = QrError;
+
+    fn try_from(lot: Lot) -> Result<Self, Self::Error> {
+        if lot.state != LotState::QrAskVerifyContact && lot.state != LotState::QrAskVerifyGroup {
+            return Err(QrError::UnsupportedProtocol);
+        }
+        let fingerprint = lot.fingerprint.ok_or(QrError::MissingFingerprint)?;
+        let invitenumber = lot.invitenumber.ok_or(QrError::MissingInviteNumber)?;
+        let authcode = lot.auth.ok_or(QrError::MissingAuthCode)?;
+        match lot.state {
+            LotState::QrAskVerifyContact => Ok(QrInvite::Contact {
+                contact_id: lot.id,
+                fingerprint,
+                invitenumber,
+                authcode,
+            }),
+            LotState::QrAskVerifyGroup => Ok(QrInvite::Group {
+                contact_id: lot.id,
+                fingerprint,
+                name: lot.text1.ok_or(QrError::MissingGroupName)?,
+                grpid: lot.text2.ok_or(QrError::MissingGroupId)?,
+                invitenumber,
+                authcode,
+            }),
+            _ => Err(QrError::UnsupportedProtocol),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum QrError {
+    #[error("Unsupported protocol in QR-code")]
+    UnsupportedProtocol,
+    #[error("Failed to read fingerprint")]
+    InvalidFingerprint(#[from] FingerprintError),
+    #[error("Missing fingerprint")]
+    MissingFingerprint,
+    #[error("Missing invitenumber")]
+    MissingInviteNumber,
+    #[error("Missing auth code")]
+    MissingAuthCode,
+    #[error("Missing group name")]
+    MissingGroupName,
+    #[error("Missing group id")]
+    MissingGroupId,
+}

--- a/src/securejoin/qrinvite.rs
+++ b/src/securejoin/qrinvite.rs
@@ -2,7 +2,7 @@
 //!
 //! QR-codes are decoded into a more general-purpose [`Lot`] struct normally, this struct is
 //! so general it is not even specific to QR-codes.  This makes working with it rather hard,
-//! so here we have a wrapper type that specifically deals weith Secure-Join QR-codes so
+//! so here we have a wrapper type that specifically deals with Secure-Join QR-codes so
 //! that the Secure-Join code can have many more guarantees when dealing with this.
 
 use std::convert::TryFrom;
@@ -37,7 +37,7 @@ impl QrInvite {
     /// The contact ID of the inviter.
     ///
     /// The actual QR-code contains a URL-encoded email address, but upon scanning this is
-    /// currently translated to a contact ID.
+    /// translated to a contact ID.
     pub fn contact_id(&self) -> u32 {
         match self {
             Self::Contact { contact_id, .. } | Self::Group { contact_id, .. } => *contact_id,
@@ -72,6 +72,9 @@ impl TryFrom<Lot> for QrInvite {
     fn try_from(lot: Lot) -> Result<Self, Self::Error> {
         if lot.state != LotState::QrAskVerifyContact && lot.state != LotState::QrAskVerifyGroup {
             return Err(QrError::UnsupportedProtocol);
+        }
+        if lot.id == 0 {
+            return Err(QrError::MissingContactId);
         }
         let fingerprint = lot.fingerprint.ok_or(QrError::MissingFingerprint)?;
         let invitenumber = lot.invitenumber.ok_or(QrError::MissingInviteNumber)?;
@@ -112,4 +115,6 @@ pub enum QrError {
     MissingGroupName,
     #[error("Missing group id")]
     MissingGroupId,
+    #[error("Missing contact id")]
+    MissingContactId,
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -116,9 +116,9 @@ impl TestContext {
         }
     }
 
-    /// Creates a new configured [TestContext].
+    /// Creates a new configured [`TestContext`].
     ///
-    /// This is a shortcut which automatically calls [TestContext::configure_alice] after
+    /// This is a shortcut which automatically calls [`TestContext::configure_alice`] after
     /// creating the context.
     pub async fn new_alice() -> Self {
         let t = Self::with_name("alice").await;
@@ -126,7 +126,7 @@ impl TestContext {
         t
     }
 
-    /// Creates a new configured [TestContext].
+    /// Creates a new configured [`TestContext`].
     ///
     /// This is a shortcut which configures bob@example.net with a fixed key.
     pub async fn new_bob() -> Self {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,6 +1,6 @@
 //! Utilities to help writing tests.
 //!
-//! This module is only compiled for test runs.
+//! This private module is only compiled for test runs.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -19,7 +19,7 @@ use tempfile::{tempdir, TempDir};
 use crate::chat::{self, Chat, ChatId, ChatItem};
 use crate::chatlist::Chatlist;
 use crate::config::Config;
-use crate::constants::DC_CONTACT_ID_SELF;
+use crate::constants::{Viewtype, DC_CONTACT_ID_SELF, DC_MSG_ID_DAYMARKER, DC_MSG_ID_MARKER1};
 use crate::contact::{Contact, Origin};
 use crate::context::Context;
 use crate::dc_receive_imf::dc_receive_imf;
@@ -30,10 +30,6 @@ use crate::key::{self, DcKey};
 use crate::message::{update_msg_state, Message, MessageState, MsgId};
 use crate::mimeparser::MimeMessage;
 use crate::param::{Param, Params};
-
-use crate::constants::Viewtype;
-use crate::constants::DC_MSG_ID_DAYMARKER;
-use crate::constants::DC_MSG_ID_MARKER1;
 
 type EventSink =
     dyn Fn(Event) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> + Send + Sync + 'static;
@@ -67,7 +63,7 @@ impl fmt::Debug for TestContext {
 }
 
 impl TestContext {
-    /// Creates a new [TestContext].
+    /// Creates a new [`TestContext`].
     ///
     /// The [Context] will be created and have an SQLite database named "db.sqlite" in the
     /// [TestContext.dir] directory.  This directory is cleaned up when the [TestContext] is
@@ -120,7 +116,7 @@ impl TestContext {
         }
     }
 
-    /// Create a new configured [TestContext].
+    /// Creates a new configured [TestContext].
     ///
     /// This is a shortcut which automatically calls [TestContext::configure_alice] after
     /// creating the context.
@@ -130,7 +126,7 @@ impl TestContext {
         t
     }
 
-    /// Create a new configured [TestContext].
+    /// Creates a new configured [TestContext].
     ///
     /// This is a shortcut which configures bob@example.net with a fixed key.
     pub async fn new_bob() -> Self {
@@ -200,7 +196,7 @@ impl TestContext {
         }
     }
 
-    /// Retrieve a sent message from the jobs table.
+    /// Retrieves a sent message from the jobs table.
     ///
     /// This retrieves and removes a message which has been scheduled to send from the jobs
     /// table.  Messages are returned in the order they have been sent.
@@ -258,7 +254,7 @@ impl TestContext {
         }
     }
 
-    /// Parse a message.
+    /// Parses a message.
     ///
     /// Parsing a message does not run the entire receive pipeline, but is not without
     /// side-effects either.  E.g. if the message includes autocrypt headers the relevant
@@ -286,7 +282,7 @@ impl TestContext {
             .unwrap();
     }
 
-    /// Get the most recent message of a chat.
+    /// Gets the most recent message of a chat.
     ///
     /// Panics on errors or if the most recent message is a marker.
     pub async fn get_last_msg_in(&self, chat_id: ChatId) -> Message {
@@ -299,13 +295,17 @@ impl TestContext {
         Message::load_from_db(&self.ctx, *msg_id).await.unwrap()
     }
 
-    /// Get the most recent message over all chats.
+    /// Gets the most recent message over all chats.
     pub async fn get_last_msg(&self) -> Message {
         let chats = Chatlist::try_load(&self.ctx, 0, None, None).await.unwrap();
         let msg_id = chats.get_msg_id(chats.len() - 1).unwrap();
         Message::load_from_db(&self.ctx, msg_id).await.unwrap()
     }
 
+    /// Creates or returns an existing 1:1 [`Chat`] with another account.
+    ///
+    /// This first creates a contact using the configured details on the other account, then
+    /// creates a 1:1 chat with this contact.
     pub async fn create_chat(&self, other: &TestContext) -> Chat {
         let (contact_id, _modified) = Contact::add_or_lookup(
             self,
@@ -324,7 +324,11 @@ impl TestContext {
         Chat::load_from_db(self, chat_id).await.unwrap()
     }
 
-    pub async fn chat_with_contact(&self, name: &str, addr: &str) -> Chat {
+    /// Creates or returns an existing [`Contact`] and 1:1 [`Chat`] with another email.
+    ///
+    /// This first creates a contact from the `name` and `addr` and then creates a 1:1 chat
+    /// with this contact.
+    pub async fn create_chat_with_contact(&self, name: &str, addr: &str) -> Chat {
         let contact = Contact::create(self, name, addr)
             .await
             .expect("failed to create contact");
@@ -332,6 +336,7 @@ impl TestContext {
         Chat::load_from_db(self, chat_id).await.unwrap()
     }
 
+    /// Retrieves the "self" chat.
     pub async fn get_self_chat(&self) -> Chat {
         let chat_id = chat::create_by_contact_id(self, DC_CONTACT_ID_SELF)
             .await
@@ -339,7 +344,11 @@ impl TestContext {
         Chat::load_from_db(self, chat_id).await.unwrap()
     }
 
-    /// Sends out the text message. If the other side shall receive it, you have to call `recv_msg()` with the returned `SentMessage`.
+    /// Sends out the text message.
+    ///
+    /// This is not hooked up to any SMTP-IMAP pipeline, so the other account must call
+    /// [`TestContext::recv_msg`] with the returned [`SentMessage`] if it wants to receive
+    /// the message.
     pub async fn send_text(&self, chat_id: ChatId, txt: &str) -> SentMessage {
         let mut msg = Message::new(Viewtype::Text);
         msg.set_text(Some(txt.to_string()));
@@ -348,8 +357,11 @@ impl TestContext {
         self.pop_sent_msg().await
     }
 
-    /// You can use this to debug your test by printing a chat structure
-    // This code is mainly the same as `log_msglist` in `cmdline.rs`, so one day, we could merge them to a public function in the `deltachat` crate.
+    /// Prints out the entire chat to stdout.
+    ///
+    /// You can use this to debug your test by printing the entire chat conversation.
+    // This code is mainly the same as `log_msglist` in `cmdline.rs`, so one day, we could
+    // merge them to a public function in the `deltachat` crate.
     #[allow(dead_code)]
     pub async fn print_chat(&self, chat: &Chat) {
         let msglist = chat::get_chat_msgs(&self, chat.get_id(), 0x1, None).await;
@@ -432,7 +444,7 @@ impl SentMessage {
 /// This saves CPU cycles by avoiding having to generate a key.
 ///
 /// The keypair was created using the crate::key::tests::gen_key test.
-pub(crate) fn alice_keypair() -> key::KeyPair {
+pub fn alice_keypair() -> key::KeyPair {
     let addr = EmailAddress::new("alice@example.com").unwrap();
     let public =
         key::SignedPublicKey::from_base64(include_str!("../test-data/key/alice-public.asc"))
@@ -450,7 +462,7 @@ pub(crate) fn alice_keypair() -> key::KeyPair {
 /// Load a pre-generated keypair for bob@example.net from disk.
 ///
 /// Like [alice_keypair] but a different key and identity.
-pub(crate) fn bob_keypair() -> key::KeyPair {
+pub fn bob_keypair() -> key::KeyPair {
     let addr = EmailAddress::new("bob@example.net").unwrap();
     let public =
         key::SignedPublicKey::from_base64(include_str!("../test-data/key/bob-public.asc")).unwrap();


### PR DESCRIPTION
This PR is still my attempt at working towards addressing #1177 by attempting to split off concerns and make things easier to modify without breaking things.  The tests have been updated in #2154 to cover all code that gets modified here, so there is pretty good confidence this doesn't break things.

There are three main things attempted here, which I failed to separate out further, I apologise for the size:
- QR handling has a specific struct and does not require brittle macros, instead there is type-safety on things being correctly accessed.
- The InnerContext::bob field has been changed to use inner-mutability, this hides the weird typing hoops from parts that don't have to care.  This type also handles other global state management on the context, like the ongoing process interactions.
- The handshake itself (for bob only in this PR) clearly separates protocol checks from interactions with the users.  This makes following and verifying the protocol logic simpler and likewise keeps the UX interactions to closer together in one place, improving verifying it is correct.

### Review guidance

- Start with `qrinvite.rs`, it's fairly small and self-contained and provides straight-forward access to the QR data.
- Next check `bobstate.rs`, its main type is the `BobState` and has some associated types, like a handle and enums to convey the state.  Look at its `pub` items as those are what will be used by the main `securejoin/mod.rs`.
- Finally the `securejoin/mod.rs` file is what used to be `securejoin.rs`.  It uses the facilities from the other files.
  - The main entry point to start reviewing here is probably the `Bob` struct, which is where the protocol handling starts.
  - The other main changes are in `handle_securejoin_handshake` which drives the main message handling, only the Bob message handling is affected here but it is responsible for the UX of the Bob-side of things.