### PR TITLE
remove dc_contact_get_first_name() api

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3834,7 +3834,7 @@ dc_msg_t*       dc_msg_get_quoted_msg         (const dc_msg_t* msg);
  * By default, these names are equal,
  * but functions working with contact names
  * (e.g. dc_contact_get_name(), dc_contact_get_display_name(),
- * dc_contact_get_name_n_addr(), dc_contact_get_first_name(),
+ * dc_contact_get_name_n_addr(),
  * dc_create_contact() or dc_add_address_book())
  * only affect the given-name.
  */
@@ -3922,19 +3922,6 @@ char*           dc_contact_get_display_name  (const dc_contact_t* contact);
  *     Never returns NULL.
  */
 char*           dc_contact_get_name_n_addr   (const dc_contact_t* contact);
-
-
-/**
- * Get the part of the name before the first space. In most languages, this seems to be
- * the prename. If there is no space, the full display name is returned.
- * If the display name is not set, the e-mail address is returned.
- *
- * @memberof dc_contact_t
- * @param contact The contact object.
- * @return String with the name to display, must be released using dc_str_unref().
- *     Never returns NULL.
- */
-char*           dc_contact_get_first_name    (const dc_contact_t* contact);
 
 
 /**

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3152,18 +3152,6 @@ pub unsafe extern "C" fn dc_contact_get_name_n_addr(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_contact_get_first_name(
-    contact: *mut dc_contact_t,
-) -> *mut libc::c_char {
-    if contact.is_null() {
-        eprintln!("ignoring careless call to dc_contact_get_first_name()");
-        return "".strdup();
-    }
-    let ffi_contact = &*contact;
-    ffi_contact.contact.get_first_name().strdup()
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn dc_contact_get_profile_image(
     contact: *mut dc_contact_t,
 ) -> *mut libc::c_char {

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -888,16 +888,6 @@ impl Contact {
         (&self.addr).into()
     }
 
-    /// Get the part of the name before the first space. In most languages, this seems to be
-    /// the prename. If there is no space, the full display name is returned.
-    /// If the display name is not set, the e-mail address is returned.
-    pub fn get_first_name(&self) -> &str {
-        if !self.name.is_empty() {
-            return get_first_name(&self.name);
-        }
-        &self.addr
-    }
-
     /// Get the contact's profile image.
     /// This is the image set by each remote user on their own
     /// using dc_set_config(context, "selfavatar", image).
@@ -1033,11 +1023,6 @@ impl Contact {
             .await
             .is_ok()
     }
-}
-
-/// Extracts first name from full name.
-fn get_first_name(full_name: &str) -> &str {
-    full_name.splitn(2, ' ').next().unwrap_or_default()
 }
 
 /// Returns false if addr is an invalid address, otherwise true.
@@ -1281,11 +1266,6 @@ mod tests {
         // normalisation preserves case to allow user-defined spelling.
         // however, case is ignored on addr_cmp()
         assert_ne!(addr_normalize("John@Doe.com"), "john@doe.com");
-    }
-
-    #[test]
-    fn test_get_first_name() {
-        assert_eq!(get_first_name("John Doe"), "John");
     }
 
     #[test]

--- a/src/message.rs
+++ b/src/message.rs
@@ -1032,7 +1032,7 @@ impl Lot {
                         self.text1 = None;
                     }
                 } else if let Some(contact) = contact {
-                    self.text1 = Some(contact.get_first_name().into());
+                    self.text1 = Some(contact.get_display_name().into());
                 } else {
                     self.text1 = None;
                 }


### PR DESCRIPTION
instead, dc_contact_get_display_name() should be used.

dc_contact_get_first_name() was created to save some space on the screen,
esp. on mobile devices,
however, this does not always work and has issues on its own
with some names ("Dr. Strangelove", ":) Name" and so on).

as with mailing lists, more apis with first_name() would be needed,
we decided to drop that instead of following that way.

it is also less an issue as some years ago as screens have become larger,
if really, needed, the ui can handle that more gracefully,
however, just using dc_contact_get_display_name() should be fine as well.

closes #2162 
help on #1964 