### PR TITLE
Depend on anyhow directly

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -2,7 +2,7 @@ extern crate dirs;
 
 use std::str::FromStr;
 
-use anyhow::{bail, ensure};
+use anyhow::{bail, ensure, Error};
 use async_std::path::Path;
 use deltachat::chat::{self, Chat, ChatId, ChatItem, ChatVisibility, ProtectionStatus};
 use deltachat::chatlist::*;
@@ -11,7 +11,6 @@ use deltachat::contact::*;
 use deltachat::context::*;
 use deltachat::dc_receive_imf::*;
 use deltachat::dc_tools::*;
-use deltachat::error::Error;
 use deltachat::imex::*;
 use deltachat::location;
 use deltachat::lot::LotState;

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -6,11 +6,10 @@ use async_std::prelude::*;
 use async_std::sync::{Arc, RwLock};
 use uuid::Uuid;
 
-use anyhow::{ensure, Context as _};
+use anyhow::{ensure, Context as _, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::context::Context;
-use crate::error::Result;
 use crate::events::Event;
 
 /// Account manager, that can handle multiple accounts in a single place.

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -7,6 +7,7 @@ use async_std::path::{Path, PathBuf};
 use async_std::prelude::*;
 use async_std::{fs, io};
 
+use anyhow::Error;
 use image::GenericImageView;
 use num_traits::FromPrimitive;
 use thiserror::Error;
@@ -17,7 +18,6 @@ use crate::constants::{
     WORSE_IMAGE_SIZE,
 };
 use crate::context::Context;
-use crate::error::Error;
 use crate::events::EventType;
 use crate::message;
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use std::time::{Duration, SystemTime};
 
 use anyhow::Context as _;
+use anyhow::{bail, ensure, format_err, Error};
 use async_std::path::{Path, PathBuf};
 use itertools::Itertools;
 use num_traits::FromPrimitive;
@@ -28,7 +29,6 @@ use crate::dc_tools::{
     improve_single_line_input, time, IsNoneOrEmpty,
 };
 use crate::ephemeral::{delete_expired_messages, schedule_ephemeral_task, Timer as EphemeralTimer};
-use crate::error::{bail, ensure, format_err, Error};
 use crate::events::EventType;
 use crate::job::{self, Action};
 use crate::message::{self, InvalidMsgId, Message, MessageState, MsgId};

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -1,5 +1,7 @@
 //! # Chat list module
 
+use anyhow::{bail, ensure, Result};
+
 use crate::chat;
 use crate::chat::{update_special_chat_names, Chat, ChatId, ChatVisibility};
 use crate::constants::{
@@ -10,7 +12,6 @@ use crate::constants::{
 use crate::contact::Contact;
 use crate::context::Context;
 use crate::ephemeral::delete_expired_messages;
-use crate::error::{bail, ensure, Result};
 use crate::lot::Lot;
 use crate::message::{Message, MessageState, MsgId};
 use crate::stock::StockMessage;

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1,5 +1,6 @@
 //! Contacts module
 
+use anyhow::{bail, ensure, format_err, Result};
 use async_std::path::PathBuf;
 use deltachat_derive::{FromSql, ToSql};
 use itertools::Itertools;
@@ -17,7 +18,6 @@ use crate::context::Context;
 use crate::dc_tools::{
     dc_get_abs_path, dc_str_to_color, improve_single_line_input, listflags_has, EmailAddress,
 };
-use crate::error::{bail, ensure, format_err, Result};
 use crate::events::EventType;
 use crate::key::{DcKey, SignedPublicKey};
 use crate::login_param::LoginParam;

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,6 +7,7 @@ use std::{
     time::Instant,
 };
 
+use anyhow::{bail, ensure, Result};
 use async_std::path::{Path, PathBuf};
 use async_std::sync::{channel, Arc, Mutex, Receiver, RwLock, Sender};
 use async_std::task;
@@ -16,7 +17,6 @@ use crate::config::Config;
 use crate::constants::DC_VERSION_STR;
 use crate::contact::Contact;
 use crate::dc_tools::duration_to_str;
-use crate::error::{bail, ensure, Result};
 use crate::events::{Event, EventEmitter, EventType, Events};
 use crate::key::{DcKey, SignedPublicKey};
 use crate::login_param::LoginParam;

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1,8 +1,8 @@
+use anyhow::{bail, ensure, format_err, Result};
 use itertools::join;
+use mailparse::SingleInfo;
 use num_traits::FromPrimitive;
 use sha2::{Digest, Sha256};
-
-use mailparse::SingleInfo;
 
 use crate::chat::{self, Chat, ChatId, ProtectionStatus};
 use crate::config::Config;
@@ -14,7 +14,6 @@ use crate::contact::{addr_cmp, normalize_name, Contact, Origin, VerifiedStatus};
 use crate::context::Context;
 use crate::dc_tools::{dc_create_smeared_timestamp, dc_smeared_time, time};
 use crate::ephemeral::{stock_ephemeral_timer_changed, Timer as EphemeralTimer};
-use crate::error::{bail, ensure, format_err, Result};
 use crate::events::EventType;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
 use crate::job::{self, Action};

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -12,13 +12,13 @@ use async_std::path::{Path, PathBuf};
 use async_std::prelude::*;
 use async_std::{fs, io};
 
+use anyhow::{bail, Error};
 use chrono::{Local, TimeZone};
 use rand::{thread_rng, Rng};
 
 use crate::chat::{add_device_msg, add_device_msg_with_importance};
 use crate::constants::{Viewtype, DC_OUTDATED_WARNING_DAYS};
 use crate::context::Context;
-use crate::error::{bail, Error};
 use crate::events::EventType;
 use crate::message::Message;
 use crate::provider::get_provider_update_timestamp;

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -2,13 +2,13 @@
 
 use std::collections::HashSet;
 
+use anyhow::{bail, ensure, format_err, Result};
 use mailparse::ParsedMail;
 use num_traits::FromPrimitive;
 
 use crate::aheader::{Aheader, EncryptPreference};
 use crate::config::Config;
 use crate::context::Context;
-use crate::error::{bail, ensure, format_err, Result};
 use crate::headerdef::HeaderDef;
 use crate::headerdef::HeaderDefMap;
 use crate::key::{DcKey, Fingerprint, SignedPublicKey, SignedSecretKey};
@@ -411,7 +411,7 @@ Sent with my Delta Chat Messenger: https://delta.chat";
     }
 
     #[async_std::test]
-    async fn test_encrypted_no_autocrypt() -> crate::error::Result<()> {
+    async fn test_encrypted_no_autocrypt() -> anyhow::Result<()> {
         let alice = TestContext::new_alice().await;
         let bob = TestContext::new_bob().await;
 

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -56,13 +56,14 @@
 //! the database entries which are expired either according to their
 //! ephemeral message timers or global `delete_server_after` setting.
 
+use anyhow::{ensure, Error};
+
 use crate::chat::{lookup_by_contact_id, send_msg, ChatId};
 use crate::constants::{
     Viewtype, DC_CHAT_ID_LAST_SPECIAL, DC_CHAT_ID_TRASH, DC_CONTACT_ID_DEVICE, DC_CONTACT_ID_SELF,
 };
 use crate::context::Context;
 use crate::dc_tools::time;
-use crate::error::{ensure, Error};
 use crate::events::EventType;
 use crate::message::{Message, MessageState, MsgId};
 use crate::mimeparser::SystemMessage;
@@ -533,7 +534,7 @@ mod tests {
     }
 
     #[async_std::test]
-    async fn test_ephemeral_timer() -> crate::error::Result<()> {
+    async fn test_ephemeral_timer() -> anyhow::Result<()> {
         let alice = TestContext::new_alice().await;
         let bob = TestContext::new_bob().await;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,5 @@
 //! # Error handling
 
-pub use anyhow::{bail, ensure, format_err, Error, Result};
-
 #[macro_export]
 macro_rules! ensure_eq {
     ($left:expr, $right:expr) => ({

--- a/src/html.rs
+++ b/src/html.rs
@@ -10,10 +10,10 @@ use futures::future::FutureExt;
 use std::future::Future;
 use std::pin::Pin;
 
+use anyhow::Result;
 use lettre_email::mime::{self, Mime};
 
 use crate::context::Context;
-use crate::error::Result;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
 use crate::message::{Message, MsgId};
 use crate::mimeparser::parse_message_id;

--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -1,11 +1,11 @@
 use super::Imap;
 
+use anyhow::{bail, format_err, Result};
 use async_imap::extensions::idle::IdleResponse;
 use async_imap::types::UnsolicitedResponse;
 use async_std::prelude::*;
 use std::time::{Duration, SystemTime};
 
-use crate::error::{bail, format_err, Result};
 use crate::{context::Context, scheduler::InterruptInfo};
 
 use super::session::Session;

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -5,7 +5,7 @@
 
 use std::{cmp, cmp::max, collections::BTreeMap};
 
-use anyhow::Context as _;
+use anyhow::{bail, format_err, Context as _, Result};
 use async_imap::{
     error::Result as ImapResult,
     types::{Capability, Fetch, Flag, Mailbox, Name, NameAttribute},
@@ -20,7 +20,6 @@ use crate::constants::{
 };
 use crate::context::Context;
 use crate::dc_receive_imf::{from_field_to_contact_id, get_prefetch_parent_message};
-use crate::error::{bail, format_err, Result};
 use crate::events::EventType;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
 use crate::job::{self, Action};

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -1,9 +1,9 @@
 use std::time::Instant;
 
-use crate::{config::Config, context::Context};
-use anyhow::Context as _;
+use anyhow::{Context as _, Result};
 
-use crate::error::Result;
+use crate::config::Config;
+use crate::context::Context;
 use crate::imap::Imap;
 use async_std::prelude::*;
 

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -3,7 +3,7 @@
 use std::any::Any;
 use std::ffi::OsStr;
 
-use anyhow::Context as _;
+use anyhow::{bail, ensure, format_err, Context as _, Result};
 use async_std::path::{Path, PathBuf};
 use async_std::{
     fs::{self, File},
@@ -22,7 +22,6 @@ use crate::dc_tools::{
     dc_open_file_std, dc_read_file, dc_write_file, get_next_backup_path, time, EmailAddress,
 };
 use crate::e2ee;
-use crate::error::{bail, ensure, format_err, Result};
 use crate::events::EventType;
 use crate::key::{self, DcKey, DcSecretKey, SignedPublicKey, SignedSecretKey};
 use crate::message::{Message, MsgId};

--- a/src/job.rs
+++ b/src/job.rs
@@ -6,19 +6,15 @@
 use std::fmt;
 use std::future::Future;
 
+use anyhow::{bail, ensure, format_err, Context as _, Error, Result};
+use async_smtp::smtp::response::{Category, Code, Detail};
 use deltachat_derive::{FromSql, ToSql};
 use itertools::Itertools;
 use rand::{thread_rng, Rng};
 
-use anyhow::Context as _;
-use async_smtp::smtp::response::Category;
-use async_smtp::smtp::response::Code;
-use async_smtp::smtp::response::Detail;
-
 use crate::context::Context;
 use crate::dc_tools::{dc_delete_file, dc_read_file, time};
 use crate::ephemeral::load_imap_deletion_msgid;
-use crate::error::{bail, ensure, format_err, Error, Result};
 use crate::events::EventType;
 use crate::imap::{Imap, ImapActionResult};
 use crate::location;

--- a/src/location.rs
+++ b/src/location.rs
@@ -1,5 +1,6 @@
 //! Location handling
 
+use anyhow::{ensure, Error};
 use bitflags::bitflags;
 use quick_xml::events::{BytesEnd, BytesStart, BytesText};
 
@@ -8,7 +9,6 @@ use crate::config::Config;
 use crate::constants::{Viewtype, DC_CONTACT_ID_SELF};
 use crate::context::Context;
 use crate::dc_tools::time;
-use crate::error::{ensure, Error};
 use crate::events::EventType;
 use crate::job::{self, Job};
 use crate::message::{Message, MsgId};

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,5 +1,6 @@
 //! # Messages and their identifiers
 
+use anyhow::{ensure, Error};
 use async_std::path::{Path, PathBuf};
 use deltachat_derive::{FromSql, ToSql};
 use itertools::Itertools;
@@ -19,7 +20,6 @@ use crate::dc_tools::{
     dc_truncate, time,
 };
 use crate::ephemeral::Timer as EphemeralTimer;
-use crate::error::{ensure, Error};
 use crate::events::EventType;
 use crate::job::{self, Action};
 use crate::lot::{Lot, LotState, Meaning};

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1,3 +1,4 @@
+use anyhow::{bail, ensure, format_err, Error};
 use chrono::TimeZone;
 use lettre_email::{mime, Address, Header, MimeMultipartType, PartBuilder};
 
@@ -12,7 +13,6 @@ use crate::dc_tools::{
 };
 use crate::e2ee::EncryptHelper;
 use crate::ephemeral::Timer as EphemeralTimer;
-use crate::error::{bail, ensure, format_err, Error};
 use crate::format_flowed::{format_flowed, format_flowed_quote};
 use crate::location;
 use crate::message::{self, Message, MsgId};

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
 
+use anyhow::{bail, Result};
 use deltachat_derive::{FromSql, ToSql};
 use lettre_email::mime::{self, Mime};
 use mailparse::{addrparse_header, DispositionType, MailHeader, MailHeaderMap, SingleInfo};
@@ -15,7 +16,6 @@ use crate::context::Context;
 use crate::dc_tools::dc_get_filemeta;
 use crate::dehtml::dehtml;
 use crate::e2ee;
-use crate::error::{bail, Result};
 use crate::events::EventType;
 use crate::format_flowed::unformat_flowed;
 use crate::headerdef::{HeaderDef, HeaderDefMap};

--- a/src/param.rs
+++ b/src/param.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::str;
 
+use anyhow::{bail, Error};
 use async_std::path::PathBuf;
 use itertools::Itertools;
 use num_traits::FromPrimitive;
@@ -9,7 +10,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::blob::{BlobError, BlobObject};
 use crate::context::Context;
-use crate::error::{self, bail};
 use crate::message::MsgId;
 use crate::mimeparser::SystemMessage;
 
@@ -163,7 +163,7 @@ impl fmt::Display for Params {
 }
 
 impl str::FromStr for Params {
-    type Err = error::Error;
+    type Err = Error;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let mut inner = BTreeMap::new();

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -1,14 +1,15 @@
 //! # [Autocrypt Peer State](https://autocrypt.org/level1.html#peer-state-management) module
+
 use std::collections::HashSet;
 use std::fmt;
 
+use anyhow::{bail, Result};
 use num_traits::FromPrimitive;
 
 use crate::aheader::{Aheader, EncryptPreference};
 use crate::chat;
 use crate::constants::Blocked;
 use crate::context::Context;
-use crate::error::{bail, Result};
 use crate::events::EventType;
 use crate::key::{DcKey, Fingerprint, SignedPublicKey};
 use crate::sql::Sql;

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::io;
 use std::io::Cursor;
 
+use anyhow::{bail, ensure, format_err, Result};
 use pgp::armor::BlockType;
 use pgp::composed::{
     Deserializable, KeyType as PgpKeyType, Message, SecretKeyParamsBuilder, SignedPublicKey,
@@ -17,7 +18,6 @@ use rand::{thread_rng, CryptoRng, Rng};
 
 use crate::constants::KeyGenType;
 use crate::dc_tools::EmailAddress;
-use crate::error::{bail, ensure, format_err, Result};
 use crate::key::{DcKey, Fingerprint};
 use crate::keyring::Keyring;
 

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -1,5 +1,6 @@
 //! # QR code module
 
+use anyhow::{bail, ensure, format_err, Error};
 use once_cell::sync::Lazy;
 use percent_encoding::percent_decode_str;
 use serde::Deserialize;
@@ -9,7 +10,6 @@ use crate::config::Config;
 use crate::constants::Blocked;
 use crate::contact::{addr_normalize, may_be_valid_addr, Contact, Origin};
 use crate::context::Context;
-use crate::error::{bail, ensure, format_err, Error};
 use crate::key::Fingerprint;
 use crate::lot::{Lot, LotState};
 use crate::message::Message;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -7,6 +7,7 @@ use std::collections::HashSet;
 use std::path::Path;
 use std::time::Duration;
 
+use anyhow::format_err;
 use rusqlite::{Connection, Error as SqlError, OpenFlags};
 
 use crate::chat::add_device_msg;
@@ -15,7 +16,6 @@ use crate::constants::{ShowEmails, DC_CHAT_ID_TRASH};
 use crate::context::Context;
 use crate::dc_tools::{dc_delete_file, time, EmailAddress};
 use crate::ephemeral::start_ephemeral_timers;
-use crate::error::format_err;
 use crate::imap;
 use crate::param::{Param, Params};
 use crate::peerstate::Peerstate;
@@ -54,7 +54,7 @@ pub enum Error {
     #[error("{0:?}")]
     BlobError(#[from] crate::blob::BlobError),
     #[error("{0}")]
-    Other(#[from] crate::error::Error),
+    Other(#[from] anyhow::Error),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -92,7 +92,7 @@ impl Sql {
         context: &Context,
         dbfile: T,
         readonly: bool,
-    ) -> crate::error::Result<()> {
+    ) -> anyhow::Result<()> {
         let res = open(context, self, &dbfile, readonly).await;
         if let Err(err) = &res {
             match err.downcast_ref::<Error>() {
@@ -697,7 +697,7 @@ async fn open(
     sql: &Sql,
     dbfile: impl AsRef<Path>,
     readonly: bool,
-) -> crate::error::Result<()> {
+) -> anyhow::Result<()> {
     if sql.is_open().await {
         error!(
             context,

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 
+use anyhow::{bail, Error};
 use strum::EnumProperty;
 use strum_macros::EnumProperty;
 
@@ -10,7 +11,6 @@ use crate::chat::ProtectionStatus;
 use crate::constants::{Viewtype, DC_CONTACT_ID_SELF};
 use crate::contact::{Contact, Origin};
 use crate::context::Context;
-use crate::error::{bail, Error};
 use crate::message::Message;
 use crate::param::Param;
 use crate::stock::StockMessage::{DeviceMessagesHint, WelcomeMessage};


### PR DESCRIPTION
This removes the proxy via crate::error to depend on anyhow directly.
There is no benefit to this indirection and this makes it simpler to
see which error types are used.