### PR TITLE
add define for removed dc_contact_get_first_name()

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3907,6 +3907,11 @@ char*           dc_contact_get_name          (const dc_contact_t* contact);
 char*           dc_contact_get_display_name  (const dc_contact_t* contact);
 
 
+// dc_contact_get_first_name is removed,
+// the following define is to make upgrading more smoothly.
+#define         dc_contact_get_first_name    dc_contact_get_display_name
+
+
 /**
  * Get a summary of name and address.
  *


### PR DESCRIPTION
#define removed ffi-funcion dc_contact_get_first_name as dc_contact_get_display_name to make updating easier

that may help on building desktop while node is not yet updated; so https://github.com/deltachat/deltachat-desktop/issues/2071 can be postponed.