### PR TITLE
fix link to virtualenv in python readme

### DIFF
--- a/python/README.rst
+++ b/python/README.rst
@@ -14,7 +14,7 @@ If you have a Linux system you may try to install the ``deltachat`` binary "whee
 without any "build-from-source" steps.
 Otherwise you need to `compile the Delta Chat bindings yourself <#sourceinstall>`_.
 
-We recommend to first `install virtualenv <https://virtualenv.pypa.io/en/stable/installation/>`_,
+We recommend to first `install virtualenv <https://virtualenv.pypa.io/en/stable/installation.html>`_,
 then create a fresh Python virtual environment and activate it in your shell::
 
         virtualenv venv  # or: python -m venv


### PR DESCRIPTION
the virtualenv.pypa.io-link without .html extension shows a 404

came over that when fixing #2146 