### PR TITLE
Disable moving to Sentbox for now

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -2251,8 +2251,9 @@ class TestOnlineAccount:
 
         Also, the newest existing emails from each folder are fetched during onboarding.
 
-        Additionally tests that bcc_self messages moved to the mvbox are marked as read."""
+        Additionally tests that bcc_self messages moved to the mvbox/sentbox are marked as read."""
         ac1 = acfactory.get_online_configuring_account(mvbox=mvbox_move, move=mvbox_move)
+        ac1.set_config("sentbox_move", "1")
         ac2 = acfactory.get_online_configuring_account()
 
         acfactory.wait_configure(ac1)

--- a/src/config.rs
+++ b/src/config.rs
@@ -290,6 +290,11 @@ impl Context {
             _ => self.sql.set_raw_config(self, key, value).await,
         }
     }
+
+    pub async fn set_config_bool(&self, key: Config, value: bool) -> crate::sql::Result<()> {
+        self.set_config(key, if value { Some("1") } else { None })
+            .await
+    }
 }
 
 /// Returns all available configuration keys concated together.

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,9 @@ pub enum Config {
     #[strum(props(default = "1"))]
     MvboxMove,
 
+    #[strum(props(default = "0"))]
+    SentboxMove, // If `MvboxMove` is true, this config is ignored. Currently only used in tests.
+
     #[strum(props(default = "0"))] // also change ShowEmails.default() on changes
     ShowEmails,
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -310,6 +310,7 @@ impl Context {
         let sentbox_watch = self.get_config_int(Config::SentboxWatch).await;
         let mvbox_watch = self.get_config_int(Config::MvboxWatch).await;
         let mvbox_move = self.get_config_int(Config::MvboxMove).await;
+        let sentbox_move = self.get_config_int(Config::SentboxMove).await;
         let folders_configured = self
             .sql
             .get_raw_config_int(self, "folders_configured")
@@ -361,6 +362,7 @@ impl Context {
         res.insert("sentbox_watch", sentbox_watch.to_string());
         res.insert("mvbox_watch", mvbox_watch.to_string());
         res.insert("mvbox_move", mvbox_move.to_string());
+        res.insert("sentbox_move", sentbox_move.to_string());
         res.insert("folders_configured", folders_configured.to_string());
         res.insert("configured_sentbox_folder", configured_sentbox_folder);
         res.insert("configured_mvbox_folder", configured_mvbox_folder);

--- a/src/message.rs
+++ b/src/message.rs
@@ -1968,6 +1968,7 @@ mod tests {
                 true,
                 false,
                 false,
+                false,
             )
             .await;
         }
@@ -1984,6 +1985,7 @@ mod tests {
                 false,
                 false,
                 false,
+                false,
             )
             .await;
         }
@@ -1991,21 +1993,26 @@ mod tests {
 
     #[async_std::test]
     async fn test_needs_move_outgoing() {
-        // Test outgoing emails
-        for (folder, mvbox_move, chat_msg, mut expected_destination) in COMBINATIONS_ACCEPTED_CHAT {
-            if *folder == "INBOX" && !mvbox_move && *chat_msg {
-                expected_destination = "Sent"
+        for sentbox_move in &[true, false] {
+            // Test outgoing emails
+            for (folder, mvbox_move, chat_msg, mut expected_destination) in
+                COMBINATIONS_ACCEPTED_CHAT
+            {
+                if *folder == "INBOX" && !mvbox_move && *chat_msg && *sentbox_move {
+                    expected_destination = "Sent"
+                }
+                check_needs_move_combination(
+                    folder,
+                    *mvbox_move,
+                    *chat_msg,
+                    expected_destination,
+                    true,
+                    true,
+                    false,
+                    *sentbox_move,
+                )
+                .await;
             }
-            check_needs_move_combination(
-                folder,
-                *mvbox_move,
-                *chat_msg,
-                expected_destination,
-                true,
-                true,
-                false,
-            )
-            .await;
         }
     }
 
@@ -2021,11 +2028,13 @@ mod tests {
                 true,
                 true,
                 true,
+                false,
             )
             .await;
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn check_needs_move_combination(
         folder: &str,
         mvbox_move: bool,
@@ -2034,6 +2043,7 @@ mod tests {
         accepted_chat: bool,
         outgoing: bool,
         setupmessage: bool,
+        sentbox_move: bool,
     ) {
         use crate::dc_receive_imf::dc_receive_imf;
         println!("Testing: For folder {}, mvbox_move {}, chat_msg {}, accepted {}, outgoing {}, setupmessage {}",
@@ -2058,6 +2068,10 @@ mod tests {
             .unwrap();
         t.ctx
             .set_config(Config::ShowEmails, Some("2"))
+            .await
+            .unwrap();
+        t.ctx
+            .set_config_bool(Config::SentboxMove, sentbox_move)
             .await
             .unwrap();
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -119,6 +119,7 @@ impl MsgId {
                 && !msg.is_setupmessage()
                 && msg.to_id != DC_CONTACT_ID_SELF // Leave self-chat-messages in the inbox, not sure about this
                 && context.is_inbox(folder).await
+                && context.get_config_bool(SentboxMove).await
                 && context.get_config(ConfiguredSentboxFolder).await.is_some()
         {
             Ok(Some(ConfiguredSentboxFolder))


### PR DESCRIPTION
fix https://github.com/deltachat/deltachat-core-rust/issues/2176

we can re-enable it when DC determines automatically which folders to watch and
this is deployed for at least 1 release.

This PR adds a config "senbox_move" that is currently only needed for the tests; we can decide what we want to do with it later.