### PR TITLE
refine decide api

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3692,12 +3692,13 @@ char*           dc_msg_get_error               (const dc_msg_t* msg);
  * (use dc_msg_get_real_chat_id() to get the chat-id for the contact request
  * and then dc_chat_is_mailing_list(), dc_chat_get_name() and so on)
  *
- * @memberof dc_msg_t
- * @param msg The message object.
+ * @memberof dc_context_t
+ * @param context The context object.
+ * @param msg_id ID of Message to decide on.
  * @param decision One of the DC_DECISION_* values.
  * @return The chat id of the created chat, if any.
  */
-uint32_t        dc_decide_on_contact_request (const dc_msg_t* msg, int decision);
+uint32_t        dc_decide_on_contact_request (dc_context_t* context, uint32_t msg_id, int decision);
 
 
 /**

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3653,31 +3653,52 @@ char*           dc_msg_get_videochat_url (const dc_msg_t* msg);
  */
 char*           dc_msg_get_error               (const dc_msg_t* msg);
 
+
+#define DC_DECISION_START_CHAT 0
+#define DC_DECISION_BLOCK      1
+#define DC_DECISION_NOT_NOW    2
+
+
 /**
  * Call this when the user decided about a deaddrop message ("Do you want to chat with NAME?").
  *
- * If the decision is Yes (0), this will create a new chat and return the chat id.
- * If the decision is No (1), this will usually block the sender.
- * If the decision is Not now (2), this will usually mark all messages from this sender as read.
+ * Possible decisions are:
+ * - DC_DECISION_START_CHAT (0)
+ *   - This will create a new chat and return the chat id.
+ * - DC_DECISION_BLOCK (1)
+ *   - This will block the sender.
+ *   - When a new message from the sender arrives,
+ *     that will not result in a new contact request.
+ *   - The blocked sender will be returned by dc_get_blocked_contacts()
+ *     typically, the UI offers an option to unblock senders from there.
+ * - DC_DECISION_NOT_NOW (2)
+ *   - This will mark all messages from this sender as noticed.
+ *   - That the contact request is removed from the chat list.
+ *   - When a new message from the sender arrives,
+ *     a new contact request with the new message will pop up in the chatlist.
+ *   - The contact request stays available in the explicit deaddrop.
+ *   - If the contact request is already noticed, nothing happens.
  *
- * If the message belongs to a mailing list, makes sure that all messages from this mailing list are
- * blocked or marked as noticed.
+ * If the message belongs to a mailing list,
+ * the function makes sure that all messages
+ * from the mailing list are blocked or marked as noticed.
  *
  * The user should be asked whether they want to chat with the _contact_ belonging to the message;
  * the group names may be really weird when taken from the subject of implicit (= ad-hoc)
  * groups and this may look confusing. Moreover, this function also scales up the origin of the contact.
  *
  * If the chat belongs to a mailing list, you can also ask
- * "Would you like to read 'MAILING LIST NAME' in Delta Chat?"
+ * "Would you like to read MAILING LIST NAME?"
  * (use dc_msg_get_real_chat_id() to get the chat-id for the contact request
  * and then dc_chat_is_mailing_list(), dc_chat_get_name() and so on)
  *
  * @memberof dc_msg_t
  * @param msg The message object.
- * @param decision 0 = Yes, 1 = No, 2 = Not now
+ * @param decision One of the DC_DECISION_* values.
  * @return The chat id of the created chat, if any.
  */
 uint32_t        dc_decide_on_contact_request (const dc_msg_t* msg, int decision);
+
 
 /**
  * Get type of videochat.

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -64,7 +64,7 @@ impl Chatlist {
     ///   The last of these messages is represented by DC_CHAT_ID_DEADDROP and you can retrieve details
     ///   about it with chatlist.get_msg_id(). Typically, the UI asks the user "Do you want to chat with NAME?"
     ///   and offers the options "Start chat", "Block" and "Not now";
-    ///   The decision is passed to dc_decide_on_contact_request().
+    ///   The decision should be passed to dc_decide_on_contact_request().
     /// - DC_CHAT_ID_ARCHIVED_LINK (6) - this special chat is present if the user has
     ///   archived *any* chat using dc_set_chat_visibility(). The UI should show a link as
     ///   "Show archived chats", if the user clicks this item, the UI should show a

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -63,9 +63,8 @@ impl Chatlist {
     ///   messages from addresses that have no relationship to the configured account.
     ///   The last of these messages is represented by DC_CHAT_ID_DEADDROP and you can retrieve details
     ///   about it with chatlist.get_msg_id(). Typically, the UI asks the user "Do you want to chat with NAME?"
-    ///   and offers the options "Yes" (call dc_create_chat_by_msg_id()), "Never" (call dc_block_contact())
-    ///   or "Not now".
-    ///   The UI can also offer a "Close" button that calls dc_marknoticed_contact() then.
+    ///   and offers the options "Start chat", "Block" and "Not now";
+    ///   The decision is passed to dc_decide_on_contact_request().
     /// - DC_CHAT_ID_ARCHIVED_LINK (6) - this special chat is present if the user has
     ///   archived *any* chat using dc_set_chat_visibility(). The UI should show a link as
     ///   "Show archived chats", if the user clicks this item, the UI should show a

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2871,8 +2871,9 @@ mod tests {
         assert_eq!(chats.get_chat_id(0), deaddrop); // Test that the message is shown in the deaddrop
 
         let msg = get_chat_msg(&t, deaddrop, 0, 1).await;
-        // ===================================== Answer "never" on the contact request =====================================
-        msg.decide_on_contact_request(&t.ctx, Never).await;
+
+        // Answer "Block" on the contact request
+        msg.decide_on_contact_request(&t.ctx, Block).await;
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 0); // Test that the message disappeared
@@ -2904,7 +2905,8 @@ mod tests {
             .unwrap();
 
         let msg = get_chat_msg(&t, deaddrop, 0, 1).await;
-        // ===================================== Answer "not now" on the contact request =====================================
+
+        // Answer "Not now" on the contact request
         msg.decide_on_contact_request(&t.ctx, NotNow).await;
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
@@ -2936,8 +2938,9 @@ mod tests {
             .unwrap();
 
         let msg = get_chat_msg(&t, deaddrop, 0, 1).await;
-        // ===================================== Answer "yes" on the contact request =====================================
-        msg.decide_on_contact_request(&t.ctx, Yes).await;
+
+        // Answer "Start chat" on the contact request
+        msg.decide_on_contact_request(&t.ctx, StartChat).await;
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1); // Test that the message is shown

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2873,7 +2873,7 @@ mod tests {
         let msg = get_chat_msg(&t, deaddrop, 0, 1).await;
 
         // Answer "Block" on the contact request
-        msg.decide_on_contact_request(&t.ctx, Block).await;
+        message::decide_on_contact_request(&t.ctx, msg.get_id(), Block).await;
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 0); // Test that the message disappeared
@@ -2907,7 +2907,7 @@ mod tests {
         let msg = get_chat_msg(&t, deaddrop, 0, 1).await;
 
         // Answer "Not now" on the contact request
-        msg.decide_on_contact_request(&t.ctx, NotNow).await;
+        message::decide_on_contact_request(&t.ctx, msg.get_id(), NotNow).await;
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 0); // Test that the message disappeared
@@ -2940,7 +2940,7 @@ mod tests {
         let msg = get_chat_msg(&t, deaddrop, 0, 1).await;
 
         // Answer "Start chat" on the contact request
-        msg.decide_on_contact_request(&t.ctx, StartChat).await;
+        message::decide_on_contact_request(&t.ctx, msg.get_id(), StartChat).await;
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1); // Test that the message is shown

--- a/src/message.rs
+++ b/src/message.rs
@@ -820,13 +820,13 @@ impl Message {
         let mut created_chat_id = None;
         use ContactRequestDecision::*;
         match (decision, chat.is_mailing_list()) {
-            (Yes, _) => match chat::create_by_msg_id(context, self.id).await {
+            (StartChat, _) => match chat::create_by_msg_id(context, self.id).await {
                 Ok(id) => created_chat_id = Some(id),
                 Err(e) => warn!(context, "decide_on_contact_request error: {}", e),
             },
 
-            (Never, false) => Contact::block(context, self.from_id).await,
-            (Never, true) => {
+            (Block, false) => Contact::block(context, self.from_id).await,
+            (Block, true) => {
                 match Contact::grpid_to_mailinglist_contact(
                     context,
                     &chat.name,
@@ -976,8 +976,8 @@ impl Message {
 
 #[derive(Display, Debug, FromPrimitive)]
 pub enum ContactRequestDecision {
-    Yes = 0,
-    Never = 1,
+    StartChat = 0,
+    Block = 1,
     NotNow = 2,
 }
 


### PR DESCRIPTION
- options are `StartChat`, `Block` and `NotNow` (instead of Yes/Never/NotNow)- esp. the wording "block" seems to be better as that wording is also used in the ui and also there are unblock functions to revert the option. also for mailinglists, we should keep that wording

- add DC_DECIDE* constants to deltachat.h

- move decide_on_contact_request() to context-object, see commit message for reasoning