### PR TITLE
dc_get_chat_encrinfo

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1221,6 +1221,18 @@ void            dc_delete_chat               (dc_context_t* context, uint32_t ch
 dc_array_t*     dc_get_chat_contacts         (dc_context_t* context, uint32_t chat_id);
 
 /**
+ * Get encryption info for a chat.
+ * Get a multi-line encryption info, containing encryption preferences of all members.
+ * Can be used to find out why messages sent to group are not encrypted.
+ *
+ * @memberof dc_context_t
+ * @param context The context object.
+ * @param chat_id ID of the chat to get the encryption info for.
+ * @return Multi-line text, must be released using dc_str_unref() after usage.
+ */
+char*           dc_get_chat_encrinfo (dc_context_t* context, uint32_t chat_id);
+
+/**
  * Get the chat's ephemeral message timer.
  * The ephemeral message timer is set by dc_set_chat_ephemeral_timer()
  * on this or any other device participating in the chat.

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5120,9 +5120,7 @@ void dc_event_unref(dc_event_t* event);
 /// Used to build the string returned by dc_get_contact_encrinfo().
 #define DC_STR_E2E_AVAILABLE              25
 
-/// "Transport-encryption."
-///
-/// Used to build the string returned by dc_get_contact_encrinfo().
+/// DEPRECATED 2021-02-07
 #define DC_STR_ENCR_TRANSP                27
 
 /// "No encryption."

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1323,6 +1323,29 @@ pub unsafe extern "C" fn dc_set_chat_mute_duration(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_get_chat_encrinfo(
+    context: *mut dc_context_t,
+    chat_id: u32,
+) -> *mut libc::c_char {
+    if context.is_null() {
+        eprintln!("ignoring careless call to dc_get_chat_encrinfo()");
+        return "".strdup();
+    }
+    let ctx = &*context;
+
+    block_on(async move {
+        ChatId::new(chat_id)
+            .get_encryption_info(&ctx)
+            .await
+            .map(|s| s.strdup())
+            .unwrap_or_else(|e| {
+                error!(&ctx, "{}", e);
+                ptr::null_mut()
+            })
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_get_chat_ephemeral_timer(
     context: *mut dc_context_t,
     chat_id: u32,

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -167,6 +167,13 @@ class Chat(object):
         """
         return lib.dc_chat_get_type(self._dc_chat)
 
+    def get_encryption_info(self):
+        """Return encryption info for this chat.
+
+        :returns: a string with encryption preferences of all chat members"""
+        res = lib.dc_get_chat_encrinfo(self.account._dc_context, self.id)
+        return from_dc_charpointer(res)
+
     def get_join_qr(self):
         """ get/create Join-Group QR Code as ascii-string.
 

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1130,6 +1130,7 @@ class TestOnlineAccount:
         msg = ac1._evtracker.wait_next_incoming_message()
         assert msg.text == "first message"
         assert not msg.is_encrypted()
+        assert msg.chat.get_encryption_info() == f"{ac2.get_config('addr')} End-to-end encryption preferred."
 
         lp.sec("ac2 learns that ac3 prefers encryption")
         ac2.create_chat(ac3)
@@ -1141,6 +1142,7 @@ class TestOnlineAccount:
         lp.sec("ac3 does not know that ac1 prefers encryption")
         ac1.create_chat(ac3)
         chat = ac3.create_chat(ac1)
+        assert chat.get_encryption_info() == f"{ac1.get_config('addr')} No encryption."
         msg = chat.send_text("not encrypted")
         msg = ac1._evtracker.wait_next_incoming_message()
         assert msg.text == "not encrypted"
@@ -1149,6 +1151,8 @@ class TestOnlineAccount:
         lp.sec("ac1 creates a group chat with ac2")
         group_chat = ac1.create_group_chat("hello")
         group_chat.add_contact(ac2)
+        encryption_info = group_chat.get_encryption_info()
+        assert encryption_info == f"{ac2.get_config('addr')} End-to-end encryption preferred."
         msg = group_chat.send_text("hi")
 
         msg = ac2._evtracker.wait_next_incoming_message()
@@ -1161,6 +1165,9 @@ class TestOnlineAccount:
 
         lp.sec("ac3 learns that ac1 prefers encryption")
         msg = ac3._evtracker.wait_next_incoming_message()
+        encryption_info = msg.chat.get_encryption_info().splitlines()
+        assert f"{ac1.get_config('addr')} End-to-end encryption preferred." in encryption_info
+        assert f"{ac2.get_config('addr')} End-to-end encryption preferred." in encryption_info
         msg = chat.send_text("encrypted")
         assert msg.is_encrypted()
 

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -25,7 +25,6 @@ use crate::message::MessageState;
 use crate::mimeparser::AvatarAction;
 use crate::param::{Param, Params};
 use crate::peerstate::{Peerstate, PeerstateVerifiedStatus};
-use crate::provider::Socket;
 use crate::stock::StockMessage;
 
 /// An object representing a single contact in memory.
@@ -687,29 +686,32 @@ impl Contact {
     /// of the contact and if the connection is encrypted the
     /// fingerprints of the keys involved.
     pub async fn get_encrinfo(context: &Context, contact_id: u32) -> Result<String> {
+        ensure!(
+            contact_id > DC_CONTACT_ID_LAST_SPECIAL,
+            "Can not provide encryption info for special contact"
+        );
+
         let mut ret = String::new();
-
         if let Ok(contact) = Contact::load_from_db(context, contact_id).await {
-            let peerstate = Peerstate::from_addr(context, &contact.addr).await?;
             let loginparam = LoginParam::from_database(context, "configured_").await;
+            let peerstate = Peerstate::from_addr(context, &contact.addr).await?;
 
-            if peerstate.is_some()
-                && peerstate
-                    .as_ref()
-                    .and_then(|p| p.peek_key(PeerstateVerifiedStatus::Unverified))
+            if let Some(peerstate) = peerstate.filter(|peerstate| {
+                peerstate
+                    .peek_key(PeerstateVerifiedStatus::Unverified)
                     .is_some()
-            {
-                let peerstate = peerstate.as_ref().unwrap();
-                let p = context
-                    .stock_str(if peerstate.prefer_encrypt == EncryptPreference::Mutual {
-                        StockMessage::E2ePreferred
-                    } else {
-                        StockMessage::E2eAvailable
-                    })
-                    .await;
-                ret += &p;
-                let p = context.stock_str(StockMessage::FingerPrints).await;
-                ret += &format!(" {}:", p);
+            }) {
+                let stock_message = match peerstate.prefer_encrypt {
+                    EncryptPreference::Mutual => StockMessage::E2ePreferred,
+                    EncryptPreference::NoPreference => StockMessage::E2eAvailable,
+                    EncryptPreference::Reset => StockMessage::EncrNone,
+                };
+
+                ret += &format!(
+                    "{}\n{}:",
+                    context.stock_str(stock_message).await,
+                    context.stock_str(StockMessage::FingerPrints).await
+                );
 
                 let fingerprint_self = SignedPublicKey::load_self(context)
                     .await?
@@ -740,10 +742,6 @@ impl Contact {
                     );
                     cat_fingerprint(&mut ret, &loginparam.addr, &fingerprint_self, "");
                 }
-            } else if loginparam.imap.security != Socket::Plain
-                && loginparam.smtp.security != Socket::Plain
-            {
-                ret += &context.stock_str(StockMessage::EncrTransp).await;
             } else {
                 ret += &context.stock_str(StockMessage::EncrNone).await;
             }
@@ -1228,6 +1226,7 @@ fn split_address_book(book: &str) -> Vec<(&str, &str)> {
 mod tests {
     use super::*;
 
+    use crate::chat::send_text_msg;
     use crate::test_utils::TestContext;
 
     #[test]
@@ -1613,5 +1612,48 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(id, Some(DC_CONTACT_ID_SELF));
+    }
+
+    #[async_std::test]
+    async fn test_contact_get_encrinfo() -> Result<()> {
+        let alice = TestContext::new_alice().await;
+
+        // Return error for special IDs
+        let encrinfo = Contact::get_encrinfo(&alice, DC_CONTACT_ID_SELF).await;
+        assert!(encrinfo.is_err());
+        let encrinfo = Contact::get_encrinfo(&alice, DC_CONTACT_ID_DEVICE).await;
+        assert!(encrinfo.is_err());
+
+        let (contact_bob_id, _modified) =
+            Contact::add_or_lookup(&alice, "Bob", "bob@example.net", Origin::ManuallyCreated)
+                .await?;
+
+        let encrinfo = Contact::get_encrinfo(&alice, contact_bob_id).await?;
+        assert_eq!(encrinfo, "No encryption.");
+
+        let bob = TestContext::new_bob().await;
+        let chat_alice = bob
+            .create_chat_with_contact("Alice", "alice@example.com")
+            .await;
+        send_text_msg(&bob, chat_alice.id, "Hello".to_string()).await?;
+        let msg = bob.pop_sent_msg().await;
+        alice.recv_msg(&msg).await;
+
+        let encrinfo = Contact::get_encrinfo(&alice, contact_bob_id).await?;
+        assert_eq!(
+            encrinfo,
+            "End-to-end encryption preferred.
+Fingerprints:
+
+alice@example.com:
+2E6F A2CB 23B5 32D7 2863
+4B58 64B0 8F61 A9ED 9443
+
+bob@example.net:
+CCCB 5AA9 F6E1 141C 9431
+65F1 DB18 B18C BCF7 0487"
+        );
+
+        Ok(())
     }
 }

--- a/src/stock.rs
+++ b/src/stock.rs
@@ -84,9 +84,6 @@ pub enum StockMessage {
     #[strum(props(fallback = "End-to-end encryption available."))]
     E2eAvailable = 25,
 
-    #[strum(props(fallback = "Transport-encryption."))]
-    EncrTransp = 27,
-
     #[strum(props(fallback = "No encryption."))]
     EncrNone = 28,
 


### PR DESCRIPTION
This PR will add a function `dc_get_chat_encrinfo` similar to `dc_get_contact_encrinfo` to make it easier to debug why the group does not encrypt. Currently the process involves sending a message and then searching the log for `peerstate`, or worse, asking someone else to do the same, often multiple times.

On Android, related "Encryption" menu item can be added to the chat profile screen to avoid cluttering the menu in the chat screen. For 1:1 chats we can either use `dc_get_contact_encrinfo` or deprecate `dc_get_contact_encrinfo` and always use `dc_get_chat_encrinfo`.

Recent related PR: #2174 