### PR TITLE
Parse QR codes without using Param

### DIFF
--- a/src/param.rs
+++ b/src/param.rs
@@ -127,15 +127,6 @@ pub enum Param {
     /// For Chats
     Devicetalk = b'D',
 
-    /// For QR
-    Auth = b's',
-
-    /// For QR
-    GroupId = b'x',
-
-    /// For QR
-    GroupName = b'g',
-
     /// For MDN-sending job
     MsgId = b'I',
 }
@@ -429,14 +420,6 @@ mod tests {
         params.set(Param::Height, "foo\nbar=baz\nquux");
         params.set(Param::Width, "\n\n\na=\n=");
         assert_eq!(params.to_string().parse::<Params>().unwrap(), params);
-    }
-
-    #[test]
-    fn test_regression() {
-        let p1: Params = "a=cli%40deltachat.de\nn=\ni=TbnwJ6lSvD5\ns=0ejvbdFSQxB"
-            .parse()
-            .unwrap();
-        assert_eq!(p1.get(Param::Forwarded).unwrap(), "cli%40deltachat.de");
     }
 
     #[async_std::test]


### PR DESCRIPTION
Param should only be used to parse dictionaries stored in SQL database, not external data.

Since Param parser has been extended to escape newlines with newlines, QR-codes parser started to treat && as escaped &, which is wrong.

This change also uses String keys like "n" for "name" instead of completely unrelated constants like Param::SetLongitude.