### PR TITLE
re-introduce Chattype::Mailinglist

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -219,6 +219,7 @@ impl ChatId {
                         }
                     }
                 }
+                Chattype::Mailinglist => bail!("Cannot protect mailing lists"),
                 Chattype::Undefined => bail!("Undefined group type"),
             },
             ProtectionStatus::Unprotected => {}
@@ -786,7 +787,7 @@ impl Chat {
     }
 
     pub fn is_mailing_list(&self) -> bool {
-        self.param.exists(Param::MailingList)
+        self.typ == Chattype::Mailinglist
     }
 
     /// Returns true if user can send messages to this chat.

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -363,19 +363,23 @@ impl Chatlist {
             return ret;
         };
 
-        let mut lastcontact = None;
-
-        let lastmsg = if let Ok(lastmsg) = Message::load_from_db(context, lastmsg_id).await {
-            if lastmsg.from_id != DC_CONTACT_ID_SELF
-                && (chat.typ == Chattype::Group || chat.typ == Chattype::Mailinglist)
-            {
-                lastcontact = Contact::load_from_db(context, lastmsg.from_id).await.ok();
-            }
-
-            Some(lastmsg)
-        } else {
-            None
-        };
+        let (lastmsg, lastcontact) =
+            if let Ok(lastmsg) = Message::load_from_db(context, lastmsg_id).await {
+                if lastmsg.from_id == DC_CONTACT_ID_SELF {
+                    (Some(lastmsg), None)
+                } else {
+                    match chat.typ {
+                        Chattype::Group | Chattype::Mailinglist => {
+                            let lastcontact =
+                                Contact::load_from_db(context, lastmsg.from_id).await.ok();
+                            (Some(lastmsg), lastcontact)
+                        }
+                        Chattype::Single | Chattype::Undefined => (Some(lastmsg), None),
+                    }
+                }
+            } else {
+                (None, None)
+            };
 
         if chat.id.is_archived_link() {
             ret.text2 = None;

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -366,7 +366,9 @@ impl Chatlist {
         let mut lastcontact = None;
 
         let lastmsg = if let Ok(lastmsg) = Message::load_from_db(context, lastmsg_id).await {
-            if lastmsg.from_id != DC_CONTACT_ID_SELF && chat.typ == Chattype::Group {
+            if lastmsg.from_id != DC_CONTACT_ID_SELF
+                && (chat.typ == Chattype::Group || chat.typ == Chattype::Mailinglist)
+            {
                 lastcontact = Contact::load_from_db(context, lastmsg.from_id).await.ok();
             }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -144,6 +144,7 @@ pub enum Chattype {
     Undefined = 0,
     Single = 100,
     Group = 120,
+    Mailinglist = 140,
 }
 
 impl Default for Chattype {

--- a/src/job.rs
+++ b/src/job.rs
@@ -690,7 +690,7 @@ impl Job {
                     }
                     Ok(c) => c,
                 };
-                if chat.typ == Chattype::Group {
+                if chat.typ == Chattype::Group || chat.typ == Chattype::Mailinglist {
                     // The next lines are actually what we do in
                     let (test_normal_chat_id, test_normal_chat_id_blocked) =
                         chat::lookup_by_contact_id(context, msg.from_id)

--- a/src/job.rs
+++ b/src/job.rs
@@ -690,18 +690,21 @@ impl Job {
                     }
                     Ok(c) => c,
                 };
-                if chat.typ == Chattype::Group || chat.typ == Chattype::Mailinglist {
-                    // The next lines are actually what we do in
-                    let (test_normal_chat_id, test_normal_chat_id_blocked) =
-                        chat::lookup_by_contact_id(context, msg.from_id)
-                            .await
-                            .unwrap_or_default();
+                match chat.typ {
+                    Chattype::Group | Chattype::Mailinglist => {
+                        // The next lines are actually what we do in
+                        let (test_normal_chat_id, test_normal_chat_id_blocked) =
+                            chat::lookup_by_contact_id(context, msg.from_id)
+                                .await
+                                .unwrap_or_default();
 
-                    if !test_normal_chat_id.is_unset()
-                        && test_normal_chat_id_blocked == Blocked::Not
-                    {
-                        chat.id.unblock(context).await;
+                        if !test_normal_chat_id.is_unset()
+                            && test_normal_chat_id_blocked == Blocked::Not
+                        {
+                            chat.id.unblock(context).await;
+                        }
                     }
+                    Chattype::Single | Chattype::Undefined => {}
                 }
             }
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1064,23 +1064,31 @@ impl Lot {
                 );
                 self.text1_meaning = Meaning::Text1Self;
             }
-        } else if chat.typ == Chattype::Group || chat.typ == Chattype::Mailinglist {
-            if msg.is_info() || contact.is_none() {
-                self.text1 = None;
-                self.text1_meaning = Meaning::None;
-            } else {
-                if chat.id.is_deaddrop() {
-                    if let Some(contact) = contact {
-                        self.text1 = Some(msg.get_sender_name(contact));
-                    } else {
+        } else {
+            match chat.typ {
+                Chattype::Group | Chattype::Mailinglist => {
+                    if msg.is_info() || contact.is_none() {
                         self.text1 = None;
+                        self.text1_meaning = Meaning::None;
+                    } else {
+                        if chat.id.is_deaddrop() {
+                            if let Some(contact) = contact {
+                                self.text1 = Some(msg.get_sender_name(contact));
+                            } else {
+                                self.text1 = None;
+                            }
+                        } else if let Some(contact) = contact {
+                            self.text1 = Some(msg.get_sender_name(contact));
+                        } else {
+                            self.text1 = None;
+                        }
+                        self.text1_meaning = Meaning::Text1Username;
                     }
-                } else if let Some(contact) = contact {
-                    self.text1 = Some(msg.get_sender_name(contact));
-                } else {
-                    self.text1 = None;
                 }
-                self.text1_meaning = Meaning::Text1Username;
+                Chattype::Single | Chattype::Undefined => {
+                    self.text1 = None;
+                    self.text1_meaning = Meaning::None;
+                }
             }
         }
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -131,9 +131,6 @@ pub enum Param {
     /// For Chats
     Devicetalk = b'D',
 
-    /// For Chats: "1" if this chat is a mailing list, all other values are invalid.
-    MailingList = b'L',
-
     /// For MDN-sending job
     MsgId = b'I',
 }


### PR DESCRIPTION
this pr merges to mailinglists2, not to master.

we can now pretty freely decide, how to handle chattype in ffi.