### PR TITLE
Remove obsolete ChatId::is_unset check

### DIFF
--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -1619,10 +1619,8 @@ pub(crate) async fn prefetch_should_download(
     // deleted from the database or has not arrived yet.
     if let Some(rfc724_mid) = headers.get_header_value(HeaderDef::MessageId) {
         if let Some(group_id) = dc_extract_grpid_from_rfc724_mid(&rfc724_mid) {
-            if let Ok((chat_id, _, _)) = get_chat_id_by_grpid(context, group_id).await {
-                if !chat_id.is_unset() {
-                    return Ok(true);
-                }
+            if let Ok((_chat_id, _, _)) = get_chat_id_by_grpid(context, group_id).await {
+                return Ok(true);
             }
         }
     }


### PR DESCRIPTION
The get_chat_id_by_grpid() call is already resultified.  The database
can only contain consistent data since on creation it inserts rows for
the special chats which do not have a grpid set so can never match.
Thus we can safely remove another use of the ChatId::is_unset call
which should be removed to clean up the type.