### PR TITLE
Remove obsolete ChatId::is_unset check

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -703,15 +703,10 @@ impl Job {
                 };
                 match chat.typ {
                     Chattype::Group | Chattype::Mailinglist => {
-                        match chat::lookup_by_contact_id(context, msg.from_id).await {
-                            Err(e) => {
-                                warn!(context, "can't get chat: {:#}", e);
-                                return Status::RetryLater;
-                            }
-                            Ok((_1to1_chat, Blocked::Not)) => {
-                                chat.id.unblock(context).await;
-                            }
-                            Ok(_) => (),
+                        if let Ok((_1to1_chat, Blocked::Not)) =
+                            chat::lookup_by_contact_id(context, msg.from_id).await
+                        {
+                            chat.id.unblock(context).await;
                         }
                     }
                     Chattype::Single | Chattype::Undefined => {}

--- a/src/job.rs
+++ b/src/job.rs
@@ -704,14 +704,12 @@ impl Job {
                 match chat.typ {
                     Chattype::Group | Chattype::Mailinglist => {
                         // The next lines are actually what we do in
-                        let (test_normal_chat_id, test_normal_chat_id_blocked) =
+                        let (_test_normal_chat_id, test_normal_chat_id_blocked) =
                             chat::lookup_by_contact_id(context, msg.from_id)
                                 .await
                                 .unwrap_or_default();
 
-                        if !test_normal_chat_id.is_unset()
-                            && test_normal_chat_id_blocked == Blocked::Not
-                        {
+                        if test_normal_chat_id_blocked == Blocked::Not {
                             chat.id.unblock(context).await;
                         }
                     }


### PR DESCRIPTION
The chat::lookup_by_contact_id call is already resultified, the
database can not contain this since the auto-increment counter is
bumped to 7 by the time the database tables are created.