### PR TITLE
Avoid ChatId::is_unset for searching messages

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1136,10 +1136,15 @@ pub unsafe extern "C" fn dc_search_msgs(
         return ptr::null_mut();
     }
     let ctx = &*context;
+    let chat_id = if chat_id == 0 {
+        None
+    } else {
+        Some(ChatId::new(chat_id))
+    };
 
     block_on(async move {
         let arr = dc_array_t::from(
-            ctx.search_msgs(ChatId::new(chat_id), to_string_lossy(query))
+            ctx.search_msgs(chat_id, to_string_lossy(query))
                 .await
                 .iter()
                 .map(|msg_id| msg_id.to_u32())

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -858,9 +858,9 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             ensure!(!arg1.is_empty(), "Argument <query> missing.");
 
             let chat = if let Some(ref sel_chat) = sel_chat {
-                sel_chat.get_id()
+                Some(sel_chat.get_id())
             } else {
-                ChatId::new(0)
+                None
             };
 
             let msglist = context.search_msgs(chat, arg1).await;


### PR DESCRIPTION
Using a ChatId value of 0 to indicate global search is a left over
from C-land.  Refactor this to be an option instead.