### PR TITLE
Disable debug info in the dev profile by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 license = "MPL-2.0"
 
+[profile.dev]
+debug = 0
+
 [profile.release]
 lto = true
 


### PR DESCRIPTION
This does not affect the release profile and it significantly speeds
up compilation.  In the rare cases where panics are not sufficient to
debug something you can manually enable this again.