### PR TITLE
Fix contact name update rules

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -435,11 +435,11 @@ class TestOfflineChat:
         email = "hello <hello@example.org>"
         contact1 = ac1.create_contact(email)
         assert contact1.addr == "hello@example.org"
-        assert contact1.display_name == "hello"
+        assert contact1.name == "hello"
         contact1 = ac1.create_contact(email, name="world")
-        assert contact1.display_name == "world"
+        assert contact1.name == "world"
         contact2 = ac1.create_contact("display1 <x@example.org>", "real")
-        assert contact2.display_name == "real"
+        assert contact2.name == "real"
 
     def test_create_chat_simple(self, acfactory):
         ac1 = acfactory.get_configured_offline_account()
@@ -2131,7 +2131,9 @@ class TestOnlineAccount:
         ac1, ac2 = acfactory.get_two_online_accounts()
         ac1.set_config("displayname", "Account 1")
 
-        chat12 = acfactory.get_accepted_chat(ac1, ac2)
+        # Similar to acfactory.get_accepted_chat, but without setting the contact name.
+        ac2.create_contact(ac1.get_config("addr")).create_chat()
+        chat12 = ac1.create_contact(ac2.get_config("addr")).create_chat()
         contact = None
 
         def update_name():
@@ -2162,12 +2164,7 @@ class TestOnlineAccount:
         # so it should not be changed.
         ac1.set_config("displayname", "Renamed again")
         updated_name = update_name()
-        if updated_name == "Renamed again":
-            # Known bug, mark as XFAIL
-            pytest.xfail("Contact was renamed after explicit rename")
-        else:
-            # No renames should happen after explicit rename
-            assert updated_name == "Renamed"
+        assert updated_name == "Renamed"
 
     def test_group_quote(self, acfactory, lp):
         """Test quoting in a group with a new member who have not seen the quoted message."""

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2422,13 +2422,9 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(
-            Contact::load_from_db(&t, carl_contact_id)
-                .await
-                .unwrap()
-                .get_name(),
-            "h2"
-        );
+        let contact = Contact::load_from_db(&t, carl_contact_id).await.unwrap();
+        assert_eq!(contact.get_name(), "");
+        assert_eq!(contact.get_display_name(), "h2");
 
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         let msg = Message::load_from_db(&t, chats.get_msg_id(0).unwrap())
@@ -2471,13 +2467,9 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(
-            Contact::load_from_db(&t, carl_contact_id)
-                .await
-                .unwrap()
-                .get_name(),
-            "Carl"
-        );
+        let contact = Contact::load_from_db(&t, carl_contact_id).await.unwrap();
+        assert_eq!(contact.get_name(), "");
+        assert_eq!(contact.get_display_name(), "Carl");
     }
 
     #[async_std::test]

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -490,6 +490,8 @@ mod tests {
         let contact = Contact::get_by_id(&ctx.ctx, res.get_id()).await.unwrap();
         assert_eq!(contact.get_addr(), "stress@test.local");
         assert_eq!(contact.get_name(), "First Last");
+        assert_eq!(contact.get_authname(), "");
+        assert_eq!(contact.get_display_name(), "First Last");
     }
 
     #[async_std::test]

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1491,6 +1491,15 @@ CREATE INDEX devmsglabels_index1 ON devmsglabels (label);
             }
             sql.set_raw_config_int(context, "dbversion", 73).await?;
         }
+        if dbversion < 74 {
+            info!(context, "[migration] v74");
+            sql.execute(
+                "UPDATE contacts SET name='' WHERE name=authname",
+                paramsv![],
+            )
+            .await?;
+            sql.set_raw_config_int(context, "dbversion", 74).await?;
+        }
 
         // (2) updates that require high-level objects
         // (the structure is complete now and all objects are usable)


### PR DESCRIPTION
The following rules apply now:
1. "name" column is only updated manually and never over the network
2. "authname" column is only updated over the network and never manually
3. Displayname is a "name" if it is non-empty, otherwise it is "authname".

This fixes a known (pytest.xfail) problem of "name" being changed over
the network when user has set it to non-empty string manually.

This also fixes the problem when "name" and "authname"
became unsynchronized accidentally, when they were equal and then
Origin::IncomingUnknownTo update arrived, setting "name" but not
"authname". Rust regression test is added for this case.