### PR TITLE
bump version to 1.51.0-alpha.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.50.0"
+version = "1.51.0-alpha.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.50.0"
+version = "1.51.0-alpha.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.50.0"
+version = "1.51.0-alpha.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.50.0"
+version = "1.51.0-alpha.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"


### PR DESCRIPTION
1.51.0-alpha.0 is somewhere between 1.50 and 1.51,
as various beta-versions come or already came out with the new core,
this is helps in logs/debugging.

i think, the version will stay untagged, it is mainly for logs
 cmp. https://github.com/deltachat/deltachat-core-rust/pull/2084