### PR TITLE
Scan folders adjustments

### DIFF
--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -44,15 +44,6 @@ impl Imap {
             };
 
             let foldername = folder.name();
-            if watched_folders.contains(&foldername.to_string()) {
-                info!(
-                    context,
-                    "Not scanning folder {} as it is watched anyway", foldername
-                );
-                continue;
-            }
-            info!(context, "Scanning folder: {}", foldername);
-
             let folder_meaning = get_folder_meaning(&folder);
             let folder_name_meaning = get_folder_meaning_by_name(foldername);
 
@@ -70,8 +61,17 @@ impl Imap {
                 spam_folder = Some(folder.name().to_string());
             }
 
-            if let Err(e) = self.fetch_new_messages(context, foldername, false).await {
-                warn!(context, "Can't fetch new msgs in scanned folder: {:#}", e);
+            if watched_folders.contains(&foldername.to_string()) {
+                info!(
+                    context,
+                    "Not scanning folder {} as it is watched anyway", foldername
+                );
+            } else {
+                info!(context, "Scanning folder: {}", foldername);
+
+                if let Err(e) = self.fetch_new_messages(context, foldername, false).await {
+                    warn!(context, "Can't fetch new msgs in scanned folder: {:#}", e);
+                }
             }
         }
 

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -20,7 +20,6 @@ impl Imap {
                 .await;
 
             if elapsed_secs < debounce_secs {
-                info!(context, "Not scanning, we scanned {}s ago", elapsed_secs);
                 return Ok(());
             }
         }


### PR DESCRIPTION
- Remove confusing log
- Only scan_folders() on the Inbox folder to prevent race conditions when multiple threads scan at once. But make sure that the inbox folder always scans. I missed this when implementing scan_folders().