### PR TITLE
add dc_contact_get_auth_name()

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4032,6 +4032,28 @@ char*           dc_contact_get_name          (const dc_contact_t* contact);
 
 
 /**
+ * Get original contact name.
+ * This is the name of the contact as defined by the contact themself.
+ * If the contact themself does not define such a name,
+ * an empty string is returned.
+ *
+ * This function is typically only needed for the controls that
+ * allow the local user to edit the name,
+ * eg. you want to show the original name somewhere in the edit dialog
+ * (you cannot use dc_contact_get_display_name() for that as
+ * this would return previously set edited names).
+ *
+ * In most other situations than the name-edit-dialog,
+ * as lists, messages etc. use dc_contact_get_display_name().
+ *
+ * @memberof dc_contact_t
+ * @return String with the original name, must be released using dc_str_unref().
+ *     Empty string if unset, never returns NULL.
+ */
+char*           dc_contact_get_auth_name     (const dc_contact_t* contact);
+
+
+/**
  * Get display name. This is the name as defined by the contact himself,
  * modified by the user or, if both are unset, the email address.
  *

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3221,6 +3221,16 @@ pub unsafe extern "C" fn dc_contact_get_name(contact: *mut dc_contact_t) -> *mut
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_contact_get_auth_name(contact: *mut dc_contact_t) -> *mut libc::c_char {
+    if contact.is_null() {
+        eprintln!("ignoring careless call to dc_contact_get_auth_name()");
+        return "".strdup();
+    }
+    let ffi_contact = &*contact;
+    ffi_contact.contact.get_authname().strdup()
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_contact_get_display_name(
     contact: *mut dc_contact_t,
 ) -> *mut libc::c_char {


### PR DESCRIPTION
in rare cases, you need the "original name" in the ui, eg. to make a placeholder as suggested at https://github.com/deltachat/deltachat-desktop/issues/2109 work properly and it is also needed for https://github.com/deltachat/deltachat-ios/pull/1051

successor of #2206