### PR TITLE
impersonate: allow to override sender name

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3817,6 +3817,21 @@ void            dc_msg_set_html               (dc_msg_t* msg, const char* html);
 
 
 /**
+ * Set different sender name for a message.
+ * This overrides the name set by the dc_set_config()-option `displayname`.
+ *
+ * Usually, this function is not needed
+ * when implementing pure messaging functions.
+ * However, it might be useful for bots eg. building bridges to other networks.
+ *
+ * @memberof dc_msg_t
+ * @param msg The message object.
+ * @param name The name to send along with the message.
+ */
+void            dc_msg_set_override_sender_name(dc_msg_t* msg, const char* name);
+
+
+/**
  * Set the file associated with a message object.
  * This does not alter any information in the database
  * nor copy or move the file or checks if the file exist.

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3029,6 +3029,21 @@ pub unsafe extern "C" fn dc_msg_set_html(msg: *mut dc_msg_t, html: *const libc::
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_msg_set_override_sender_name(
+    msg: *mut dc_msg_t,
+    name: *const libc::c_char,
+) {
+    if msg.is_null() {
+        eprintln!("ignoring careless call to dc_msg_set_override_sender_name()");
+        return;
+    }
+    let ffi_msg = &mut *msg;
+    ffi_msg
+        .message
+        .set_override_sender_name(to_opt_string_lossy(name))
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_msg_set_file(
     msg: *mut dc_msg_t,
     file: *const libc::c_char,

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -43,6 +43,7 @@ pub enum HeaderDef {
     SecureJoinFingerprint,
     SecureJoinInvitenumber,
     SecureJoinAuth,
+    Sender,
     EphemeralTimer,
     Received,
     _TestHeader,

--- a/src/param.rs
+++ b/src/param.rs
@@ -23,7 +23,8 @@ pub enum Param {
     File = b'f',
 
     /// For messages: This name should be shown instead of contact.get_display_name()
-    /// (used if this is a mailinglist)
+    /// (used if this is a mailinglist
+    /// or explictly set using set_override_sender_name(), eg. by bots)
     OverrideSenderDisplayname = b'O',
 
     /// For Messages


### PR DESCRIPTION
this pr introduces `dc_msg_set_override_sender_name()` that allows to set a sender name that is valid only for a single message. this is useful for impersonation, for bots and bridges. the pr is build on things that were already introduced by the mailinglists in #1964, so, a UI that implements receiving mailing lists also supports these manually set per-message-names.

once a recipient receives a message with override-sender-name set, it does _not_ update the name in the contact database (as done usually), so the rename does not affect past and future messages.

**on protocol-level,** the question discussed recently on irc was, how the per-message-name can be identified, one option would be a separate header, however, quite a few ppl are sceptical in introducing more headers. an alternative that pop up on irc discussion was to prefix the name by some character, eg. the `@`. this pr picks up this idea, however, uses `~` instead - as `@` might be used in names as it is very present. the `~` is known from whatsapp to indicate contacts with "unverified" names (contacts not in the addressbook), and i also liked the interpretation "circa".

the `~` is currently not shown in Delta Chat (it will be visible in other MUA), but we could change that. there is also the question what to do if the user enters a name starting with `~` manually (@adbenitez will try :) and maybe some other, however, might be we do that completely differently on protocol level at the end, so i'd say we target these cornercases if we really decide to keep the `~` thing (it is just a suggestion, it is the second commit in this pr that needs to be changed)

EDIT: we decided to move from `~` prefix to setting `Sender:`, i will change this pr.

finally, i could not resist:

![zak_mckracken_and_the_alien_mindbenders_03](https://user-images.githubusercontent.com/9800740/107848896-8e7f7700-6df7-11eb-9806-b1a95c0916dc.gif)
