### PR TITLE
Refactor MimeFactory

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -971,7 +971,7 @@ impl Contact {
     pub async fn is_verified_ex(
         &self,
         context: &Context,
-        peerstate: Option<&Peerstate<'_>>,
+        peerstate: Option<&Peerstate>,
     ) -> VerifiedStatus {
         // We're always sort of secured-verified as we could verify the key on this device any time with the key
         // on this device

--- a/src/job.rs
+++ b/src/job.rs
@@ -488,7 +488,7 @@ impl Job {
         let msg = job_try!(Message::load_from_db(context, msg_id).await);
         let mimefactory =
             job_try!(MimeFactory::from_mdn(context, &msg, additional_rfc724_mids).await);
-        let rendered_msg = job_try!(mimefactory.render().await);
+        let rendered_msg = job_try!(mimefactory.render(context).await);
         let body = rendered_msg.message;
 
         let addr = contact.get_addr();
@@ -961,7 +961,7 @@ pub async fn send_msg_job(context: &Context, msg_id: MsgId) -> Result<Option<Job
         return Ok(None);
     }
 
-    let rendered_msg = match mimefactory.render().await {
+    let rendered_msg = match mimefactory.render(context).await {
         Ok(res) => Ok(res),
         Err(err) => {
             message::set_msg_failed(context, msg_id, Some(err.to_string())).await;

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1172,7 +1172,7 @@ async fn update_gossip_peerstates(
                     peerstate.apply_gossip(header, message_time);
                     peerstate.save_to_db(&context.sql, false).await?;
                 } else {
-                    let p = Peerstate::from_gossip(context, header, message_time);
+                    let p = Peerstate::from_gossip(header, message_time);
                     p.save_to_db(&context.sql, true).await?;
                     peerstate = Some(p);
                 }

--- a/src/securejoin/mod.rs
+++ b/src/securejoin/mod.rs
@@ -1124,7 +1124,6 @@ mod tests {
         // Ensure Bob knows Alice_FP
         let alice_pubkey = SignedPublicKey::load_self(&alice.ctx).await.unwrap();
         let peerstate = Peerstate {
-            context: &bob.ctx,
             addr: "alice@example.com".into(),
             last_seen: 10,
             last_seen_autocrypt: 10,


### PR DESCRIPTION
Reduce the number of lifetimes and move message building to the end of MimeFactory.render()

This is the first part of #2232