### PR TITLE
support mailinglists without ListId-header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 - new chat type and apis for the new mailing list support,
   `DC_CHAT_TYPE_MAILINGLIST`, `dc_msg_get_real_chat_id()`,
-  `dc_msg_get_override_sender_name()` #1964 #2181 #2185 #2195 #2211 #2210
+  `dc_msg_get_override_sender_name()` #1964 #2181 #2185 #2195 #2211 #2210 #2240
 
 - new api `dc_decide_on_contact_request()`,
   deprecated `dc_create_chat_by_msg_id()` and `dc_marknoticed_contact()` #1964

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -528,7 +528,6 @@ async fn add_parts(
                         let (new_chat_id, new_chat_id_blocked) = create_or_lookup_mailinglist(
                             context,
                             allow_creation,
-                            Blocked::Deaddrop,
                             list_id,
                             &mime_parser.get_subject().unwrap_or_default(),
                         )
@@ -542,7 +541,6 @@ async fn add_parts(
                         let (new_chat_id, new_chat_id_blocked) = create_or_lookup_mailinglist(
                             context,
                             allow_creation,
-                            Blocked::Deaddrop,
                             sender,
                             &mime_parser.get_subject().unwrap_or_default(),
                         )
@@ -1497,7 +1495,6 @@ async fn create_or_lookup_group(
 async fn create_or_lookup_mailinglist(
     context: &Context,
     allow_creation: bool,
-    create_blocked: Blocked,
     list_id_header: &str,
     subject: &str,
 ) -> (ChatId, Blocked) {
@@ -1534,14 +1531,14 @@ async fn create_or_lookup_mailinglist(
             Chattype::Mailinglist,
             &listid,
             &name,
-            create_blocked,
+            Blocked::Deaddrop,
             ProtectionStatus::Unprotected,
         )
         .await
         {
             Ok(chat_id) => {
                 chat::add_to_chat_contacts_table(context, chat_id, DC_CONTACT_ID_SELF).await;
-                (chat_id, create_blocked)
+                (chat_id, Blocked::Deaddrop)
             }
             Err(e) => {
                 warn!(
@@ -1551,7 +1548,7 @@ async fn create_or_lookup_mailinglist(
                     &listid,
                     e.to_string()
                 );
-                (ChatId::new(0), create_blocked)
+                (ChatId::new(0), Blocked::Deaddrop)
             }
         }
     } else {

--- a/src/message.rs
+++ b/src/message.rs
@@ -2576,5 +2576,10 @@ mod tests {
         );
         assert_eq!(msg.get_sender_name(&contact), "over ride".to_string());
         assert_ne!(contact.get_display_name(), "over ride".to_string());
+
+        // explicitly check that the message does not create a mailing list
+        // (mailing lists may also use `Sender:`-header)
+        let chat = Chat::load_from_db(&bob, msg.chat_id).await.unwrap();
+        assert_ne!(chat.typ, Chattype::Mailinglist);
     }
 }

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -408,7 +408,7 @@ impl MimeMessage {
 
             // For mailing lists, always add the subject because sometimes there are different topics
             // and otherwise it might be hard to keep track:
-            if self.get(HeaderDef::ListId).is_some() {
+            if self.is_mailinglist_message() {
                 prepend_subject = true;
             }
 


### PR DESCRIPTION
closes #2235 

moreover, this pr ensures, all detected mailinglists are also handled somehow; before, not all lists detected by is_mailing_list_message() were treated as mailinglists.

if we encounter in the future, that the `Precedence` + `Sender` check misses too many mailing lists, `get_mailinglist_type()` should be pretty easy to adapt. however, i think, the vast majority of mailing lists have a `ListId` anyway.