### PR TITLE
improve outlook compatibility

### DIFF
--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -11,10 +11,19 @@ pub enum HeaderDef {
     To,
     Cc,
     Disposition,
+
+    /// Used in the "Body Part Header" of MDNs as of RFC 8098.
+    /// Indicates the Message-ID of the message for which the MDN is being issued.
     OriginalMessageId,
 
     /// Delta Chat extension for message IDs in combined MDNs
     AdditionalMessageIds,
+
+    /// Outlook-SMTP-server replace the `Message-ID:`-header
+    /// and write the original ID to `X-Microsoft-Original-Message-ID`.
+    /// To sort things correctly and to not show outgoing messages twice,
+    /// we need to check that header as well.
+    XMicrosoftOriginalMessageId,
 
     ListId,
     References,

--- a/src/imap/mod.rs
+++ b/src/imap/mod.rs
@@ -72,8 +72,14 @@ const PREFETCH_FLAGS: &str = "(UID BODY.PEEK[HEADER.FIELDS (\
                               CHAT-VERSION \
                               AUTOCRYPT-SETUP-MESSAGE\
                               )])";
-const DELETE_CHECK_FLAGS: &str = "(UID BODY.PEEK[HEADER.FIELDS (MESSAGE-ID)])";
-const RFC724MID_UID: &str = "(UID BODY.PEEK[HEADER.FIELDS (MESSAGE-ID)])";
+const DELETE_CHECK_FLAGS: &str = "(UID BODY.PEEK[HEADER.FIELDS (\
+                                  MESSAGE-ID \
+                                  X-MICROSOFT-ORIGINAL-MESSAGE-ID\
+                                  )])";
+const RFC724MID_UID: &str = "(UID BODY.PEEK[HEADER.FIELDS (\
+                             MESSAGE-ID \
+                             X-MICROSOFT-ORIGINAL-MESSAGE-ID\
+                             )])";
 const JUST_UID: &str = "(UID)";
 const BODY_FLAGS: &str = "(FLAGS BODY.PEEK[])";
 
@@ -1594,7 +1600,9 @@ fn get_fetch_headers(prefetch_msg: &Fetch) -> Result<Vec<mailparse::MailHeader>>
 }
 
 fn prefetch_get_message_id(headers: &[mailparse::MailHeader]) -> Result<String> {
-    if let Some(message_id) = headers.get_header_value(HeaderDef::MessageId) {
+    if let Some(message_id) = headers.get_header_value(HeaderDef::XMicrosoftOriginalMessageId) {
+        Ok(crate::mimeparser::parse_message_id(&message_id)?)
+    } else if let Some(message_id) = headers.get_header_value(HeaderDef::MessageId) {
         Ok(crate::mimeparser::parse_message_id(&message_id)?)
     } else {
         bail!("prefetch: No message ID found");

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -514,12 +514,6 @@ impl<'a> MimeFactory<'a> {
             ));
         }
 
-        // we could also store the message-id in the protected headers
-        // which would probably help to survive providers like
-        // Outlook.com or hotmail which mangle the Message-ID.
-        // but they also strip the Autocrypt header so we probably
-        // never get a chance to tunnel our protected headers in a
-        // cryptographic payload.
         unprotected_headers.push(Header::new(
             "Message-ID".into(),
             render_rfc724_mid(&rfc724_mid),


### PR DESCRIPTION
outlooks SMTP-server change the Message-ID of messages
and put the original Message-ID to X-Microsoft-Original-Message-ID.

the changed Message-ID has some issues:

- outgoing messages with bcc_self enabled are shown twice
  as the self-copy got the changed Message-ID while the database uses
  the original one

- read receipts do not work as they refer to the changed message id

- in general, sender and recipient see different Message-IDs

the issues can be fixed by

1. **let all receivers use the original Message-ID**

	this is what this pr is doing
    and this should fix all issues with delta-to-delta communication,
	including groups, group-images etc.
    there may be issues left in communication
	with other MUAs as they are using another Message-ID.

2. ftr, this is not what this pr is doing:
    **updating the Message-ID in the database of the sender to the new one**

	this requires bcc_self always enabled (which is not the case)
    and may also result easily in race conditions
    (Bob answers before Alice sees its self-sent message),
    however, has the advantage of better compatibility with other MUA,

if needed, the compatibility with other MUA could be improved by remembering
both Messages-IDs, maybe we could treat the modified as References or so,
however, i think, this could be part of another PR if we know better about
real, in the wild issues.

ahh: and prefetch is not changed, so, it may still be that messages are downloaded twice
(not added twice to the database, of couse),
however, of course, only if you are using an outlook account.
not sure, if it is worth the effort - also as this would mean some useless additional bytes in requests of _all_ other delta users not using outlook :)

EDIT: after some off-pr discussions, thinks to be done:

- [x] recognize `X-Microsoft-Original-Message-ID` header for both, incoming- and bcc_self-messages and use this header instead of `Message-ID`
- [x] on deletion, check the known Message-ID against both headers
- [x] check, what needs to be done in `resync_folder_uids()`

with these points being done, delta-to-delta should be fine 
and we can test and better see how communication with other MUA work out.

the remaining issue is probably  a replying MUA that does not use the `X-Original-Message-ID` and uses the server-created `Message-ID` in replies. here the idea is to go for refined References handling if needed in a second independent PR.

closes #1006