### PR TITLE
Fix ongoing management in securejoin

### DIFF
--- a/src/securejoin/bobstate.rs
+++ b/src/securejoin/bobstate.rs
@@ -117,7 +117,7 @@ impl<'a> BobStateHandle<'a> {
     /// allowing a new handshake to be started from [`Bob`].
     ///
     /// Note that the state is only cleared on Drop since otherwise the invariant that the
-    /// state is always consistent is violated.  However the "ongoing" prococess is released
+    /// state is always consistent is violated.  However the "ongoing" process is released
     /// here a little bit earlier as this requires access to the Context, which we do not
     /// have on Drop (Drop can not run asynchronous code).  Stopping the "ongoing" process
     /// will release [`securejoin`](super::securejoin) which in turn will finally free the

--- a/src/securejoin/bobstate.rs
+++ b/src/securejoin/bobstate.rs
@@ -119,7 +119,9 @@ impl<'a> BobStateHandle<'a> {
     /// Note that the state is only cleared on Drop since otherwise the invariant that the
     /// state is always consistent is violated.  However the "ongoing" prococess is released
     /// here a little bit earlier as this requires access to the Context, which we do not
-    /// have on Drop (Drop can not run asynchronous code).
+    /// have on Drop (Drop can not run asynchronous code).  Stopping the "ongoing" process
+    /// will release [`securejoin`](super::securejoin) which in turn will finally free the
+    /// ongoing process using [`Context::free_ongoing`].
     ///
     /// [`InnerContext::bob`]: crate::context::InnerContext::bob
     /// [`Bob`]: super::Bob


### PR DESCRIPTION
This fixes #2246.

It's probably best to look at the two commits separately:

1. The first commit fixes the bug.

2. The second commit is actually a new feature, I noticed we can do
   better than just sleep while waiting for the ongoing process.