### PR TITLE
add decision- and blocking-functions to repl, cleanup

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1757,6 +1757,7 @@ dc_array_t*     dc_get_contacts              (dc_context_t* context, uint32_t fl
 /**
  * Get the number of blocked contacts.
  *
+ * @deprecated Deprecated on 2021-02-22: Use dc_array_get_cnt() on dc_get_blocked_contacts() instead.
  * @memberof dc_context_t
  * @param context The context object.
  * @return The number of blocked contacts.

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -672,8 +672,6 @@ dc_chatlist_t*  dc_get_chatlist              (dc_context_t* context, int flags, 
 // handle chats
 
 /**
- * DEPRECATED Use dc_decide_on_contact_request().
- *
  * Create a normal chat or a group chat by a messages ID that comes typically
  * from the deaddrop, DC_CHAT_ID_DEADDROP (1).
  *
@@ -693,7 +691,7 @@ dc_chatlist_t*  dc_get_chatlist              (dc_context_t* context, int flags, 
  * same group may be shown or not - so, all in all, it is fine to show the
  * contact name only.
  *
- * @deprecated Use dc_decide_on_contact_request() instead
+ * @deprecated Deprecated 2021-02-07, use dc_decide_on_contact_request() instead
  * @memberof dc_context_t
  * @param context The context object as returned from dc_context_new().
  * @param msg_id The message ID to create the chat for.
@@ -1547,8 +1545,6 @@ void            dc_forward_msgs              (dc_context_t* context, const uint3
 
 
 /**
- * DEPRECATED
- *
  * Mark all messages sent by the given contact as _noticed_.
  * This function is typically used to ignore a user in the deaddrop temporarily ("Not now" button).
  *
@@ -1557,7 +1553,7 @@ void            dc_forward_msgs              (dc_context_t* context, const uint3
  *
  * See also dc_marknoticed_chat() and dc_markseen_msgs()
  *
- * @deprecated Use dc_decide_on_contact_request() if the user just hit "Not now" on a button in the deaddrop,
+ * @deprecated Deprecated 2021-02-07, use dc_decide_on_contact_request() if the user just hit "Not now" on a button in the deaddrop,
  *      dc_marknoticed_chat() if the user has entered a chat
  *      and dc_markseen_msgs() if the user actually _saw_ a message.
  * @memberof dc_context_t
@@ -1757,7 +1753,7 @@ dc_array_t*     dc_get_contacts              (dc_context_t* context, uint32_t fl
 /**
  * Get the number of blocked contacts.
  *
- * @deprecated Deprecated on 2021-02-22: Use dc_array_get_cnt() on dc_get_blocked_contacts() instead.
+ * @deprecated Deprecated 2021-02-22, use dc_array_get_cnt() on dc_get_blocked_contacts() instead.
  * @memberof dc_context_t
  * @param context The context object.
  * @return The number of blocked contacts.
@@ -5286,7 +5282,7 @@ void dc_event_unref(dc_event_t* event);
 /// Used to build the string returned by dc_get_contact_encrinfo().
 #define DC_STR_E2E_AVAILABLE              25
 
-/// DEPRECATED 2021-02-07
+/// @deprecated Deprecated 2021-02-07, this string is no longer needed.
 #define DC_STR_ENCR_TRANSP                27
 
 /// "No encryption."
@@ -5476,9 +5472,7 @@ void dc_event_unref(dc_event_t* event);
 /// Used in status messages.
 #define DC_STR_EPHEMERAL_WEEK             80
 
-/// DEPRECATED
-///
-/// DC_STR_EPHEMERAL_WEEKS is used instead.
+/// @deprecated Deprecated 2021-01-30, DC_STR_EPHEMERAL_WEEKS is used instead.
 #define DC_STR_EPHEMERAL_FOUR_WEEKS       81
 
 /// "Video chat invitation"

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1640,7 +1640,7 @@ pub unsafe extern "C" fn dc_get_blocked_cnt(context: *mut dc_context_t) -> libc:
     }
     let ctx = &*context;
 
-    block_on(Contact::get_blocked_cnt(&ctx)) as libc::c_int
+    block_on(async move { Contact::get_all_blocked(&ctx).await.len() as libc::c_int })
 }
 
 #[no_mangle]

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -359,7 +359,6 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                  listarchived\n\
                  chat [<chat-id>|0]\n\
                  createchat <contact-id>\n\
-                 createchatbymsg <msg-id>\n\
                  creategroup <name>\n\
                  createprotected <name>\n\
                  addmember <contact-id>\n\
@@ -386,6 +385,10 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                  protect <chat-id>\n\
                  unprotect <chat-id>\n\
                  delchat <chat-id>\n\
+                 ===========================Contact requests==\n\
+                 decidestartchat <msg-id>\n\
+                 decideblock <msg-id>\n\
+                 decidenotnow <msg-id>\n\
                  ===========================Message commands==\n\
                  listmsgs <query>\n\
                  msginfo <msg-id>\n\
@@ -659,7 +662,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
 
             println!("Single#{} created successfully.", chat_id,);
         }
-        "createchatbymsg" => {
+        "decidestartchat" | "createchatbymsg" => {
             ensure!(!arg1.is_empty(), "Argument <msg-id> missing");
             let msg_id = MsgId::new(arg1.parse()?);
             match message::decide_on_contact_request(
@@ -675,6 +678,18 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                 }
                 None => println!("Cannot crate chat."),
             }
+        }
+        "decidenotnow" => {
+            ensure!(!arg1.is_empty(), "Argument <msg-id> missing");
+            let msg_id = MsgId::new(arg1.parse()?);
+            message::decide_on_contact_request(&context, msg_id, ContactRequestDecision::NotNow)
+                .await;
+        }
+        "decideblock" => {
+            ensure!(!arg1.is_empty(), "Argument <msg-id> missing");
+            let msg_id = MsgId::new(arg1.parse()?);
+            message::decide_on_contact_request(&context, msg_id, ContactRequestDecision::Block)
+                .await;
         }
         "creategroup" => {
             ensure!(!arg1.is_empty(), "Argument <name> missing.");

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -168,12 +168,14 @@ const DB_COMMANDS: [&str; 9] = [
     "housekeeping",
 ];
 
-const CHAT_COMMANDS: [&str; 28] = [
+const CHAT_COMMANDS: [&str; 30] = [
     "listchats",
     "listarchived",
     "chat",
     "createchat",
-    "createchatbymsg",
+    "decidestartchat",
+    "decideblock",
+    "decidenotnow",
     "creategroup",
     "createverified",
     "addmember",

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -208,13 +208,16 @@ const MESSAGE_COMMANDS: [&str; 6] = [
     "markseen",
     "delmsg",
 ];
-const CONTACT_COMMANDS: [&str; 6] = [
+const CONTACT_COMMANDS: [&str; 9] = [
     "listcontacts",
     "listverified",
     "addcontact",
     "contactinfo",
     "delcontact",
     "cleanupcontacts",
+    "block",
+    "unblock",
+    "listblocked",
 ];
 const MISC_COMMANDS: [&str; 10] = [
     "getqr",

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -674,18 +674,6 @@ impl Contact {
         Ok(ret)
     }
 
-    pub async fn get_blocked_cnt(context: &Context) -> usize {
-        context
-            .sql
-            .query_get_value::<isize>(
-                context,
-                "SELECT COUNT(*) FROM contacts WHERE id>? AND blocked!=0",
-                paramsv![DC_CONTACT_ID_LAST_SPECIAL as i32],
-            )
-            .await
-            .unwrap_or_default() as usize
-    }
-
     /// Get blocked contacts.
     pub async fn get_all_blocked(context: &Context) -> Vec<u32> {
         context


### PR DESCRIPTION
this pr adds some missing functionality to the repl tool to make testing easier.

moreover, this pr deprecates `dc_get_blocked_cnt()` - as far as i see, this was not really used anywhere, just for a test in node (therefore, it is still there, not yet removed ;)
getting rid of this functions makes upcoming changes wrt blocking easier as there is only one function left to deal with blocked contacts.
