### PR TITLE
allow unblocking mailinglists using the existing api

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1640,7 +1640,13 @@ pub unsafe extern "C" fn dc_get_blocked_cnt(context: *mut dc_context_t) -> libc:
     }
     let ctx = &*context;
 
-    block_on(async move { Contact::get_all_blocked(&ctx).await.len() as libc::c_int })
+    block_on(async move {
+        Contact::get_all_blocked(&ctx)
+            .await
+            .log_err(&ctx, "Can't get blocked count")
+            .unwrap_or_default()
+            .len() as libc::c_int
+    })
 }
 
 #[no_mangle]
@@ -1655,7 +1661,10 @@ pub unsafe extern "C" fn dc_get_blocked_contacts(
 
     block_on(async move {
         Box::into_raw(Box::new(dc_array_t::from(
-            Contact::get_all_blocked(&ctx).await,
+            Contact::get_all_blocked(&ctx)
+                .await
+                .log_err(&ctx, "Can't get blocked contacts")
+                .unwrap_or_default(),
         )))
     })
 }

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -1103,7 +1103,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             Contact::unblock(&context, contact_id).await;
         }
         "listblocked" => {
-            let contacts = Contact::get_all_blocked(&context).await;
+            let contacts = Contact::get_all_blocked(&context).await?;
             log_contactlist(&context, &contacts).await;
             println!("{} blocked contacts.", contacts.len());
         }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -679,7 +679,7 @@ impl Contact {
         context
             .sql
             .query_map(
-                "SELECT id FROM contacts WHERE id>? AND blocked!=0 ORDER BY LOWER(name||addr),id;",
+                "SELECT id FROM contacts WHERE id>? AND blocked!=0 ORDER BY LOWER(iif(name='',authname,name)||addr),id;",
                 paramsv![DC_CONTACT_ID_LAST_SPECIAL as i32],
                 |row| row.get::<_, u32>(0),
                 |ids| {

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -675,8 +675,8 @@ impl Contact {
     }
 
     /// Get blocked contacts.
-    pub async fn get_all_blocked(context: &Context) -> Vec<u32> {
-        context
+    pub async fn get_all_blocked(context: &Context) -> Result<Vec<u32>> {
+        let ret = context
             .sql
             .query_map(
                 "SELECT id FROM contacts WHERE id>? AND blocked!=0 ORDER BY LOWER(iif(name='',authname,name)||addr),id;",
@@ -687,8 +687,8 @@ impl Contact {
                         .map_err(Into::into)
                 },
             )
-            .await
-            .unwrap_or_default()
+            .await?;
+        Ok(ret)
     }
 
     /// Returns a textual summary of the encryption state for the contact.


### PR DESCRIPTION
for review: **only the last commit contains the logic** (only one file affected), the other commits are cleanup, a fix and a test. some in advance:

to get #1964 in, we postponed the question about unblocking mailing lists - on current master, they can be blocked but there is no method to unblock them.

this pr picks up the original idea and keeps the existing api (therefore, no adaption is needed in ui, see comment 3. at https://github.com/deltachat/deltachat-core-rust/pull/1964/commits/3c0d1a591bd4e893b1c4def01ac460958e246dd6).

however, instead of introducing a "pseudo contact" that is always added to the mailing list, we add such a contact only if the mailing list is actually blocked and if the blocked-list is requested. `Origin::MailinglistAddress` makes sure, the contact is not created through other channels.

in the usual Mailinglist processing, the special contact is not needed and is not assigned eg. as a "member". that preserves the option to do sth. else with the member list, eg. show recent senders there, if we want to.

if we decide to go for another unblock api someday, this is easily possible by just doing a "DELETE FROM contacts WHERE origin=MailinglistAddress", same if we need to tweak the current approach.

however, for now, i think the big advantage is that the api stays unchanged and no adaptions in the UI are needed for this bit (that is not even used in most of the cases).  
also, i am not sure that a "block chat", as discussed here and there, is really superior over "block contact" - and to have both is maybe a bit much ux wise - esp. for mailing lists, where the user does not see a big difference imho. for all of these reasons, i like to postpone the discussion wrt another unblock api :)