### PR TITLE
Deal with long incoming messages

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -168,12 +168,30 @@ pub const DC_MSG_ID_LAST_SPECIAL: u32 = 9;
 /// string that indicates sth. is left out or truncated
 pub const DC_ELLIPSE: &str = "[...]";
 
-/// to keep bubbles and chat flow usable, we limit the text length to DC_DESIRED_TEXT_LEN.
+/// to keep bubbles and chat flow usable,
+/// and to avoid problems with controls using very long texts,
+/// we limit the text length to DC_DESIRED_TEXT_LEN.
 /// if the text is longer, the full text can be retrieved usind has_html()/get_html().
-pub const DC_DESIRED_TEXT_LEN: usize = 20000;
+///
+/// we are using a bit less than DC_MAX_GET_TEXT_LEN to avoid cutting twice
+/// (a bit less as truncation may not be exact and ellipses may be added).
+///
+/// note, that DC_DESIRED_TEXT_LEN and DC_MAX_GET_TEXT_LEN
+/// define max. number of bytes, _not_ unicode graphemes.
+/// in general, that seems to be okay for such an upper limit,
+/// esp. as calculating the number of graphemes is not simple
+/// (one graphemes may be a sequence of code points which is a sequence of bytes).
+/// also even if we have the exact number of graphemes,
+/// that would not always help on getting an idea about the screen space used
+/// (to keep bubbles and chat flow usable).
+///
+/// therefore, the number of bytes is only a very rough estimation,
+/// however, the ~30K seems to work okayish for a while,
+/// if it turns out, it is too few for some alphabet, we can still increase.
+pub const DC_DESIRED_TEXT_LEN: usize = 29_000;
 
-/// approx. max. length returned by dc_msg_get_text()
-pub const DC_MAX_GET_TEXT_LEN: usize = 30000;
+/// approx. max. length (number of bytes) returned by dc_msg_get_text()
+pub const DC_MAX_GET_TEXT_LEN: usize = 30_000;
 
 /// approx. max. length returned by dc_get_msg_info()
 pub const DC_MAX_GET_INFO_LEN: usize = 100_000;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -165,8 +165,16 @@ pub const DC_MSG_ID_MARKER1: u32 = 1;
 pub const DC_MSG_ID_DAYMARKER: u32 = 9;
 pub const DC_MSG_ID_LAST_SPECIAL: u32 = 9;
 
+/// string that indicates sth. is left out or truncated
+pub const DC_ELLIPSE: &str = "[...]";
+
+/// to keep bubbles and chat flow usable, we limit the text length to DC_DESIRED_TEXT_LEN.
+/// if the text is longer, the full text can be retrieved usind has_html()/get_html().
+pub const DC_DESIRED_TEXT_LEN: usize = 20000;
+
 /// approx. max. length returned by dc_msg_get_text()
 pub const DC_MAX_GET_TEXT_LEN: usize = 30000;
+
 /// approx. max. length returned by dc_get_msg_info()
 pub const DC_MAX_GET_INFO_LEN: usize = 100_000;
 

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -17,7 +17,7 @@ use chrono::{Local, TimeZone};
 use rand::{thread_rng, Rng};
 
 use crate::chat::{add_device_msg, add_device_msg_with_importance};
-use crate::constants::{Viewtype, DC_OUTDATED_WARNING_DAYS};
+use crate::constants::{Viewtype, DC_ELLIPSE, DC_OUTDATED_WARNING_DAYS};
 use crate::context::Context;
 use crate::events::EventType;
 use crate::message::Message;
@@ -28,10 +28,8 @@ use crate::stock_str;
 /// end of the shortened string.
 #[allow(clippy::indexing_slicing)]
 pub(crate) fn dc_truncate(buf: &str, approx_chars: usize) -> Cow<str> {
-    let ellipse = "[...]";
-
     let count = buf.chars().count();
-    if approx_chars > 0 && count > approx_chars + ellipse.len() {
+    if approx_chars > 0 && count > approx_chars + DC_ELLIPSE.len() {
         let end_pos = buf
             .char_indices()
             .nth(approx_chars)
@@ -39,9 +37,9 @@ pub(crate) fn dc_truncate(buf: &str, approx_chars: usize) -> Cow<str> {
             .unwrap_or_default();
 
         if let Some(index) = buf[..end_pos].rfind(|c| c == ' ' || c == '\n') {
-            Cow::Owned(format!("{}{}", &buf[..=index], ellipse))
+            Cow::Owned(format!("{}{}", &buf[..=index], DC_ELLIPSE))
         } else {
-            Cow::Owned(format!("{}{}", &buf[..end_pos], ellipse))
+            Cow::Owned(format!("{}{}", &buf[..end_pos], DC_ELLIPSE))
         }
     } else {
         Cow::Borrowed(buf)

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -12,10 +12,10 @@ use percent_encoding::percent_decode_str;
 
 use crate::aheader::Aheader;
 use crate::blob::BlobObject;
-use crate::constants::Viewtype;
+use crate::constants::{Viewtype, DC_DESIRED_TEXT_LEN, DC_ELLIPSE};
 use crate::contact::addr_normalize;
 use crate::context::Context;
-use crate::dc_tools::dc_get_filemeta;
+use crate::dc_tools::{dc_get_filemeta, dc_truncate};
 use crate::dehtml::dehtml;
 use crate::e2ee;
 use crate::events::EventType;
@@ -816,6 +816,14 @@ impl MimeMessage {
                         } else {
                             (simplified_txt, top_quote)
                         };
+
+                        let simplified_txt =
+                            if simplified_txt.len() > DC_DESIRED_TEXT_LEN + DC_ELLIPSE.len() {
+                                self.is_mime_modified = true;
+                                dc_truncate(&*simplified_txt, DC_DESIRED_TEXT_LEN).to_string()
+                            } else {
+                                simplified_txt
+                            };
 
                         if !simplified_txt.is_empty() || simplified_quote.is_some() {
                             let mut part = Part {
@@ -2781,6 +2789,7 @@ On 2020-10-25, Bob wrote:
         static REPEAT_TXT: &str = "this text with 42 chars is just repeated.\n";
         static REPEAT_CNT: usize = 2000; // results in a text of 84k, should be more than DC_MAX_GET_TEXT_LEN
         let long_txt = format!("From: alice@c.de\n\n{}", REPEAT_TXT.repeat(REPEAT_CNT));
+        assert!(DC_DESIRED_TEXT_LEN + DC_ELLIPSE.len() < DC_MAX_GET_TEXT_LEN);
 
         let mimemsg = MimeMessage::from_bytes(&t, long_txt.as_ref())
             .await


### PR DESCRIPTION
see #2213 for reasoning.

the pr just truncates text after ~~20000~~ 29000 characters unconditionally, the limit is a bit lower that the old, hard cut, as we not only truncate the text but also offer a "Show full message" button. to keep things simple, the pr does not handle long links or so (see issue), if really needed, we can do that at some later point, but i would suggest to see how this simple approach works out first.

closes #2213