### PR TITLE
set References header to Message-ID on top-level messages

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1058,7 +1058,16 @@ impl Chat {
                     new_references = format!("{} {}", parent_in_reply_to, parent_rfc724_mid);
                 } else if !parent_in_reply_to.is_empty() {
                     new_references = parent_in_reply_to;
+                } else {
+                    // as a fallback, use our Message-ID, see reasoning below.
+                    new_references = new_rfc724_mid.clone();
                 }
+            } else {
+                // this is a top-level message, add our Message-ID as first reference.
+                // as we always try to extract the grpid also from `References:`-header,
+                // this allows group conversations also if smtp-server as outlook change `Message-ID:`-header
+                // (MUAs usually keep the first Message-ID in `References:`-header unchanged).
+                new_references = new_rfc724_mid.clone();
             }
         }
 


### PR DESCRIPTION
this adds some resilience against smtp-server changing Message-ID header, before, these headers were unset.

`In-Reply-To:`-header is still unset, so, MUA should still be able to detecht things accordingly; `References` is usually only used as a "further hint", iirc. the related RFC is https://tools.ietf.org/html/rfc5322#page-25 - seems as if we are not even breaking that :)

on incoming messages, no changes seems to be needed as we already try to extract the grpid from `References:`-header before.

i tested that with an outlook-com-delta-chat client communicating with thunderbird-non-outlook 🗡️ 

closes #2252 