### PR TITLE
tweak mailinglist names

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1539,6 +1539,24 @@ async fn create_or_lookup_mailinglist(
         name = cap[1].to_string();
     }
 
+    // if we do not have a name yet and `From` indicates, that this is a notification list,
+    // a usable name is often in the `From` header.
+    // this pattern was seen for parcel service notifications
+    // and is similar to mailchimp above, however, with weaker conditions.
+    if name.is_empty() {
+        if let Some(from) = mime_parser.from.first() {
+            if from.addr.contains("noreply")
+                || from.addr.contains("no-reply")
+                || from.addr.starts_with("notifications@")
+            {
+                if let Some(display_name) = &from.display_name {
+                    name = display_name.clone();
+                }
+            }
+        }
+    }
+
+    // as a last resort, use the ListId as the name
     if name.is_empty() {
         name = listid.clone();
     }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3041,6 +3041,60 @@ mod tests {
     }
 
     #[async_std::test]
+    async fn test_dhl_mailing_list() {
+        let t = TestContext::new_alice().await;
+        t.set_config(Config::ShowEmails, Some("2")).await.unwrap();
+
+        dc_receive_imf(
+            &t,
+            include_bytes!("../test-data/message/mailinglist_dhl.eml"),
+            "INBOX",
+            1,
+            false,
+        )
+        .await
+        .unwrap();
+        let msg = t.get_last_msg().await;
+        assert_eq!(
+            msg.text,
+            Some("Ihr Paket ist in der Packstation 123 – bla bla".to_string())
+        );
+        assert!(msg.has_html());
+        let chat = Chat::load_from_db(&t, msg.chat_id).await.unwrap();
+        assert_eq!(chat.typ, Chattype::Mailinglist);
+        assert_eq!(chat.blocked, Blocked::Deaddrop);
+        assert_eq!(chat.grpid, "1234ABCD-123LMNO.mailing.dhl.de");
+        assert_eq!(chat.name, "DHL Paket");
+    }
+
+    #[async_std::test]
+    async fn test_dpd_mailing_list() {
+        let t = TestContext::new_alice().await;
+        t.set_config(Config::ShowEmails, Some("2")).await.unwrap();
+
+        dc_receive_imf(
+            &t,
+            include_bytes!("../test-data/message/mailinglist_dpd.eml"),
+            "INBOX",
+            1,
+            false,
+        )
+        .await
+        .unwrap();
+        let msg = t.get_last_msg().await;
+        assert_eq!(
+            msg.text,
+            Some("Bald ist Ihr DPD Paket da – bla bla".to_string())
+        );
+        assert!(msg.has_html());
+        let chat = Chat::load_from_db(&t, msg.chat_id).await.unwrap();
+        assert_eq!(chat.typ, Chattype::Mailinglist);
+        assert_eq!(chat.blocked, Blocked::Deaddrop);
+        assert_eq!(chat.grpid, "dpdde.mxmail.service.dpd.de");
+        assert_eq!(chat.name, "DPD");
+    }
+
+    #[async_std::test]
     async fn test_dont_show_tokens_in_contacts_list() {
         check_dont_show_in_contacts_list(
             "reply+OGHVYCLVBEGATYBICAXBIRQATABUOTUCERABERAHNO@reply.github.com",

--- a/test-data/message/mailinglist_dhl.eml
+++ b/test-data/message/mailinglist_dhl.eml
@@ -1,0 +1,52 @@
+Return-Path: <return@mailing.dhl.de>
+X-Original-To: alice@example.org
+Delivered-To: m1234567@dd12345.kasserver.com
+Received: from mail23-52.srv2.de (mail23-52.srv2.de [12.123.12.12])
+	by dd12345.kasserver.com (Postfix) with ESMTPS id 123456789000
+	for <alice@example.org>; Fri, 26 Feb 2021 13:52:22 +0100 (CET)
+Message-ID: <123456789.1234567.1234567891234@rnd-17.broadmail.live>
+MIME-Version: 1.0
+Content-Type: multipart/signed; protocol="application/pkcs7-signature"; micalg=sha-256;
+	boundary="----=_Part_1234567_123456789.1614343941878"
+Date: Fri, 26 Feb 2021 13:52:21 +0100 (CET)
+From: DHL Paket <noreply.packstation@dhl.de>
+Reply-To: DHL Paket <noreply.packstation@dhl.de>
+To: alice@example.org
+Subject: Ihr Paket ist in der Packstation 123
+X-ulpe: re-1234567890x57b7k6dveEHmqr-1234SULP-123M6T60-123J47@mailing.dhl.de
+List-Id: <1234ABCD-123LMNO.mailing.dhl.de>
+X-Report-Spam: complaints@episerver.com
+X-CSA-Complaints: csa-complaints@eco.de
+List-Unsubscribe: <mailto:listoff-1234XYZA-1234ABCD-123111@mailing.dhl.de?subject=unsubscribe>,<https://mailing.dhl.de/go/11/1234XYZA-1234ABCD-1234567-123456-UL.html>
+List-Unsubscribe-Post: List-Unsubscribe=One-Click
+mkaTechnicalID: 59630749051
+Feedback-ID: 1CZ4Z7YB:349M6T60:episerver
+
+------=_Part_1234567_123456789.1614343941878
+Content-Type: multipart/alternative;
+	boundary="----=_Part_2345678_234567890.1614343941876"
+
+------=_Part_2345678_234567890.1614343941876
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+
+bla bla
+------=_Part_2345678_234567890.1614343941876
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+
+<html>bla bla!</html>
+------=_Part_2345678_234567890.1614343941876--
+
+------=_Part_1234567_123456789.1614343941878
+Content-Type: application/pkcs7-signature; name=smime.p7s; smime-type=signed-data
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="smime.p7s"
+Content-Description: S/MIME Cryptographic Signature
+
+MIAGCSqGSIb3DQEHAqCAMIACAQExDzANBglghkgBZQMEAgEFADCABgkqhkiG9w0BBwEAAKCAMIIE
+2TCCA8GgAwIBAgIQAZqdBKdhliD9nM3n971RjjANBgkqhkiG9w0BAQsFADBDMQswCQYDVQQGEwJE
+...
+------=_Part_1234567_123456789.1614343941878--

--- a/test-data/message/mailinglist_dpd.eml
+++ b/test-data/message/mailinglist_dpd.eml
@@ -1,0 +1,30 @@
+Return-Path: <bounce_dpdde+mma1234567890u2ln2dv2ca5unq@service.dpd.de>
+X-Original-To: alice@example.org
+Delivered-To: m1234567@dd12345.kasserver.com
+Received: from inxmx185.inxserver.de (inxmx185.inxserver.de [12.123.123.123])
+	by dd12345.kasserver.com (Postfix) with ESMTPS id 1234567C6F00
+	for <alice@example.org>; Thu, 25 Feb 2021 18:22:22 +0100 (CET)
+X-Inx-Account: dpdde@mx-auth
+IronPort-SDR: Eg4123456789012345678901234567890OBl6dSxiUIClsmw6YinLT8n0waG/Xj8Spgcape6JP
+ mLzNAfcaDruw==
+X-IronPort-AV: E=Sophos;i="5.81,206,1234567000";
+   d="scan'208,217";a="123456782"
+From: DPD <noreply@service.dpd.de>
+To: alice@example.org
+Message-ID: <INXCOM3.dpdde.m.ma123456789123456789.gxg123456789123456789jppdm@service.dpd.de>
+Subject: Bald ist Ihr DPD Paket da
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+	boundary="----=_Part_1234567_1234567890.1234567890123"
+Date: Thu, 25 Feb 2021 18:22:21 +0100 (CET)
+List-Help: <https://www.inxmail.de/unternehmen/kontakt>
+List-Id: <dpdde.mxmail.service.dpd.de>
+X-CSA-Complaints: csa-complaints@eco.de
+Feedback-ID: xcom-dpdde-mx:xcom-dpdde:mx:inxmailde
+
+------=_Part_1234567_1234567890.1234567890123
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+<html>bla bla</html>
+------=_Part_1234567_1234567890.1234567890123--


### PR DESCRIPTION
if mailinglists are sent from an address that appears to be a "noreply" address AND we do not have found out a name yet, the name in `From:`-header is probably better than the (often partly random/numeric) List-id which we would use as a last resort otherwise.

i've seen this pattern today for two bit german parcel services (which i wrote the tests for), but i assume, this pr will also catch other similar mailinglists and get them a nicer name :)