### PR TITLE
exclude muted chats from notified-list

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1039,8 +1039,12 @@ int             dc_get_msg_cnt               (dc_context_t* context, uint32_t ch
 
 
 /**
- * Get the number of _fresh_ messages in a chat.  Typically used to implement
- * a badge with a number in the chatlist.
+ * Get the number of _fresh_ messages in a chat.
+ * Typically used to implement a badge with a number in the chatlist.
+ *
+ * If the specified chat is muted,
+ * the UI should show the badge counter "less obtrusive",
+ * eg. using "gray" instead of "red" color.
  *
  * @memberof dc_context_t
  * @param context The context object as returned from dc_context_new().
@@ -1067,10 +1071,19 @@ int             dc_get_fresh_msg_cnt         (dc_context_t* context, uint32_t ch
  */
 int             dc_estimate_deletion_cnt    (dc_context_t* context, int from_server, int64_t seconds);
 
+
 /**
  * Returns the message IDs of all _fresh_ messages of any chat.
- * Typically used for implementing notification summaries.
+ * Typically used for implementing notification summaries
+ * or badge counters eg. on the app-icon.
  * The list is already sorted and starts with the most recent fresh message.
+ *
+ * Messages belonging to muted chats are not returned,
+ * as they should not be notified
+ * and also a badge counters should not include messages of muted chats.
+ *
+ * To get the number of fresh messages for a single chat, muted or not,
+ * use dc_get_fresh_msg_cnt().
  *
  * @memberof dc_context_t
  * @param context The context object as returned from dc_context_new().
@@ -1426,13 +1439,21 @@ int             dc_set_chat_profile_image    (dc_context_t* context, uint32_t ch
 /**
  * Set mute duration of a chat.
  *
- * The UI can then call dc_chat_is_muted() when receiving a new message to decide whether it should trigger an notification.
+ * The UI can then call dc_chat_is_muted() when receiving a new message
+ * to decide whether it should trigger an notification.
+ *
+ * Muted chats should not sound or vibrate
+ * and should not show a visual notification in the system area.
+ * Moreover, muted chats should be excluded from global badge counter
+ * (dc_get_fresh_msgs() skips muted chats therefore)
+ * and the in-app, per-chat badge counter should use a less obtrusive color.
  *
  * Sends out #DC_EVENT_CHAT_MODIFIED.
  *
  * @memberof dc_context_t
  * @param chat_id The chat ID to set the mute duration.
- * @param duration The duration (0 for no mute, -1 for forever mute, everything else is is the relative mute duration from now in seconds)
+ * @param duration The duration (0 for no mute, -1 for forever mute,
+ *      everything else is is the relative mute duration from now in seconds)
  * @param context The context object.
  * @return 1=success, 0=error
  */

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -925,6 +925,8 @@ pub unsafe extern "C" fn dc_get_fresh_msgs(
         let arr = dc_array_t::from(
             ctx.get_fresh_msgs()
                 .await
+                .log_err(ctx, "Failed to get fresh messages")
+                .unwrap_or_default()
                 .iter()
                 .map(|msg_id| msg_id.to_u32())
                 .collect::<Vec<u32>>(),

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -1000,7 +1000,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             println!("HTML written to: {:#?}", file);
         }
         "listfresh" => {
-            let msglist = context.get_fresh_msgs().await;
+            let msglist = context.get_fresh_msgs().await?;
 
             log_msglist(&context, &msglist).await?;
             print!("{} fresh messages.", msglist.len());

--- a/src/context.rs
+++ b/src/context.rs
@@ -431,8 +431,9 @@ impl Context {
     /// and is typically used to show notifications.
     /// Moreover, the number of returned messages
     /// can be used for a badge counter on the app icon.
-    pub async fn get_fresh_msgs(&self) -> Vec<MsgId> {
-        self.sql
+    pub async fn get_fresh_msgs(&self) -> Result<Vec<MsgId>> {
+        let ret = self
+            .sql
             .query_map(
                 concat!(
                     "SELECT m.id",
@@ -459,8 +460,8 @@ impl Context {
                     Ok(ret)
                 },
             )
-            .await
-            .unwrap_or_default()
+            .await?;
+        Ok(ret)
     }
 
     /// Searches for messages containing the query string.
@@ -610,7 +611,7 @@ mod tests {
     #[async_std::test]
     async fn test_get_fresh_msgs() {
         let t = TestContext::new().await;
-        let fresh = t.get_fresh_msgs().await;
+        let fresh = t.get_fresh_msgs().await.unwrap();
         assert!(fresh.is_empty())
     }
 


### PR DESCRIPTION
~~this still needs a test.~~ EDIT: test added.

closes #2268, closes https://github.com/deltachat/deltachat-desktop/issues/2147

nb: for whatsapp, a similar fix made it to theverge: https://www.theverge.com/2019/10/29/20937835/whatsapp-muted-chats-notification-badges-ios-update