### PR TITLE
save subject for messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - breaking change: You have to call dc_stop_io()/dc_start_io() before/after EXPORT_BACKUP:
   fix race condition and db corruption when a message was received during backup #2253
 
+- save subject for messages:
+  new api `dc_msg_get_subject()`,
+  when quoting, use the subject of the quoted message as the new subject, instead of the
+  last subject in the chat
+
 - new apis to get full or html message,
   `dc_msg_has_html()` and `dc_get_msg_html()` #2125 #2151
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3348,13 +3348,16 @@ char*           dc_msg_get_text               (const dc_msg_t* msg);
 
 /**
  * Get the subject of the email.
- * In the very rare case where there is no subject associated with the message, an empty string is returned.
+ * If there is no subject associated with the message, an empty string is returned.
  * NULL is never returned.
  *
  * You usually don't need this; if the core thinks that the subject might contain important
  * information, it automatically prepends it to the message text.
  *
- * You can use the subject e.g. as the title for the full-message-view (see dc_get_msg_html())
+ * This function was introduced so that you can use the subject as the title for the 
+ * full-message-view (see dc_get_msg_html()).
+ *
+ * For outgoing messages, the subject is not stored and an empty string is returned.
  */
 char*           dc_msg_get_subject            (const dc_msg_t* msg);
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3358,6 +3358,10 @@ char*           dc_msg_get_text               (const dc_msg_t* msg);
  * full-message-view (see dc_get_msg_html()).
  *
  * For outgoing messages, the subject is not stored and an empty string is returned.
+ *
+ * @memberof dc_msg_t
+ * @param msg The message object.
+ * @return The subject. The result must be released using dc_str_unref(). Never returns NULL.
  */
 char*           dc_msg_get_subject            (const dc_msg_t* msg);
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1498,6 +1498,8 @@ char*           dc_get_msg_info              (dc_context_t* context, uint32_t ms
  * this removes the need for the UI
  * to deal with different formatting options of PLAIN-parts.
  *
+ * As the title of the full-message-view, you can use the subject (see dc_msg_get_subject()).
+ *
  * **Note:** The returned HTML-code may contain scripts,
  * external images that may be misused as hidden read-receipts and so on.
  * Taking care of these parts
@@ -3343,6 +3345,18 @@ int64_t          dc_msg_get_sort_timestamp     (const dc_msg_t* msg);
  */
 char*           dc_msg_get_text               (const dc_msg_t* msg);
 
+
+/**
+ * Get the subject of the email.
+ * In the very rare case where there is no subject associated with the message, an empty string is returned.
+ * NULL is never returned.
+ *
+ * You usually don't need this; if the core thinks that the subject might contain important
+ * information, it automatically prepends it to the message text.
+ *
+ * You can use the subject e.g. as the title for the full-message-view (see dc_get_msg_html())
+ */
+char*           dc_msg_get_subject            (const dc_msg_t* msg);
 
 /**
  * Find out full path, file name and extension of the file associated with a

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2699,6 +2699,16 @@ pub unsafe extern "C" fn dc_msg_get_text(msg: *mut dc_msg_t) -> *mut libc::c_cha
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_msg_get_subject(msg: *mut dc_msg_t) -> *mut libc::c_char {
+    if msg.is_null() {
+        eprintln!("ignoring careless call to dc_msg_get_subject()");
+        return "".strdup();
+    }
+    let ffi_msg = &*msg;
+    ffi_msg.message.get_subject().strdup()
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_msg_get_file(msg: *mut dc_msg_t) -> *mut libc::c_char {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_file()");

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1507,7 +1507,6 @@ class TestOnlineAccount:
             messages = chat2.get_messages()
             assert len(messages) == 2
             assert messages[0].text == "msg1"
-            lp.sec("dbg file"+messages[1].filename)
             assert messages[1].filemime == "image/png"
             assert os.stat(messages[1].filename).st_size == os.stat(original_image_path).st_size
             ac.set_config("displayname", "new displayname")

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -912,10 +912,10 @@ async fn add_parts(
                 let mut stmt = conn.prepare_cached(
                     "INSERT INTO msgs \
          (rfc724_mid, server_folder, server_uid, chat_id, from_id, to_id, timestamp, \
-         timestamp_sent, timestamp_rcvd, type, state, msgrmsg,  txt, txt_raw, param, \
+         timestamp_sent, timestamp_rcvd, type, state, msgrmsg,  txt, subject, txt_raw, param, \
          bytes, hidden, mime_headers,  mime_in_reply_to, mime_references, mime_modified, \
          error, ephemeral_timer, ephemeral_timestamp) \
-         VALUES (?,?,?,?,?,?,?, ?,?,?,?,?,?,?,?, ?,?,?,?,?,?, ?,?,?);",
+         VALUES (?,?,?,?,?,?,?, ?,?,?,?,?,?,?,?,?, ?,?,?,?,?,?, ?,?,?);",
                 )?;
 
                 let is_location_kml = location_kml_is
@@ -974,6 +974,7 @@ async fn add_parts(
                     if trash { "" } else { &part.msg },
                     // txt_raw might contain invalid utf8
                     if trash { "" } else { &txt_raw },
+                    if trash { "" } else { &subject },
                     if trash {
                         "".to_string()
                     } else {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -972,9 +972,9 @@ async fn add_parts(
                     state,
                     is_dc_message,
                     if trash { "" } else { &part.msg },
+                    if trash { "" } else { &subject },
                     // txt_raw might contain invalid utf8
                     if trash { "" } else { &txt_raw },
-                    if trash { "" } else { &subject },
                     if trash {
                         "".to_string()
                     } else {

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -311,7 +311,7 @@ pub(crate) async fn delete_expired_messages(context: &Context) -> Result<bool, E
             // If you change which information is removed here, also change MsgId::trash() and
             // which information dc_receive_imf::add_parts() still adds to the db if the chat_id is TRASH
             "UPDATE msgs \
-             SET chat_id=?, txt='', txt_raw='', mime_headers='', from_id=0, to_id=0, param='' \
+             SET chat_id=?, txt='', subject='', txt_raw='', mime_headers='', from_id=0, to_id=0, param='' \
              WHERE \
              ephemeral_timestamp != 0 \
              AND ephemeral_timestamp <= ? \

--- a/src/message.rs
+++ b/src/message.rs
@@ -2157,7 +2157,7 @@ mod tests {
                 *mvbox_move,
                 *chat_msg,
                 if folder == &"Spam" { "INBOX" } else { folder }, // Never move setup messages, except if they are in "Spam"
-                true,
+                false,
                 true,
                 true,
                 false,

--- a/src/message.rs
+++ b/src/message.rs
@@ -307,6 +307,7 @@ pub struct Message {
     pub(crate) ephemeral_timer: EphemeralTimer,
     pub(crate) ephemeral_timestamp: i64,
     pub(crate) text: Option<String>,
+    /// The value of the Subject header. Not set for messages that we sent ourselves.
     pub(crate) subject: String,
     pub(crate) rfc724_mid: String,
     pub(crate) in_reply_to: Option<String>,

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1710,7 +1710,7 @@ mod tests {
             .await
             .unwrap();
 
-            let arrived_msg = t.get_last_msg().await; // TODO maybe fix get_last_msg
+            let arrived_msg = t.get_last_msg().await;
             assert_eq!(arrived_msg.chat_id, incoming_msg.chat_id);
             t.print_chat(arrived_msg.chat_id).await;
         }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1568,7 +1568,7 @@ mod tests {
             let mut new_msg = Message::new(Viewtype::Text);
             new_msg.set_text(Some("Hi".to_string()));
             if let Some(q) = quote {
-                new_msg.set_quote(&t, q).await.unwrap();
+                new_msg.set_quote(t, q).await.unwrap();
             }
             let sent = t.send_msg(group_id, &mut new_msg).await;
             t.parse_msg(&sent).await.get_subject().unwrap()
@@ -1691,17 +1691,14 @@ mod tests {
         if message_arrives_inbetween {
             dc_receive_imf(
                 &t,
-                format!(
-                    "Received: (Postfix, from userid 1000); Mon, 4 Dec 2006 14:51:39 +0100 (CET)\n\
+                b"Received: (Postfix, from userid 1000); Mon, 4 Dec 2006 14:51:39 +0100 (CET)\n\
                     From: Bob <bob@example.com>\n\
                     To: alice@example.com\n\
                     Subject: Some other, completely unrelated subject\n\
                     Message-ID: <3cl4@example.com>\n\
                     Date: Sun, 22 Mar 2020 22:37:56 +0000\n\
                     \n\
-                    Some other, completely unrelated content\n"
-                )
-                .as_bytes(),
+                    Some other, completely unrelated content\n",
                 "INBOX",
                 2,
                 false,

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -363,7 +363,8 @@ impl<'a> MimeFactory<'a> {
                 }
 
                 if chat.typ == Chattype::Group && self.quoted_msg_subject.is_none_or_empty() {
-                    // If we have a parent_subj
+                    // If we have a `quoted_msg_subject`, we use the subject of the quoted message
+                    // instead of the group name
                     let re = if self.in_reply_to.is_empty() {
                         ""
                     } else {
@@ -410,9 +411,7 @@ impl<'a> MimeFactory<'a> {
                     }
                 }
             }
-            Loaded::MDN { .. } => {
-                return Ok(stock_str::read_rcpt(context).await);
-            }
+            Loaded::MDN { .. } => stock_str::read_rcpt(context).await,
         })
     }
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1300,14 +1300,14 @@ fn maybe_encode_words(words: &str) -> String {
 mod tests {
     use super::*;
     use crate::chat::ChatId;
-    use crate::constants::DC_CHAT_ID_DEADDROP;
+
     use crate::contact::Origin;
     use crate::dc_receive_imf::dc_receive_imf;
     use crate::mimeparser::MimeMessage;
     use crate::test_utils::TestContext;
     use crate::{chatlist::Chatlist, test_utils::get_chat_msg};
-    use chat::create_group_chat;
-    use pretty_assertions::{assert_eq, assert_ne};
+
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn test_render_email_address() {
@@ -1637,7 +1637,7 @@ mod tests {
     async fn msg_to_subject_str(imf_raw: &[u8]) -> String {
         let subject_str = msg_to_subject_str_inner(imf_raw, false, false, false).await;
 
-        // Check that all combinations of true and false reproduce the same subject_str
+        // Check that combinations of true and false reproduce the same subject_str:
         assert_eq!(
             subject_str,
             msg_to_subject_str_inner(imf_raw, true, false, false).await
@@ -1654,23 +1654,23 @@ mod tests {
             subject_str,
             msg_to_subject_str_inner(imf_raw, true, true, false).await
         );
-        // assert_eq!(
-        //     subject_str,
-        //     msg_to_subject_str_inner(imf_raw, true, true, true).await
-        // ); TODO this one would be kinda mean (and rare in production, as few people quote deleted messages), maybe just remove it
 
-        // These two combinations can't work, though: If `message_arrives_inbetween` is true,
-        // `reply` has to be true, too, so that the core has a chance to know which subject to
-        // use.
-        // In other cases, it is expected that DC fails to find the correct subject.
-        assert_ne!(
-            subject_str,
+        // These two combinations are different: If `message_arrives_inbetween` is true, but
+        // `reply` is false, the core is actually expected to use the subject of the message
+        // that arrived inbetween.
+        assert_eq!(
+            "Re: Some other, completely unrelated subject",
             msg_to_subject_str_inner(imf_raw, false, false, true).await
         );
-        assert_ne!(
-            subject_str,
+        assert_eq!(
+            "Re: Some other, completely unrelated subject",
             msg_to_subject_str_inner(imf_raw, true, false, true).await
         );
+
+        // We leave away the combination (true, true, true) here:
+        // It would mean that the original message is quoted without sending the quoting message
+        // out yet, then the original message is deleted, then another unrelated message arrives
+        // and then the message with the quote is sent out. Not very realistic.
 
         subject_str
     }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1708,7 +1708,6 @@ mod tests {
 
             let arrived_msg = t.get_last_msg().await;
             assert_eq!(arrived_msg.chat_id, incoming_msg.chat_id);
-            t.print_chat(arrived_msg.chat_id).await;
         }
 
         if reply {

--- a/src/param.rs
+++ b/src/param.rs
@@ -126,7 +126,9 @@ pub enum Param {
     /// For Chats
     Selftalk = b'K',
 
-    /// For Chats: So that on sending a new message we can sent the subject to "Re: <last subject>"
+    /// For Chats: On sending a new message we set the subject to "Re: <last subject>".
+    /// Usually we just use the subject of the parent message, but if the parent message
+    /// is deleted, we use the LastSubject of the chat.
     LastSubject = b't',
 
     /// For Chats

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -1504,6 +1504,15 @@ CREATE INDEX devmsglabels_index1 ON devmsglabels (label);
             .await?;
             sql.set_raw_config_int(context, "dbversion", 75).await?;
         }
+        if dbversion < 76 {
+            info!(context, "[migration] v76");
+            sql.execute(
+                "ALTER TABLE msgs ADD COLUMN subject TEXT DEFAULT '';",
+                paramsv![],
+            )
+            .await?;
+            sql.set_raw_config_int(context, "dbversion", 76).await?;
+        }
 
         // (2) updates that require high-level objects
         // (the structure is complete now and all objects are usable)

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -314,11 +314,11 @@ impl TestContext {
     /// Gets the most recent message over all chats.
     pub async fn get_last_msg(&self) -> Message {
         let chats = Chatlist::try_load(&self.ctx, 0, None, None).await.unwrap();
-        let msg_id = chats.get_msg_id(0).unwrap();
-        // 0 is correct here (as opposed to `chats.len() - 1`, which would be the last element):
+        // 0 is correct in the next line (as opposed to `chats.len() - 1`, which would be the last element):
         // The chatlist describes what you see when you open DC, a list of chats and in each of them
         // the first words of the last message. To get the last message overall, we look at the chat at the top of the
         // list, which has the index 0.
+        let msg_id = chats.get_msg_id(0).unwrap();
         Message::load_from_db(&self.ctx, msg_id).await.unwrap()
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -392,6 +392,7 @@ impl TestContext {
     // This code is mainly the same as `log_msglist` in `cmdline.rs`, so one day, we could
     // merge them to a public function in the `deltachat` crate.
     #[allow(dead_code)]
+    #[allow(clippy::clippy::indexing_slicing)]
     pub async fn print_chat(&self, chat_id: ChatId) {
         let msglist = chat::get_chat_msgs(self, chat_id, 0x1, None).await;
         let msglist: Vec<MsgId> = msglist
@@ -427,7 +428,7 @@ impl TestContext {
             } else {
                 ""
             },
-            match sel_chat.get_profile_image(&self).await {
+            match sel_chat.get_profile_image(self).await {
                 Some(icon) => match icon.to_str() {
                     Some(icon) => format!(" Icon: {}", icon),
                     _ => " Icon: Err".to_string(),

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -315,7 +315,8 @@ impl TestContext {
     pub async fn get_last_msg(&self) -> Message {
         let chats = Chatlist::try_load(&self.ctx, 0, None, None).await.unwrap();
         let msg_id = chats.get_msg_id(0).unwrap();
-        // 0 is correct here: The chatlist describes what you see when you open DC, a list of chats and in each of them
+        // 0 is correct here (as opposed to `chats.len() - 1`, which would be the last element):
+        // The chatlist describes what you see when you open DC, a list of chats and in each of them
         // the first words of the last message. To get the last message overall, we look at the chat at the top of the
         // list, which has the index 0.
         Message::load_from_db(&self.ctx, msg_id).await.unwrap()

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -371,8 +371,17 @@ impl TestContext {
     pub async fn send_text(&self, chat_id: ChatId, txt: &str) -> SentMessage {
         let mut msg = Message::new(Viewtype::Text);
         msg.set_text(Some(txt.to_string()));
-        chat::prepare_msg(self, chat_id, &mut msg).await.unwrap();
-        chat::send_msg(self, chat_id, &mut msg).await.unwrap();
+        self.send_msg(chat_id, &mut msg).await
+    }
+
+    /// Sends out the message to the specified chat.
+    ///
+    /// This is not hooked up to any SMTP-IMAP pipeline, so the other account must call
+    /// [`TestContext::recv_msg`] with the returned [`SentMessage`] if it wants to receive
+    /// the message.
+    pub async fn send_msg(&self, chat_id: ChatId, msg: &mut Message) -> SentMessage {
+        chat::prepare_msg(self, chat_id, msg).await.unwrap();
+        chat::send_msg(self, chat_id, msg).await.unwrap();
         self.pop_sent_msg().await
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -375,8 +375,8 @@ impl TestContext {
     // This code is mainly the same as `log_msglist` in `cmdline.rs`, so one day, we could
     // merge them to a public function in the `deltachat` crate.
     #[allow(dead_code)]
-    pub async fn print_chat(&self, chat: &Chat) {
-        let msglist = chat::get_chat_msgs(self, chat.get_id(), 0x1, None).await;
+    pub async fn print_chat(&self, chat_id: ChatId) {
+        let msglist = chat::get_chat_msgs(self, chat_id, 0x1, None).await;
         let msglist: Vec<MsgId> = msglist
             .into_iter()
             .map(|x| match x {


### PR DESCRIPTION
fix  #2138

new api `dc_msg_get_subject()`,

when quoting, use the subject of the quoted message as the new subject, instead of the
last subject in the chat