### PR TITLE
fix muted-check in get_fresh_msgs()

### DIFF
--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -168,7 +168,7 @@ const DB_COMMANDS: [&str; 9] = [
     "housekeeping",
 ];
 
-const CHAT_COMMANDS: [&str; 30] = [
+const CHAT_COMMANDS: [&str; 34] = [
     "listchats",
     "listarchived",
     "chat",
@@ -198,6 +198,10 @@ const CHAT_COMMANDS: [&str; 30] = [
     "unarchive",
     "pin",
     "unpin",
+    "mute",
+    "unmute",
+    "protect",
+    "unprotect",
     "delchat",
 ];
 const MESSAGE_COMMANDS: [&str; 6] = [

--- a/src/context.rs
+++ b/src/context.rs
@@ -447,7 +447,7 @@ impl Context {
                     "   AND m.chat_id>9",
                     "   AND ct.blocked=0",
                     "   AND c.blocked=0",
-                    "   AND NOT(c.muted_until=-1 OR (c.muted_until>0 AND c.muted_until<?))",
+                    "   AND NOT(c.muted_until=-1 OR c.muted_until>?)",
                     " ORDER BY m.timestamp DESC,m.id DESC;"
                 ),
                 paramsv![MessageState::InFresh, time()],


### PR DESCRIPTION
this is a successor or #2269 that excludes muted chats from `get_fresh_msgs()`. unfortunately, the used condition was just wrong.

moreover, this pr adds a test and the "mute functionality" to the repl tool.

closes #2276