### PR TITLE
let get_html() return first instead of last text

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3157,6 +3157,31 @@ mod tests {
     }
 
     #[async_std::test]
+    async fn test_mailing_list_with_mimepart_footer_signed() {
+        let t = TestContext::new_alice().await;
+        t.set_config(Config::ShowEmails, Some("2")).await.unwrap();
+
+        dc_receive_imf(
+            &t,
+            include_bytes!("../test-data/message/mailinglist_with_mimepart_footer_signed.eml"),
+            "INBOX",
+            1,
+            false,
+        )
+        .await
+        .unwrap();
+        let msg = t.get_last_msg().await;
+        assert_eq!(get_chat_msgs(&t, msg.chat_id, 0, None).await.len(), 1);
+        let text = msg.text.clone().unwrap();
+        assert!(text.contains("content text"));
+        assert!(!text.contains("footer text"));
+        assert!(msg.has_html());
+        let html = msg.get_id().get_html(&t).await.unwrap();
+        assert!(html.contains("content text"));
+        assert!(!html.contains("footer text"));
+    }
+
+    #[async_std::test]
     async fn test_dont_show_tokens_in_contacts_list() {
         check_dont_show_in_contacts_list(
             "reply+OGHVYCLVBEGATYBICAXBIRQATABUOTUCERABERAHNO@reply.github.com",

--- a/src/html.rs
+++ b/src/html.rs
@@ -138,9 +138,11 @@ impl HtmlMsgParser {
                 }
                 MimeMultipartType::Single => {
                     let mimetype = mail.ctype.mimetype.parse::<Mime>()?;
-                    if mimetype == mime::TEXT_HTML && self.html.is_empty() {
-                        if let Ok(decoded_data) = mail.get_body() {
-                            self.html = decoded_data;
+                    if mimetype == mime::TEXT_HTML {
+                        if self.html.is_empty() {
+                            if let Ok(decoded_data) = mail.get_body() {
+                                self.html = decoded_data;
+                            }
                         }
                     } else if mimetype == mime::TEXT_PLAIN && self.plain.is_none() {
                         if let Ok(decoded_data) = mail.get_body() {

--- a/test-data/message/mailinglist_with_mimepart_footer_signed.eml
+++ b/test-data/message/mailinglist_with_mimepart_footer_signed.eml
@@ -1,0 +1,80 @@
+Return-Path: <intern-bounces@lists.abc.de>
+X-Original-To: bp@def.com
+Delivered-To: m1234567@dd12345.kasserver.com
+X-policyd-weight: using cached result; rate: -6.1
+Received: from mail.alfi.li (mail.alfi.li [85.14.254.25])
+	by dd12345.kasserver.com (Postfix) with ESMTPS id 123456789598
+	for <bp@def.com>; Wed,  3 Mar 2021 01:01:25 +0100 (CET)
+To: intern@lists.abc.de
+References: <12345678-1234-1234-1234-123456789012@mr.de>
+From: mr <mr@mr.de>
+Message-ID: <22222222-2222-2222-2222-222222222222@mr.de>
+Date: Wed, 3 Mar 2021 01:01:11 +0100
+In-Reply-To: <12345678-1234-1234-1234-123456789012@mr.de>
+Subject: Re: [Intern] more important stuff
+X-BeenThere: intern@lists.abc.de
+X-Mailman-Version: 2.1.29
+Precedence: list
+List-Id: <intern.lists.abc.de>
+List-Unsubscribe: <http://lists.abc.de/mailman/options/intern>,
+ <mailto:intern-request@lists.abc.de?subject=unsubscribe>
+List-Archive: <http://lists.abc.de/mailman/private/intern/>
+List-Post: <mailto:intern@lists.abc.de>
+List-Help: <mailto:intern-request@lists.abc.de?subject=help>
+List-Subscribe: <http://lists.abc.de/mailman/listinfo/intern>,
+ <mailto:intern-request@lists.abc.de?subject=subscribe>
+Content-Type: multipart/mixed; boundary="===============1234567890253566549=="
+Errors-To: intern-bounces@lists.abc.de
+Sender: "Intern" <intern-bounces@lists.abc.de>
+
+This is an OpenPGP/MIME signed message (RFC 4880 and 3156)
+--===============1234567890253566549==
+Content-Type: multipart/signed; micalg=pgp-sha256;
+ protocol="application/pgp-signature";
+ boundary="2222222222nheMkezDtEaCy2H1M0Q3wtX"
+
+This is an OpenPGP/MIME signed message (RFC 4880 and 3156)
+--2222222222nheMkezDtEaCy2H1M0Q3wtX
+Content-Type: multipart/mixed; boundary="kpbXdSJRuZxNyB43gEja0tpvinYpituTJ";
+ protected-headers="v1"
+From: mr <mr@mr.de>
+To: intern@lists.abc.de
+Message-ID: <22222222-2222-2222-2222-222222222222@mr.de>
+Subject: Re: more important stuff
+References: <12345678-1234-1234-1234-123456789012@mr.de>
+In-Reply-To: <12345678-1234-1234-1234-123456789012@mr.de>
+
+--kpbXdSJRuZxNyB43gEja0tpvinYpituTJ
+Content-Type: text/plain; charset=utf-8
+Content-Language: en-US
+Content-Transfer-Encoding: quoted-printable
+
+On 02.03.21 22:41, mr wrote:
+> quote to trigger has_html
+
+content text
+
+--kpbXdSJRuZxNyB43gEja0tpvinYpituTJ--
+
+--2222222222nheMkezDtEaCy2H1M0Q3wtX
+Content-Type: application/pgp-signature; name="OpenPGP_signature.asc"
+Content-Description: OpenPGP digital signature
+Content-Disposition: attachment; filename="OpenPGP_signature"
+
+-----BEGIN PGP SIGNATURE-----
+
+ws1234567890FiEEiGlkiQz18Vyq7pbiOWr31234567890A+0ccFAwAAAAAACgkQOWr3EM0fY5yc=
+=oIB5
+-----END PGP SIGNATURE-----
+
+--2222222222nheMkezDtEaCy2H1M0Q3wtX--
+
+--===============1234567890253566549==
+Content-Type: text/plain; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+Content-Disposition: inline
+
+footer text
+
+--===============1234567890253566549==--
+


### PR DESCRIPTION
usually, there is at most one text/html and one text/plain part.

multiple text/plain parts, however,
are known to be generated by mailinglist software that want to add a footer
but cannot alter the original content part -
maybe because it is html and things are hard to stitch
or maybe because the content part is cryptographically signed
and cannot be altered therefore.

related #2270 
closes #2278 