### PR TITLE
Explicit API for creating chats with blocked status

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -639,7 +639,7 @@ pub unsafe extern "C" fn dc_create_chat_by_contact_id(
     let ctx = &*context;
 
     block_on(async move {
-        chat::create_by_contact_id(&ctx, contact_id)
+        ChatId::create_for_contact(&ctx, contact_id)
             .await
             .log_err(ctx, "Failed to create chat from contact_id")
             .map(|id| id.to_u32())
@@ -659,11 +659,12 @@ pub unsafe extern "C" fn dc_get_chat_id_by_contact_id(
     let ctx = &*context;
 
     block_on(async move {
-        chat::get_by_contact_id(&ctx, contact_id)
+        ChatId::lookup_by_contact(&ctx, contact_id)
             .await
             .log_err(ctx, "Failed to get chat for contact_id")
+            .unwrap_or_default() // unwraps the Result
             .map(|id| id.to_u32())
-            .unwrap_or(0)
+            .unwrap_or(0) // unwraps the Option
     })
 }
 

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -675,7 +675,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
         "createchat" => {
             ensure!(!arg1.is_empty(), "Argument <contact-id> missing.");
             let contact_id: u32 = arg1.parse()?;
-            let chat_id = chat::create_by_contact_id(&context, contact_id).await?;
+            let chat_id = ChatId::create_for_contact(&context, contact_id).await?;
 
             println!("Single#{} created successfully.", chat_id,);
         }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 use tempfile::tempdir;
 
-use deltachat::chat;
+use deltachat::chat::{self, ChatId};
 use deltachat::chatlist::*;
 use deltachat::config;
 use deltachat::contact::*;
@@ -70,7 +70,7 @@ async fn main() {
     let contact_id = Contact::create(&ctx, "dignifiedquire", "dignifiedquire@gmail.com")
         .await
         .unwrap();
-    let chat_id = chat::create_by_contact_id(&ctx, contact_id).await.unwrap();
+    let chat_id = ChatId::create_for_contact(&ctx, contact_id).await.unwrap();
 
     for i in 0..1 {
         log::info!("sending message {}", i);

--- a/src/context.rs
+++ b/src/context.rs
@@ -609,8 +609,7 @@ mod tests {
     use super::*;
 
     use crate::chat::{
-        create_by_contact_id, get_chat_contacts, get_chat_msgs, send_msg, set_muted, Chat,
-        MuteDuration,
+        get_chat_contacts, get_chat_msgs, send_msg, set_muted, Chat, ChatId, MuteDuration,
     };
     use crate::constants::{Viewtype, DC_CONTACT_ID_SELF};
     use crate::dc_receive_imf::dc_receive_imf;
@@ -893,7 +892,7 @@ mod tests {
     #[async_std::test]
     async fn test_search_msgs() -> Result<()> {
         let alice = TestContext::new_alice().await;
-        let self_talk = create_by_contact_id(&alice, DC_CONTACT_ID_SELF).await?;
+        let self_talk = ChatId::create_for_contact(&alice, DC_CONTACT_ID_SELF).await?;
         let chat = alice
             .create_chat_with_contact("Bob", "bob@example.org")
             .await;

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -474,10 +474,9 @@ async fn add_parts(
             }
         }
 
-        let (test_normal_chat_id, test_normal_chat_id_blocked) =
-            chat::lookup_by_contact_id(context, from_id)
-                .await
-                .unwrap_or_default();
+        let test_normal_chat = ChatIdBlocked::lookup_by_contact(context, from_id)
+            .await
+            .unwrap_or_default();
 
         // get the chat_id - a chat_id here is no indicator that the chat is displayed in the normal list,
         // it might also be blocked and displayed in the deaddrop as a result
@@ -498,17 +497,18 @@ async fn add_parts(
         if chat_id.is_unset() {
             // try to create a group
 
-            let create_blocked =
-                if !test_normal_chat_id.is_unset() && test_normal_chat_id_blocked == Blocked::Not {
-                    Blocked::Not
-                } else {
-                    Blocked::Deaddrop
-                };
+            let create_blocked = match test_normal_chat {
+                Some(ChatIdBlocked {
+                    id: _,
+                    blocked: Blocked::Not,
+                }) => Blocked::Not,
+                _ => Blocked::Deaddrop,
+            };
 
             let (new_chat_id, new_chat_id_blocked) = create_or_lookup_group(
                 context,
                 &mut mime_parser,
-                if test_normal_chat_id.is_unset() {
+                if test_normal_chat.is_none() {
                     allow_creation
                 } else {
                     true
@@ -600,9 +600,9 @@ async fn add_parts(
                 Blocked::Deaddrop
             };
 
-            if !test_normal_chat_id.is_unset() {
-                *chat_id = test_normal_chat_id;
-                chat_id_blocked = test_normal_chat_id_blocked;
+            if let Some(chat) = test_normal_chat {
+                *chat_id = chat.id;
+                chat_id_blocked = chat.blocked;
             } else if allow_creation {
                 if let Ok(chat) = ChatIdBlocked::get_for_contact(context, from_id, create_blocked)
                     .await
@@ -2358,7 +2358,7 @@ mod tests {
         let t = TestContext::new_alice().await;
 
         let bob_id = Contact::create(&t, "bob", "bob@example.com").await.unwrap();
-        let one2one_id = chat::create_by_contact_id(&t, bob_id).await.unwrap();
+        let one2one_id = ChatId::create_for_contact(&t, bob_id).await.unwrap();
         one2one_id
             .set_visibility(&t, ChatVisibility::Archived)
             .await
@@ -2527,7 +2527,7 @@ mod tests {
         let contact_id = Contact::create(&t, "foobar", "foobar@example.com")
             .await
             .unwrap();
-        let chat_id = chat::create_by_contact_id(&t, contact_id).await.unwrap();
+        let chat_id = ChatId::create_for_contact(&t, contact_id).await.unwrap();
         dc_receive_imf(
             &t,
             b"From: =?UTF-8?B?0JjQvNGPLCDQpNCw0LzQuNC70LjRjw==?= <foobar@example.com>\n\

--- a/src/events.rs
+++ b/src/events.rs
@@ -213,6 +213,8 @@ pub enum EventType {
     /// - Messages sent, received or removed
     /// - Chats created, deleted or archived
     /// - A draft has been set
+    ///
+    /// The `chat_id` and `msg_id` values will be 0 if more than one message is changed.
     #[strum(props(id = "2000"))]
     MsgsChanged { chat_id: ChatId, msg_id: MsgId },
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -126,7 +126,7 @@ where
     }
 }
 
-impl<T: Default, E: std::fmt::Display> LogExt<T, E> for Result<T, E> {
+impl<T, E: std::fmt::Display> LogExt<T, E> for Result<T, E> {
     #[track_caller]
     fn log_err_inner(self, context: &Context, msg: Option<&str>) -> Result<T, E> {
         if let Err(e) = &self {

--- a/src/message.rs
+++ b/src/message.rs
@@ -1941,10 +1941,9 @@ pub async fn estimate_deletion_cnt(
     from_server: bool,
     seconds: i64,
 ) -> Result<usize> {
-    let self_chat_id = chat::lookup_by_contact_id(context, DC_CONTACT_ID_SELF)
-        .await
-        .unwrap_or_default()
-        .0;
+    let self_chat_id = ChatId::lookup_by_contact(context, DC_CONTACT_ID_SELF)
+        .await?
+        .unwrap_or_default();
     let threshold_timestamp = time() - seconds;
 
     let cnt = if from_server {
@@ -2226,7 +2225,7 @@ mod tests {
             let contact_id = Contact::create(&t.ctx, "", "bob@example.net")
                 .await
                 .unwrap();
-            chat::create_by_contact_id(&t.ctx, contact_id)
+            ChatId::create_for_contact(&t.ctx, contact_id)
                 .await
                 .unwrap();
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -2592,10 +2592,9 @@ mod tests {
         // test that get_width() and get_height() are returning some dimensions for images;
         // (as the device-chat contains a welcome-images, we check that)
         t.update_device_chats().await.ok();
-        let (device_chat_id, _) =
-            chat::create_or_lookup_by_contact_id(&t, DC_CONTACT_ID_DEVICE, Blocked::Not)
-                .await
-                .unwrap();
+        let device_chat_id = ChatId::get_for_contact(&t, DC_CONTACT_ID_DEVICE)
+            .await
+            .unwrap();
 
         let mut has_image = false;
         let chatitems = chat::get_chat_msgs(&t, device_chat_id, 0, None)

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1348,11 +1348,11 @@ mod tests {
     use async_std::prelude::*;
 
     use crate::chat::ChatId;
+    use crate::chatlist::Chatlist;
     use crate::contact::Origin;
     use crate::dc_receive_imf::dc_receive_imf;
     use crate::mimeparser::MimeMessage;
-    use crate::test_utils::TestContext;
-    use crate::{chatlist::Chatlist, test_utils::get_chat_msg};
+    use crate::test_utils::{get_chat_msg, TestContext};
 
     use async_std::fs::File;
     use pretty_assertions::assert_eq;
@@ -1687,7 +1687,7 @@ mod tests {
                 .unwrap()
                 .0;
 
-        let chat_id = chat::create_by_contact_id(&t, contact_id).await.unwrap();
+        let chat_id = ChatId::create_for_contact(&t, contact_id).await.unwrap();
 
         let mut new_msg = Message::new(Viewtype::Text);
         new_msg.set_text(Some("Hi".to_string()));

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -304,7 +304,7 @@ async fn securejoin(context: &Context, qr: &str) -> Result<ChatId, JoinError> {
         StartedProtocolVariant::SetupContact => {
             // for a one-to-one-chat, the chat is already known, return the chat-id,
             // the verification runs in background
-            let chat_id = chat::create_by_contact_id(context, invite.contact_id())
+            let chat_id = ChatId::create_for_contact(context, invite.contact_id())
                 .await
                 .map_err(JoinError::UnknownContact)?;
             Ok(chat_id)

--- a/src/securejoin/bobstate.rs
+++ b/src/securejoin/bobstate.rs
@@ -185,7 +185,7 @@ impl BobState {
         context: &Context,
         invite: QrInvite,
     ) -> Result<(Self, BobHandshakeStage), JoinError> {
-        let chat_id = chat::create_by_contact_id(context, invite.contact_id())
+        let chat_id = ChatId::create_for_contact(context, invite.contact_id())
             .await
             .map_err(JoinError::UnknownContact)?;
         if fingerprint_equals_sender(context, invite.fingerprint(), chat_id).await? {

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -8,8 +8,7 @@ use strum::EnumProperty;
 use strum_macros::EnumProperty;
 
 use crate::blob::BlobObject;
-use crate::chat;
-use crate::chat::ProtectionStatus;
+use crate::chat::{self, ChatId, ProtectionStatus};
 use crate::config::Config;
 use crate::constants::{Viewtype, DC_CONTACT_ID_SELF};
 use crate::contact::{Contact, Origin};
@@ -916,7 +915,7 @@ impl Context {
             self.sql
                 .set_raw_config_bool("self-chat-added", true)
                 .await?;
-            chat::create_by_contact_id(self, DC_CONTACT_ID_SELF).await?;
+            ChatId::create_for_contact(self, DC_CONTACT_ID_SELF).await?;
         }
 
         // add welcome-messages. by the label, this is done only once,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -355,7 +355,7 @@ impl TestContext {
         .await
         .unwrap();
 
-        let chat_id = chat::create_by_contact_id(self, contact_id).await.unwrap();
+        let chat_id = ChatId::create_for_contact(self, contact_id).await.unwrap();
         Chat::load_from_db(self, chat_id).await.unwrap()
     }
 
@@ -367,13 +367,13 @@ impl TestContext {
         let contact = Contact::create(self, name, addr)
             .await
             .expect("failed to create contact");
-        let chat_id = chat::create_by_contact_id(self, contact).await.unwrap();
+        let chat_id = ChatId::create_for_contact(self, contact).await.unwrap();
         Chat::load_from_db(self, chat_id).await.unwrap()
     }
 
     /// Retrieves the "self" chat.
     pub async fn get_self_chat(&self) -> Chat {
-        let chat_id = chat::create_by_contact_id(self, DC_CONTACT_ID_SELF)
+        let chat_id = ChatId::create_for_contact(self, DC_CONTACT_ID_SELF)
             .await
             .unwrap();
         Chat::load_from_db(self, chat_id).await.unwrap()


### PR DESCRIPTION
This introduces the explicit ChatIdBlocked struct to more explicitly
create a chat with a blocked status.  It also adds a common shortcut
to ChatId itself which is more natural to use in many cases.

In the second commit this moves some constructors to associated methods on the type, which makes the creation of `ChatId`s more coherent.

I admit some of this is rather subjective, I think the `ChatId::get_for_contact()` shortcut is probably the most significant addition.  As are some small fixes on callers that `_or_default()` and documenting the SQL a bit better.

Additionally however my main driving factor is the further pursuit of removing the usage of `ChatId(0)` occurrences.  While this is not yet achieved, this fixes up some usages and isolates the remaining usages of `<ChatId as Default>::default()`.  After this it might be achievable to remove the `Default` impl from `ChatId` in one PR, or at worst only a few more.

**Review notes**: The main changes are in `chat.rs`.  Reviewing both commits separately might also be easier, though not required.

Also note the `lookup_*` functions now return a `Result<Option<..>>` so that a `None` can represent a not-found, before the `Err` represented both errors and not found.  This helps with removing the need for `ChatId(0)`.