### PR TITLE
Even nicer logging: Add log_m()

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3451,18 +3451,25 @@ pub unsafe extern "C" fn dc_str_unref(s: *mut libc::c_char) {
 }
 
 trait ResultExt<T, E> {
+    /// Like `log_err()`, but:
+    /// - returns the default value instead of an Err value.
+    /// - emits an error instead of a warning for an [Err] result. This means
+    /// that the error will be shown to the user in a small pop-up.
+    #[track_caller]
     fn unwrap_or_log_default(self, context: &context::Context, message: &str) -> T;
 
-    /// Log a warning to a [ContextWrapper] for an [Err] result.
+    /// Logs a warning to a [ContextWrapper] for an [Err] result.
     ///
     /// Does nothing for an [Ok].
     ///
     /// You can do this as soon as the wrapper exists, it does not
     /// have to be open (which is required for the `warn!()` macro).
+    #[track_caller]
     fn log_err(self, wrapper: &Context, message: &str) -> Result<T, E>;
 }
 
 impl<T: Default, E: std::fmt::Display> ResultExt<T, E> for Result<T, E> {
+    #[track_caller]
     fn unwrap_or_log_default(self, context: &context::Context, message: &str) -> T {
         match self {
             Ok(t) => t,
@@ -3473,6 +3480,7 @@ impl<T: Default, E: std::fmt::Display> ResultExt<T, E> for Result<T, E> {
         }
     }
 
+    #[track_caller]
     fn log_err(self, ctx: &Context, message: &str) -> Result<T, E> {
         self.map_err(|err| {
             // We are using Anyhow's .context() and to show the inner error, too, we need the {:#}:

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -514,7 +514,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             context.maybe_network().await;
         }
         "housekeeping" => {
-            sql::housekeeping(&context).await.log(&context);
+            sql::housekeeping(&context).await.ok_or_log(&context);
         }
         "listchats" | "listarchived" | "chats" => {
             let listflags = if arg0 == "listarchived" { 0x01 } else { 0 };

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -676,7 +676,7 @@ async fn export_backup(context: &Context, dir: impl AsRef<Path>) -> Result<()> {
         .sql
         .set_raw_config_int(context, "backup_time", now as i32)
         .await?;
-    sql::housekeeping(context).await.log(context);
+    sql::housekeeping(context).await.ok_or_log(context);
 
     context
         .sql

--- a/src/job.rs
+++ b/src/job.rs
@@ -1157,7 +1157,7 @@ async fn perform_job_action(
         Action::MoveMsg => job.move_msg(context, connection.inbox()).await,
         Action::FetchExistingMsgs => job.fetch_existing_msgs(context, connection.inbox()).await,
         Action::Housekeeping => {
-            sql::housekeeping(context).await.log(context);
+            sql::housekeeping(context).await.ok_or_log(context);
             Status::Finished(Ok(()))
         }
     };

--- a/src/log.rs
+++ b/src/log.rs
@@ -69,14 +69,16 @@ pub trait LogExt<T> {
     /// - You won't get any warnings about unused results but can still use the value if you need it
     /// - This prevents the same warning from being printed to the log multiple times
     ///
+    // Sidenote: If 'javascript' below is removed or replaced with 'ignore', then the CI doc-tests
+    // fail (apparently, ignoring doesn't work)
     /// Example: This:
-    /// ```ignore
+    /// ```javascript
     /// if let Err(e) = do_something() {
     ///     warn!(context, "{:#}", e);
     /// }
     /// ```
     /// can be replaced with:
-    /// ```ignore
+    /// ```javascript
     /// do_something().log(context);
     /// ```
     ///
@@ -93,14 +95,16 @@ pub trait LogExt<T> {
 
     /// Like `log()`, but you can pass an extra message that is prepended in the log.
     ///
+    // Sidenote: If 'javascript' below is removed or replaced with 'ignore', then the CI doc-tests
+    // fail (apparently, ignoring doesn't work)
     /// Example: This:
-    /// ```ignore
+    /// ```javascript
     /// if let Err(e) = do_something() {
     ///     warn!(context, "Something went wrong: {:#}", e);
     /// }
     /// ```
     /// can be replaced with:
-    /// ```ignore
+    /// ```javascript
     /// do_something().log_m(context, "Something went wrong");
     /// ```
     #[track_caller]

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,5 +1,6 @@
 //! # Logging
 use crate::context::Context;
+use anyhow::Context as _;
 
 #[macro_export]
 macro_rules! info {
@@ -63,25 +64,6 @@ macro_rules! emit_event {
 pub trait LogExt<T> {
     /// Emits a warning if the receiver contains an Err value.
     ///
-    /// If you want to add context to the log, use `log_m()`.
-    ///
-    /// Returns an [`Option<T>`] with the `Ok(_)` value, if any:
-    /// - You won't get any warnings about unused results but can still use the value if you need it
-    /// - This prevents the same warning from being printed to the log multiple times
-    ///
-    // Sidenote: If 'javascript' below is removed or replaced with 'ignore', then the CI doc-tests
-    // fail (apparently, ignoring doesn't work)
-    /// Example: This:
-    /// ```javascript
-    /// if let Err(e) = do_something() {
-    ///     warn!(context, "{:#}", e);
-    /// }
-    /// ```
-    /// can be replaced with:
-    /// ```javascript
-    /// do_something().log(context);
-    /// ```
-    ///
     /// Thanks to the [track_caller](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html#track_caller)
     /// feature, the location of the caller is printed to the log, just like with the warn!() macro.
     ///
@@ -91,67 +73,79 @@ pub trait LogExt<T> {
     /// like warn!(), since the file!() and line!() macros don't work with track_caller)  
     /// See https://github.com/rust-lang/rust/issues/78840 for progress on this.
     #[track_caller]
-    fn log(self, context: &Context) -> Option<T>;
+    fn log_err(self, context: &Context) -> Self;
 
-    /// Like `log()`, but you can pass an extra message that is prepended in the log.
+    /// Emits a warning if the receiver contains an Err value.
     ///
-    // Sidenote: If 'javascript' below is removed or replaced with 'ignore', then the CI doc-tests
-    // fail (apparently, ignoring doesn't work)
-    /// Example: This:
-    /// ```javascript
+    /// Unlike `log_err()`, returns an [`Option<T>`] instead of Self.
+    ///
+    /// Example:
+    /// ```text
+    /// if let Err(e) = do_something() {
+    ///     warn!(context, "{:#}", e);
+    /// }
+    /// ```
+    /// is equivalent to:
+    /// ```text
+    /// do_something().ok_or_log(context);
+    /// ```
+    /// and is also equivalent to:
+    /// ```text
+    /// do_something().log_err(context).ok();
+    /// ```
+    ///
+    /// For a note on the `track_caller` feature, see the doc comment on `log_err()`.
+    #[track_caller]
+    fn ok_or_log(self, context: &Context) -> Option<T>;
+
+    /// Like `ok_or_log()`, but you can pass an extra message that is prepended in the log.
+    ///
+    /// Example:
+    /// ```text
     /// if let Err(e) = do_something() {
     ///     warn!(context, "Something went wrong: {:#}", e);
     /// }
     /// ```
-    /// can be replaced with:
-    /// ```javascript
-    /// do_something().log_m(context, "Something went wrong");
+    /// is equivalent to:
+    /// ```text
+    /// do_something().ok_or_log_msg(context, "Something went wrong");
     /// ```
+    /// and is also equivalent to:
+    /// ```text
+    /// do_something().context("Something went wrong").ok_or_log(context);
+    /// ```
+    ///
+    /// For a note on the `track_caller` feature, see the doc comment on `log_err()`.
     #[track_caller]
-    fn log_m(self, context: &Context, msg: &str) -> Option<T>;
+    fn ok_or_log_msg(self, context: &Context, msg: &'static str) -> Option<T>;
 }
 
 impl<T> LogExt<T> for anyhow::Result<T> {
     #[track_caller]
-    fn log(self, context: &Context) -> Option<T> {
-        match self {
-            Err(e) => {
-                let location = std::panic::Location::caller();
-                // We are using Anyhow's .context() and to show the inner error, too, we need the {:#}:
-                let full = format!(
-                    "{file}:{line}: {e:#}",
-                    file = location.file(),
-                    line = location.line(),
-                    e = e
-                );
-                // We can't use the warn!() macro here as the file!() and line!() macros
-                // don't work with #[track_caller]
-                emit_event!(context, crate::EventType::Warning(full));
-                None
-            }
-            Ok(v) => Some(v),
-        }
+    fn log_err(self, context: &Context) -> Self {
+        self.map_err(|e| {
+            let location = std::panic::Location::caller();
+            // We are using Anyhow's .context() and to show the inner error, too, we need the {:#}:
+            let full = format!(
+                "{file}:{line}: {e:#}",
+                file = location.file(),
+                line = location.line(),
+                e = e
+            );
+            // We can't use the warn!() macro here as the file!() and line!() macros
+            // don't work with #[track_caller]
+            emit_event!(context, crate::EventType::Warning(full));
+            e
+        })
     }
 
     #[track_caller]
-    fn log_m(self, context: &Context, msg: &str) -> Option<T> {
-        match self {
-            Err(e) => {
-                let location = std::panic::Location::caller();
-                // We are using Anyhow's .context() and to show the inner error, too, we need the {:#}:
-                let full = format!(
-                    "{file}:{line}: {msg}: {e:#}",
-                    file = location.file(),
-                    line = location.line(),
-                    msg = msg,
-                    e = e
-                );
-                // We can't use the warn!() macro here as the file!() and line!() macros
-                // don't work with #[track_caller]
-                emit_event!(context, crate::EventType::Warning(full));
-                None
-            }
-            Ok(v) => Some(v),
-        }
+    fn ok_or_log(self, context: &Context) -> Option<T> {
+        self.log_err(context).ok()
+    }
+
+    #[track_caller]
+    fn ok_or_log_msg(self, context: &Context, msg: &'static str) -> Option<T> {
+        self.context(msg).log_err(context).ok()
     }
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -68,7 +68,7 @@ pub trait LogExt<T> {
     /// feature, the location of the caller is printed to the log, just like with the warn!() macro.
     ///
     /// Unfortunately, the track_caller feature does not work on async functions (as of Rust 1.50).
-    /// Once it is, you can add `#[track_caller]` to helper functions that use `log()` and `log_m()`
+    /// Once it is, you can add `#[track_caller]` to helper functions that use one of the log helpers here
     /// so that the location of the caller can be seen in the log. (this won't work with the macros,
     /// like warn!(), since the file!() and line!() macros don't work with track_caller)  
     /// See https://github.com/rust-lang/rust/issues/78840 for progress on this.

--- a/src/log.rs
+++ b/src/log.rs
@@ -63,18 +63,20 @@ macro_rules! emit_event {
 pub trait LogExt<T> {
     /// Emits a warning if the receiver contains an Err value.
     ///
+    /// If you want to add context to the log, use `log_m()`.
+    ///
     /// Returns an [`Option<T>`] with the `Ok(_)` value, if any:
     /// - You won't get any warnings about unused results but can still use the value if you need it
     /// - This prevents the same warning from being printed to the log multiple times
     ///
     /// Example: This:
-    /// ```
+    /// ```ignore
     /// if let Err(e) = do_something() {
     ///     warn!(context, "{:#}", e);
     /// }
     /// ```
     /// can be replaced with:
-    /// ```
+    /// ```ignore
     /// do_something().log(context);
     /// ```
     ///
@@ -82,22 +84,23 @@ pub trait LogExt<T> {
     /// feature, the location of the caller is printed to the log, just like with the warn!() macro.
     ///
     /// Unfortunately, the track_caller feature does not work on async functions (as of Rust 1.50).
-    /// This means that we can't make our logs even better by adding `#[track_caller]` to our helper
-    /// functions.  
+    /// Once it is, you can add `#[track_caller]` to helper functions that use `log()` and `log_m()`
+    /// so that the location of the caller can be seen in the log. (this won't work with the macros,
+    /// like warn!(), since the file!() and line!() macros don't work with track_caller)  
     /// See https://github.com/rust-lang/rust/issues/78840 for progress on this.
     #[track_caller]
     fn log(self, context: &Context) -> Option<T>;
 
-    /// Like `log()`, but you can pass an extra string message.
+    /// Like `log()`, but you can pass an extra message that is prepended in the log.
     ///
     /// Example: This:
-    /// ```
+    /// ```ignore
     /// if let Err(e) = do_something() {
     ///     warn!(context, "Something went wrong: {:#}", e);
     /// }
     /// ```
     /// can be replaced with:
-    /// ```
+    /// ```ignore
     /// do_something().log_m(context, "Something went wrong");
     /// ```
     #[track_caller]

--- a/src/log.rs
+++ b/src/log.rs
@@ -65,7 +65,7 @@ where
     Self: std::marker::Sized,
 {
     #[track_caller]
-    fn format_log(self, context: &Context, msg: Option<&str>) -> Result<T, E>;
+    fn log_err_inner(self, context: &Context, msg: Option<&str>) -> Result<T, E>;
 
     /// Emits a warning if the receiver contains an Err value.
     ///
@@ -79,7 +79,7 @@ where
     /// See https://github.com/rust-lang/rust/issues/78840 for progress on this.
     #[track_caller]
     fn log_err(self, context: &Context, msg: &str) -> Result<T, E> {
-        self.format_log(context, Some(msg))
+        self.log_err_inner(context, Some(msg))
     }
 
     /// Emits a warning if the receiver contains an Err value and returns an [`Option<T>`].
@@ -98,7 +98,7 @@ where
     /// For a note on the `track_caller` feature, see the doc comment on `log_err()`.
     #[track_caller]
     fn ok_or_log(self, context: &Context) -> Option<T> {
-        self.format_log(context, None).ok()
+        self.log_err_inner(context, None).ok()
     }
 
     /// Like `ok_or_log()`, but you can pass an extra message that is prepended in the log.
@@ -122,13 +122,13 @@ where
     /// For a note on the `track_caller` feature, see the doc comment on `log_err()`.
     #[track_caller]
     fn ok_or_log_msg(self, context: &Context, msg: &'static str) -> Option<T> {
-        self.format_log(context, Some(msg)).ok()
+        self.log_err_inner(context, Some(msg)).ok()
     }
 }
 
 impl<T: Default, E: std::fmt::Display> LogExt<T, E> for Result<T, E> {
     #[track_caller]
-    fn format_log(self, context: &Context, msg: Option<&str>) -> Result<T, E> {
+    fn log_err_inner(self, context: &Context, msg: Option<&str>) -> Result<T, E> {
         if let Err(e) = &self {
             let location = std::panic::Location::caller();
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -148,27 +148,3 @@ impl<T> LogExt<T> for anyhow::Result<T> {
         }
     }
 }
-
-// #[track_caller]
-// fn do_something_with_sql(context: &Context) {
-//     // context
-//     //     .sql
-//     //     .table_exists("config")
-//     //     .await
-//     goes_wrong().log_m(context, "Can't do something");
-// }
-
-// fn goes_wrong() -> anyhow::Result<()> {
-//     Err(anyhow::format_err!("went wrong"))
-// }
-
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     #[async_std::test]
-//     async fn test_log() {
-//         let t = crate::test_utils::TestContext::new_alice().await;
-//         t.sql.close().await;
-//         do_something_with_sql(&t);
-//     }
-// }

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,5 +1,4 @@
 //! # Logging
-
 use crate::context::Context;
 
 #[macro_export]
@@ -68,10 +67,41 @@ pub trait LogExt<T> {
     /// - You won't get any warnings about unused results but can still use the value if you need it
     /// - This prevents the same warning from being printed to the log multiple times
     ///
+    /// Example: This:
+    /// ```
+    /// if let Err(e) = do_something() {
+    ///     warn!(context, "{:#}", e);
+    /// }
+    /// ```
+    /// can be replaced with:
+    /// ```
+    /// do_something().log(context);
+    /// ```
+    ///
     /// Thanks to the [track_caller](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html#track_caller)
     /// feature, the location of the caller is printed to the log, just like with the warn!() macro.
+    ///
+    /// Unfortunately, the track_caller feature does not work on async functions (as of Rust 1.50).
+    /// This means that we can't make our logs even better by adding `#[track_caller]` to our helper
+    /// functions.  
+    /// See https://github.com/rust-lang/rust/issues/78840 for progress on this.
     #[track_caller]
     fn log(self, context: &Context) -> Option<T>;
+
+    /// Like `log()`, but you can pass an extra string message.
+    ///
+    /// Example: This:
+    /// ```
+    /// if let Err(e) = do_something() {
+    ///     warn!(context, "Something went wrong: {:#}", e);
+    /// }
+    /// ```
+    /// can be replaced with:
+    /// ```
+    /// do_something().log_m(context, "Something went wrong");
+    /// ```
+    #[track_caller]
+    fn log_m(self, context: &Context, msg: &str) -> Option<T>;
 }
 
 impl<T> LogExt<T> for anyhow::Result<T> {
@@ -88,7 +118,29 @@ impl<T> LogExt<T> for anyhow::Result<T> {
                     e = e
                 );
                 // We can't use the warn!() macro here as the file!() and line!() macros
-                // don't work well with #[track_caller]
+                // don't work with #[track_caller]
+                emit_event!(context, crate::EventType::Warning(full));
+                None
+            }
+            Ok(v) => Some(v),
+        }
+    }
+
+    #[track_caller]
+    fn log_m(self, context: &Context, msg: &str) -> Option<T> {
+        match self {
+            Err(e) => {
+                let location = std::panic::Location::caller();
+                // We are using Anyhow's .context() and to show the inner error, too, we need the {:#}:
+                let full = format!(
+                    "{file}:{line}: {msg}: {e:#}",
+                    file = location.file(),
+                    line = location.line(),
+                    msg = msg,
+                    e = e
+                );
+                // We can't use the warn!() macro here as the file!() and line!() macros
+                // don't work with #[track_caller]
                 emit_event!(context, crate::EventType::Warning(full));
                 None
             }
@@ -96,3 +148,27 @@ impl<T> LogExt<T> for anyhow::Result<T> {
         }
     }
 }
+
+// #[track_caller]
+// fn do_something_with_sql(context: &Context) {
+//     // context
+//     //     .sql
+//     //     .table_exists("config")
+//     //     .await
+//     goes_wrong().log_m(context, "Can't do something");
+// }
+
+// fn goes_wrong() -> anyhow::Result<()> {
+//     Err(anyhow::format_err!("went wrong"))
+// }
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+//     #[async_std::test]
+//     async fn test_log() {
+//         let t = crate::test_utils::TestContext::new_alice().await;
+//         t.sql.close().await;
+//         do_something_with_sql(&t);
+//     }
+// }


### PR DESCRIPTION
I started to implement this as I wanted to use `log_m()` in https://github.com/deltachat/deltachat-core-rust/pull/2283 but then decided to make an extra PR.