### PR TITLE
 When forwarding a message that is an impersonating message, the forwarder should not be impersonating

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2768,6 +2768,7 @@ pub async fn forward_msgs(
             msg.param.remove(Param::GuaranteeE2ee);
             msg.param.remove(Param::ForcePlaintext);
             msg.param.remove(Param::Cmd);
+            msg.param.remove(Param::OverrideSenderDisplayname);
 
             let new_msg_id: MsgId;
             if msg.state == MessageState::OutPreparing {


### PR DESCRIPTION
fix #2287