### PR TITLE
add alias support

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2033,7 +2033,7 @@ fn dc_create_incoming_rfc724_mid(
 mod tests {
     use super::*;
 
-    use crate::chat::{get_chat_msgs, ChatItem, ChatVisibility};
+    use crate::chat::{get_chat_contacts, get_chat_msgs, ChatItem, ChatVisibility};
     use crate::chatlist::Chatlist;
     use crate::constants::{DC_CHAT_ID_DEADDROP, DC_CONTACT_ID_INFO, DC_GCL_NO_SPECIALS};
     use crate::message::ContactRequestDecision::*;
@@ -3470,5 +3470,108 @@ YEAAAAAA!.
         let chat = Chat::load_from_db(&t, msg.chat_id).await.unwrap();
         assert_eq!(chat.typ, Chattype::Single);
         assert_eq!(msg.get_text().unwrap(), "private reply");
+    }
+
+    async fn test_alias() -> (TestContext, Chat) {
+        // Claire, a customer, sends a support request
+        // to the alias address <support@example.org> from a classic MUA.
+        // The alias expands to the supporters Alice and Bob.
+        // Check that Alice receives the message in a group chat.
+        let alice = TestContext::new_alice().await;
+        alice
+            .set_config(Config::ShowEmails, Some("2"))
+            .await
+            .unwrap();
+
+        dc_receive_imf(
+            &alice,
+            b"To: support@example.org\n\
+                From: claire@example.org\n\
+                Subject: i have a question\n\
+                Message-ID: <non-dc-1@example.org>\n\
+                Date: Sun, 14 Mar 2021 17:04:36 +0100\n\
+                Content-Type: text/plain\n\
+                \n\
+                hi support! what is the current version?",
+            "INBOX",
+            1,
+            false,
+        )
+        .await
+        .unwrap();
+        let msg = alice.get_last_msg().await;
+        assert_eq!(msg.get_subject(), "i have a question");
+        assert!(msg.get_text().unwrap().contains("hi support!"));
+        let chat = Chat::load_from_db(&alice, msg.chat_id).await.unwrap();
+        assert_eq!(chat.typ, Chattype::Group);
+        assert_eq!(get_chat_msgs(&alice, chat.id, 0, None).await.len(), 1);
+        assert_eq!(get_chat_contacts(&alice, chat.id).await.len(), 3);
+        (alice, chat)
+    }
+
+    #[async_std::test]
+    async fn test_alias_support_answer_from_nondc() {
+        let (alice, chat) = test_alias().await;
+
+        // Bob, the other supporter, answers with a classic MUA.
+        // Check that Alice gets the message in the same chat.
+        dc_receive_imf(
+            &alice,
+            b"To: support@example.org, claire@example.org\n\
+                From: bob@example.net\n\
+                Subject: =?utf-8?q?Re=3A_i_have_a_question?=\n\
+                References: <non-dc-1@example.org>\n\
+                In-Reply-To: <non-dc-1@example.org>\n\
+                Message-ID: <non-dc-2@example.net>\n\
+                Date: Sun, 14 Mar 2021 16:04:57 +0000\n\
+                Content-Type: text/plain\n\
+                \n\
+                hi claire, the version is 1.0, cheers bob",
+            "INBOX",
+            2,
+            false,
+        )
+        .await
+        .unwrap();
+        let msg = alice.get_last_msg().await;
+        assert_eq!(msg.get_subject(), "Re: i have a question");
+        assert!(msg.get_text().unwrap().contains("the version is 1.0"));
+        assert_eq!(msg.chat_id, chat.id);
+        assert_eq!(get_chat_contacts(&alice, chat.id).await.len(), 4);
+    }
+
+    #[async_std::test]
+    async fn test_alias_answer_from_dc() {
+        let (alice, chat) = test_alias().await;
+
+        // Bob, the other supporter, answers with Delta Chat.
+        // Check that Alice gets the message in the same chat.
+        dc_receive_imf(
+            &alice,
+            b"To: support@example.org, claire@example.org\n\
+                From: bob@example.net\n\
+                Subject: =?utf-8?q?Re=3A_i_have_a_question?=\n\
+                References: <Gr.af9e810c9b592927.gNm8dVdkZsH@example.net>\n\
+                In-Reply-To: <non-dc-1@example.org>\n\
+                Message-ID: <Gr.af9e810c9b592927.gNm8dVdkZsH@example.net>\n\
+                Date: Sun, 14 Mar 2021 16:04:57 +0000\n\
+                Chat-Version: 1.0\n\
+                Chat-Group-ID: af9e810c9b592927\n\
+                Chat-Group-Name: =?utf-8?q?i_have_a_question?=\n\
+                Chat-Disposition-Notification-To: bob@example.net\n\
+                Content-Type: text/plain\n\
+                \n\
+                hi claire, the version is 1.0, cheers bob",
+            "INBOX",
+            2,
+            false,
+        )
+        .await
+        .unwrap();
+        let msg = alice.get_last_msg().await;
+        assert_eq!(msg.get_subject(), "Re: i have a question");
+        assert!(msg.get_text().unwrap().contains("the version is 1.0"));
+        assert_eq!(msg.chat_id, chat.id); // FIXME: that fails
+        assert_eq!(get_chat_contacts(&alice, chat.id).await.len(), 4); // FIXME: that fails
     }
 }


### PR DESCRIPTION
improve alias-support as described in #2073

while assigning messages to the correct chat via `In-Reply-To`/`References` works already, at least these additional adaptions are needed:

- [x] the member list needs to be updated
- [ ] answers from DC create an ad-hoc group-id, that make things worse (see second test)

a test for the sender using DC to write to support@example.org is missing.

closes #2073