### PR TITLE
qr: return QrFprMismatch on fingerprint mismatch

### DIFF
--- a/src/lot.rs
+++ b/src/lot.rs
@@ -87,7 +87,7 @@ pub enum LotState {
     QrFprOk = 210,
 
     /// id=contact
-    QrFprMissmatch = 220,
+    QrFprMismatch = 220,
 
     /// test1=formatted fingerprint
     QrFprWithoutAddr = 230,


### PR DESCRIPTION
Previously QrFprWithoutAddr was returned incorrectly.

Also fix spelling error ("Missmatch").