### PR TITLE
Add alias support 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 - improve compatibility with providers changing the Message-ID
   (as Outlook.com) #2250 #2265
 
+- correctly show emails that were sent to an alias and then bounced 
+
 - implement Consistent Color Generation (XEP-0392),
   that results in contact colors be be changed #2228 #2229 #2239
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3547,17 +3547,31 @@ char*           dc_msg_get_summarytext        (const dc_msg_t* msg, int approx_c
 
 /**
  * Get the name that should be shown over the message (in a group chat) instead of the contact
- * display name.
+ * display name, or NULL.
+ *
+ * If this returns non-NULL, put a `~` before the override-sender-name and show the
+ * override-sender-name and the sender's avatar even in 1:1 chats.
  *
  * In mailing lists, sender display name and sender address do not always belong together.
  * In this case, this function gives you the name that should actually be shown over the message.
+ *
+ * Also, sometimes, we need to indicate a different sender in 1:1 chats:
+ * Suppose that our user writes an email to support@delta.chat, which forwards to 
+ * Bob <bob@delta.chat>, and Bob replies.
+ * 
+ * Then, Bob's reply is shown in our 1:1 chat with support@delta.chat and the override-sender-name is
+ * set to `Bob`. The UI should show the sender name as `~Bob` and view the avatar, just
+ * as in group messages. If the user then taps on the avatar, they can see that this message
+ * comes from bob@delta.chat.
+ * 
+ * You should show a `~` before the override-sender-name in chats, so that the user can
+ * see that this isn't the sender's actual name.
  *
  * @memberof dc_msg_t
  * @param msg The message object.
  * @return the name to show over this message or NULL.
  *     If this returns NULL, call `dc_contact_get_display_name()`.
  *     The returned string must be released using dc_str_unref().
- *     Returns an empty string on errors, never returns NULL.
  */
 char*           dc_msg_get_override_sender_name(const dc_msg_t* msg);
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3560,7 +3560,7 @@ char*           dc_msg_get_summarytext        (const dc_msg_t* msg, int approx_c
  * Bob <bob@delta.chat>, and Bob replies.
  * 
  * Then, Bob's reply is shown in our 1:1 chat with support@delta.chat and the override-sender-name is
- * set to `Bob`. The UI should show the sender name as `~Bob` and view the avatar, just
+ * set to `Bob`. The UI should show the sender name as `~Bob` and show the avatar, just
  * as in group messages. If the user then taps on the avatar, they can see that this message
  * comes from bob@delta.chat.
  * 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3877,8 +3877,8 @@ YEAAAAAA!.
         )
         .await
         .unwrap();
-        let msg = get_chat_msg(&t, chat_id, 0, 1).await;
-        assert!(!msg.chat_id.is_special());
+        let msg = t.get_last_msg().await;
+        assert!(!msg.chat_id.is_special()); // Esp. check that the chat_id is not TRASH
         assert_eq!(msg.text.unwrap(), "Reply");
     }
 }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3695,11 +3695,14 @@ YEAAAAAA!.
         assert!(msg.get_text().unwrap().contains("hi support!"));
         let chat = Chat::load_from_db(&alice, msg.chat_id).await.unwrap();
         assert_eq!(chat.typ, Chattype::Group);
-        assert_eq!(get_chat_msgs(&alice, chat.id, 0, None).await.len(), 1);
+        assert_eq!(
+            get_chat_msgs(&alice, chat.id, 0, None).await.unwrap().len(),
+            1
+        );
         if group_request {
-            assert_eq!(get_chat_contacts(&alice, chat.id).await.len(), 4);
+            assert_eq!(get_chat_contacts(&alice, chat.id).await.unwrap().len(), 4);
         } else {
-            assert_eq!(get_chat_contacts(&alice, chat.id).await.len(), 3);
+            assert_eq!(get_chat_contacts(&alice, chat.id).await.unwrap().len(), 3);
         }
         assert_eq!(msg.get_override_sender_name(), None);
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3730,7 +3730,13 @@ YEAAAAAA!.
         } else {
             assert_eq!(chat.typ, Chattype::Single);
         }
-        assert_eq!(get_chat_msgs(&claire, chat.id, 0, None).await.len(), 1);
+        assert_eq!(
+            get_chat_msgs(&claire, chat.id, 0, None)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
         assert_eq!(msg.get_override_sender_name(), None);
 
         (claire, alice)
@@ -3748,12 +3754,16 @@ YEAAAAAA!.
         assert_eq!(answer.get_subject(), "Re: i have a question");
         assert!(answer.get_text().unwrap().contains("the version is 1.0"));
         assert_eq!(answer.chat_id, request.chat_id);
+        let chat_contacts = get_chat_contacts(&alice, answer.chat_id)
+            .await
+            .unwrap()
+            .len();
         if group_request {
             // Claire, Support, CEO and Alice (Bob is not added)
-            assert_eq!(get_chat_contacts(&alice, answer.chat_id).await.len(), 4);
+            assert_eq!(chat_contacts, 4);
         } else {
             // Claire, Support and Alice
-            assert_eq!(get_chat_contacts(&alice, answer.chat_id).await.len(), 3);
+            assert_eq!(chat_contacts, 3);
         }
         assert_eq!(
             answer.get_override_sender_name().unwrap(),
@@ -3848,7 +3858,7 @@ YEAAAAAA!.
         println!("\n========= Delete the message ==========");
         msg.id.trash(&t).await.unwrap();
 
-        let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0, None).await;
+        let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0, None).await.unwrap();
         assert_eq!(msgs.len(), 0);
 
         println!("\n========= Receive a message that is a reply to the deleted message ==========");

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1209,7 +1209,7 @@ async fn lookup_chat_by_reply(
     if (!private_message) || classical_email {
         if let Some(parent) = get_parent_message(context, mime_parser).await? {
             let parent_chat = Chat::load_from_db(context, parent.chat_id).await?;
-            let chat_contacts = chat::get_chat_contacts(context, parent_chat.id).await;
+            let chat_contacts = chat::get_chat_contacts(context, parent_chat.id).await?;
 
             if let Some(msg_grpid) = try_getting_grpid(mime_parser) {
                 if msg_grpid == parent_chat.grpid {
@@ -1228,7 +1228,7 @@ async fn lookup_chat_by_reply(
                 return Ok((ChatId::new(0), Blocked::Not));
             }
 
-            if parent_chat.id == ChatId::new(DC_CHAT_ID_TRASH) {
+            if parent_chat.id == DC_CHAT_ID_TRASH {
                 return Ok((ChatId::new(0), Blocked::Not));
             }
 


### PR DESCRIPTION
fix  #2073
fix #2292 (I think)

- Messages can be assigned to any chat by the References and In-Reply-To, also to 1:1 chats; this has higher priority than the group id because with ad-hoc groups, it can happen that two devices have different group ids for the same conversation thread.
- If `From` is not in the chat (we call this "shadow sender"), `OverrideSenderDisplayname` is set. This communicates to the UI that:
  - A `~`should be added in front of the sender's displayname.
  - Also in 1:1 chats, the sender's displayname and avatar is shown, as if this was a group.

  The "Unknown sender for this chat" messages are completely removed for unprotected groups.

For protected chats, everything stays as it was before.

POSTPONED:

- Maybe (if it turns out to be still necessary):
  - The ad-hoc group id is computed by the the References, instead of the member list, as it is currently done
  - How do we prevent that the message can't be assigned to the correct chat as the parent message was deleted?
