### PR TITLE
set_draft message changed event returns now draft's msg id

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -469,7 +469,7 @@ impl ChatId {
             context.emit_event(EventType::MsgsChanged {
                 chat_id: self,
                 msg_id: if msg_is_some {
-                    match self.get_draft_msg_id(context).await {
+                    match self.get_draft_msg_id(context).await? {
                         Some(msg_id) => msg_id,
                         None => MsgId::new(0),
                     }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -458,6 +458,8 @@ impl ChatId {
             return Ok(());
         }
 
+        let msg_is_some = msg.is_some();
+
         let changed = match msg {
             None => self.maybe_delete_draft(context).await?,
             Some(msg) => self.set_draft_raw(context, msg).await?,
@@ -466,9 +468,13 @@ impl ChatId {
         if changed {
             context.emit_event(EventType::MsgsChanged {
                 chat_id: self,
-                msg_id: match self.get_draft_msg_id(context).await {
-                    Some(msg_id) => msg_id,
-                    None => MsgId::new(0),
+                msg_id: if msg_is_some {
+                    match self.get_draft_msg_id(context).await {
+                        Some(msg_id) => msg_id,
+                        None => MsgId::new(0),
+                    }
+                } else {
+                    MsgId::new(0)
                 },
             });
         }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -466,7 +466,10 @@ impl ChatId {
         if changed {
             context.emit_event(EventType::MsgsChanged {
                 chat_id: self,
-                msg_id: MsgId::new(0),
+                msg_id: match self.get_draft_msg_id(context).await {
+                    Some(msg_id) => msg_id,
+                    None => MsgId::new(0),
+                },
             });
         }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -453,14 +453,12 @@ impl ChatId {
     /// Sets draft message.
     ///
     /// Passing `None` as message just deletes the draft
-    pub async fn set_draft(self, context: &Context, msg: Option<&mut Message>) -> Result<()> {
+    pub async fn set_draft(self, context: &Context, mut msg: Option<&mut Message>) -> Result<()> {
         if self.is_special() {
             return Ok(());
         }
 
-        let msg_is_some = msg.is_some();
-
-        let changed = match msg {
+        let changed = match &mut msg {
             None => self.maybe_delete_draft(context).await?,
             Some(msg) => self.set_draft_raw(context, msg).await?,
         };
@@ -468,7 +466,7 @@ impl ChatId {
         if changed {
             context.emit_event(EventType::MsgsChanged {
                 chat_id: self,
-                msg_id: if msg_is_some {
+                msg_id: if msg.is_some() {
                     match self.get_draft_msg_id(context).await? {
                         Some(msg_id) => msg_id,
                         None => MsgId::new(0),


### PR DESCRIPTION
set_draft message changed event returns now draft msg id instead of 0.

We found this out while investigating ways to solve https://github.com/deltachat/deltachat-desktop/issues/2131#issuecomment-801181618, but unfortunately that bug was not fixed by this yet.