### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,7 @@ dependencies = [
  "async-tar",
  "async-trait",
  "backtrace",
- "base64 0.12.3",
+ "base64 0.13.0",
  "bitflags",
  "byteorder",
  "charset",
@@ -1187,7 +1187,7 @@ dependencies = [
  "hex",
  "image",
  "indexmap",
- "itertools 0.9.0",
+ "itertools 0.10.0",
  "kamadak-exif",
  "lettre_email",
  "libc",
@@ -3645,15 +3645,15 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "strum"
-version = "0.19.5"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89a286a7e3b5720b9a477b23253bc50debac207c8d21505f8e70b36792f11b5"
+checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
 
 [[package]]
 name = "strum_macros"
-version = "0.19.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61bb0be289045cb80bfce000512e32d09f8337e54c186725da381377ad1f8d5"
+checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,78 +12,76 @@ debug = 0
 lto = true
 
 [dependencies]
-libc = "0.2.51"
-pgp = { version = "0.7.0", default-features = false } 
-hex = "0.4.0"
-sha-1 = "0.9.3"
-sha2 = "0.9.0"
-rand = "0.7.0"
-smallvec = "1.0.0"
-surf = { version = "2.0.0-alpha.4", default-features = false, features = ["h1-client"] }
-num-derive = "0.3.0"
-num-traits = "0.2.6"
-async-smtp = { git = "https://github.com/async-email/async-smtp", rev="2275fd8d13e39b2c58d6605c786ff06ff9e05708" }
-email = { git = "https://github.com/deltachat/rust-email", branch = "master" }
-lettre_email = { git = "https://github.com/deltachat/lettre", branch = "master" }
+ansi_term = { version = "0.12.1", optional = true }
+anyhow = "1.0.28"
 async-imap = "0.4.0"
 async-native-tls = { version = "0.3.3" }
+async-smtp = { git = "https://github.com/async-email/async-smtp", rev="2275fd8d13e39b2c58d6605c786ff06ff9e05708" }
+async-std-resolver = "0.19.5"
 async-std = { version = "~1.8.0", features = ["unstable"] }
+async-tar = "0.3.0"
+async-trait = "0.1.31"
+backtrace = "0.3.33"
 base64 = "0.12"
+bitflags = "1.1.0"
+byteorder = "1.3.1"
 charset = "0.1"
-percent-encoding = "2.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 chrono = "0.4.6"
+dirs = { version = "3.0.1", optional=true }
+email = { git = "https://github.com/deltachat/rust-email", branch = "master" }
+encoded-words = { git = "https://github.com/async-email/encoded-words", branch="master" }
+escaper = "0.1.0"
+futures = "0.3.4"
+hex = "0.4.0"
+image = { version = "0.23.5", default-features=false, features = ["gif", "jpeg", "ico", "png", "pnm", "webp", "bmp"] }
 indexmap = "1.3.0"
+itertools = "0.9.0"
 kamadak-exif = "0.5"
+lettre_email = { git = "https://github.com/deltachat/lettre", branch = "master" }
+libc = "0.2.51"
+log = {version = "0.4.8", optional = true }
+mailparse = "0.13.0"
+native-tls = "0.2.3"
+num_cpus = "1.13.0"
+num-derive = "0.3.0"
+num-traits = "0.2.6"
 once_cell = "1.4.1"
+percent-encoding = "2.0"
+pgp = { version = "0.7.0", default-features = false }
+pretty_env_logger = { version = "0.4.0", optional = true }
+quick-xml = "0.18.1"
+rand = "0.7.0"
 regex = "1.1.6"
+rust-hsluv = "0.1.4"
+rustyline = { version = "4.1.0", optional = true }
+sanitize-filename = "0.3.0"
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+sha-1 = "0.9.3"
+sha2 = "0.9.0"
+smallvec = "1.0.0"
+sqlx = { git = "https://github.com/launchbadge/sqlx", branch = "master", features = ["runtime-async-std-native-tls", "sqlite"] }
+# keep in sync with sqlx
+libsqlite3-sys = { version = "0.22.0", default-features = false, features = [ "pkg-config", "vcpkg", "bundled" ] }
+stop-token = { version = "0.1.1", features = ["unstable"] }
 strum = "0.19.0"
 strum_macros = "0.19.0"
-backtrace = "0.3.33"
-byteorder = "1.3.1"
-itertools = "0.9.0"
-quick-xml = "0.18.1"
-escaper = "0.1.0"
-bitflags = "1.1.0"
-sanitize-filename = "0.3.0"
-stop-token = { version = "0.1.1", features = ["unstable"] }
-mailparse = "0.13.0"
-encoded-words = { git = "https://github.com/async-email/encoded-words", branch="master" }
-native-tls = "0.2.3"
-image = { version = "0.23.5", default-features=false, features = ["gif", "jpeg", "ico", "png", "pnm", "webp", "bmp"] }
-futures = "0.3.4"
+surf = { version = "2.0.0-alpha.4", default-features = false, features = ["h1-client"] }
 thiserror = "1.0.14"
-anyhow = "1.0.28"
-async-trait = "0.1.31"
-url = "2.1.1"
-async-std-resolver = "0.19.5"
-async-tar = "0.3.0"
-uuid = { version = "0.8", features = ["serde", "v4"] }
-rust-hsluv = "0.1.4"
-sqlx = { git = "https://github.com/launchbadge/sqlx", branch = "master", features = ["runtime-async-std-native-tls", "sqlite"] }
-# keep in sync with sqlx 
-libsqlite3-sys = { version = "0.22.0", default-features = false, features = [ "pkg-config", "vcpkg", "bundled" ] }
-
-pretty_env_logger = { version = "0.4.0", optional = true }
-log = {version = "0.4.8", optional = true }
-rustyline = { version = "4.1.0", optional = true }
-ansi_term = { version = "0.12.1", optional = true }
-dirs = { version = "3.0.1", optional=true }
 toml = "0.5.6"
-num_cpus = "1.13.0"
-
+url = "2.1.1"
+uuid = { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]
-tempfile = "3.0"
+ansi_term = "0.12.0"
+async-std = { version = "1.6.4", features = ["unstable", "attributes"] }
+criterion = "0.3"
+futures-lite = "1.7.0"
+log = "0.4.11"
 pretty_assertions = "0.6.1"
 pretty_env_logger = "0.4.0"
 proptest = "0.10"
-async-std = { version = "1.6.4", features = ["unstable", "attributes"] }
-futures-lite = "1.7.0"
-criterion = "0.3"
-ansi_term = "0.12.0"
-log = "0.4.11"
+tempfile = "3.0"
 
 [workspace]
 members = [
@@ -111,4 +109,3 @@ internals = []
 repl = ["internals", "rustyline", "log", "pretty_env_logger", "ansi_term", "dirs"]
 vendored = ["async-native-tls/vendored", "async-smtp/native-tls-vendored"]
 nightly = ["pgp/nightly"]
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ async-std = { version = "~1.8.0", features = ["unstable"] }
 async-tar = "0.3.0"
 async-trait = "0.1.31"
 backtrace = "0.3.33"
-base64 = "0.12"
+base64 = "0.13"
 bitflags = "1.1.0"
 byteorder = "1.3.1"
 charset = "0.1"
@@ -35,7 +35,7 @@ futures = "0.3.4"
 hex = "0.4.0"
 image = { version = "0.23.5", default-features=false, features = ["gif", "jpeg", "ico", "png", "pnm", "webp", "bmp"] }
 indexmap = "1.3.0"
-itertools = "0.9.0"
+itertools = "0.10.0"
 kamadak-exif = "0.5"
 lettre_email = { git = "https://github.com/deltachat/lettre", branch = "master" }
 libc = "0.2.51"
@@ -64,8 +64,8 @@ sqlx = { git = "https://github.com/launchbadge/sqlx", branch = "master", feature
 # keep in sync with sqlx
 libsqlite3-sys = { version = "0.22.0", default-features = false, features = [ "pkg-config", "vcpkg", "bundled" ] }
 stop-token = { version = "0.1.1", features = ["unstable"] }
-strum = "0.19.0"
-strum_macros = "0.19.0"
+strum = "0.20.0"
+strum_macros = "0.20.1"
 surf = { version = "2.0.0-alpha.4", default-features = false, features = ["h1-client"] }
 thiserror = "1.0.14"
 toml = "0.5.6"


### PR DESCRIPTION
I sorted dependencies alphabetically (like we do in rPGP) and updated some `0.x` crates because they will not update automatically. Failed to update `rand` because of rPGP dependencies: https://github.com/rpgp/rpgp/issues/127