### PR TITLE
[Python Bindings] Fix Chat.send_msg()

### DIFF
--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -196,7 +196,7 @@ class Chat(object):
         :raises ValueError: if message can not be sent.
 
         :returns: a :class:`deltachat.message.Message` instance as
-           sent out.  This is the same object as was passed in, which
+           sent out.  This is the same object that was passed in, which
            has been modified with the new state of the core.
         """
         if msg.is_out_preparing():

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -208,6 +208,7 @@ class Chat(object):
             raise ValueError("message could not be sent")
         # modify message in place to avoid bad state for the caller
         msg._dc_msg = Message.from_db(self.account, sent_id)._dc_msg
+        msg.id = sent_id
         return msg
 
     def send_text(self, text):


### PR DESCRIPTION
`Chat.send_msg()` was returning the object with `_dc_msg` updated from db but `Message.id` was still  `0`  