### PR TITLE
Add support for "Mixed Up" MIME format

### DIFF
--- a/standards.md
+++ b/standards.md
@@ -11,7 +11,7 @@ Filename encoding                | Encoded Words ([RFC 2047](https://tools.ietf.
 Identify server folders          | IMAP LIST Extension ([RFC 6154](https://tools.ietf.org/html/rfc6154))
 Push                             | IMAP IDLE ([RFC 2177](https://tools.ietf.org/html/rfc2177))
 Authorization                    | OAuth2 ([RFC 6749](https://tools.ietf.org/html/rfc6749))
-End-to-end encryption            | [Autocrypt Level 1](https://autocrypt.org/level1.html), OpenPGP ([RFC 4880](https://tools.ietf.org/html/rfc4880)) and Security Multiparts for MIME ([RFC 1847](https://tools.ietf.org/html/rfc1847))
+End-to-end encryption            | [Autocrypt Level 1](https://autocrypt.org/level1.html), OpenPGP ([RFC 4880](https://tools.ietf.org/html/rfc4880)), Security Multiparts for MIME ([RFC 1847](https://tools.ietf.org/html/rfc1847)) and [“Mixed Up” Encryption repairing](https://tools.ietf.org/id/draft-dkg-openpgp-pgpmime-message-mangling-00.html)
 Configuration assistance         | [Autoconfigure](https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration) and [Autodiscover](https://technet.microsoft.com/library/bb124251(v=exchg.150).aspx)
 Messenger functions              | [Chat-over-Email](https://github.com/deltachat/deltachat-core-rust/blob/master/spec.md#chat-over-email-specification)
 Detect mailing list              | List-Id ([RFC 2919](https://tools.ietf.org/html/rfc2919)) and Precedence ([RFC 3834](https://tools.ietf.org/html/rfc3834))

--- a/test-data/message/protonmail-mixed-up.eml
+++ b/test-data/message/protonmail-mixed-up.eml
@@ -1,0 +1,36 @@
+Return-Path: <alice@example.com>
+Delivered-To: bob@example.org
+Date: Mon, 29 Mar 2021 11:30:57 +0000
+To: Bob <bob@example.org>
+From: Alice <alice@example.com>
+Reply-To: Alice <alice@example.com>
+Subject: ...
+Message-ID: <Mr.AkmaxDNOYj0.oNPtoFR8EHC@example.com>
+In-Reply-To: <Mr.Y1EWG9-FLhN.KUZ4cu74MYR@example.org>
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary="b1_01FB8kHjERilpSep0FbmgBMNYR3TvWQ30jPthW5L0"
+
+This is a multi-part message in MIME format.
+
+--b1_01FB8kHjERilpSep0FbmgBMNYR3TvWQ30jPthW5L0
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+Empty Message
+--b1_01FB8kHjERilpSep0FbmgBMNYR3TvWQ30jPthW5L0
+Content-Type: application/pgp-encrypted; name=attachment.pgp
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename=attachment.pgp
+
+VmVyc2lvbjogMQ0KDQo=
+
+--b1_01FB8kHjERilpSep0FbmgBMNYR3TvWQ30jPthW5L0
+Content-Type: application/octet-stream; name=encrypted.asc
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename=encrypted.asc
+
+UEdQIFBBWUxPQUQgV0FTIEhFUkUK
+
+--b1_01FB8kHjERilpSep0FbmgBMNYR3TvWQ30jPthW5L0--
+

--- a/test-data/message/protonmail-repaired.eml
+++ b/test-data/message/protonmail-repaired.eml
@@ -1,0 +1,31 @@
+Return-Path: <alice@example.com>
+Delivered-To: bob@example.org
+Date: Mon, 29 Mar 2021 11:30:57 +0000
+To: Bob <bob@example.org>
+From: Alice <alice@example.com>
+Reply-To: Alice <alice@example.com>
+Subject: ...
+Message-ID: <Mr.AkmaxDNOYj0.oNPtoFR8EHC@example.com>
+In-Reply-To: <Mr.Y1EWG9-FLhN.KUZ4cu74MYR@example.org>
+MIME-Version: 1.0
+Content-Type: multipart/encrypted;
+  protocol="application/pgp-encrypted";
+  boundary="b1_01FB8kHjERilpSep0FbmgBMNYR3TvWQ30jPthW5L0"
+X-Enigmail-Info: Fixed broken PGP/MIME message
+
+--b1_01FB8kHjERilpSep0FbmgBMNYR3TvWQ30jPthW5L0
+Content-Type: application/pgp-encrypted; name=attachment.pgp
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename=attachment.pgp
+
+VmVyc2lvbjogMQ0KDQo=
+
+--b1_01FB8kHjERilpSep0FbmgBMNYR3TvWQ30jPthW5L0
+Content-Type: application/octet-stream; name=encrypted.asc
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename=encrypted.asc
+
+UEdQIFBBWUxPQUQgV0FTIEhFUkUK
+
+--b1_01FB8kHjERilpSep0FbmgBMNYR3TvWQ30jPthW5L0--
+


### PR DESCRIPTION
This is an PGP/MIME format produced by Microsoft Exchange and ProtonMail IMAP/SMTP Bridge, described in detail in https://tools.ietf.org/id/draft-dkg-openpgp-pgpmime-message-mangling-00.html

This patch adds seamless support for "Mixed Up" Encryption, repairing mangled Autocrypt messages without notifying the user.

Fixes #2320 