### PR TITLE
sqlx-port: do not re-use bind parameters

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -505,9 +505,10 @@ impl Contact {
                         match context
                             .sql
                             .execute(
-                                sqlx::query("UPDATE chats SET name=? WHERE id=? AND name!=?1")
+                                sqlx::query("UPDATE chats SET name=?1 WHERE id=?2 AND name!=?3")
                                     .bind(&new_name)
-                                    .bind(chat_id),
+                                    .bind(chat_id)
+                                    .bind(&new_name),
                             )
                             .await
                         {


### PR DESCRIPTION
sqlx does not bind the first `?` implicitly to `?1`,
therefore the sql-statement fails 
(returns count==0 and the ChatModified-event is not sent).

we could use `?1` several times, however,
i did not find good documentation about that,
and even if that works now, that could fail with other db
or even with sqlite in newer versions.

therefore, we just bind every parameter explicitly.

~~not sure yet, if that alone fixes the issue, though.~~
EDIT: seems so, only 5 failing python tests left, test_contact_rename passes with this pr.  
i also checked similar occurances, however, did not find more issues of the same type.