### PR TITLE
sqlx: fix failing TestOnlineAccount::test_saved_mime_on_received_message

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1482,11 +1482,14 @@ pub unsafe extern "C" fn dc_get_mime_headers(
     let ctx = &*context;
 
     block_on(async move {
-        message::get_mime_headers(&ctx, MsgId::new(msg_id))
+        let mime = message::get_mime_headers(&ctx, MsgId::new(msg_id))
             .await
             .unwrap_or_log_default(ctx, "failed to get mime headers")
-            .map(|s| s.strdup())
-            .unwrap_or_else(ptr::null_mut)
+            .unwrap_or_else(|| "".to_string());
+        if mime.is_empty() {
+            return ptr::null_mut();
+        }
+        mime.strdup()
     })
 }
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1485,7 +1485,7 @@ pub unsafe extern "C" fn dc_get_mime_headers(
         let mime = message::get_mime_headers(&ctx, MsgId::new(msg_id))
             .await
             .unwrap_or_log_default(ctx, "failed to get mime headers")
-            .unwrap_or_else(|| "".to_string());
+            .unwrap_or_else(|| String::new());
         if mime.is_empty() {
             return ptr::null_mut();
         }

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1485,7 +1485,7 @@ pub unsafe extern "C" fn dc_get_mime_headers(
         let mime = message::get_mime_headers(&ctx, MsgId::new(msg_id))
             .await
             .unwrap_or_log_default(ctx, "failed to get mime headers")
-            .unwrap_or_else(|| String::new());
+            .unwrap_or_else(String::new);
         if mime.is_empty() {
             return ptr::null_mut();
         }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -893,7 +893,7 @@ async fn add_parts(
     let mut save_mime_modified = mime_parser.is_mime_modified;
 
     let mime_headers = if save_mime_headers || save_mime_modified {
-        if mime_parser.was_encrypted() {
+        if mime_parser.was_encrypted() && !mime_parser.decoded_data.is_empty() {
             Some(String::from_utf8_lossy(&mime_parser.decoded_data).to_string())
         } else {
             Some(String::from_utf8_lossy(imf_raw).to_string())

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3535,68 +3535,50 @@ YEAAAAAA!.
     }
 
     #[async_std::test]
-    async fn test_save_mime_headers_off() {
+    async fn test_save_mime_headers_off() -> anyhow::Result<()> {
         let alice = TestContext::new_alice().await;
         let bob = TestContext::new_bob().await;
         let chat_alice = alice.create_chat(&bob).await;
-        chat::send_text_msg(&alice, chat_alice.id, "hi!".to_string())
-            .await
-            .ok();
+        chat::send_text_msg(&alice, chat_alice.id, "hi!".to_string()).await?;
 
         bob.recv_msg(&alice.pop_sent_msg().await).await;
         let msg = bob.get_last_msg().await;
         assert_eq!(msg.get_text(), Some("hi!".to_string()));
         assert!(!msg.get_showpadlock());
-        let mime = message::get_mime_headers(&bob, msg.id)
-            .await
-            .unwrap()
-            .unwrap();
-        assert!(mime.is_empty())
+        let mime = message::get_mime_headers(&bob, msg.id).await?.unwrap();
+        assert!(mime.is_empty());
+        Ok(())
     }
 
     #[async_std::test]
-    async fn test_save_mime_headers_on() {
+    async fn test_save_mime_headers_on() -> anyhow::Result<()> {
         let alice = TestContext::new_alice().await;
-        alice
-            .set_config_bool(Config::SaveMimeHeaders, true)
-            .await
-            .unwrap();
+        alice.set_config_bool(Config::SaveMimeHeaders, true).await?;
         let bob = TestContext::new_bob().await;
-        bob.set_config_bool(Config::SaveMimeHeaders, true)
-            .await
-            .unwrap();
+        bob.set_config_bool(Config::SaveMimeHeaders, true).await?;
 
         // alice sends a message to bob, bob sees full mime
         let chat_alice = alice.create_chat(&bob).await;
-        chat::send_text_msg(&alice, chat_alice.id, "hi!".to_string())
-            .await
-            .ok();
+        chat::send_text_msg(&alice, chat_alice.id, "hi!".to_string()).await?;
 
         bob.recv_msg(&alice.pop_sent_msg().await).await;
         let msg = bob.get_last_msg().await;
         assert_eq!(msg.get_text(), Some("hi!".to_string()));
         assert!(!msg.get_showpadlock());
-        let mime = message::get_mime_headers(&bob, msg.id)
-            .await
-            .unwrap()
-            .unwrap();
+        let mime = message::get_mime_headers(&bob, msg.id).await?.unwrap();
         assert!(mime.contains("Received:"));
         assert!(mime.contains("From:"));
 
         // another one, from bob to alice, that gets encrypted
         let chat_bob = bob.create_chat(&alice).await;
-        chat::send_text_msg(&bob, chat_bob.id, "ho!".to_string())
-            .await
-            .ok();
+        chat::send_text_msg(&bob, chat_bob.id, "ho!".to_string()).await?;
         alice.recv_msg(&bob.pop_sent_msg().await).await;
         let msg = alice.get_last_msg().await;
         assert_eq!(msg.get_text(), Some("ho!".to_string()));
         assert!(msg.get_showpadlock());
-        let mime = message::get_mime_headers(&alice, msg.id)
-            .await
-            .unwrap()
-            .unwrap();
+        let mime = message::get_mime_headers(&alice, msg.id).await?.unwrap();
         assert!(mime.contains("Received:"));
         assert!(mime.contains("From:"));
+        Ok(())
     }
 }


### PR DESCRIPTION
this pr adds a rust-test to check the save_mime_headers flag; the rust-test test even more circumstances than the python test.

the second and third commit fix the issue.

in fact, the issue was already there on master [[1]](https://app.circleci.com/pipelines/github/deltachat/deltachat-core-rust/8107/workflows/6419f0b1-ee27-4657-8c14-66dfd1e0873c/jobs/31047), however, for whatever reason, was not fixed there. the issue was that, by html-mails, if introduce a "raw-decrypted" field which, for preformance reasons, is set only when needed by html-view. `save_mime_headers` flag tries to save it unconditionally for encrypted messages (the second mail in the test is encrypted).  
(wondering, if this `save_mime_headers` is acutally in use somewhere, however, now it is fixed, so we can postpone this decision :)

another thing i encountered during checking: when we insert `None` as the mime-headers, sqlx actually inserts it as an empty string imu - maybe because of the missing `NULL` declaration. at a first glance, `mime_headers` can be "empty string" or `NULL` for "unset", so, maybe just stop using `NULL` here - we are not doing this at other places in the database as well.  