### PR TITLE
set max_connections=10 (default), show num_cpus in get_info()

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -93,6 +93,7 @@ pub fn get_info() -> BTreeMap<&'static str, String> {
     res.insert("deltachat_core_version", format!("v{}", &*DC_VERSION_STR));
     res.insert("sqlite_version", crate::sql::version().to_string());
     res.insert("arch", (std::mem::size_of::<usize>() * 8).to_string());
+    res.insert("num_cpus", num_cpus::get().to_string());
     res.insert("level", "awesome".into());
     res
 }

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -115,7 +115,7 @@ PRAGMA temp_store=memory; -- Avoid SQLITE_IOERR_GETTEMPPATH errors on Android
             .synchronous(SqliteSynchronous::Normal);
 
         PoolOptions::<Sqlite>::new()
-            .max_connections(num_cpus::get() as u32)
+            .max_connections(10)
             .after_connect(|conn| {
                 Box::pin(async move {
                     let q = r#"


### PR DESCRIPTION
setting the number of connections
to the number of cpus seems to be to low in general:

- on a mac i5 from 2017, that would result in 4 connections
- on an iphone7, that would result in only 2 connections

the sqlx-default is 10 connections,
so, this pr uses that default (plus 1 connection for the writer tag).

on the iphone7, that change was directly noticable -
sqlx with 2 connections feelt not much faster that rusqlite with 10 connections,
however, using sqlx with the 10+1 connection was a real boost,
at least at a first glance :)

might be, fewer connections would be sufficient as well,
however, i do not see much reasons not to go with the default here.