### PR TITLE
make Message.id a dynamic property

### DIFF
--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -254,17 +254,19 @@ class Chat(object):
         return Message.from_db(self.account, sent_id)
 
     def prepare_message(self, msg):
-        """ create a new prepared message.
+        """ prepare a message for sending.
 
         :param msg: the message to be prepared.
-        :returns: :class:`deltachat.message.Message` instance.
+        :returns: a :class:`deltachat.message.Message` instance.
+           This is the same object that was passed in, which
+           has been modified with the new state of the core.
         """
         msg_id = lib.dc_prepare_msg(self.account._dc_context, self.id, msg._dc_msg)
         if msg_id == 0:
             raise ValueError("message could not be prepared")
-        # invalidate passed in message which is not safe to use anymore
-        msg._dc_msg = msg.id = None
-        return Message.from_db(self.account, msg_id)
+        # modify message in place to avoid bad state for the caller
+        msg._dc_msg = Message.from_db(self.account, msg_id)._dc_msg
+        return msg
 
     def prepare_message_file(self, path, mime_type=None, view_type="file"):
         """ prepare a message for sending and return the resulting Message instance.

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -21,8 +21,8 @@ class Message(object):
         assert isinstance(dc_msg, ffi.CData)
         assert dc_msg != ffi.NULL
         self._dc_msg = dc_msg
-        self.id = lib.dc_msg_get_id(dc_msg)
-        assert self.id is not None and self.id >= 0, repr(self.id)
+        msg_id = self.id
+        assert msg_id is not None and msg_id >= 0, repr(msg_id)
 
     def __eq__(self, other):
         return self.account == other.account and self.id == other.id
@@ -71,6 +71,11 @@ class Message(object):
         ctx = self.account._dc_context
         self._dc_msg = ffi.gc(lib.dc_get_msg(ctx, self.id), lib.dc_msg_unref)
         return Chat(self.account, chat_id)
+
+    @props.with_doc
+    def id(self):
+        """id of this message. """
+        return lib.dc_msg_get_id(self._dc_msg)
 
     @props.with_doc
     def text(self):


### PR DESCRIPTION
`Chat.send_msg()` is updating `Message._dc_msg` but `Message.id` is not a dynamic property so message id was still `0` in the message object, not synchronized with the real id from the database.