### PR TITLE
sql: enable virtual statement cache on the reader pool

### DIFF
--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -112,7 +112,6 @@ PRAGMA temp_store=memory; -- Avoid SQLITE_IOERR_GETTEMPPATH errors on Android
             .filename(dbfile.as_ref())
             .read_only(readonly)
             .busy_timeout(Duration::from_secs(100))
-            .statement_cache_capacity(0) // XXX workaround for https://github.com/launchbadge/sqlx/issues/1147
             .synchronous(SqliteSynchronous::Normal);
 
         PoolOptions::<Sqlite>::new()


### PR DESCRIPTION
A follow-up to 720135a915759d8014a27b7944ae2975bae32a4d