### PR TITLE
fix single chat search

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -501,13 +501,15 @@ impl Contact {
                         ).bind(Chattype::Single).bind(row_id)
                     ).await?;
                     if let Some(chat_id) = chat_id {
+                        let contact = Contact::get_by_id(context, row_id as u32).await?;
+                        let chat_name = contact.get_display_name();
                         match context
                             .sql
                             .execute(
                                 sqlx::query("UPDATE chats SET name=?1 WHERE id=?2 AND name!=?3")
-                                    .bind(&new_name)
+                                    .bind(&chat_name)
                                     .bind(chat_id)
-                                    .bind(&new_name),
+                                    .bind(&chat_name),
                             )
                             .await
                         {


### PR DESCRIPTION
the user-given contact name may be set to an empty string;
in this case the authname or the email is used for the contact
and also for the name of possibly existing chats.

this works well for `dc_chat_get_name()` as that just uses
`dc_contact_get_display_name()` for single-chats.

it did not work for `dc_get_chatlist(query)` as that
uses the database for performance reasons -
however, in the database, the empty string is written
instead of the display name is written for a chat.

this is fixed by this pr by also using
`dc_contact_get_display_name()` when updating the chats-table
(similar to `dc_create_chat_by_contact_id()`)

closes #2343 

i came over that when tweaking the global search on ios in https://github.com/deltachat/deltachat-ios/pull/1140 :)

i also checked the official android 1.14 release: here the the issue is not yet there, i think, it was introduced by some recent changes, maybe https://github.com/deltachat/deltachat-core-rust/pull/2206; therefore, i do not think it is worth to fix the database by a migration.