### PR TITLE
prepare 1.52

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,6 @@ workflows:
           filters:
             branches:
               only: master
-            #tags:
-            #  only: /.*/
 
       - upload_docs_wheels:
           requires:
@@ -63,12 +61,8 @@ workflows:
           filters:
             branches:
               only: master
-            tags:
-              only: /.*/
 
       - build_doxygen:
           filters:
             branches:
               only: master
-            tags:
-              only: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog 
 
+## 1.52.0
+
+- database library changed from rusqlite to sqlx #2089 #2331 #2336 #2340
+
+- add alias support: UIs should check for `dc_msg_get_override_sender_name()`
+  also in single-chats now and display divergent names and avatars #2297
+
+- parse blockquote-tags for better quote detection #2313
+
+- ignore unknown classical emails from spam folder #2311
+
+- support "Mixed Up” encryption repairing #2321
+
+- fix single chat search #2344
+
+- fix nightly clippy and rustc errors #2341
+
+- update dependencies #2350
+
+- improve ci #2342
+
+- improve python bindings #2332 #2326
+
+
 ## 1.51.0
 
 - breaking change: You have to call `dc_stop_io()`/`dc_start_io()`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.51.0"
+version = "1.52.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",
@@ -1229,7 +1229,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.51.0"
+version = "1.52.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.51.0"
+version = "1.52.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.51.0"
+version = "1.52.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"


### PR DESCRIPTION
core52 to have an official version with sqlx merged in, even if there are some known issues, see below.

as sqlx is quite a huge change, beta-releases based on core52 should also be bumped, so eg. android/ios 1.19 then, not 1.17.x.

what's left for a final, stable core53+:

- finish the avatar-pr #2232 

- not sure about the blocker #2335 in the [email-compat](https://github.com/orgs/deltachat/projects/31) project - is that really a blocker? 