### PR TITLE
sql: enable shared cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3465,8 +3465,7 @@ dependencies = [
 [[package]]
 name = "sqlx"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d582b9bc04ec6c03084196efc42c2226b018e9941f03ee62bd88921d500917c0"
+source = "git+https://github.com/deltachat/sqlx?branch=master#7a3c367a94902edc92ed58914301052a0a9ac466"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -3475,8 +3474,7 @@ dependencies = [
 [[package]]
 name = "sqlx-core"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de52d1d473cebb2abb79c886ef6a8023e965e34c0676a99cfeac2cc7f0fde4c1"
+source = "git+https://github.com/deltachat/sqlx?branch=master#7a3c367a94902edc92ed58914301052a0a9ac466"
 dependencies = [
  "ahash 0.7.2",
  "atoi",
@@ -3514,8 +3512,7 @@ dependencies = [
 [[package]]
 name = "sqlx-macros"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a40f0be97e704d3fbf059e7e3333c3735639146a72d586c5534c70e79da88a4"
+source = "git+https://github.com/deltachat/sqlx?branch=master#7a3c367a94902edc92ed58914301052a0a9ac466"
 dependencies = [
  "dotenv",
  "either",
@@ -3533,8 +3530,7 @@ dependencies = [
 [[package]]
 name = "sqlx-rt"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6ae97ab05063ed515cdc23d90253213aa24dda0a288c5ec079af3d10f9771bc"
+source = "git+https://github.com/deltachat/sqlx?branch=master#7a3c367a94902edc92ed58914301052a0a9ac466"
 dependencies = [
  "async-native-tls",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ serde = { version = "1.0", features = ["derive"] }
 sha-1 = "0.9.3"
 sha2 = "0.9.0"
 smallvec = "1.0.0"
-sqlx = { version = "0.5.2", features = ["runtime-async-std-native-tls", "sqlite"] }
+sqlx = { git = "https://github.com/deltachat/sqlx", branch = "master", features = ["runtime-async-std-native-tls", "sqlite"] }
 # keep in sync with sqlx
 libsqlite3-sys = { version = "0.22.0", default-features = false, features = [ "pkg-config", "vcpkg", "bundled" ] }
 stop-token = { version = "0.1.1", features = ["unstable"] }

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -86,6 +86,7 @@ impl Sql {
             .read_only(false)
             .busy_timeout(Duration::from_secs(100))
             .create_if_missing(true)
+            .shared_cache(true)
             .synchronous(SqliteSynchronous::Normal);
 
         PoolOptions::<Sqlite>::new()
@@ -112,6 +113,7 @@ PRAGMA temp_store=memory; -- Avoid SQLITE_IOERR_GETTEMPPATH errors on Android
             .journal_mode(SqliteJournalMode::Wal)
             .filename(dbfile.as_ref())
             .read_only(readonly)
+            .shared_cache(true)
             .busy_timeout(Duration::from_secs(100))
             .synchronous(SqliteSynchronous::Normal);
 
@@ -122,6 +124,7 @@ PRAGMA temp_store=memory; -- Avoid SQLITE_IOERR_GETTEMPPATH errors on Android
                     let q = r#"
 PRAGMA temp_store=memory; -- Avoid SQLITE_IOERR_GETTEMPPATH errors on Android
 PRAGMA query_only=1; -- Protect against writes even in read-write mode
+PRAGMA read_uncommitted=1; -- This helps avoid "table locked" errors in shared cache mode
 "#;
 
                     conn.execute_many(sqlx::query(q))


### PR DESCRIPTION
This is based on #2355, which should be merged in first.

Fixes #2353

I am not sure about safety of `PRAGMA read_uncommitted=1;`, but it is suggested by https://sqlite.org/sharedcache.html and I get "table locked" errors otherwise. I think it should not cause significant issues because we usually don't commit many rows in a single transaction and don't rely on them being either written or not at the same time during reading.