### PR TITLE
dc_receive_imf: remove unnecessary check for empty folder name

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -71,11 +71,7 @@ pub(crate) async fn dc_receive_imf_inner(
     info!(
         context,
         "Receiving message {}/{}, seen={}...",
-        if !server_folder.as_ref().is_empty() {
-            server_folder.as_ref()
-        } else {
-            "?"
-        },
+        server_folder.as_ref(),
         server_uid,
         seen
     );


### PR DESCRIPTION
This check dates back to C core, where it checked for NULL, not empty string.