### PR TITLE
LIMIT global search

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1272,6 +1272,12 @@ uint32_t dc_get_chat_ephemeral_timer (dc_context_t* context, uint32_t chat_id);
  * search results may just hilite the corresponding messages and present a
  * prev/next button.
  *
+ * For global search, result is limited to 1000 messages,
+ * this allows incremental search done fast.
+ * So, when getting exactly 1000 results, the result may be truncated;
+ * the UIs may display sth. as "1000+ messages found" in this case.
+ * Chat search (if a chat_id is set) is not limited.
+ *
  * @memberof dc_context_t
  * @param context The context object as returned from dc_context_new().
  * @param chat_id ID of the chat to search messages in.

--- a/src/context.rs
+++ b/src/context.rs
@@ -503,6 +503,11 @@ impl Context {
             //
             // Unlike chat view, sorting by `timestamp` is not necessary but slows down the query by
             // ~25% according to benchmarks.
+            //
+            // To speed up incremental search, where queries for few characters usually return lots
+            // of unwanted results that are discarded moments later, we added `LIMIT 1000`.
+            // According to some tests, this limit speeds up eg. 2 character searches by factor 10.
+            // The limit is documented and UI may add a hint when getting 1000 results.
             self.sql
                 .fetch(
                     sqlx::query(
@@ -517,7 +522,7 @@ impl Context {
                    AND c.blocked=0
                    AND ct.blocked=0
                    AND m.txt LIKE ?
-                 ORDER BY m.id DESC",
+                 ORDER BY m.id DESC LIMIT 1000",
                     )
                     .bind(str_like_in_text),
                 )


### PR DESCRIPTION
see code documentation for details.

EDIT: i also just tested on android, _without_ this pr: depending on typing speed, search_msgs() is called for lots result, easily resulting in execution times of >10s on a bigger database; avoiding exactly these long runs is what this pr is about.

EDIT: yip, i can confirm, the max search time is reliably limited to <1s on the testphone, making the overall ux of incremental search much smooth :)