### PR TITLE
Fix #2335 (delete job flooding)

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -130,7 +130,7 @@ impl From<Action> for Thread {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Job {
     pub job_id: u32,
     pub action: Action,
@@ -1030,7 +1030,7 @@ pub(crate) enum Connection<'a> {
     Smtp(&'a mut Smtp),
 }
 
-async fn load_imap_deletion_job(context: &Context) -> sql::Result<Option<Job>> {
+pub(crate) async fn load_imap_deletion_job(context: &Context) -> sql::Result<Option<Job>> {
     let res = if let Some(msg_id) = load_imap_deletion_msgid(context).await? {
         info!(context, "verbose (issue 2335): loading imap deletion job");
         Some(Job::new(


### PR DESCRIPTION
Fix #2335

The problem was:
- You are offline, and an ephemeral message is due to delete.
- load_imap_deletion_job() is called and returns a deletion job for it.
- The job fails because, well, we are offline.
- The job is saved into the database.
- load_imap_deletion_job() is called again, and so on.

Now, this doesn't check if there is already a postponed message deletion job for this message before saving a new one to the database because I was unsure how to do it: The nicest way to do it seems to be to let SQL make sure that there aren't two jobs with the same thread, action, foreign_id and param. Is this maybe possible?

Otherwise, should we just check in job::save() whether there is an existing job? As above, it would probably make sense to not only do this for DeleteMsgOnImap, but also for other actions?