### PR TITLE
mark deaddrop as 'noticed' in dc_marknoticed_chat() instead of dc_markseen_msgs()

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1594,13 +1594,22 @@ void            dc_marknoticed_contact       (dc_context_t* context, uint32_t co
 
 
 /**
- * Mark a message as _seen_, updates the IMAP state and
- * sends MDNs. If the message is not in a real chat (e.g. a contact request), the
- * message is only marked as NOTICED and no IMAP/MDNs is done.  See also
- * dc_marknoticed_chat().
+ * Mark messages as presented to the user.
+ * Typically, UIs call this function on scrolling through the chatlist,
+ * when the messages are presented at least for a little moment.
+ * The concrete action depends on the type of the chat and on the users settings
+ * (dc_msgs_presented() may be a better name therefore, but well :)
  *
- * Moreover, if messages belong to a chat with ephemeral messages enabled,
- * the ephemeral timer is started for these messages.
+ * - For normal chats, the IMAP state is updated, MDN is sent
+ *   (if dc_set_config()-options `mdns_enabled` is set)
+ *   and the internal state is changed to DC_STATE_IN_SEEN to reflect these actions.
+ *
+ * - For the deaddrop, no IMAP or MNDs is done
+ *   and the internal change is not changed therefore.
+ *   See also dc_marknoticed_chat().
+ *
+ * Moreover, timer is started for incoming ephemeral messages.
+ * This also happens for messages in the deaddrop.
  *
  * One #DC_EVENT_MSGS_NOTICED event is emitted per modified chat.
  *

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1078,9 +1078,9 @@ int             dc_estimate_deletion_cnt    (dc_context_t* context, int from_ser
  * or badge counters eg. on the app-icon.
  * The list is already sorted and starts with the most recent fresh message.
  *
- * Messages belonging to muted chats are not returned,
- * as they should not be notified
- * and also a badge counters should not include messages of muted chats.
+ * Messages belonging to muted chats or to the deaddrop are not returned;
+ * these messages should not be notified
+ * and also badge counters should not include these messages.
  *
  * To get the number of fresh messages for a single chat, muted or not,
  * use dc_get_fresh_msg_cnt().
@@ -1104,7 +1104,8 @@ dc_array_t*     dc_get_fresh_msgs            (dc_context_t* context);
  *
  * @memberof dc_context_t
  * @param context The context object as returned from dc_context_new().
- * @param chat_id The chat ID of which all messages should be marked as being noticed.
+ * @param chat_id The chat ID of which all messages should be marked as being noticed
+ *     (this also works for the virtual chat ID DC_CHAT_ID_DEADDROP).
  */
 void            dc_marknoticed_chat          (dc_context_t* context, uint32_t chat_id);
 

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -603,8 +603,11 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             ensure!(sel_chat.is_some(), "Failed to select chat");
             let sel_chat = sel_chat.as_ref().unwrap();
 
+            let time_start = std::time::SystemTime::now();
             let msglist =
                 chat::get_chat_msgs(&context, sel_chat.get_id(), DC_GCM_ADDDAYMARKER, None).await?;
+            let time_needed = time_start.elapsed().unwrap_or_default();
+
             let msglist: Vec<MsgId> = msglist
                 .into_iter()
                 .map(|x| match x {
@@ -659,7 +662,15 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                 "{} messages.",
                 sel_chat.get_id().get_msg_cnt(&context).await?
             );
+
+            let time_noticed_start = std::time::SystemTime::now();
             chat::marknoticed_chat(&context, sel_chat.get_id()).await?;
+            let time_noticed_needed = time_noticed_start.elapsed().unwrap_or_default();
+
+            println!(
+                "{:?} to create this list, {:?} to mark all messages as noticed.",
+                time_needed, time_noticed_needed
+            );
         }
         "createchat" => {
             ensure!(!arg1.is_empty(), "Argument <contact-id> missing.");

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3937,4 +3937,98 @@ mod tests {
             2
         );
     }
+
+    #[async_std::test]
+    async fn test_marknoticed_chat() -> anyhow::Result<()> {
+        let t = TestContext::new_alice().await;
+        let chat = t.create_chat_with_contact("bob", "bob@example.org").await;
+
+        dc_receive_imf(
+            &t,
+            b"From: bob@example.org\n\
+                 To: alice@example.com\n\
+                 Message-ID: <1@example.org>\n\
+                 Chat-Version: 1.0\n\
+                 Date: Fri, 23 Apr 2021 10:00:57 +0000\n\
+                 \n\
+                 hello\n",
+            "INBOX",
+            1,
+            false,
+        )
+        .await?;
+
+        let chats = Chatlist::try_load(&t, 0, None, None).await?;
+        assert_eq!(chats.len(), 1);
+        assert_eq!(chats.get_chat_id(0), chat.id);
+        assert_ne!(chats.get_chat_id(0), DC_CHAT_ID_DEADDROP);
+        assert_eq!(chat.id.get_fresh_msg_cnt(&t).await?, 1);
+        assert_eq!(t.get_fresh_msgs().await?.len(), 1);
+
+        let msgs = get_chat_msgs(&t, chat.id, 0, None).await?;
+        assert_eq!(msgs.len(), 1);
+        let msg_id = match msgs.first().unwrap() {
+            ChatItem::Message { msg_id } => *msg_id,
+            _ => MsgId::new_unset(),
+        };
+        let msg = message::Message::load_from_db(&t, msg_id).await?;
+        assert_eq!(msg.state, MessageState::InFresh);
+
+        marknoticed_chat(&t, chat.id).await?;
+
+        let chats = Chatlist::try_load(&t, 0, None, None).await?;
+        assert_eq!(chats.len(), 1);
+        let msg = message::Message::load_from_db(&t, msg_id).await?;
+        assert_eq!(msg.state, MessageState::InNoticed);
+        assert_eq!(chat.id.get_fresh_msg_cnt(&t).await?, 0);
+        assert_eq!(t.get_fresh_msgs().await?.len(), 0);
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_marknoticed_deaddrop_chat() -> anyhow::Result<()> {
+        let t = TestContext::new_alice().await;
+
+        let chats = Chatlist::try_load(&t, 0, None, None).await?;
+        assert_eq!(chats.len(), 0);
+
+        dc_receive_imf(
+            &t,
+            b"From: bob@example.org\n\
+                 To: alice@example.com\n\
+                 Message-ID: <1@example.org>\n\
+                 Chat-Version: 1.0\n\
+                 Date: Sun, 22 Mar 2021 19:37:57 +0000\n\
+                 \n\
+                 hello\n",
+            "INBOX",
+            1,
+            false,
+        )
+        .await?;
+
+        let chats = Chatlist::try_load(&t, 0, None, None).await?;
+        assert_eq!(chats.len(), 1);
+        assert_eq!(chats.get_chat_id(0), DC_CHAT_ID_DEADDROP);
+        let msgs = get_chat_msgs(&t, DC_CHAT_ID_DEADDROP, 0, None).await?;
+        assert_eq!(msgs.len(), 1);
+        let msg_id = match msgs.first().unwrap() {
+            ChatItem::Message { msg_id } => *msg_id,
+            _ => MsgId::new_unset(),
+        };
+        let msg = message::Message::load_from_db(&t, msg_id).await?;
+        assert_eq!(msg.state, MessageState::InFresh);
+        assert_eq!(t.get_fresh_msgs().await?.len(), 0); // deaddrop is excluded from global badge
+
+        marknoticed_chat(&t, DC_CHAT_ID_DEADDROP).await?;
+
+        let chats = Chatlist::try_load(&t, 0, None, None).await?;
+        assert_eq!(chats.len(), 0);
+        let msg = message::Message::load_from_db(&t, msg_id).await?;
+        assert_eq!(msg.state, MessageState::InNoticed);
+        assert_eq!(t.get_fresh_msgs().await?.len(), 0);
+
+        Ok(())
+    }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1545,21 +1545,18 @@ pub async fn markseen_msgs(context: &Context, msg_ids: Vec<MsgId>) -> bool {
             continue;
         }
 
-        if curr_blocked == Blocked::Not {
-            if curr_state == MessageState::InFresh || curr_state == MessageState::InNoticed {
-                update_msg_state(context, id, MessageState::InSeen).await;
-                info!(context, "Seen message {}.", id);
+        if curr_blocked == Blocked::Not
+            && (curr_state == MessageState::InFresh || curr_state == MessageState::InNoticed)
+        {
+            update_msg_state(context, id, MessageState::InSeen).await;
+            info!(context, "Seen message {}.", id);
 
-                job::add(
-                    context,
-                    job::Job::new(Action::MarkseenMsgOnImap, id.to_u32(), Params::new(), 0),
-                )
-                .await;
-                updated_chat_ids.insert(curr_chat_id, true);
-            }
-        } else if curr_state == MessageState::InFresh {
-            update_msg_state(context, id, MessageState::InNoticed).await;
-            updated_chat_ids.insert(DC_CHAT_ID_DEADDROP, true);
+            job::add(
+                context,
+                job::Job::new(Action::MarkseenMsgOnImap, id.to_u32(), Params::new(), 0),
+            )
+            .await;
+            updated_chat_ids.insert(curr_chat_id, true);
         }
     }
 


### PR DESCRIPTION
UIs call `dc_marknoticed_chat()` when the  deaddrop is opened as well as `dc_markseen_msgs()` for messages scrolled over. 

up to now, messages in the deaddrop are marked as _noticed_ in `dc_markseen_msgs()`, this has the following disadvantages:

1. depending on the scrolling through the deaddrop, by debouncing, _some_ messages may be marked as noticed (see #2371) - which results in a bit random contact requests appearing in the chatlist (which show unnoticed, _fresh_ messages)

2. the UIs do not have control about _when_ things are marked as noticed (`dc_markseen_msgs()` does some more things and needs to be called unconditionally, see comment in .h)

this pr moves the mark-as-noticed action to `dc_marknoticed_chat()`, fixing 1. by that and allowing an explicit "Not now for all" button for the deaddrop if the UI decide to do so.

moreover, this pr adds several tests, both functions were not tested well before.

closes #2371 