### PR TITLE
Compress avatar to below 20k

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -423,7 +423,7 @@ impl<'a> BlobObject<'a> {
             };
 
         let new_name = self.recode_to_size(context, blob_abs, img_wh, None).await?;
-        if new_name != "" {
+        if !new_name.is_empty() {
             return Err(format_err!(
                 "Internal error: recode_to_size(..., None) shouldn't change the name of the image"
             )
@@ -460,7 +460,7 @@ impl<'a> BlobObject<'a> {
             encoded: &mut Vec<u8>,
         ) -> anyhow::Result<bool> {
             if let Some(max_bytes) = max_bytes {
-                encode_img(&img, encoded)?;
+                encode_img(img, encoded)?;
                 if encoded.len() > max_bytes {
                     info!(
                         context,

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -401,7 +401,7 @@ impl<'a> BlobObject<'a> {
         let new_name = self
             .recode_to_size(context, blob_abs, img_wh, Some(20_000))
             .await?;
-        if new_name != "" {
+        if !new_name.is_empty() {
             self.name = new_name;
         }
         Ok(())

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -382,7 +382,6 @@ impl<'a> BlobObject<'a> {
     }
 
     pub async fn recode_to_avatar_size(&self, context: &Context) -> Result<(), BlobError> {
-        // TODO can fail now!!!!
         let blob_abs = self.to_abs_path();
 
         let img_wh =
@@ -447,12 +446,11 @@ impl<'a> BlobObject<'a> {
             if let Some(max_bytes) = max_bytes {
                 while img.as_bytes().len() > max_bytes {
                     img_wh = img_wh / 2;
-                    if img_wh < 50 {
-                        return Err(format_err!(
-                            "Image witdh is 50, but size is still {}",
+                    if img_wh < 20 {
+                        Err(format_err!(
+                            "Image width is 20, but size is still {}",
                             img.as_bytes().len()
-                        )
-                        .into());
+                        ))?
                     }
                     img = img.thumbnail(img_wh, img_wh);
                 }

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -395,7 +395,8 @@ impl<'a> BlobObject<'a> {
                 MediaQuality::Worse => WORSE_AVATAR_SIZE,
             };
 
-        // max_bytes is 20_000 bytes as that's the max header size of some servers
+        // max_bytes is 20_000 bytes: Outlook servers don't allow headers larger than 32k.
+        // 32 / 4 * 3 = 24k if you account for base64 encoding. To be safe, we reduced this to 20k.
         let new_name = self
             .recode_to_size(context, blob_abs, img_wh, Some(20_000))
             .await?;

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1,5 +1,6 @@
 //! # Blob directory management
 
+use core::cmp::max;
 use std::ffi::OsStr;
 use std::fmt;
 
@@ -495,7 +496,7 @@ impl<'a> BlobObject<'a> {
                 if !exceeds_width {
                     // The image is already smaller than img_wh, but exceeds max_bytes
                     // We can directly start with trying to scale down to 2/3 of its current width
-                    img_wh = img.width() * 2 / 3 // TODO should be {max or min}(img.width(), img.height())
+                    img_wh = max(img.width(), img.height()) * 2 / 3
                 }
 
                 loop {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2710,7 +2710,7 @@ pub async fn set_chat_profile_image(
         msg.param.remove(Param::Arg);
         msg.text = Some(stock_str::msg_grp_img_deleted(context, DC_CONTACT_ID_SELF as u32).await);
     } else {
-        let image_blob = match BlobObject::from_path(context, Path::new(new_image.as_ref())) {
+        let mut image_blob = match BlobObject::from_path(context, Path::new(new_image.as_ref())) {
             Ok(blob) => Ok(blob),
             Err(err) => match err {
                 BlobError::WrongBlobdir { .. } => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -331,12 +331,8 @@ mod tests {
     use std::string::ToString;
 
     use crate::constants;
-    use crate::constants::BALANCED_AVATAR_SIZE;
     use crate::test_utils::TestContext;
-    use image::GenericImageView;
     use num_traits::FromPrimitive;
-    use std::fs::File;
-    use std::io::Write;
 
     #[test]
     fn test_to_string() {
@@ -348,82 +344,6 @@ mod tests {
             Config::from_str("sys.config_keys"),
             Ok(Config::SysConfigKeys)
         );
-    }
-
-    #[async_std::test]
-    async fn test_selfavatar_outside_blobdir() {
-        let t = TestContext::new().await;
-        let avatar_src = t.dir.path().join("avatar.jpg");
-        let avatar_bytes = include_bytes!("../test-data/image/avatar1000x1000.jpg");
-        File::create(&avatar_src)
-            .unwrap()
-            .write_all(avatar_bytes)
-            .unwrap();
-        let avatar_blob = t.get_blobdir().join("avatar.jpg");
-        assert!(!avatar_blob.exists().await);
-        t.set_config(Config::Selfavatar, Some(avatar_src.to_str().unwrap()))
-            .await
-            .unwrap();
-        assert!(avatar_blob.exists().await);
-        assert!(std::fs::metadata(&avatar_blob).unwrap().len() < avatar_bytes.len() as u64);
-        let avatar_cfg = t.get_config(Config::Selfavatar).await.unwrap();
-        assert_eq!(avatar_cfg, avatar_blob.to_str().map(|s| s.to_string()));
-
-        let img = image::open(avatar_src).unwrap();
-        assert_eq!(img.width(), 1000);
-        assert_eq!(img.height(), 1000);
-
-        let img = image::open(avatar_blob).unwrap();
-        assert_eq!(img.width(), BALANCED_AVATAR_SIZE);
-        assert_eq!(img.height(), BALANCED_AVATAR_SIZE);
-    }
-
-    #[async_std::test]
-    async fn test_selfavatar_in_blobdir() {
-        let t = TestContext::new().await;
-        let avatar_src = t.get_blobdir().join("avatar.png");
-        let avatar_bytes = include_bytes!("../test-data/image/avatar900x900.png");
-        File::create(&avatar_src)
-            .unwrap()
-            .write_all(avatar_bytes)
-            .unwrap();
-
-        let img = image::open(&avatar_src).unwrap();
-        assert_eq!(img.width(), 900);
-        assert_eq!(img.height(), 900);
-
-        t.set_config(Config::Selfavatar, Some(avatar_src.to_str().unwrap()))
-            .await
-            .unwrap();
-        let avatar_cfg = t.get_config(Config::Selfavatar).await.unwrap();
-        assert_eq!(avatar_cfg, avatar_src.to_str().map(|s| s.to_string()));
-
-        let img = image::open(avatar_src).unwrap();
-        assert_eq!(img.width(), BALANCED_AVATAR_SIZE);
-        assert_eq!(img.height(), BALANCED_AVATAR_SIZE);
-    }
-
-    #[async_std::test]
-    async fn test_selfavatar_copy_without_recode() {
-        let t = TestContext::new().await;
-        let avatar_src = t.dir.path().join("avatar.png");
-        let avatar_bytes = include_bytes!("../test-data/image/avatar64x64.png");
-        File::create(&avatar_src)
-            .unwrap()
-            .write_all(avatar_bytes)
-            .unwrap();
-        let avatar_blob = t.get_blobdir().join("avatar.png");
-        assert!(!avatar_blob.exists().await);
-        t.set_config(Config::Selfavatar, Some(avatar_src.to_str().unwrap()))
-            .await
-            .unwrap();
-        assert!(avatar_blob.exists().await);
-        assert_eq!(
-            std::fs::metadata(&avatar_blob).unwrap().len(),
-            avatar_bytes.len() as u64
-        );
-        let avatar_cfg = t.get_config(Config::Selfavatar).await.unwrap();
-        assert_eq!(avatar_cfg, avatar_blob.to_str().map(|s| s.to_string()));
     }
 
     #[async_std::test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -249,7 +249,7 @@ impl Context {
                     .await?;
                 match value {
                     Some(value) => {
-                        let blob = BlobObject::new_from_path(self, value).await?;
+                        let mut blob = BlobObject::new_from_path(self, value).await?;
                         blob.recode_to_avatar_size(self).await?;
                         self.sql.set_raw_config(key, Some(blob.as_name())).await?;
                         Ok(())

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -14,6 +14,7 @@ use async_std::{fs, io};
 
 use anyhow::{bail, Error};
 use chrono::{Local, TimeZone};
+use image::DynamicImage;
 use rand::{thread_rng, Rng};
 
 use crate::chat::{add_device_msg, add_device_msg_with_importance};
@@ -680,6 +681,33 @@ pub fn remove_subject_prefix(last_subject: &str) -> String {
         .collect::<String>()
         .trim()
         .to_string()
+}
+
+struct ByteCounter {
+    count: usize,
+}
+
+impl ByteCounter {
+    fn new() -> Self {
+        ByteCounter { count: 0 }
+    }
+}
+
+impl std::io::Write for ByteCounter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.count += buf.len();
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+pub(crate) fn count_bytes(img: &DynamicImage) -> anyhow::Result<usize> {
+    let mut writer = ByteCounter::new();
+    img.write_to(&mut writer, image::ImageFormat::Jpeg)?;
+    Ok(writer.count)
 }
 
 #[cfg(test)]

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -14,7 +14,6 @@ use async_std::{fs, io};
 
 use anyhow::{bail, Error};
 use chrono::{Local, TimeZone};
-use image::DynamicImage;
 use rand::{thread_rng, Rng};
 
 use crate::chat::{add_device_msg, add_device_msg_with_importance};
@@ -681,33 +680,6 @@ pub fn remove_subject_prefix(last_subject: &str) -> String {
         .collect::<String>()
         .trim()
         .to_string()
-}
-
-struct ByteCounter {
-    count: usize,
-}
-
-impl ByteCounter {
-    fn new() -> Self {
-        ByteCounter { count: 0 }
-    }
-}
-
-impl std::io::Write for ByteCounter {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.count += buf.len();
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-pub(crate) fn count_bytes(img: &DynamicImage) -> anyhow::Result<usize> {
-    let mut writer = ByteCounter::new();
-    img.write_to(&mut writer, image::ImageFormat::Jpeg)?;
-    Ok(writer.count)
 }
 
 #[cfg(test)]

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -11,6 +11,7 @@ use anyhow::Context as _;
 use async_std::prelude::*;
 use rusqlite::OpenFlags;
 
+use crate::blob::BlobObject;
 use crate::chat::{add_device_msg, update_device_icon, update_saved_messages_icon};
 use crate::config::Config;
 use crate::constants::{Viewtype, DC_CHAT_ID_TRASH};
@@ -138,7 +139,7 @@ impl Sql {
             // this should be done before updates that use high-level objects that
             // rely themselves on the low-level structure.
 
-            let (recalc_fingerprints, update_icons, disable_server_delete) =
+            let (recalc_fingerprints, update_icons, disable_server_delete, recode_avatar) =
                 migrations::run(context, self).await?;
 
             // (2) updates that require high-level objects
@@ -181,6 +182,16 @@ impl Sql {
                     context
                         .set_config(Config::DeleteServerAfter, Some("0"))
                         .await?;
+                }
+            }
+
+            if recode_avatar {
+                if let Some(avatar) = context.get_config(Config::Selfavatar).await? {
+                    let blob = BlobObject::new_from_path(context, avatar).await?;
+                    if let Err(e) = blob.recode_to_avatar_size(context).await {
+                        warn!(context, "Migrations can't recode avatar, removing. {:#}", e);
+                        context.set_config(Config::Selfavatar, None).await?
+                    }
                 }
             }
         }

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -10,7 +10,7 @@ const DBVERSION: i32 = 68;
 const VERSION_CFG: &str = "dbversion";
 const TABLES: &str = include_str!("./tables.sql");
 
-pub async fn run(context: &Context, sql: &Sql) -> Result<(bool, bool, bool)> {
+pub async fn run(context: &Context, sql: &Sql) -> Result<(bool, bool, bool, bool)> {
     let mut recalc_fingerprints = false;
     let mut exists_before_update = false;
     let mut dbversion_before_update = DBVERSION;
@@ -39,6 +39,7 @@ pub async fn run(context: &Context, sql: &Sql) -> Result<(bool, bool, bool)> {
     let dbversion = dbversion_before_update;
     let mut update_icons = !exists_before_update;
     let mut disable_server_delete = false;
+    let mut recode_avatar = false;
 
     if dbversion < 1 {
         info!(context, "[migration] v1");
@@ -460,8 +461,17 @@ paramsv![]
         sql.execute_migration("ALTER TABLE msgs ADD COLUMN subject TEXT DEFAULT '';", 76)
             .await?;
     }
+    if dbversion < 77 {
+        info!(context, "[migration] v77");
+        recode_avatar = true;
+    }
 
-    Ok((recalc_fingerprints, update_icons, disable_server_delete))
+    Ok((
+        recalc_fingerprints,
+        update_icons,
+        disable_server_delete,
+        recode_avatar,
+    ))
 }
 
 impl Sql {


### PR DESCRIPTION
- Currently, group images are compressed as well because it was easier to implement that way.
- Currently, in the unlikely case that the avatar is compressed down to 20x20 pixels but still bigger than 20KB, the user doesn't get any indication of this, the avatar simply isn't changed (at least on Android).

  If we want to change this, the easiest way is probably to let `dc_set_config()` in the ffi call `error!()` if `Selfavatar` can't be set. The same might make sense for some or all other configs. BUUUUUT: At least Android doesn't show error!() toasts anymore, probably because they were used too often and too spammy.
- The factor by which we scale down if the file is too big is 1.5.

I hope everything is clear :joy: there were surprisingly many small problems.