### PR TITLE
contact: synchronize status between devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - fix creation of many delete jobs when being offline #2372
 
+- synchronize status between devices #2386
+
 - deaddrop (contact requests) chat improvements #2373
 
 - improve tests #2360 #2362 #2370 #2377

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -243,6 +243,8 @@ pub(crate) async fn dc_receive_imf_inner(
             context,
             from_id,
             mime_parser.footer.clone().unwrap_or_default(),
+            mime_parser.was_encrypted(),
+            mime_parser.has_chat_version(),
         )
         .await
         {


### PR DESCRIPTION
This feature is similar to existing avatar synchronization.

Whenever encrypted BCC-to-self copy of chat message is received, status
setting is updated with the signature of the message.

Closes #2219 