### PR TITLE
github: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "cargo"


### PR DESCRIPTION
Configuration file is documented at https://docs.github.com/en/code-security/supply-chain-security/enabling-and-disabling-version-updates