### PR TITLE
python: list `requests` as a requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 - python: fix building of bindings against system-wide install of `libdeltachat` #2383
 
+- python: list `requests` as a requirement #2390
+
 - fix creation of many delete jobs when being offline #2372
 
 - deaddrop (contact requests) chat improvements #2373

--- a/python/setup.py
+++ b/python/setup.py
@@ -18,7 +18,7 @@ def main():
         description='Python bindings for the Delta Chat Core library using CFFI against the Rust-implemented libdeltachat',
         long_description=long_description,
         author='holger krekel, Floris Bruynooghe, Bjoern Petersen and contributors',
-        install_requires=['cffi>=1.0.0', 'pluggy', 'imapclient'],
+        install_requires=['cffi>=1.0.0', 'pluggy', 'imapclient', 'requests'],
         packages=setuptools.find_packages('src'),
         package_dir={'': 'src'},
         cffi_modules=['src/deltachat/_build.py:ffibuilder'],


### PR DESCRIPTION
It is used in `testplugin.py`.

Fixes #2330 