### PR TITLE
ci: remove CIRCLE_* environment variables from scripts

### DIFF
--- a/.github/workflows/remote_tests.yml
+++ b/.github/workflows/remote_tests.yml
@@ -5,9 +5,6 @@ jobs:
     name: Remote Python tests
     runs-on: ubuntu-latest
     env:
-      CIRCLE_BRANCH: ${{ github.ref }}
-      CIRCLE_JOB: remote_tests_python
-      CIRCLE_BUILD_NUM: ${{ github.run_number }}
       DCC_NEW_TMP_EMAIL: ${{ secrets.DCC_NEW_TMP_EMAIL }}
     steps:
       - uses: actions/checkout@v2
@@ -18,4 +15,4 @@ jobs:
         shell: bash
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
-      - run: scripts/remote_tests_python.sh
+      - run: scripts/remote_tests_python.sh "deltachat-core/python/${{ github.ref }}/${{ github.run_number }}"

--- a/scripts/manual_remote_tests.sh
+++ b/scripts/manual_remote_tests.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
-
 set -xe
-export CIRCLE_JOB=remote_tests_${1:?need to specify 'rust' or 'python'} 
-export CIRCLE_BUILD_NUM=$USER
-export CIRCLE_BRANCH=`git branch | grep \* | cut -d ' ' -f2`
-export CIRCLE_PROJECT_REPONAME=$(basename `git rev-parse --show-toplevel`)
 
-time bash scripts/$CIRCLE_JOB.sh 
+JOB=${1:?need to specify 'rust' or 'python'}
+BRANCH="$(git branch | grep \* | cut -d ' ' -f2)"
+REPONAME="$(basename $(git rev-parse --show-toplevel))"
+
+time bash "scripts/remote_tests_$JOB.sh" "$USER-$BRANCH-$REPONAME"

--- a/scripts/remote_tests_python.sh
+++ b/scripts/remote_tests_python.sh
@@ -1,10 +1,9 @@
 #!/bin/bash 
 
-export BRANCH=${CIRCLE_BRANCH:-master}
-export REPONAME=${CIRCLE_PROJECT_REPONAME:-deltachat-core-rust}
-export SSHTARGET=${SSHTARGET-ci@b1.delta.chat}
+BUILD_ID=${1:?specify build ID}
 
-export BUILDDIR=ci_builds/$REPONAME/$BRANCH/${CIRCLE_JOB:?jobname}/${CIRCLE_BUILD_NUM:?circle-build-number}
+SSHTARGET=${SSHTARGET-ci@b1.delta.chat}
+BUILDDIR=ci_builds/$BUILD_ID
 
 echo "--- Copying files to $SSHTARGET:$BUILDDIR"
 
@@ -18,7 +17,7 @@ rsync --delete --files-from=.rsynclist -az ./ "$SSHTARGET:$BUILDDIR"
 
 set +x
 
-echo "--- Running $CIRCLE_JOB remotely"
+echo "--- Running Python tests remotely"
 
 ssh $SSHTARGET <<_HERE
     set +x -e

--- a/scripts/remote_tests_rust.sh
+++ b/scripts/remote_tests_rust.sh
@@ -1,20 +1,19 @@
 #!/bin/bash 
 
-export BRANCH=${CIRCLE_BRANCH:-master}
-export REPONAME=${CIRCLE_PROJECT_REPONAME:-deltachat-core-rust}
-export SSHTARGET=${SSHTARGET-ci@b1.delta.chat}
+BUILD_ID=${1:?specify build ID}
 
-export BUILDDIR=ci_builds/$REPONAME/$BRANCH/${CIRCLE_JOB:?jobname}/${CIRCLE_BUILD_NUM:?circle-build-number}
+SSHTARGET=${SSHTARGET-ci@b1.delta.chat}
+BUILDDIR=ci_builds/$BUILD_ID
 
 set -e
 
 echo "--- Copying files to $SSHTARGET:$BUILDDIR"
 
-ssh -oBatchMode=yes -oStrictHostKeyChecking=no  $SSHTARGET mkdir -p "$BUILDDIR"
-git ls-files >.rsynclist 
+ssh -oBatchMode=yes -oStrictHostKeyChecking=no $SSHTARGET mkdir -p "$BUILDDIR"
+git ls-files >.rsynclist
 rsync --delete --files-from=.rsynclist -az ./ "$SSHTARGET:$BUILDDIR"
 
-echo "--- Running $CIRCLE_JOB remotely"
+echo "--- Running Rust tests remotely"
 
 ssh $SSHTARGET <<_HERE
     set +x -e


### PR DESCRIPTION
Instead, allow specifying free-form BUILD_ID from the command line.

scripts/remote_python_packaging.sh still uses CIRCLE_ variables to avoid
changing working CircleCI config.