### PR TITLE
Cargo.toml: move "rusqlite/bundled" to "vendored" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,9 +115,8 @@ name = "search_msgs"
 harness = false
 
 [features]
-default = ["bundled-sqlite"]
+default = []
 internals = []
 repl = ["internals", "rustyline", "log", "pretty_env_logger", "ansi_term", "dirs"]
-vendored = ["async-native-tls/vendored", "async-smtp/native-tls-vendored"]
+vendored = ["async-native-tls/vendored", "async-smtp/native-tls-vendored", "rusqlite/bundled"]
 nightly = ["pgp/nightly"]
-bundled-sqlite = ["rusqlite/bundled"]


### PR DESCRIPTION
It is enabled from deltachat-ffi/Cargo.toml by default.

Fix for abac35c872adb55ff9b1ef8ffe134ffe61d5e445