### PR TITLE
Increase minimal origin for contact list

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1678,7 +1678,7 @@ pub unsafe extern "C" fn dc_get_contacts(
     let query = to_opt_string_lossy(query);
 
     block_on(async move {
-        match Contact::get_all(&ctx, flags, query).await {
+        match Contact::get_all(&ctx, flags, query.as_deref()).await {
             Ok(contacts) => Box::into_raw(Box::new(dc_array_t::from(contacts))),
             Err(_) => ptr::null_mut(),
         }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -104,7 +104,7 @@ pub enum Origin {
     UnhandledQrScan = 0x80,
 
     /// Reply-To: of incoming message of known sender
-    /// Contacts with at least this origin value are shown in the contact list.
+    /// Contacts with at least this origin value are shown in search results.
     IncomingReplyTo = 0x100,
 
     /// Cc: of incoming message of known sender
@@ -114,6 +114,7 @@ pub enum Origin {
     IncomingTo = 0x400,
 
     /// a chat was manually created for this user, but no message yet sent
+    /// Contacts with at least this origin value are shown in the contact list.
     CreateChat = 0x800,
 
     /// message sent by us
@@ -620,7 +621,7 @@ impl Contact {
     pub async fn get_all(
         context: &Context,
         listflags: u32,
-        query: Option<impl AsRef<str>>,
+        query: Option<&str>,
     ) -> Result<Vec<u32>> {
         let self_addr = context
             .get_config(Config::ConfiguredAddr)
@@ -633,13 +634,7 @@ impl Contact {
         let flag_add_self = (listflags & DC_GCL_ADD_SELF) != 0;
 
         if flag_verified_only || query.is_some() {
-            let s3str_like_cmd = format!(
-                "%{}%",
-                query
-                    .as_ref()
-                    .map(|s| s.as_ref().to_string())
-                    .unwrap_or_default()
-            );
+            let s3str_like_cmd = format!("%{}%", query.unwrap_or_default());
             context
                 .sql
                 .query_map(
@@ -677,9 +672,9 @@ impl Contact {
             let self_name2 = stock_str::self_msg(context);
 
             if let Some(query) = query {
-                if self_addr.contains(query.as_ref())
-                    || self_name.contains(query.as_ref())
-                    || self_name2.await.contains(query.as_ref())
+                if self_addr.contains(query)
+                    || self_name.contains(query)
+                    || self_name2.await.contains(query)
                 {
                     add_self = true;
                 }
@@ -701,7 +696,7 @@ impl Contact {
                     paramsv![
                         self_addr,
                         DC_CONTACT_ID_LAST_SPECIAL as i32,
-                        Origin::IncomingReplyTo
+                        Origin::CreateChat,
                     ],
                     |row| row.get::<_, i32>(0),
                     |ids| {
@@ -1493,6 +1488,11 @@ mod tests {
         assert_eq!(contacts.len(), 1);
         assert_eq!(contacts.get(0), Some(&id));
 
+        // `Origin::IncomingReplyTo` is insufficient to show Bob in the contact list without
+        // searching.
+        let contacts = Contact::get_all(&context.ctx, 0, None).await?;
+        assert!(contacts.is_empty());
+
         // Search by address.
         let contacts = Contact::get_all(&context.ctx, 0, Some("user")).await?;
         assert_eq!(contacts.len(), 1);
@@ -1515,6 +1515,11 @@ mod tests {
         assert_eq!(contact.get_name(), "someone");
         assert_eq!(contact.get_authname(), "bob");
         assert_eq!(contact.get_display_name(), "someone");
+
+        // Manually created contacts show up in unfiltered contact list.
+        let contacts = Contact::get_all(&context.ctx, 0, None).await?;
+        assert_eq!(contacts.len(), 1);
+        assert_eq!(contacts.get(0), Some(&id));
 
         // Not searchable by authname, because it is not displayed.
         let contacts = Contact::get_all(&context.ctx, 0, Some("bob")).await?;

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2897,9 +2897,7 @@ mod tests {
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
-        let contacts = Contact::get_all(&t.ctx, 0, None as Option<String>)
-            .await
-            .unwrap();
+        let contacts = Contact::get_all(&t.ctx, 0, None).await.unwrap();
         assert_eq!(contacts.len(), 0); // mailing list recipients and senders do not count as "known contacts"
 
         let msg1 = get_chat_msg(&t, chat_id, 0, 2).await;


### PR DESCRIPTION
Currently contact list contains contacts from all groups, which makes
it cluttered with every contact, including bots, that has ever been in
the same group as you.

For search, minimal origin remains the same as before, so it is possible
to find anyone you want by searching, for example if you want to create
a new group but don't want to start 1:1 chat with every member first.