### PR TITLE
scripts/set_core_version.py: suggest using annotated tags

### DIFF
--- a/scripts/set_core_version.py
+++ b/scripts/set_core_version.py
@@ -84,7 +84,7 @@ def main():
 
     print("after commit, on master make sure to: ")
     print("")
-    print("   git tag {}".format(newversion))
+    print("   git tag -a {}".format(newversion))
     print("   git push origin {}".format(newversion))
     print("")
 


### PR DESCRIPTION
According to `git help tag`, annotated tags are meant for releases.

If tags are not annotated, `git describe` ignores them.