### PR TITLE
Debloat the binary by using less `AsRef` arguments

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -271,7 +271,7 @@ pub unsafe extern "C" fn dc_get_oauth2_url(
     let redirect = to_string_lossy(redirect);
 
     block_on(async move {
-        match oauth2::dc_get_oauth2_url(&ctx, addr, redirect).await {
+        match oauth2::dc_get_oauth2_url(&ctx, &addr, &redirect).await {
             Some(res) => res.strdup(),
             None => ptr::null_mut(),
         }
@@ -1188,7 +1188,7 @@ pub unsafe extern "C" fn dc_search_msgs(
 
     block_on(async move {
         let arr = dc_array_t::from(
-            ctx.search_msgs(chat_id, to_string_lossy(query))
+            ctx.search_msgs(chat_id, &to_string_lossy(query))
                 .await
                 .unwrap_or_log_default(ctx, "Failed search_msgs")
                 .iter()
@@ -1237,7 +1237,7 @@ pub unsafe extern "C" fn dc_create_group_chat(
     };
 
     block_on(async move {
-        chat::create_group_chat(&ctx, protect, to_string_lossy(name))
+        chat::create_group_chat(&ctx, protect, &to_string_lossy(name))
             .await
             .log_err(ctx, "Failed to create group chat")
             .map(|id| id.to_u32())
@@ -1312,7 +1312,7 @@ pub unsafe extern "C" fn dc_set_chat_name(
     let ctx = &*context;
 
     block_on(async move {
-        chat::set_chat_name(&ctx, ChatId::new(chat_id), to_string_lossy(name))
+        chat::set_chat_name(&ctx, ChatId::new(chat_id), &to_string_lossy(name))
             .await
             .map(|_| 1)
             .unwrap_or_log_default(&ctx, "Failed to set chat name")
@@ -1642,7 +1642,7 @@ pub unsafe extern "C" fn dc_create_contact(
     let name = to_string_lossy(name);
 
     block_on(async move {
-        Contact::create(&ctx, name, to_string_lossy(addr))
+        Contact::create(&ctx, &name, &to_string_lossy(addr))
             .await
             .unwrap_or(0)
     })
@@ -1660,7 +1660,7 @@ pub unsafe extern "C" fn dc_add_address_book(
     let ctx = &*context;
 
     block_on(async move {
-        match Contact::add_address_book(&ctx, to_string_lossy(addr_book)).await {
+        match Contact::add_address_book(&ctx, &to_string_lossy(addr_book)).await {
             Ok(cnt) => cnt as libc::c_int,
             Err(_) => 0,
         }
@@ -1827,7 +1827,7 @@ pub unsafe extern "C" fn dc_imex(
 
     if let Some(param1) = to_opt_string_lossy(param1) {
         spawn(async move {
-            imex::imex(&ctx, what, &param1)
+            imex::imex(&ctx, what, param1.as_ref())
                 .await
                 .log_err(ctx, "IMEX failed")
         });
@@ -1848,7 +1848,7 @@ pub unsafe extern "C" fn dc_imex_has_backup(
     let ctx = &*context;
 
     block_on(async move {
-        match imex::has_backup(&ctx, to_string_lossy(dir)).await {
+        match imex::has_backup(&ctx, to_string_lossy(dir).as_ref()).await {
             Ok(res) => res.strdup(),
             Err(err) => {
                 // do not bubble up error to the user,
@@ -1929,7 +1929,7 @@ pub unsafe extern "C" fn dc_check_qr(
     let ctx = &*context;
 
     block_on(async move {
-        let lot = qr::check_qr(&ctx, to_string_lossy(qr)).await;
+        let lot = qr::check_qr(&ctx, &to_string_lossy(qr)).await;
         Box::into_raw(Box::new(lot))
     })
 }

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -457,20 +457,20 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
         }
         "export-backup" => {
             let dir = dirs::home_dir().unwrap_or_default();
-            imex(&context, ImexMode::ExportBackup, &dir).await?;
+            imex(&context, ImexMode::ExportBackup, dir.as_ref()).await?;
             println!("Exported to {}.", dir.to_string_lossy());
         }
         "import-backup" => {
             ensure!(!arg1.is_empty(), "Argument <backup-file> missing.");
-            imex(&context, ImexMode::ImportBackup, arg1).await?;
+            imex(&context, ImexMode::ImportBackup, arg1.as_ref()).await?;
         }
         "export-keys" => {
             let dir = dirs::home_dir().unwrap_or_default();
-            imex(&context, ImexMode::ExportSelfKeys, &dir).await?;
+            imex(&context, ImexMode::ExportSelfKeys, dir.as_ref()).await?;
             println!("Exported to {}.", dir.to_string_lossy());
         }
         "import-keys" => {
-            imex(&context, ImexMode::ImportSelfKeys, arg1).await?;
+            imex(&context, ImexMode::ImportSelfKeys, arg1.as_ref()).await?;
         }
         "export-setup" => {
             let setup_code = create_setup_code(&context);
@@ -1086,7 +1086,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
 
             if !arg2.is_empty() {
                 let book = format!("{}\n{}", arg1, arg2);
-                Contact::add_address_book(&context, book).await?;
+                Contact::add_address_book(&context, &book).await?;
             } else {
                 Contact::create(&context, "", arg1).await?;
             }

--- a/src/color.rs
+++ b/src/color.rs
@@ -8,8 +8,8 @@ use hsluv::hsluv_to_rgb;
 use sha1::{Digest, Sha1};
 
 /// Converts an identifier to Hue angle.
-fn str_to_angle(s: impl AsRef<str>) -> f64 {
-    let bytes = s.as_ref().as_bytes();
+fn str_to_angle(s: &str) -> f64 {
+    let bytes = s.as_bytes();
     let result = Sha1::digest(bytes);
     let checksum: u16 = result.get(0).map_or(0, |&x| u16::from(x))
         + 256 * result.get(1).map_or(0, |&x| u16::from(x));
@@ -31,7 +31,7 @@ fn rgb_to_u32((r, g, b): (f64, f64, f64)) -> u32 {
 ///
 /// Saturation is set to maximum (100.0) to make colors distinguishable, and lightness is set to
 /// half (50.0) to make colors suitable both for light and dark theme.
-pub(crate) fn str_to_color(s: impl AsRef<str>) -> u32 {
+pub(crate) fn str_to_color(s: &str) -> u32 {
     rgb_to_u32(hsluv_to_rgb((str_to_angle(s), 100.0, 50.0)))
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -249,7 +249,7 @@ impl Context {
                     .await?;
                 match value {
                     Some(value) => {
-                        let mut blob = BlobObject::new_from_path(self, value).await?;
+                        let mut blob = BlobObject::new_from_path(self, value.as_ref()).await?;
                         blob.recode_to_avatar_size(self).await?;
                         self.sql.set_raw_config(key, Some(blob.as_name())).await?;
                         Ok(())

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -449,7 +449,7 @@ async fn get_autoconfig(
 ) -> Option<Vec<ServerParams>> {
     if let Ok(res) = moz_autoconfigure(
         ctx,
-        format!(
+        &format!(
             "https://autoconfig.{}/mail/config-v1.1.xml?emailaddress={}",
             param_domain, param_addr_urlencoded
         ),
@@ -464,7 +464,7 @@ async fn get_autoconfig(
     if let Ok(res) = moz_autoconfigure(
         ctx,
         // the doc does not mention `emailaddress=`, however, Thunderbird adds it, see https://releases.mozilla.org/pub/thunderbird/ ,  which makes some sense
-        format!(
+        &format!(
             "https://{}/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress={}",
             &param_domain, &param_addr_urlencoded
         ),
@@ -503,7 +503,7 @@ async fn get_autoconfig(
     // always SSL for Thunderbird's database
     if let Ok(res) = moz_autoconfigure(
         ctx,
-        format!("https://autoconfig.thunderbird.net/v1.1/{}", &param_domain),
+        &format!("https://autoconfig.thunderbird.net/v1.1/{}", &param_domain),
         param,
     )
     .await

--- a/src/configure/auto_mozilla.rs
+++ b/src/configure/auto_mozilla.rs
@@ -251,10 +251,10 @@ fn parse_serverparams(in_emailaddr: &str, xml_raw: &str) -> Result<Vec<ServerPar
 
 pub(crate) async fn moz_autoconfigure(
     context: &Context,
-    url: impl AsRef<str>,
+    url: &str,
     param_in: &LoginParam,
 ) -> Result<Vec<ServerParams>, Error> {
-    let xml_raw = read_url(context, url.as_ref()).await?;
+    let xml_raw = read_url(context, url).await?;
 
     let res = parse_serverparams(&param_in.addr, &xml_raw);
     if let Err(err) = &res {

--- a/src/context.rs
+++ b/src/context.rs
@@ -463,12 +463,8 @@ impl Context {
     ///
     /// If `chat_id` is provided this searches only for messages in this chat, if `chat_id`
     /// is `None` this searches messages from all chats.
-    pub async fn search_msgs(
-        &self,
-        chat_id: Option<ChatId>,
-        query: impl AsRef<str>,
-    ) -> Result<Vec<MsgId>> {
-        let real_query = query.as_ref().trim();
+    pub async fn search_msgs(&self, chat_id: Option<ChatId>, query: &str) -> Result<Vec<MsgId>> {
+        let real_query = query.trim();
         if real_query.is_empty() {
             return Ok(Vec::new());
         }
@@ -535,28 +531,27 @@ impl Context {
         Ok(list)
     }
 
-    pub async fn is_inbox(&self, folder_name: impl AsRef<str>) -> Result<bool> {
+    pub async fn is_inbox(&self, folder_name: &str) -> Result<bool> {
         let inbox = self.get_config(Config::ConfiguredInboxFolder).await?;
-        Ok(inbox == Some(folder_name.as_ref().to_string()))
+        Ok(inbox.as_deref() == Some(folder_name))
     }
 
-    pub async fn is_sentbox(&self, folder_name: impl AsRef<str>) -> Result<bool> {
+    pub async fn is_sentbox(&self, folder_name: &str) -> Result<bool> {
         let sentbox = self.get_config(Config::ConfiguredSentboxFolder).await?;
 
-        Ok(sentbox == Some(folder_name.as_ref().to_string()))
+        Ok(sentbox.as_deref() == Some(folder_name))
     }
 
-    pub async fn is_mvbox(&self, folder_name: impl AsRef<str>) -> Result<bool> {
+    pub async fn is_mvbox(&self, folder_name: &str) -> Result<bool> {
         let mvbox = self.get_config(Config::ConfiguredMvboxFolder).await?;
 
-        Ok(mvbox == Some(folder_name.as_ref().to_string()))
+        Ok(mvbox.as_deref() == Some(folder_name))
     }
 
-    pub async fn is_spam_folder(&self, folder_name: impl AsRef<str>) -> Result<bool> {
-        let is_spam = self.get_config(Config::ConfiguredSpamFolder).await?
-            == Some(folder_name.as_ref().to_string());
+    pub async fn is_spam_folder(&self, folder_name: &str) -> Result<bool> {
+        let spam = self.get_config(Config::ConfiguredSpamFolder).await?;
 
-        Ok(is_spam)
+        Ok(spam.as_deref() == Some(folder_name))
     }
 
     pub fn derive_blobdir(dbfile: &PathBuf) -> PathBuf {

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -641,9 +641,8 @@ impl rusqlite::types::ToSql for EmailAddress {
 }
 
 /// Makes sure that a user input that is not supposed to contain newlines does not contain newlines.
-pub(crate) fn improve_single_line_input(input: impl AsRef<str>) -> String {
+pub(crate) fn improve_single_line_input(input: &str) -> String {
     input
-        .as_ref()
         .replace("\n", " ")
         .replace("\r", " ")
         .trim()

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -710,7 +710,7 @@ impl Imap {
         }
 
         let (largest_uid_processed, error_cnt) = self
-            .fetch_many_msgs(context, &folder, uids, fetch_existing_msgs)
+            .fetch_many_msgs(context, folder, uids, fetch_existing_msgs)
             .await;
         read_errors += error_cnt;
 
@@ -858,10 +858,10 @@ impl Imap {
     /// Fetches a list of messages by server UID.
     ///
     /// Returns the last uid fetch successfully and an error count.
-    async fn fetch_many_msgs<S: AsRef<str>>(
+    async fn fetch_many_msgs(
         &mut self,
         context: &Context,
-        folder: S,
+        folder: &str,
         server_uids: Vec<u32>,
         fetching_existing_messages: bool,
     ) -> (Option<u32>, usize) {
@@ -899,14 +899,14 @@ impl Imap {
                         context,
                         "Error on fetching messages #{} from folder \"{}\"; error={}.",
                         &set,
-                        folder.as_ref(),
+                        folder,
                         err
                     );
                     return (None, server_uids.len());
                 }
             };
 
-            let folder = folder.as_ref().to_string();
+            let folder = folder.to_string();
 
             while let Some(Ok(msg)) = msgs.next().await {
                 let server_uid = msg.uid.unwrap_or_default();
@@ -1129,7 +1129,7 @@ impl Imap {
                 return Some(ImapActionResult::RetryLater);
             }
         }
-        match self.select_folder(context, Some(&folder)).await {
+        match self.select_folder(context, Some(folder)).await {
             Ok(_) => None,
             Err(select_folder::Error::ConnectionLost) => {
                 warn!(context, "Lost imap connection");

--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -27,7 +27,7 @@ impl Imap {
         }
         self.setup_handle(context).await?;
 
-        self.select_folder(context, watch_folder.clone()).await?;
+        self.select_folder(context, watch_folder.as_deref()).await?;
 
         let timeout = Duration::from_secs(23 * 60);
         let mut info = Default::default();

--- a/src/job.rs
+++ b/src/job.rs
@@ -904,8 +904,8 @@ async fn add_all_recipients_as_contacts(context: &Context, imap: &mut Imap, fold
 
                 match Contact::add_or_lookup(
                     context,
-                    display_name_normalized,
-                    contact.addr,
+                    &display_name_normalized,
+                    &contact.addr,
                     Origin::OutgoingTo,
                 )
                 .await

--- a/src/message.rs
+++ b/src/message.rs
@@ -2034,7 +2034,7 @@ pub(crate) async fn rfc724_mid_exists(
 pub async fn update_server_uid(
     context: &Context,
     rfc724_mid: &str,
-    server_folder: impl AsRef<str>,
+    server_folder: &str,
     server_uid: u32,
 ) {
     match context
@@ -2042,7 +2042,7 @@ pub async fn update_server_uid(
         .execute(
             "UPDATE msgs SET server_folder=?, server_uid=? \
              WHERE rfc724_mid=?",
-            paramsv![server_folder.as_ref(), server_uid, rfc724_mid],
+            paramsv![server_folder, server_uid, rfc724_mid],
         )
         .await
     {

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1278,7 +1278,7 @@ async fn build_body_file(
 }
 
 fn build_selfavatar_file(context: &Context, path: &str) -> Result<String> {
-    let blob = BlobObject::from_path(context, path)?;
+    let blob = BlobObject::from_path(context, path.as_ref())?;
     let body = std::fs::read(blob.to_abs_path())?;
     let encoded_body = wrapped_base64_encode(&body);
     Ok(encoded_body)
@@ -1328,8 +1328,8 @@ fn encode_words(word: &str) -> String {
     encoded_words::encode(word, None, encoded_words::EncodingFlag::Shortest, None)
 }
 
-fn needs_encoding(to_check: impl AsRef<str>) -> bool {
-    !to_check.as_ref().chars().all(|c| {
+fn needs_encoding(to_check: &str) -> bool {
+    !to_check.chars().all(|c| {
         c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '~' || c == '%'
     })
 }

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -524,7 +524,7 @@ impl MimeMessage {
                 } else {
                     String::new()
                 };
-                match BlobObject::create(context, format!("avatar{}", extension), &decoded_data)
+                match BlobObject::create(context, &format!("avatar{}", extension), &decoded_data)
                     .await
                 {
                     Ok(blob) => Some(AvatarAction::Change(blob.as_name().to_string())),

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -53,20 +53,20 @@ struct Response {
 
 pub async fn dc_get_oauth2_url(
     context: &Context,
-    addr: impl AsRef<str>,
-    redirect_uri: impl AsRef<str>,
+    addr: &str,
+    redirect_uri: &str,
 ) -> Option<String> {
     if let Some(oauth2) = Oauth2::from_address(addr).await {
         if context
             .sql
-            .set_raw_config("oauth2_pending_redirect_uri", Some(redirect_uri.as_ref()))
+            .set_raw_config("oauth2_pending_redirect_uri", Some(redirect_uri))
             .await
             .is_err()
         {
             return None;
         }
-        let oauth2_url = replace_in_uri(&oauth2.get_code, "$CLIENT_ID", &oauth2.client_id);
-        let oauth2_url = replace_in_uri(&oauth2_url, "$REDIRECT_URI", redirect_uri.as_ref());
+        let oauth2_url = replace_in_uri(oauth2.get_code, "$CLIENT_ID", oauth2.client_id);
+        let oauth2_url = replace_in_uri(&oauth2_url, "$REDIRECT_URI", redirect_uri);
 
         Some(oauth2_url)
     } else {
@@ -76,8 +76,8 @@ pub async fn dc_get_oauth2_url(
 
 pub async fn dc_get_oauth2_access_token(
     context: &Context,
-    addr: impl AsRef<str>,
-    code: impl AsRef<str>,
+    addr: &str,
+    code: &str,
     regenerate: bool,
 ) -> Result<Option<String>> {
     if let Some(oauth2) = Oauth2::from_address(addr).await {
@@ -101,7 +101,7 @@ pub async fn dc_get_oauth2_access_token(
             .unwrap_or_else(|| "unset".into());
 
         let (redirect_uri, token_url, update_redirect_uri_on_success) =
-            if refresh_token.is_none() || refresh_token_for != code.as_ref() {
+            if refresh_token.is_none() || refresh_token_for != code {
                 info!(context, "Generate OAuth2 refresh_token and access_token...",);
                 (
                     context
@@ -145,7 +145,7 @@ pub async fn dc_get_oauth2_access_token(
             } else if value == "$REDIRECT_URI" {
                 value = &redirect_uri;
             } else if value == "$CODE" {
-                value = code.as_ref();
+                value = code;
             } else if value == "$REFRESH_TOKEN" && refresh_token.is_some() {
                 value = refresh_token.as_ref().unwrap();
             }
@@ -179,7 +179,7 @@ pub async fn dc_get_oauth2_access_token(
                 .await?;
             context
                 .sql
-                .set_raw_config("oauth2_refresh_token_for", Some(code.as_ref()))
+                .set_raw_config("oauth2_refresh_token_for", Some(code))
                 .await?;
         }
 
@@ -222,10 +222,10 @@ pub async fn dc_get_oauth2_access_token(
 
 pub async fn dc_get_oauth2_addr(
     context: &Context,
-    addr: impl AsRef<str>,
-    code: impl AsRef<str>,
+    addr: &str,
+    code: &str,
 ) -> Result<Option<String>> {
-    let oauth2 = match Oauth2::from_address(addr.as_ref()).await {
+    let oauth2 = match Oauth2::from_address(addr).await {
         Some(o) => o,
         None => return Ok(None),
     };
@@ -233,16 +233,14 @@ pub async fn dc_get_oauth2_addr(
         return Ok(None);
     }
 
-    if let Some(access_token) =
-        dc_get_oauth2_access_token(context, addr.as_ref(), code.as_ref(), false).await?
-    {
-        let addr_out = oauth2.get_addr(context, access_token).await;
+    if let Some(access_token) = dc_get_oauth2_access_token(context, addr, code, false).await? {
+        let addr_out = oauth2.get_addr(context, &access_token).await;
         if addr_out.is_none() {
             // regenerate
             if let Some(access_token) =
                 dc_get_oauth2_access_token(context, addr, code, true).await?
             {
-                Ok(oauth2.get_addr(context, access_token).await)
+                Ok(oauth2.get_addr(context, &access_token).await)
             } else {
                 Ok(None)
             }
@@ -255,8 +253,8 @@ pub async fn dc_get_oauth2_addr(
 }
 
 impl Oauth2 {
-    async fn from_address(addr: impl AsRef<str>) -> Option<Self> {
-        let addr_normalized = normalize_addr(addr.as_ref());
+    async fn from_address(addr: &str) -> Option<Self> {
+        let addr_normalized = normalize_addr(addr);
         if let Some(domain) = addr_normalized
             .find('@')
             .map(|index| addr_normalized.split_at(index + 1).1)
@@ -274,9 +272,9 @@ impl Oauth2 {
         None
     }
 
-    async fn get_addr(&self, context: &Context, access_token: impl AsRef<str>) -> Option<String> {
+    async fn get_addr(&self, context: &Context, access_token: &str) -> Option<String> {
         let userinfo_url = self.get_userinfo.unwrap_or("");
-        let userinfo_url = replace_in_uri(&userinfo_url, "$ACCESS_TOKEN", access_token);
+        let userinfo_url = replace_in_uri(userinfo_url, "$ACCESS_TOKEN", access_token);
 
         // should returns sth. as
         // {
@@ -326,9 +324,9 @@ async fn is_expired(context: &Context) -> Result<bool> {
     Ok(true)
 }
 
-fn replace_in_uri(uri: impl AsRef<str>, key: impl AsRef<str>, value: impl AsRef<str>) -> String {
-    let value_urlencoded = utf8_percent_encode(value.as_ref(), NON_ALPHANUMERIC).to_string();
-    uri.as_ref().replace(key.as_ref(), &value_urlencoded)
+fn replace_in_uri(uri: &str, key: &str, value: &str) -> String {
+    let value_urlencoded = utf8_percent_encode(value, NON_ALPHANUMERIC).to_string();
+    uri.replace(key, &value_urlencoded)
 }
 
 fn normalize_addr(addr: &str) -> &str {

--- a/src/param.rs
+++ b/src/param.rs
@@ -306,8 +306,8 @@ impl Params {
         let file = ParamsFile::from_param(context, val)?;
         let blob = match file {
             ParamsFile::FsPath(path) => match create {
-                true => BlobObject::new_from_path(context, path).await?,
-                false => BlobObject::from_path(context, path)?,
+                true => BlobObject::new_from_path(context, &path).await?,
+                false => BlobObject::from_path(context, &path)?,
             },
             ParamsFile::Blob(blob) => blob,
         };

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -115,14 +115,14 @@ pub fn get_provider_by_domain(domain: &str) -> Option<&'static Provider> {
 /// Finds a provider based on MX record for the given domain.
 ///
 /// For security reasons, only Gmail can be configured this way.
-pub async fn get_provider_by_mx(domain: impl AsRef<str>) -> Option<&'static Provider> {
+pub async fn get_provider_by_mx(domain: &str) -> Option<&'static Provider> {
     if let Ok(resolver) = resolver(
         config::ResolverConfig::default(),
         config::ResolverOpts::default(),
     )
     .await
     {
-        let mut fqdn: String = String::from(domain.as_ref());
+        let mut fqdn: String = domain.to_string();
         if !fqdn.ends_with('.') {
             fqdn.push('.');
         }

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -296,7 +296,7 @@ async fn securejoin(context: &Context, qr: &str) -> Result<ChatId, JoinError> {
     ========================================================*/
 
     info!(context, "Requesting secure-join ...",);
-    let qr_scan = check_qr(context, &qr).await;
+    let qr_scan = check_qr(context, qr).await;
 
     let invite = QrInvite::try_from(qr_scan)?;
 
@@ -365,9 +365,9 @@ async fn send_handshake_msg(
     context: &Context,
     contact_chat_id: ChatId,
     step: &str,
-    param2: impl AsRef<str>,
+    param2: &str,
     fingerprint: Option<Fingerprint>,
-    grpid: impl AsRef<str>,
+    grpid: &str,
 ) -> Result<(), SendMsgError> {
     let mut msg = Message {
         viewtype: Viewtype::Text,
@@ -381,14 +381,14 @@ async fn send_handshake_msg(
     } else {
         msg.param.set(Param::Arg, step);
     }
-    if !param2.as_ref().is_empty() {
+    if !param2.is_empty() {
         msg.param.set(Param::Arg2, param2);
     }
     if let Some(fp) = fingerprint {
         msg.param.set(Param::Arg3, fp.hex());
     }
-    if !grpid.as_ref().is_empty() {
-        msg.param.set(Param::Arg4, grpid.as_ref());
+    if !grpid.is_empty() {
+        msg.param.set(Param::Arg4, grpid);
     }
     if step == "vg-request" || step == "vc-request" {
         msg.param.set_int(Param::ForcePlaintext, 1);

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -925,7 +925,7 @@ impl Context {
         chat::add_device_msg(self, Some("core-about-device-chat"), Some(&mut msg)).await?;
 
         let image = include_bytes!("../assets/welcome-image.jpg");
-        let blob = BlobObject::create(self, "welcome-image.jpg".to_string(), image).await?;
+        let blob = BlobObject::create(self, "welcome-image.jpg", image).await?;
         let mut msg = Message::new(Viewtype::Image);
         msg.param.set(Param::File, blob.as_name());
         chat::add_device_msg(self, Some("core-welcome-image"), Some(&mut msg)).await?;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -338,13 +338,13 @@ impl TestContext {
     pub async fn create_chat(&self, other: &TestContext) -> Chat {
         let (contact_id, _modified) = Contact::add_or_lookup(
             self,
-            other
+            &other
                 .ctx
                 .get_config(Config::Displayname)
                 .await
                 .unwrap_or_default()
                 .unwrap_or_default(),
-            other
+            &other
                 .ctx
                 .get_config(Config::ConfiguredAddr)
                 .await


### PR DESCRIPTION
Using `impl AsRef<str>` as the argument instead of `&str` makes it
possible to call the function with `&str`, `String` and other types
that implement `AsRef` trait.

The cost of it is that compiled binary contains mulitple versions of
the same function, one for each variant of types. If function contains
multiple generic `impl AsRef` arguments, the number of versions possibly
compiled into binary grows exponentially with the number of arguments.

Simple way to avoid it is to call `.as_ref()` on the caller side to
convert the argument to `&str`. In most cases even adding a `&` and
relying on `Deref` coercion is sufficient.

This patch changes many functions that accepted `impl AsRef<str>` and
`impl AsRef<Path>` to accept `&str` and `&Path` instead.

In some places `.clone()` calls are removed. Calling `.clone()` on
`String` and passing `String` to a function accepting `impl
AsRef<str>` is completely unnecessary as `&str` reference could be
passed instead. There is no clippy warning against it yet, but
changing argument type to `&str` allowed to find these cases.

The result of debloating is not impressive, several hundred kilobytes
are saved, which is about 3% of the `.so` binary, but the code is
cleaner too.