### PR TITLE
events: work around the bug in concurrent-queue

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -18,7 +18,7 @@ pub struct Events {
 
 impl Default for Events {
     fn default() -> Self {
-        let (sender, receiver) = channel::bounded(1_000);
+        let (sender, receiver) = channel::bounded(1_024);
 
         Self { receiver, sender }
     }

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -973,7 +973,7 @@ mod tests {
         let bob = TestContext::new_bob().await;
 
         // Setup JoinerProgress sinks.
-        let (joiner_progress_tx, joiner_progress_rx) = async_std::channel::bounded(100);
+        let (joiner_progress_tx, joiner_progress_rx) = async_std::channel::bounded(128);
         bob.add_event_sink(move |event: Event| {
             let joiner_progress_tx = joiner_progress_tx.clone();
             async move {
@@ -1164,7 +1164,7 @@ mod tests {
         let bob = TestContext::new_bob().await;
 
         // Setup JoinerProgress sinks.
-        let (joiner_progress_tx, joiner_progress_rx) = async_std::channel::bounded(100);
+        let (joiner_progress_tx, joiner_progress_rx) = async_std::channel::bounded(128);
         bob.add_event_sink(move |event: Event| {
             let joiner_progress_tx = joiner_progress_tx.clone();
             async move {
@@ -1312,7 +1312,7 @@ mod tests {
         let bob = TestContext::new_bob().await;
 
         // Setup JoinerProgress sinks.
-        let (joiner_progress_tx, joiner_progress_rx) = async_std::channel::bounded(100);
+        let (joiner_progress_tx, joiner_progress_rx) = async_std::channel::bounded(128);
         bob.add_event_sink(move |event: Event| {
             let joiner_progress_tx = joiner_progress_tx.clone();
             async move {


### PR DESCRIPTION
Use power of 2 channel capacity to avoid occasional out of bounds access panic.

Address #2442