### PR TITLE
Make scan_folders work when inbox is not watched

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -2400,7 +2400,7 @@ class TestOnlineAccount:
         ("xyz", False, "xyz", "1"),  # Test that emails are recognized in a random folder but not moved
         ("xyz", True, "DeltaChat", "1"),  # ...emails are found in a random folder and moved to DeltaChat
         ("Spam", False, "INBOX", "1"),  # ...emails are moved from the spam folder to the Inbox
-        ("INBOX", False, "INBOX", "0"),  # ...emails are found in the `Inbox` folder even if `inbox_move` is "0"
+        ("INBOX", False, "INBOX", "0"),  # ...emails are found in the `Inbox` folder even if `inbox_watch` is "0"
     ])
     # Testrun.org does not support the CREATE-SPECIAL-USE capability, which means that we can't create a folder with
     # the "\Junk" flag (see https://tools.ietf.org/html/rfc6154). So, we can't test spam folder detection by flag.

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -25,7 +25,7 @@ impl Imap {
         }
         info!(context, "Starting full folder scan");
 
-        self.setup_handle(context).await?;
+        self.connect_configured(context).await?;
         let session = self.session.as_mut();
         let session = session.context("scan_folders(): IMAP No Connection established")?;
         let folders: Vec<_> = session.list(Some(""), Some("*")).await?.collect().await;


### PR DESCRIPTION
Issue Reported by @webratte

When watch_inbox was off, scan_folders failed and a toast "IMAP operation attempted while it is torn down" was shown.

--

The problem was:

When inbox_watch is off, scan_folders() is called at https://github.com/deltachat/deltachat-core-rust/blob/244260a9789a34c8cdd50c73b96557a8ced40345/src/scheduler.rs#L107 but connect_configured() is not called before.