### PR TITLE
Fix all outgoing messages popping up in selfchat

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -662,7 +662,11 @@ async fn add_parts(
         // the mail is on the IMAP server, probably it is also delivered.
         // We cannot recreate other states (read, error).
         state = MessageState::OutDelivered;
-        to_id = to_ids.get_index(0).cloned().unwrap_or_default();
+        to_id = *to_ids
+            .iter()
+            .find(|id| **id != DC_CONTACT_ID_SELF)
+            .or_else(|| to_ids.first())
+            .unwrap_or(&0);
 
         // handshake may mark contacts as verified and must be processed before chats are created
         if mime_parser.get(HeaderDef::SecureJoin).is_some() {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3989,25 +3989,22 @@ YEAAAAAA!.
 
     #[async_std::test]
     async fn test_dont_show_all_outgoing_msgs_in_self_chat() {
+        // Regression test for https://github.com/deltachat/deltachat-android/issues/1940:
+        // Some servers add a `Bcc: <Self>` header, which caused all outgoing messages to
+        // be shown in the self-chat.
         let t = TestContext::new_alice().await;
 
         dc_receive_imf(
             &t,
             b"Bcc: alice@example.com
 Received: from [127.0.0.1]
-Content-Type: text/plain; charset=utf-8; format=flowed; delsp=no
 Subject: s
-MIME-Version: 1.0
-Date: Thu, 27 May 2021 06:32:44 +0000
 Chat-Version: 1.0
-Message-ID: <hijk@gmail.com>
+Message-ID: <abcd@gmail.com>
 To: <me@other.maildomain.com>
 From: <alice@example.com>
 
-Message content...
-
--- 
-Skickat fran Delta Chat: https://delta.chat",
+Message content",
             "Inbox",
             1,
             false,

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3994,30 +3994,20 @@ YEAAAAAA!.
         dc_receive_imf(
             &t,
             b"Bcc: alice@example.com
-Return-Path: <alice@example.com>
-Received: from [127.0.0.1] (c80-216-143-104.bredband.tele2.se. [80.216.143.104])
-        by smtp.gmail.com with UTF8SMTPSA id f3sm109466lfu.271.2021.05.26.23.32.44
-        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
-        Wed, 26 May 2021 23:32:44 -0700 (PDT)
+Received: from [127.0.0.1]
 Content-Type: text/plain; charset=utf-8; format=flowed; delsp=no
-Chat-Disposition-Notification-To: alice@example.com
-Subject: =?utf-8?q?Re=3A_Meddelande_fr=C3=A5n_XXXXXX
+Subject: s
 MIME-Version: 1.0
-References: <Mr.0QjSFh-XUmS.tj2vVs5ZJnx@gmail.com>
-	<Mr.dM6crEU09G0.ISm3PN-aYOm@other.maildomain.com>
-In-Reply-To: <Mr.dM6crEU09G0.ISm3PN-aYOm@other.maildomain.com>
 Date: Thu, 27 May 2021 06:32:44 +0000
 Chat-Version: 1.0
-Autocrypt: addr=alice@example.com;
-	keydata=XXXXXXXXXXXXX
-Message-ID: <Mr.nYtIW4fVo6q.AXaQtjM4PL-@gmail.com>
-To: =?utf-8?q?Stefan_Bj=C3=B6rk?= <me@other.maildomain.com>
+Message-ID: <hijk@gmail.com>
+To: <me@other.maildomain.com>
 From: <alice@example.com>
 
 Message content...
 
 -- 
-Skickat fran Delta Chat: https://delta.chat", // TODO was "från"
+Skickat fran Delta Chat: https://delta.chat",
             "Inbox",
             1,
             false,

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3986,4 +3986,46 @@ YEAAAAAA!.
             .await,
         );
     }
+
+    #[async_std::test]
+    async fn test_dont_show_all_outgoing_msgs_in_self_chat() {
+        let t = TestContext::new_alice().await;
+
+        dc_receive_imf(
+            &t,
+            b"Bcc: alice@example.com
+Return-Path: <alice@example.com>
+Received: from [127.0.0.1] (c80-216-143-104.bredband.tele2.se. [80.216.143.104])
+        by smtp.gmail.com with UTF8SMTPSA id f3sm109466lfu.271.2021.05.26.23.32.44
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Wed, 26 May 2021 23:32:44 -0700 (PDT)
+Content-Type: text/plain; charset=utf-8; format=flowed; delsp=no
+Chat-Disposition-Notification-To: alice@example.com
+Subject: =?utf-8?q?Re=3A_Meddelande_fr=C3=A5n_XXXXXX
+MIME-Version: 1.0
+References: <Mr.0QjSFh-XUmS.tj2vVs5ZJnx@gmail.com>
+	<Mr.dM6crEU09G0.ISm3PN-aYOm@other.maildomain.com>
+In-Reply-To: <Mr.dM6crEU09G0.ISm3PN-aYOm@other.maildomain.com>
+Date: Thu, 27 May 2021 06:32:44 +0000
+Chat-Version: 1.0
+Autocrypt: addr=alice@example.com;
+	keydata=XXXXXXXXXXXXX
+Message-ID: <Mr.nYtIW4fVo6q.AXaQtjM4PL-@gmail.com>
+To: =?utf-8?q?Stefan_Bj=C3=B6rk?= <me@other.maildomain.com>
+From: <alice@example.com>
+
+Message content...
+
+-- 
+Skickat fran Delta Chat: https://delta.chat", // TODO was "från"
+            "Inbox",
+            1,
+            false,
+        )
+        .await
+        .unwrap();
+
+        let msg = t.get_last_msg().await;
+        assert_ne!(msg.chat_id, t.get_self_chat().await.id);
+    }
 }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -662,11 +662,7 @@ async fn add_parts(
         // the mail is on the IMAP server, probably it is also delivered.
         // We cannot recreate other states (read, error).
         state = MessageState::OutDelivered;
-        to_id = *to_ids
-            .iter()
-            .find(|id| **id != DC_CONTACT_ID_SELF)
-            .or_else(|| to_ids.first())
-            .unwrap_or(&0);
+        to_id = to_ids.get_index(0).cloned().unwrap_or_default();
 
         // handshake may mark contacts as verified and must be processed before chats are created
         if mime_parser.get(HeaderDef::SecureJoin).is_some() {

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1585,7 +1585,7 @@ fn get_attachment_filename(
 /// Returned addresses are normalized and lowercased.
 pub(crate) fn get_recipients(headers: &[MailHeader]) -> Vec<SingleInfo> {
     get_all_addresses_from_header(headers, |header_key| {
-        header_key == "to" || header_key == "cc" || header_key == "bcc"
+        header_key == "to" || header_key == "cc"
     })
 }
 


### PR DESCRIPTION
Fix https://github.com/deltachat/deltachat-android/issues/1940, fix https://github.com/deltachat/deltachat-core-rust/issues/2220 (I assume these are the same bug)

The problem was:
- Gmail adds a header `Bcc: <self-address>` to our bcc-self message
- `to_id` was just set to the first recipient, in this case _self_
- it was seen that `to_id` is _self_, so it's a self-sent message