### PR TITLE
imap: refactor to always create Imap configured

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -161,7 +161,9 @@ impl Context {
 
         {
             let l = &mut *self.inner.scheduler.write().await;
-            l.start(self.clone()).await;
+            if let Err(err) = l.start(self.clone()).await {
+                error!(self, "Failed to start IO: {}", err)
+            }
         }
     }
 

--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -25,7 +25,7 @@ impl Imap {
         if !self.can_idle() {
             bail!("IMAP server does not have IDLE capability");
         }
-        self.setup_handle(context).await?;
+        self.prepare(context).await?;
 
         self.select_folder(context, watch_folder.as_deref()).await?;
 
@@ -158,7 +158,7 @@ impl Imap {
                     // try to connect with proper login params
                     // (setup_handle_if_needed might not know about them if we
                     // never successfully connected)
-                    if let Err(err) = self.connect_configured(context).await {
+                    if let Err(err) = self.prepare(context).await {
                         warn!(context, "fake_idle: could not connect: {}", err);
                         continue;
                     }

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -25,7 +25,7 @@ impl Imap {
         }
         info!(context, "Starting full folder scan");
 
-        self.connect_configured(context).await?;
+        self.prepare(context).await?;
         let session = self.session.as_mut();
         let session = session.context("scan_folders(): IMAP No Connection established")?;
         let folders: Vec<_> = session.list(Some(""), Some("*")).await?.collect().await;

--- a/src/job.rs
+++ b/src/job.rs
@@ -532,7 +532,7 @@ impl Job {
     }
 
     async fn move_msg(&mut self, context: &Context, imap: &mut Imap) -> Status {
-        if let Err(err) = imap.connect_configured(context).await {
+        if let Err(err) = imap.prepare(context).await {
             warn!(context, "could not connect: {:?}", err);
             return Status::RetryLater;
         }
@@ -594,7 +594,7 @@ impl Job {
     /// records pointing to the same message on the server, the job
     /// also removes the message on the server.
     async fn delete_msg_on_imap(&mut self, context: &Context, imap: &mut Imap) -> Status {
-        if let Err(err) = imap.connect_configured(context).await {
+        if let Err(err) = imap.prepare(context).await {
             warn!(context, "could not connect: {:?}", err);
             return Status::RetryLater;
         }
@@ -682,7 +682,7 @@ impl Job {
         if job_try!(context.get_config_bool(Config::Bot).await) {
             return Status::Finished(Ok(())); // Bots don't want those messages
         }
-        if let Err(err) = imap.connect_configured(context).await {
+        if let Err(err) = imap.prepare(context).await {
             warn!(context, "could not connect: {:?}", err);
             return Status::RetryLater;
         }
@@ -755,7 +755,7 @@ impl Job {
     /// Chat in contrast to the Sent folder, which is normally managed
     /// by the user via webmail or another email client.
     async fn resync_folders(&mut self, context: &Context, imap: &mut Imap) -> Status {
-        if let Err(err) = imap.connect_configured(context).await {
+        if let Err(err) = imap.prepare(context).await {
             warn!(context, "could not connect: {:?}", err);
             return Status::RetryLater;
         }
@@ -779,7 +779,7 @@ impl Job {
     }
 
     async fn markseen_msg_on_imap(&mut self, context: &Context, imap: &mut Imap) -> Status {
-        if let Err(err) = imap.connect_configured(context).await {
+        if let Err(err) = imap.prepare(context).await {
             warn!(context, "could not connect: {:?}", err);
             return Status::RetryLater;
         }


### PR DESCRIPTION
`Imap` structure is always created in a configured state now. There is
no default value for `ImapConfig` anymore.

Also resultify Scheduler::start() to fail on database errors, for
example if IMAP configuration cannot be read from the database during
`start_io()`. Previosuly errors during reading keys such as
`mvbox_watch` were simply ignored and folders were not watched until
the application is completely restarted, now start_io() will fail and
scheduler will only be started at the next start_io() call which
usually happens when app is brought to the foreground.