### PR TITLE
[postponed] add quota check job and quota report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### API Changes
 - breaking change: removed `DC_EVENT_ERROR_NETWORK` and `DC_STR_SERVER_RESPONSE`
+
   Instead, there is a new api `dc_get_connectivity()`
   and `dc_get_connectivity_html()`;
   `DC_EVENT_CONNECTIVITY_CHANGED` is emitted on changes
@@ -27,6 +28,7 @@
 - chat: make `get_msg_cnt()` and `get_fresh_msg_cnt()` work for deaddrop chat #2493
 - withdraw/revive own qr-codes #2512
 - add Connectivity view (a better api for getting the connection status) #2319
+- add daily quota check job, which triggers a warning in device-chat if quota is running full. can be disabled via the `disable_quota_check` config.
 
 ### Changes
 - updated spec: new `Chat-User-Avatar` usage, `Chat-Content: sticker`, structure, copyright year #2480

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,8 +236,7 @@ dependencies = [
 [[package]]
 name = "async-imap"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb2df4b37a99456360a9ab475b723e3a499d51e060ab1bdd8d7565d23dcb74b"
+source = "git+https://github.com/simon-laux/async-imap?branch=quota_support#5b5388100d6edeb88d351fc1d2abd08a2001a7fc"
 dependencies = [
  "async-native-tls",
  "async-std",
@@ -248,7 +247,7 @@ dependencies = [
  "imap-proto",
  "lazy_static",
  "log",
- "nom 5.1.2",
+ "nom 6.1.2",
  "pin-utils",
  "rental",
  "stop-token",
@@ -520,6 +519,18 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bitvec"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -1587,6 +1598,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
 name = "futures"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1922,7 +1939,12 @@ dependencies = [
  "uuid",
 ]
 
+[[package]]
+name = "humansize"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
+
 [[package]]
 name = "humantime"
 version = "1.3.0"
@@ -1968,11 +1990,11 @@ dependencies = [
 
 [[package]]
 name = "imap-proto"
-version = "0.11.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3091b99ee5b80f9b010eb6f962af9495ad06561bf662126b077e8ca30e463182"
+checksum = "3ad9b46a79efb6078e578ae04e51463d7c3e8767864687f7e63095b3cbefafbb"
 dependencies = [
- "nom 5.1.2",
+ "nom 6.1.2",
 ]
 
 [[package]]
@@ -2345,6 +2367,19 @@ version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check 0.9.3",
+]
+
+[[package]]
+name = "nom"
+version = "6.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+dependencies = [
+ "bitvec",
+ "funty",
  "lexical-core",
  "memchr",
  "version_check 0.9.3",
@@ -2880,6 +2915,12 @@ dependencies = [
  "r2d2",
  "rusqlite",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "radix_trie"
@@ -3659,6 +3700,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4172,6 +4219,12 @@ checksum = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x25519-dalek"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 name = "async-imap"
 version = "0.5.0"
-source = "git+https://github.com/simon-laux/async-imap?branch=quota_support#5b5388100d6edeb88d351fc1d2abd08a2001a7fc"
+source = "git+https://github.com/simon-laux/async-imap?branch=quota_support#492ee4adb9ef54db2cf504f3dd49e5826d45818a"
 dependencies = [
  "async-native-tls",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 name = "async-imap"
 version = "0.5.0"
-source = "git+https://github.com/simon-laux/async-imap?branch=quota_support#ea157748846187db3cf5f7b8a0eec036f7570447"
+source = "git+https://github.com/simon-laux/async-imap?branch=quota_support#f976dc05aa10e79f86afdfd7d79c1d1d1aba438b"
 dependencies = [
  "async-native-tls",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 name = "async-imap"
 version = "0.5.0"
-source = "git+https://github.com/simon-laux/async-imap?branch=quota_support#492ee4adb9ef54db2cf504f3dd49e5826d45818a"
+source = "git+https://github.com/simon-laux/async-imap?branch=quota_support#ea157748846187db3cf5f7b8a0eec036f7570447"
 dependencies = [
  "async-native-tls",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 name = "async-imap"
 version = "0.5.0"
-source = "git+https://github.com/simon-laux/async-imap?branch=quota_support#f976dc05aa10e79f86afdfd7d79c1d1d1aba438b"
+source = "git+https://github.com/async-email/async-imap#e76cd705063d4a0d5af4fb0df05c3cbba33808be"
 dependencies = [
  "async-native-tls",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1133,6 +1133,7 @@ dependencies = [
  "futures",
  "futures-lite",
  "hex",
+ "humansize",
  "image",
  "indexmap",
  "itertools 0.10.1",
@@ -1921,6 +1922,7 @@ dependencies = [
  "uuid",
 ]
 
+checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 [[package]]
 name = "humantime"
 version = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ deltachat_derive = { path = "./deltachat_derive" }
 
 ansi_term = { version = "0.12.1", optional = true }
 anyhow = "1.0.41"
-async-imap = { git="https://github.com/simon-laux/async-imap", branch="quota_support" }
+async-imap = { git = "https://github.com/async-email/async-imap" }
 async-native-tls = { version = "0.3.3" }
 async-smtp = { git = "https://github.com/async-email/async-smtp", rev="2275fd8d13e39b2c58d6605c786ff06ff9e05708" }
 async-std-resolver = "0.20.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ deltachat_derive = { path = "./deltachat_derive" }
 
 ansi_term = { version = "0.12.1", optional = true }
 anyhow = "1.0.41"
-async-imap = "0.5.0"
+async-imap = { git="https://github.com/simon-laux/async-imap", branch="quota_support" }
 async-native-tls = { version = "0.3.3" }
 async-smtp = { git = "https://github.com/async-email/async-smtp", rev="2275fd8d13e39b2c58d6605c786ff06ff9e05708" }
 async-std-resolver = "0.20.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ thiserror = "1.0.25"
 toml = "0.5.6"
 url = "2.2.2"
 uuid = { version = "0.8", features = ["serde", "v4"] }
+humansize = "1.1.1"
 
 [dev-dependencies]
 ansi_term = "0.12.0"

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5775,26 +5775,27 @@ void dc_event_unref(dc_event_t* event);
 /// Send as device message to the user when their email provider does not support the quota extention.
 #define DC_STR_QUOTA_NOT_SUPPORTED        99
 
-/// "Messages"
+/// "Messages: %1$s/%2$s"
 ///
 /// Used in the quota report message.
 ///
 /// Example usage: Messages: 3912/6000
-#define DC_STR_QUOTA_MESSAGES            100
+#define DC_STR_QUOTA_MESSAGES_USAGE      100
 
-/// "Storage"
+/// "Storage: %1$s/%2$s"
 ///
 /// Used in the quota report message.
 ///
 /// Example usage: Storage: 169.33 MiB/1000 MiB
-#define DC_STR_QUOTA_STORAGE             101
+#define DC_STR_QUOTA_STORAGE_USAGE       101
 
 /// "%1$s: %2$s/%3$s"
 ///
-/// The format Used in the quota report message.
+/// Used in the quota report message, this is the the format used
+/// when the resource type is something different than message-count or storage.
 ///
-/// Example usage: $type_name: $usage/$limit (see examples of DC_STR_QUOTA_MESSAGES and DC_STR_QUOTA_STORAGE)
-#define DC_STR_QUOTA_USAGE             102
+/// Example usage: $type_name: $usage/$limit
+#define DC_STR_QUOTA_RESOURCE_USAGE      102
 
 /**
  * @}

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5771,7 +5771,7 @@ void dc_event_unref(dc_event_t* event);
 
 /// "Your email server does not support the quota extension"
 ///
-/// U
+/// Send as device message to the user when their email provider does not support the quota extention.
 #define DC_STR_QUOTA_NOT_SUPPORTED        99
 
 /// "Messages"

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -359,6 +359,7 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  * - `fetch_existing_msgs` = 1=fetch most recent existing messages on configure (default),
  *                    0=do not fetch existing messages on configure.
  *                    In both cases, existing recipients are added to the contact database.
+ * - `disable_quota_check` = Set to one to "1" disable the daily quotacheck.
  *
  * If you want to retrieve a value, use dc_get_config().
  *

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5762,6 +5762,32 @@ void dc_event_unref(dc_event_t* event);
 /// Used in message summary text for notifications and chatlist.
 #define DC_STR_FORWARDED                  97
 
+/// "Your mailbox on your email account is running full! [...]"
+///
+/// Send as device message to the user when their mailbox is nearly full
+///
+/// The message is longer and also contains suggestions for possible solutions.
+#define DC_STR_QUOTA_MAILBOX_NEARLY_FULL  98
+
+/// "Your email server does not support the quota extension"
+///
+/// U
+#define DC_STR_QUOTA_NOT_SUPPORTED        99
+
+/// "Messages"
+///
+/// Used in the quota report message.
+///
+/// Example usage: 3912/6000 Messages
+#define DC_STR_QUOTA_MESSAGES            100
+
+/// "Storage"
+///
+/// Used in the quota report message.
+///
+/// Example usage: 169.33 MiB/1000 MiB Storage
+#define DC_STR_QUOTA_STORAGE             101
+
 /**
  * @}
  */

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5778,14 +5778,14 @@ void dc_event_unref(dc_event_t* event);
 ///
 /// Used in the quota report message.
 ///
-/// Example usage: 3912/6000 Messages
+/// Example usage: Messages: 3912/6000
 #define DC_STR_QUOTA_MESSAGES            100
 
 /// "Storage"
 ///
 /// Used in the quota report message.
 ///
-/// Example usage: 169.33 MiB/1000 MiB Storage
+/// Example usage: Storage: 169.33 MiB/1000 MiB
 #define DC_STR_QUOTA_STORAGE             101
 
 /**

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5789,6 +5789,13 @@ void dc_event_unref(dc_event_t* event);
 /// Example usage: Storage: 169.33 MiB/1000 MiB
 #define DC_STR_QUOTA_STORAGE             101
 
+/// "%1$s: %2$s/%3$s"
+///
+/// The format Used in the quota report message.
+///
+/// Example usage: $type_name: $usage/$limit (see examples of DC_STR_QUOTA_MESSAGES and DC_STR_QUOTA_STORAGE)
+#define DC_STR_QUOTA_USAGE             102
+
 /**
  * @}
  */

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -214,6 +214,19 @@ void            dc_context_unref             (dc_context_t* context);
 
 
 /**
+ * Generates a detailed report about the current Quota usage on the for deltachat relevant folders
+ * and sends it to the user as devicemessage.
+ *
+ * It's a bit like the prepaid mobile carrier service menu/messages,
+ * where you type a special number and then get a message back with your current balance.
+ *
+ * @memberof dc_context_t
+ * @param context The context object as created by dc_context_new().
+ */
+void            dc_request_quota_report      (dc_context_t* context);
+
+
+/**
  * Get the ID of a context object.
  * Each context has an ID assigned.
  * If the context was created through the dc_accounts_t account manager,

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -121,6 +121,17 @@ pub unsafe extern "C" fn dc_get_blobdir(context: *mut dc_context_t) -> *mut libc
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_request_quota_report(context: *mut dc_context_t) {
+    if context.is_null() {
+        eprintln!("ignoring careless call to dc_request_quota_report()");
+    }
+    let ctx = &*context;
+    block_on(async move {
+        ctx.request_quota_report().await;
+    })
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_set_config(
     context: *mut dc_context_t,
     key: *const libc::c_char,

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -124,6 +124,7 @@ pub unsafe extern "C" fn dc_get_blobdir(context: *mut dc_context_t) -> *mut libc
 pub unsafe extern "C" fn dc_request_quota_report(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_request_quota_report()");
+        return;
     }
     let ctx = &*context;
     block_on(async move {

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -1216,7 +1216,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                 seconds, device_cnt, server_cnt
             );
         }
-        "requestquotareport"=> {
+        "requestquotareport" => {
             context.request_quota_report().await;
         }
         "" => (),

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -419,6 +419,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                  event <event-id to test>\n\
                  fileinfo <file>\n\
                  estimatedeletion <seconds>\n\
+                 requestquotareport\n\
                  clear -- clear screen\n\
                  exit or quit\n\
                  ============================================="

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -1216,6 +1216,9 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                 seconds, device_cnt, server_cnt
             );
         }
+        "requestquotareport"=> {
+            context.request_quota_report().await;
+        }
         "" => (),
         _ => bail!("Unknown command: \"{}\" type ? for help.", arg0),
     }

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -232,7 +232,7 @@ const MISC_COMMANDS: [&str; 11] = [
     "quit",
     "help",
     "estimatedeletion",
-    "requestquotareport"
+    "requestquotareport",
 ];
 
 impl Hinter for DcHelper {

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -221,7 +221,7 @@ const CONTACT_COMMANDS: [&str; 9] = [
     "unblock",
     "listblocked",
 ];
-const MISC_COMMANDS: [&str; 10] = [
+const MISC_COMMANDS: [&str; 11] = [
     "getqr",
     "getbadqr",
     "checkqr",
@@ -232,6 +232,7 @@ const MISC_COMMANDS: [&str; 10] = [
     "quit",
     "help",
     "estimatedeletion",
+    "requestquotareport"
 ];
 
 impl Hinter for DcHelper {

--- a/src/config.rs
+++ b/src/config.rs
@@ -156,6 +156,9 @@ pub enum Config {
     /// Timestamp of the last time housekeeping was run
     LastHousekeeping,
 
+    /// Timestamp of the last time check quota was run
+    LastQuotaCheck,
+
     /// To how many seconds to debounce scan_all_folders. Used mainly in tests, to disable debouncing completely.
     #[strum(props(default = "60"))]
     ScanAllFoldersDebounceSecs,

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,6 +159,10 @@ pub enum Config {
     /// Timestamp of the last time check quota was run
     LastQuotaCheck,
 
+    /// Allows the user to disable the quotacheck when their mailserver sends wrong quota resource usage.
+    /// So they don't get the warning message each day in that case.
+    DisableQuotaCheck,
+
     /// To how many seconds to debounce scan_all_folders. Used mainly in tests, to disable debouncing completely.
     #[strum(props(default = "60"))]
     ScanAllFoldersDebounceSecs,

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -123,12 +123,6 @@ pub const DC_RESEND_USER_AVATAR_DAYS: i64 = 14;
 // do not use too small value that will annoy users checking for nonexistant updates.
 pub const DC_OUTDATED_WARNING_DAYS: i64 = 365;
 
-/// warn about a nearly full mailbox after this usage percentage is reached.
-pub const DC_QUOTA_WARN_THRESHOLD_PERCENTAGE: u64 = 90;
-
-/// Minutes until the quota will be checked again
-pub const DC_CHECK_QUOTA_FREQUENCY: i64 = 60 * 60 * 24;
-
 /// virtual chat showing all messages belonging to chats flagged with chats.blocked=2
 pub const DC_CHAT_ID_DEADDROP: ChatId = ChatId::new(1);
 /// messages that should be deleted get this chat_id; the messages are deleted from the working thread later then. This is also needed as rfc724_mid should be preset as long as the message is not deleted on the server (otherwise it is downloaded again)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -123,6 +123,12 @@ pub const DC_RESEND_USER_AVATAR_DAYS: i64 = 14;
 // do not use too small value that will annoy users checking for nonexistant updates.
 pub const DC_OUTDATED_WARNING_DAYS: i64 = 365;
 
+/// warn about a nearly full mailbox after this usage percentage is reached.
+pub const DC_QUOTA_WARN_THRESHOLD_PERCENTAGE: u64 = 90;
+
+/// Minutes until the quota will be checked again
+pub const DC_CHECK_QUOTA_FREQUENCY: i64 = 60 * 60 * 24;
+
 /// virtual chat showing all messages belonging to chats flagged with chats.blocked=2
 pub const DC_CHAT_ID_DEADDROP: ChatId = ChatId::new(1);
 /// messages that should be deleted get this chat_id; the messages are deleted from the working thread later then. This is also needed as rfc724_mid should be preset as long as the message is not deleted on the server (otherwise it is downloaded again)

--- a/src/context.rs
+++ b/src/context.rs
@@ -571,7 +571,7 @@ impl Context {
     /// where you type a special number and then get a message back with your current balance.
     pub async fn request_quota_report(&self) {
         job::add(
-            &self,
+            self,
             job::Job::new(Action::GenerateQuotaUsageReport, 0, Params::new(), 1),
         )
         .await;

--- a/src/context.rs
+++ b/src/context.rs
@@ -578,7 +578,7 @@ impl Context {
     pub async fn request_quota_report(&self) {
         job::add(
             self,
-            job::Job::new(Action::GenerateQuotaUsageReport, 0, Params::new(), 1),
+            job::Job::new(Action::GenerateQuotaUsageReport, 0, Params::new(), 0),
         )
         .await;
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -414,6 +414,12 @@ impl Context {
                 .to_string(),
         );
         res.insert(
+            "last_quota_check",
+            self.get_config_int(Config::LastQuotaCheck)
+                .await?
+                .to_string(),
+        );
+        res.insert(
             "scan_all_folders_debounce_secs",
             self.get_config_int(Config::ScanAllFoldersDebounceSecs)
                 .await?

--- a/src/context.rs
+++ b/src/context.rs
@@ -420,6 +420,12 @@ impl Context {
                 .to_string(),
         );
         res.insert(
+            "disable_quota_check",
+            self.get_config_int(Config::DisableQuotaCheck)
+                .await?
+                .to_string(),
+        );
+        res.insert(
             "scan_all_folders_debounce_secs",
             self.get_config_int(Config::ScanAllFoldersDebounceSecs)
                 .await?

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -155,7 +155,7 @@ struct ImapConfig {
     pub can_move: bool,
 
     /// True if the server has QUOTA capability as defined in
-    /// https://tools.ietf.org/html/rfc2087
+    /// <https://tools.ietf.org/html/rfc2087>
     pub can_check_quota: bool,
 }
 

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -381,13 +381,6 @@ impl Imap {
         }
     }
 
-    /// True if CAPABILITY command was run successfully once and config.can_* contain correct
-    /// values.
-    // This function exists to have a readonly way to access it
-    pub fn capabilities_determined(&self) -> bool {
-        self.capabilities_determined
-    }
-
     /// Prepare for IMAP operation.
     ///
     /// Ensure that IMAP client is connected, folders are created and IMAP capabilities are

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -8,8 +8,7 @@ use std::{cmp, cmp::max, collections::BTreeMap};
 use anyhow::{anyhow, bail, format_err, Context as _, Result};
 use async_imap::{
     error::Result as ImapResult,
-    types::{Fetch, Flag, Mailbox, Name, NameAttribute, UnsolicitedResponse},
-    imap_proto::{Quota, QuotaRoot},
+    types::{Fetch, Flag, Mailbox, Name, NameAttribute, UnsolicitedResponse, Quota, QuotaRoot},
 };
 use async_std::channel::Receiver;
 use async_std::prelude::*;
@@ -1413,7 +1412,7 @@ impl Imap {
 
     pub async fn get_quota_roots(
         mailbox_name: &str,
-    ) -> Result<(Vec<QuotaRoot<'_>>, Vec<Quota<'_>>)> {
+    ) -> Result<(Vec<QuotaRoot>, Vec<Quota>)> {
         if let Some(session) = self.session.as_mut() {
             let quota_roots = session.get_quota_root(mailbox_name).await?;
             Ok(quota_roots)

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -8,7 +8,7 @@ use std::{cmp, cmp::max, collections::BTreeMap};
 use anyhow::{anyhow, bail, format_err, Context as _, Result};
 use async_imap::{
     error::Result as ImapResult,
-    types::{Fetch, Flag, Mailbox, Name, NameAttribute, UnsolicitedResponse, Quota, QuotaRoot},
+    types::{Fetch, Flag, Mailbox, Name, NameAttribute, Quota, QuotaRoot, UnsolicitedResponse},
 };
 use async_std::channel::Receiver;
 use async_std::prelude::*;
@@ -1398,12 +1398,13 @@ impl Imap {
         }
         unsolicited_exists
     }
-    
+
     pub fn can_check_quota(&self) -> bool {
         self.config.can_check_quota
     }
 
     pub async fn get_quota_roots(
+        &mut self,
         mailbox_name: &str,
     ) -> Result<(Vec<QuotaRoot>, Vec<Quota>)> {
         if let Some(session) = self.session.as_mut() {
@@ -1411,6 +1412,7 @@ impl Imap {
             Ok(quota_roots)
         } else {
             Err(anyhow!("Not connected to IMAP, no session"))
+        }
     }
 }
 

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -3,7 +3,7 @@
 //! uses [async-email/async-imap](https://github.com/async-email/async-imap)
 //! to implement connect, fetch, delete functionality with standard IMAP servers.
 
-use std::{borrow::Cow, cmp, cmp::max, collections::BTreeMap};
+use std::{cmp, cmp::max, collections::BTreeMap};
 
 use anyhow::{anyhow, bail, format_err, Context as _, Result};
 use async_imap::{
@@ -1414,7 +1414,8 @@ impl Imap {
     pub async fn get_quota_roots(
         mailbox_name: &str,
     ) -> Result<(Vec<QuotaRoot<'_>>, Vec<Quota<'_>>)> {
-            let quota_roots = session.get_quota_root(Cow::Borrowed(mailbox_name)).await?;
+        if let Some(session) = self.session.as_mut() {
+            let quota_roots = session.get_quota_root(mailbox_name).await?;
             Ok(quota_roots)
         } else {
             Err(anyhow!("Not connected to IMAP, no session"))

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -93,7 +93,7 @@ impl Imap {
     }
 }
 
-async fn get_watched_folders(context: &Context) -> Vec<String> {
+pub(crate) async fn get_watched_folders(context: &Context) -> Vec<String> {
     let mut res = Vec::new();
     let folder_watched_configured = &[
         (Config::SentboxWatch, Config::ConfiguredSentboxFolder),

--- a/src/job.rs
+++ b/src/job.rs
@@ -890,7 +890,6 @@ impl Job {
             }
         }
 
-
         if let Err(err) = check_quota_job(context, imap).await {
             warn!(context, "check quota failed: {:?}", err);
             return Status::RetryLater;

--- a/src/job.rs
+++ b/src/job.rs
@@ -1347,7 +1347,10 @@ async fn load_housekeeping_job(context: &Context) -> Option<Job> {
 }
 
 async fn load_check_quota_job(context: &Context) -> Option<Job> {
-    // FIX ME This spams this job when offline and the job is not yet done for today
+    if action_exists(&context, Action::CheckQuota).await {
+        return None;
+    }
+
     let last_time = match context.get_config_i64(Config::LastQuotaCheck).await {
         Ok(last_time) => last_time,
         Err(err) => {

--- a/src/job.rs
+++ b/src/job.rs
@@ -1363,7 +1363,7 @@ async fn load_check_quota_job(context: &Context) -> Option<Job> {
     let next_time = last_time + CHECK_QUOTA_FREQUENCY;
     if next_time <= time() {
         kill_action(context, Action::CheckQuota).await;
-        Some(Job::new(Action::CheckQuota, 0, Params::new(), 10))
+        Some(Job::new(Action::CheckQuota, 0, Params::new(), 0))
     } else {
         None
     }

--- a/src/job.rs
+++ b/src/job.rs
@@ -1347,6 +1347,7 @@ async fn load_housekeeping_job(context: &Context) -> Option<Job> {
 }
 
 async fn load_check_quota_job(context: &Context) -> Option<Job> {
+    // FIX ME This spams this job when offline and the job is not yet done for today
     let last_time = match context.get_config_i64(Config::LastQuotaCheck).await {
         Ok(last_time) => last_time,
         Err(err) => {

--- a/src/job.rs
+++ b/src/job.rs
@@ -1499,10 +1499,10 @@ LIMIT 1;
                 }
             } else if let Some(job) = load_imap_deletion_job(context).await.unwrap_or_default() {
                 Some(job)
-            } else if let Some(job) = load_check_quota_job(context).await {
+            } else if let Some(job) = load_housekeeping_job(context).await {
                 Some(job)
             } else {
-                load_housekeeping_job(context).await
+                load_check_quota_job(context).await
             }
         }
         Thread::Smtp => job,

--- a/src/job.rs
+++ b/src/job.rs
@@ -858,11 +858,6 @@ impl Job {
     /// It's a bit like the prepaid mobile carrier service menu/messages,
     /// where you type a special number and then get a message back with your current balance.
     async fn generate_quota_usage_report(&mut self, context: &Context, imap: &mut Imap) -> Status {
-        if let Err(err) = imap.prepare(context).await {
-            warn!(context, "could not connect: {:?}", err);
-            return Status::RetryLater;
-        }
-
         if let Err(err) = quota_usage_report_job(context, imap).await {
             warn!(context, "check quota failed: {:?}", err);
             return Status::RetryLater;

--- a/src/job.rs
+++ b/src/job.rs
@@ -34,7 +34,7 @@ use crate::{
 };
 use crate::{
     chat::{self, Chat, ChatId, ChatIdBlocked, ChatItem},
-    constants::DC_CHECK_QUOTA_FREQUENCY,
+    quota::CHECK_QUOTA_FREQUENCY,
 };
 
 // results in ~3 weeks for the last backoff timespan
@@ -1359,7 +1359,7 @@ async fn load_check_quota_job(context: &Context) -> Option<Job> {
         }
     };
 
-    let next_time = last_time + DC_CHECK_QUOTA_FREQUENCY;
+    let next_time = last_time + CHECK_QUOTA_FREQUENCY;
     if next_time <= time() {
         kill_action(context, Action::CheckQuota).await;
         Some(Job::new(Action::CheckQuota, 0, Params::new(), 10))

--- a/src/job.rs
+++ b/src/job.rs
@@ -853,7 +853,7 @@ impl Job {
     }
 
     /// Generates a detailed report about the current Quota usage on the for deltachat relevant folders
-    /// and sends it to the user via [add_device_msg]
+    /// and sends it to the user via devicemessage
     ///
     /// It's a bit like the prepaid mobile carrier service menu/messages,
     /// where you type a special number and then get a message back with your current balance.
@@ -863,7 +863,7 @@ impl Job {
             return Status::RetryLater;
         }
 
-        if let Err(err) = quota_usage_report_job(&context, imap).await {
+        if let Err(err) = quota_usage_report_job(context, imap).await {
             warn!(context, "check quota failed: {:?}", err);
             return Status::RetryLater;
         }
@@ -879,7 +879,7 @@ impl Job {
             return Status::RetryLater;
         }
 
-        if let Err(err) = check_quota_job(&context, imap).await {
+        if let Err(err) = check_quota_job(context, imap).await {
             warn!(context, "check quota failed: {:?}", err);
             return Status::RetryLater;
         }
@@ -1347,7 +1347,7 @@ async fn load_housekeeping_job(context: &Context) -> Option<Job> {
 }
 
 async fn load_check_quota_job(context: &Context) -> Option<Job> {
-    if action_exists(&context, Action::CheckQuota).await {
+    if action_exists(context, Action::CheckQuota).await {
         return None;
     }
 

--- a/src/job.rs
+++ b/src/job.rs
@@ -858,7 +858,7 @@ impl Job {
     /// It's a bit like the prepaid mobile carrier service menu/messages,
     /// where you type a special number and then get a message back with your current balance.
     async fn generate_quota_usage_report(&mut self, context: &Context, imap: &mut Imap) -> Status {
-        if let Err(err) = imap.connect_configured(context).await {
+        if let Err(err) = imap.prepare(context).await {
             warn!(context, "could not connect: {:?}", err);
             return Status::RetryLater;
         }
@@ -874,7 +874,7 @@ impl Job {
     /// Regular quota check that should run once per day and inform the user when their account is running full
     /// by posting a devicemessage suggesting to enable autodeletion.
     async fn check_quota(&mut self, context: &Context, imap: &mut Imap) -> Status {
-        if let Err(err) = imap.connect_configured(context).await {
+        if let Err(err) = imap.prepare(context).await {
             warn!(context, "could not connect: {:?}", err);
             return Status::RetryLater;
         }

--- a/src/job.rs
+++ b/src/job.rs
@@ -871,7 +871,8 @@ impl Job {
         Status::Finished(Ok(()))
     }
 
-    /// Regular quota check that should run once per day and inform the user when their account is running full
+    /// Regular quota check that should run once per CHECK_QUOTA_FREQUENCY
+    /// and inform the user when their account is running full
     /// by posting a devicemessage suggesting to enable autodeletion.
     async fn check_quota(&mut self, context: &Context, imap: &mut Imap) -> Status {
         if let Err(err) = imap.prepare(context).await {

--- a/src/job.rs
+++ b/src/job.rs
@@ -877,11 +877,6 @@ impl Job {
             warn!(context, "Can't set config: {}", e);
         }
 
-        if let Err(err) = imap.prepare(context).await {
-            warn!(context, "could not connect: {:?}", err);
-            return Status::RetryLater;
-        }
-
         if let Err(err) = check_quota_job(context, imap).await {
             warn!(context, "check quota failed: {:?}", err);
             return Status::RetryLater;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,7 @@ pub mod peerstate;
 pub mod pgp;
 pub mod provider;
 pub mod qr;
+pub mod quota;
 pub mod securejoin;
 mod simplify;
 mod smtp;

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -1,0 +1,88 @@
+use anyhow::{anyhow, Result};
+use async_imap::imap_proto::{Quota, QuotaResource};
+use humansize::{file_size_opts, FileSize};
+use itertools::Itertools;
+
+use crate::context::Context;
+use crate::imap::Imap;
+use crate::{
+    chat::add_device_msg, constants::Viewtype, imap::scan_folders::get_watched_folders,
+    message::Message,
+};
+
+pub(crate) async fn quota_usage_report_job(context: &Context, imap: &mut Imap) -> Result<()> {
+    if imap.check_for_quota_support().await? {
+        let folders = get_watched_folders(&context).await;
+        let mut unique_quota_roots: Vec<(String, Vec<QuotaResource<'static>>)> = Vec::new();
+
+        for folder in folders {
+            let (quota_roots, quotas) = &imap.get_quota_roots(&folder).await?;
+            // if there are new quota roots found in this imap folder, add them to the list
+            for qr_entries in quota_roots {
+                for quota_root_name in &qr_entries.quota_root_names {
+                    // the quota for that quota root
+                    let quota: Quota<'static> = quotas
+                        .iter()
+                        .find(|q| &q.root_name == quota_root_name)
+                        .map(|q| q.clone().into_owned())
+                        .ok_or(anyhow!("quota_root should have a quota"))?;
+                    match unique_quota_roots
+                        .iter()
+                        .find_position(|(root_name, _)| root_name == quota_root_name)
+                    {
+                        None => {
+                            unique_quota_roots
+                                .push((quota_root_name.clone().into_owned(), quota.resources));
+                        }
+                        Some((position, ..)) => {
+                            // replace old quotas, because between fetching quotaroots for folders,
+                            // messages could be recieved and so the usage could have been changed
+                            unique_quota_roots[position].1 = quota.resources;
+                        }
+                    }
+                }
+            }
+        }
+
+        // build report message
+        let mut message: String = "".to_owned();
+
+        for (name, quota_resources) in unique_quota_roots {
+            message.push_str(&format!("{}:\n", &name));
+            use async_imap::imap_proto::QuotaResourceName::*;
+            for resource in quota_resources {
+                message.push_str(&match resource.name {
+                    Atom(name) => {
+                        format!("[{}/{}] {}\n", resource.usage, resource.limit, name)
+                    }
+                    Message => {
+                        format!("{}/{} Messages\n", resource.usage, resource.limit)
+                    } // TODO stockstring
+                    Storage => {
+                        let used = (resource.usage * 1024)
+                            .file_size(file_size_opts::BINARY)
+                            .map_err(|err| anyhow!("{}", err))?;
+                        let limit = (resource.limit * 1024)
+                            .file_size(file_size_opts::BINARY)
+                            .map_err(|err| anyhow!("{}", err))?;
+                        format!("{}/{} Storage\n", used, limit) // TODO stockstring
+                    }
+                });
+            }
+        }
+
+        let mut msg = Message::new(Viewtype::Text);
+        msg.text = Some(message);
+        add_device_msg(&context, None, Some(&mut msg)).await?;
+    } else {
+        warn!(
+            context,
+            "the email server does not support the quota extention"
+        );
+        let mut msg = Message::new(Viewtype::Text);
+        msg.text = Some("the email server does not support the quota extention".to_owned()); // todo stock string?
+        add_device_msg(&context, None, Some(&mut msg)).await?;
+    }
+
+    Ok(())
+}

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -1,78 +1,27 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use async_imap::imap_proto::{Quota, QuotaResource};
 use humansize::{file_size_opts, FileSize};
 use itertools::Itertools;
 
+use crate::constants::DC_QUOTA_WARN_THRESHOLD_PERCENTAGE;
 use crate::context::Context;
 use crate::imap::Imap;
 use crate::{
-    chat::add_device_msg, constants::Viewtype, imap::scan_folders::get_watched_folders,
+    chat::{add_device_msg, add_device_msg_with_importance},
+    constants::Viewtype,
+    imap::scan_folders::get_watched_folders,
     message::Message,
 };
 
 pub(crate) async fn quota_usage_report_job(context: &Context, imap: &mut Imap) -> Result<()> {
+    // IDEA: OPTIMIZATION: check_for_quota_support could be cached in the config, would increase code complexity but decrease traffic a bit
     if imap.check_for_quota_support().await? {
         let folders = get_watched_folders(&context).await;
-        let mut unique_quota_roots: Vec<(String, Vec<QuotaResource<'static>>)> = Vec::new();
+        let unique_quota_roots = get_unique_quota_roots_and_usage(folders, imap).await?;
 
-        for folder in folders {
-            let (quota_roots, quotas) = &imap.get_quota_roots(&folder).await?;
-            // if there are new quota roots found in this imap folder, add them to the list
-            for qr_entries in quota_roots {
-                for quota_root_name in &qr_entries.quota_root_names {
-                    // the quota for that quota root
-                    let quota: Quota<'static> = quotas
-                        .iter()
-                        .find(|q| &q.root_name == quota_root_name)
-                        .map(|q| q.clone().into_owned())
-                        .ok_or(anyhow!("quota_root should have a quota"))?;
-                    match unique_quota_roots
-                        .iter()
-                        .find_position(|(root_name, _)| root_name == quota_root_name)
-                    {
-                        None => {
-                            unique_quota_roots
-                                .push((quota_root_name.clone().into_owned(), quota.resources));
-                        }
-                        Some((position, ..)) => {
-                            // replace old quotas, because between fetching quotaroots for folders,
-                            // messages could be recieved and so the usage could have been changed
-                            unique_quota_roots[position].1 = quota.resources;
-                        }
-                    }
-                }
-            }
-        }
-
-        // build report message
-        let mut message: String = "".to_owned();
-
-        for (name, quota_resources) in unique_quota_roots {
-            message.push_str(&format!("{}:\n", &name));
-            use async_imap::imap_proto::QuotaResourceName::*;
-            for resource in quota_resources {
-                message.push_str(&match resource.name {
-                    Atom(name) => {
-                        format!("[{}/{}] {}\n", resource.usage, resource.limit, name)
-                    }
-                    Message => {
-                        format!("{}/{} Messages\n", resource.usage, resource.limit)
-                    } // TODO stockstring
-                    Storage => {
-                        let used = (resource.usage * 1024)
-                            .file_size(file_size_opts::BINARY)
-                            .map_err(|err| anyhow!("{}", err))?;
-                        let limit = (resource.limit * 1024)
-                            .file_size(file_size_opts::BINARY)
-                            .map_err(|err| anyhow!("{}", err))?;
-                        format!("{}/{} Storage\n", used, limit) // TODO stockstring
-                    }
-                });
-            }
-        }
-
+        // build and send report message
         let mut msg = Message::new(Viewtype::Text);
-        msg.text = Some(message);
+        msg.text = Some(generate_report_message(&unique_quota_roots)?);
         add_device_msg(&context, None, Some(&mut msg)).await?;
     } else {
         warn!(
@@ -81,7 +30,149 @@ pub(crate) async fn quota_usage_report_job(context: &Context, imap: &mut Imap) -
         );
         let mut msg = Message::new(Viewtype::Text);
         msg.text = Some("the email server does not support the quota extention".to_owned()); // todo stock string?
-        add_device_msg(&context, None, Some(&mut msg)).await?;
+        add_device_msg_with_importance(&context, None, Some(&mut msg), true).await?;
+    }
+
+    Ok(())
+}
+
+fn generate_report_message(
+    unique_quota_roots: &Vec<(String, Vec<QuotaResource>)>,
+) -> Result<String> {
+    let mut message: String = "".to_owned();
+    for (name, quota_resources) in unique_quota_roots {
+        message.push_str(&format!("{}:\n", &name));
+        use async_imap::imap_proto::QuotaResourceName::*;
+        for resource in quota_resources {
+            message.push_str(&match &resource.name {
+                Atom(name) => {
+                    format!("[{}/{}] {}\n", resource.usage, resource.limit, name)
+                }
+                Message => {
+                    format!("{}/{} Messages\n", resource.usage, resource.limit)
+                } // TODO stockstring
+                Storage => {
+                    let used = (resource.usage * 1024)
+                        .file_size(file_size_opts::BINARY)
+                        .map_err(|err| anyhow!("{}", err))?;
+                    let limit = (resource.limit * 1024)
+                        .file_size(file_size_opts::BINARY)
+                        .map_err(|err| anyhow!("{}", err))?;
+                    format!("{}/{} Storage\n", used, limit) // TODO stockstring
+                }
+            });
+        }
+    }
+    Ok(message)
+}
+
+async fn get_unique_quota_roots_and_usage(
+    folders: Vec<String>,
+    imap: &mut Imap,
+) -> Result<Vec<(String, Vec<QuotaResource<'static>>)>> {
+    // IDEA: OPTIMIZATION:
+    // the unique quota roots of get_unique_quota_roots_and_usage could be cached and then the server could be asked for the quotas of those.
+    // this would reduce incoming traffic and for most cases also outgoing traffic, because most email server share quota roots across folders/mailboxes.
+    // Again at the cost of increasing code complexity and the question for how long it should be cached
+    // IDEA2: maybe the provider db could also contain quota root names?
+    let mut unique_quota_roots: Vec<(String, Vec<QuotaResource<'static>>)> = Vec::new();
+    for folder in folders {
+        let (quota_roots, quotas) = &imap.get_quota_roots(&folder).await?;
+        // if there are new quota roots found in this imap folder, add them to the list
+        for qr_entries in quota_roots {
+            for quota_root_name in &qr_entries.quota_root_names {
+                // the quota for that quota root
+                let quota: Quota<'static> = quotas
+                    .iter()
+                    .find(|q| &q.root_name == quota_root_name)
+                    .map(|q| q.clone().into_owned())
+                    .ok_or(anyhow!("quota_root should have a quota"))?;
+                match unique_quota_roots
+                    .iter()
+                    .find_position(|(root_name, _)| root_name == quota_root_name)
+                {
+                    None => {
+                        unique_quota_roots
+                            .push((quota_root_name.clone().into_owned(), quota.resources));
+                    }
+                    Some((position, ..)) => {
+                        // replace old quotas, because between fetching quotaroots for folders,
+                        // messages could be recieved and so the usage could have been changed
+                        unique_quota_roots[position].1 = quota.resources;
+                    }
+                }
+            }
+        }
+    }
+    Ok(unique_quota_roots)
+}
+
+fn get_highest_usage<'t>(
+    unique_quota_roots: &'t Vec<(String, Vec<QuotaResource<'t>>)>,
+) -> Result<(u64, &'t String, &QuotaResource<'t>)> {
+    let mut highest: Option<(u64, &'t String, &QuotaResource<'t>)> = None;
+    for (name, resources) in unique_quota_roots {
+        for r in resources {
+            let usage_percent = r.usage.saturating_mul(100) / r.limit;
+            match highest {
+                None => {
+                    highest = Some((usage_percent, name, r));
+                }
+                Some((up, ..)) if up <= usage_percent => {
+                    highest = Some((usage_percent, name, r));
+                }
+                Some(_) => {
+                    unreachable!()
+                }
+            };
+        }
+    }
+
+    return Ok(highest.ok_or(anyhow!("no quota_resource found, this is unexpected"))?);
+}
+
+pub(crate) async fn check_quota_job(context: &Context, imap: &mut Imap) -> Result<()> {
+    // does server support quota
+    if !imap.check_for_quota_support().await? {
+        warn!(
+            context,
+            "QuotaCheck: the email server does not support the quota extention"
+        );
+    } else {
+        let folders = get_watched_folders(&context).await;
+        let unique_quota_roots = get_unique_quota_roots_and_usage(folders, imap).await?;
+        if unique_quota_roots.len() == 0 {
+            bail!("no quota root");
+        }
+        // whats the highest quota
+        let (usage_percentage, root_name, quota_resource) = get_highest_usage(&unique_quota_roots)?;
+        // post highest quota to info! for debugging purposes
+        info!(
+            context,
+            "QuotaCheck: highest QuotaResource is {}% full: {:?} (root_name: {})",
+            usage_percentage,
+            quota_resource,
+            root_name
+        );
+        // check if highest usage percent reaches warning threshold
+        if usage_percentage >= DC_QUOTA_WARN_THRESHOLD_PERCENTAGE {
+            // why log it? because then we can see it also in logs users might send us.
+            warn!(
+                context,
+                "QuotaCheck: resource usage percentage({}%) higher than threshold({}%)",
+                usage_percentage,
+                DC_QUOTA_WARN_THRESHOLD_PERCENTAGE
+            );
+
+            let mut details_msg = Message::new(Viewtype::Text);
+            details_msg.text = Some(generate_report_message(&unique_quota_roots)?);
+            add_device_msg(&context, None, Some(&mut details_msg)).await?;
+
+            // if yes post a device message informing the user that the mailbox is nearly full.
+            let mut msg = Message::new(Viewtype::Text);
+            msg.text = Some("Your mailbox on your email account is running full!\n Possible Solutions:\n - Delete old messages on the server\n- or enable \"Delete old messages from server\" in the deltachat settings\n- or upgrade your plan with your email provider\nIf you don't take action you will soon be unable to recieve messages.".to_owned()); // todo stock string?
+            add_device_msg_with_importance(&context, None, Some(&mut msg), true).await?;
+        }
     }
 
     Ok(())

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -68,8 +68,8 @@ async fn generate_report_message(
                 }
                 Message => {
                     format!(
-                        "{}/{} {}\n",
-                        resource.usage, resource.limit, messages_stock_string
+                        "{}: {}/{}\n",
+                        messages_stock_string, resource.usage, resource.limit
                     )
                 }
                 Storage => {
@@ -79,7 +79,7 @@ async fn generate_report_message(
                     let limit = (resource.limit * 1024)
                         .file_size(file_size_opts::BINARY)
                         .map_err(|err| anyhow!("{}", err))?;
-                    format!("{}/{} {}\n", used, limit, storage_stock_string)
+                    format!("{}: {}/{}\n", storage_stock_string, used, limit)
                 }
             });
         }

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -27,7 +27,8 @@ pub const CHECK_QUOTA_FREQUENCY: i64 = 60 * 60 * 24;
 /// It's a bit like the prepaid mobile carrier service menu/messages,
 /// where you type a special number and then get a message back with your current balance.
 pub(crate) async fn quota_usage_report_job(context: &Context, imap: &mut Imap) -> Result<()> {
-    if !imap.capabilities_determined() {
+    if let Err(err) = imap.prepare(context).await {
+        warn!(context, "could not connect: {:?}", err);
         bail!("imap is not ready");
     }
 

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -18,7 +18,7 @@ use crate::{
 /// warn about a nearly full mailbox after this usage percentage is reached.
 pub const QUOTA_WARN_THRESHOLD_PERCENTAGE: u64 = 90;
 
-/// Minutes until the quota will be checked again
+/// Seconds until the quota will be checked again
 pub const CHECK_QUOTA_FREQUENCY: i64 = 60 * 60 * 24;
 
 /// Generates a detailed report about the current Quota usage on the for deltachat relevant folders

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -5,19 +5,21 @@ use itertools::Itertools;
 
 use crate::context::Context;
 use crate::imap::Imap;
+use crate::stock_str::{
+    quota_mailbox_nearly_full, quota_not_supported, quota_resource_messages, quota_resource_storage,
+};
 use crate::{
     chat::{add_device_msg, add_device_msg_with_importance},
     constants::Viewtype,
     imap::scan_folders::get_watched_folders,
     message::Message,
 };
-use crate::{
-    constants::DC_QUOTA_WARN_THRESHOLD_PERCENTAGE,
-    stock_str::{
-        quota_mailbox_nearly_full, quota_not_supported, quota_resource_messages,
-        quota_resource_storage,
-    },
-};
+
+/// warn about a nearly full mailbox after this usage percentage is reached.
+pub const QUOTA_WARN_THRESHOLD_PERCENTAGE: u64 = 90;
+
+/// Minutes until the quota will be checked again
+pub const CHECK_QUOTA_FREQUENCY: i64 = 60 * 60 * 24;
 
 /// Generates a detailed report about the current Quota usage on the for deltachat relevant folders
 /// and sends it to the user via [add_device_msg]
@@ -177,13 +179,13 @@ pub(crate) async fn check_quota_job(context: &Context, imap: &mut Imap) -> Resul
             root_name
         );
         // check if highest usage percent reaches warning threshold
-        if usage_percentage >= DC_QUOTA_WARN_THRESHOLD_PERCENTAGE {
+        if usage_percentage >= QUOTA_WARN_THRESHOLD_PERCENTAGE {
             // why log it? because then we can see it also in logs users might send us.
             warn!(
                 context,
                 "QuotaCheck: resource usage percentage({}%) higher than threshold({}%)",
                 usage_percentage,
-                DC_QUOTA_WARN_THRESHOLD_PERCENTAGE
+                QUOTA_WARN_THRESHOLD_PERCENTAGE
             );
 
             let mut details_msg = Message::new(Viewtype::Text);

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -90,11 +90,6 @@ async fn get_unique_quota_roots_and_usage(
     folders: Vec<String>,
     imap: &mut Imap,
 ) -> Result<Vec<(String, Vec<QuotaResource>)>> {
-    // IDEA: OPTIMIZATION:
-    // the unique quota roots of get_unique_quota_roots_and_usage could be cached and then the server could be asked for the quotas of those.
-    // this would reduce incoming traffic and for most cases also outgoing traffic, because most email server share quota roots across folders/mailboxes.
-    // Again at the cost of increasing code complexity and the question for how long it should be cached
-    // IDEA2: maybe the provider db could also contain quota root names?
     let mut unique_quota_roots: Vec<(String, Vec<QuotaResource>)> = Vec::new();
     for folder in folders {
         let (quota_roots, quotas) = &imap.get_quota_roots(&folder).await?;

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -53,7 +53,7 @@ async fn generate_report_message(
     unique_quota_roots: &[(String, Vec<QuotaResource>)],
     context: &Context,
 ) -> Result<String> {
-    let mut message: String = "".to_owned();
+    let mut message = String::new();
 
     let storage_stock_string = quota_resource_storage(context).await;
     let messages_stock_string = quota_resource_messages(context).await;
@@ -63,7 +63,7 @@ async fn generate_report_message(
         for resource in quota_resources {
             message.push_str(&match &resource.name {
                 Atom(name) => {
-                    format!("[{}/{}] {}\n", resource.usage, resource.limit, name)
+                    format!("{}: {}/{} \n", name, resource.usage, resource.limit)
                 }
                 Message => {
                     format!(

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -39,7 +39,7 @@ pub(crate) async fn quota_usage_report_job(context: &Context, imap: &mut Imap) -
         // build and send report message
         let mut msg = Message::new(Viewtype::Text);
         msg.text = Some(generate_report_message(&unique_quota_roots, context).await?);
-        add_device_msg(context, None, Some(&mut msg)).await?;
+        add_device_msg_with_importance(context, None, Some(&mut msg), true).await?;
     } else {
         warn!(
             context,

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -106,7 +106,7 @@ async fn get_unique_quota_roots_and_usage(
                 let quota: Quota = quotas
                     .iter()
                     .find(|q| &q.root_name == quota_root_name)
-                    .map(|q| q.clone())
+                    .cloned()
                     .ok_or_else(|| anyhow!("quota_root should have a quota"))?;
                 match unique_quota_roots
                     .iter()
@@ -133,7 +133,7 @@ fn get_highest_usage<'t>(
     let mut highest: Option<(u64, &'t String, &QuotaResource)> = None;
     for (name, resources) in unique_quota_roots {
         for r in resources {
-            let usage_percent = r.usage.saturating_mul(100) / r.limit;
+            let usage_percent = r.get_usage_percentage();
             match highest {
                 None => {
                     highest = Some((usage_percent, name, r));

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -150,7 +150,8 @@ fn get_highest_usage<'t>(
 }
 
 pub(crate) async fn check_quota_job(context: &Context, imap: &mut Imap) -> Result<()> {
-    if !imap.capabilities_determined() {
+    if let Err(err) = imap.prepare(context).await {
+        warn!(context, "could not connect: {:?}", err);
         bail!("imap is not ready");
     }
 

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -91,7 +91,7 @@ async fn generate_report_message(
                     quota_resource_usage(context, &storage_stock_string, used, limit).await
                 }
             });
-            message.push_str("\n");
+            message.push('\n');
         }
     }
     Ok(message)

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -41,12 +41,8 @@ pub(crate) async fn quota_usage_report_job(context: &Context, imap: &mut Imap) -
         msg.text = Some(generate_report_message(&unique_quota_roots, context).await?);
         add_device_msg_with_importance(context, None, Some(&mut msg), true).await?;
     } else {
-        warn!(
-            context,
-            "the email server does not support the quota extention"
-        );
         let mut msg = Message::new(Viewtype::Text);
-        msg.text = Some(quota_not_supported(context).await); // todo stock string?
+        msg.text = Some(quota_not_supported(context).await);
         add_device_msg_with_importance(context, None, Some(&mut msg), true).await?;
     }
 

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -261,6 +261,23 @@ pub enum StockMessage {
 
     #[strum(props(fallback = "Forwarded"))]
     Forwarded = 97,
+
+    #[strum(props(fallback = "Your mailbox on your email account is running full!\
+        \nPossible Solutions:\
+        \n- Delete old messages on the server\
+        \n- or enable \"Delete old messages from server\" in the deltachat settings\
+        \n- or upgrade your plan with your email provider\
+        \nIf you don't take action you will soon be unable to receive messages."))]
+    QuotaMailboxNearlyFull = 98,
+
+    #[strum(props(fallback = "Your email server does not support the quota extension"))]
+    QuotaNotSupported = 99,
+
+    #[strum(props(fallback = "Messages"))]
+    QuotaResourceMessages = 100,
+
+    #[strum(props(fallback = "Storage"))]
+    QuotaResourceStorage = 101,
 }
 
 impl StockMessage {
@@ -846,6 +863,26 @@ pub(crate) async fn msg_ephemeral_timer_weeks(
 /// Stock string: `Forwarded`.
 pub(crate) async fn forwarded(context: &Context) -> String {
     translated(context, StockMessage::Forwarded).await
+}
+
+/// Stock string: `QuotaMailboxNearlyFull`.
+pub(crate) async fn quota_mailbox_nearly_full(context: &Context) -> String {
+    translated(context, StockMessage::QuotaMailboxNearlyFull).await
+}
+
+/// Stock string: `QuotaNotSupported`.
+pub(crate) async fn quota_not_supported(context: &Context) -> String {
+    translated(context, StockMessage::QuotaNotSupported).await
+}
+
+/// Stock string: `QuotaResourceMessages`.
+pub(crate) async fn quota_resource_messages(context: &Context) -> String {
+    translated(context, StockMessage::QuotaResourceMessages).await
+}
+
+/// Stock string: `QuotaResourceStorage`.
+pub(crate) async fn quota_resource_storage(context: &Context) -> String {
+    translated(context, StockMessage::QuotaResourceStorage).await
 }
 
 impl Context {

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -278,6 +278,9 @@ pub enum StockMessage {
 
     #[strum(props(fallback = "Storage"))]
     QuotaResourceStorage = 101,
+
+    #[strum(props(fallback = "%1$s: %2$s/%3$s"))]
+    QuotaResourceUsage = 102,
 }
 
 impl StockMessage {
@@ -319,6 +322,17 @@ trait StockStringMods: AsRef<str> + Sized {
             .replacen("%2$s", replacement.as_ref(), 1)
             .replacen("%2$d", replacement.as_ref(), 1)
             .replacen("%2$@", replacement.as_ref(), 1)
+    }
+
+    /// Substitutes the third replacement value if one is present.
+    ///
+    /// Be aware you probably should have also called [`StockStringMods::replace1`]
+    /// and [`StockStringMods::replace2`] if you are calling this.
+    fn replace3(&self, replacement: impl AsRef<str>) -> String {
+        self.as_ref()
+            .replacen("%3$s", replacement.as_ref(), 1)
+            .replacen("%3$d", replacement.as_ref(), 1)
+            .replacen("%3$@", replacement.as_ref(), 1)
     }
 
     /// Augments the message by saying it was performed by a user.
@@ -883,6 +897,20 @@ pub(crate) async fn quota_resource_messages(context: &Context) -> String {
 /// Stock string: `QuotaResourceStorage`.
 pub(crate) async fn quota_resource_storage(context: &Context) -> String {
     translated(context, StockMessage::QuotaResourceStorage).await
+}
+
+/// Stock string: `QuotaResourceUsage`.
+pub(crate) async fn quota_resource_usage(
+    context: &Context,
+    resource_name: impl AsRef<str>,
+    usage: impl AsRef<str>,
+    limit: impl AsRef<str>,
+) -> String {
+    translated(context, StockMessage::QuotaResourceUsage)
+        .await
+        .replace1(resource_name)
+        .replace2(usage)
+        .replace3(limit)
 }
 
 impl Context {

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -273,11 +273,11 @@ pub enum StockMessage {
     #[strum(props(fallback = "Your email server does not support the quota extension"))]
     QuotaNotSupported = 99,
 
-    #[strum(props(fallback = "Messages"))]
-    QuotaResourceMessages = 100,
+    #[strum(props(fallback = "Messages: %1$s/%2$s"))]
+    QuotaMessagesUsage = 100,
 
-    #[strum(props(fallback = "Storage"))]
-    QuotaResourceStorage = 101,
+    #[strum(props(fallback = "Storage: %1$s/%2$s"))]
+    QuotaStorageUsage = 101,
 
     #[strum(props(fallback = "%1$s: %2$s/%3$s"))]
     QuotaResourceUsage = 102,
@@ -889,14 +889,28 @@ pub(crate) async fn quota_not_supported(context: &Context) -> String {
     translated(context, StockMessage::QuotaNotSupported).await
 }
 
-/// Stock string: `QuotaResourceMessages`.
-pub(crate) async fn quota_resource_messages(context: &Context) -> String {
-    translated(context, StockMessage::QuotaResourceMessages).await
+/// Stock string: `QuotaMessagesUsage`.
+pub(crate) async fn quota_messages_usage(
+    context: &Context,
+    usage: impl AsRef<str>,
+    limit: impl AsRef<str>,
+) -> String {
+    translated(context, StockMessage::QuotaMessagesUsage)
+        .await
+        .replace1(usage)
+        .replace2(limit)
 }
 
-/// Stock string: `QuotaResourceStorage`.
-pub(crate) async fn quota_resource_storage(context: &Context) -> String {
-    translated(context, StockMessage::QuotaResourceStorage).await
+/// Stock string: `QuotaStorageUsage`.
+pub(crate) async fn quota_storage_usage(
+    context: &Context,
+    usage: impl AsRef<str>,
+    limit: impl AsRef<str>,
+) -> String {
+    translated(context, StockMessage::QuotaStorageUsage)
+        .await
+        .replace1(usage)
+        .replace2(limit)
 }
 
 /// Stock string: `QuotaResourceUsage`.


### PR DESCRIPTION
## The Problem
A full mailbox goes often unnoticed, others have to use a different communication channel to notify you that your mailbox if full and it rejected the mails that they sent to you.

## My Solution
My proposed solution to this has two parts, an active user-triggered quota usage report and a passive daily quota check that sends a warning when the highest quota resource usage exceeds a threshold  90% in this case (`DC_QUOTA_WARN_THRESHOLD_PERCENTAGE`, `DC_CHECK_QUOTA_FREQUENCY`).

### Part 1 - Generate Quota Report
A button that triggers a device message that contains all quota roots with their quota resources and their usage.

A bit like the prepaid mobile carrier service menu/messages, where you type a special number and then get a message back with your current balance.

![2021-06-01_17-13](https://user-images.githubusercontent.com/18725968/120463275-08823e80-c39c-11eb-94d0-1cbc3efe78a7.png)
![2021-06-01_17-15](https://user-images.githubusercontent.com/18725968/120463293-0e781f80-c39c-11eb-8526-3b6b0dcaea70.png)

Or a message if the mail-server doesn't support the quota extension:
![2021-06-01_17-13_1](https://user-images.githubusercontent.com/18725968/120463367-2059c280-c39c-11eb-9022-661755e130ed.png)

### Part 2 - Daily Quota Check Job
Check Quota daily and sends a quota report and a warning that your mailbox is nearly full as device messages if the highest quota resource usage exceeds 90%.
```
[Sample report message, riseup in this case]
Your Riseup mail quota:
184.42 MiB/1000 MiB Storage
```
```
Your mailbox on your email account is running full!
Possible Solutions:
- Delete old messages on the server
- or enable \"Delete old messages from server\" in the deltachat settings
- or upgrade your plan with your email provider
If you don't take action you will soon be unable to receive messages.
```

## ToDo

- [ ] reference a `async-imap` release that has https://github.com/async-email/async-imap/pull/47 merged
- [x] fix job spamming issue -> when offline the quota-check job gets spamed
- [x] use stockstrings for user facing messages - to allow for translations
- [x] ~~Disable the job via internal config option if the server doesn't have the quota extension/capability on configuration? or is the check during login sufficient?~~ check during login is done anyways so it's fine.
- [x] repl tool support for the generation
- [x] fix that quota report seems to wait for imap to be interrupted before running


## Related
https://github.com/djc/tokio-imap/pull/124
https://github.com/async-email/async-imap/pull/47

### Desktop pr's for testing
you need both branches to test it:
https://github.com/deltachat/deltachat-node/tree/request_quota_report
https://github.com/deltachat/deltachat-desktop/tree/experimental-function-to-trigger-quota-report -> `exp.requestQuotaReport()` in dev console to trigger report generation
