### PR TITLE
Fix downscaling images

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -512,6 +512,10 @@ impl<'a> BlobObject<'a> {
 
                         img_wh = img_wh * 2 / 3;
                     } else {
+                        if encoded.is_empty() {
+                            encode_img(&new_img, &mut encoded)?;
+                        }
+
                         info!(
                             context,
                             "Final scaled-down image size: {}B ({}px)",

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -458,7 +458,6 @@ impl<'a> BlobObject<'a> {
             max_bytes: Option<usize>,
             encoded: &mut Vec<u8>,
         ) -> anyhow::Result<bool> {
-            // encode_img(img, encoded)?; // TODO this would solve the other bug, but will be a problem if the image needs to be rotated down but not scaled down
             if let Some(max_bytes) = max_bytes {
                 encode_img(img, encoded)?;
                 if encoded.len() > max_bytes {

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -452,7 +452,7 @@ impl<'a> BlobObject<'a> {
             img.write_to(encoded, image::ImageFormat::Jpeg)?;
             Ok(())
         }
-        fn encode_img_exceeds_bytes(
+        fn encoded_img_exceeds_bytes(
             context: &Context,
             img: &DynamicImage,
             max_bytes: Option<usize>,
@@ -478,7 +478,7 @@ impl<'a> BlobObject<'a> {
         let exceeds_width = img.width() > img_wh || img.height() > img_wh;
 
         let do_scale =
-            exceeds_width || encode_img_exceeds_bytes(context, &img, max_bytes, &mut encoded)?;
+            exceeds_width || encoded_img_exceeds_bytes(context, &img, max_bytes, &mut encoded)?;
         let do_rotate = matches!(orientation, Ok(90) | Ok(180) | Ok(270));
 
         if do_scale || do_rotate {
@@ -501,7 +501,7 @@ impl<'a> BlobObject<'a> {
                 loop {
                     let new_img = img.thumbnail(img_wh, img_wh);
 
-                    if encode_img_exceeds_bytes(context, &new_img, max_bytes, &mut encoded)? {
+                    if encoded_img_exceeds_bytes(context, &new_img, max_bytes, &mut encoded)? {
                         if img_wh < 20 {
                             return Err(format_err!(
                                 "Failed to scale image to below {}B",


### PR DESCRIPTION
Fix #2468

The problem was:

If `max_bytes` is `None`, `encoded_img_exceeds_bytes` does nothing, esp. it doesn't encode the image into `encoded`.

Then,
https://github.com/deltachat/deltachat-core-rust/blob/c183203577d8c0b397a3c6216d80c1f2d3112d06/src/blob.rs#L537-L539
encoded the image into `encoded`, but without scaling it down.

(these three lines are needed in case the image does not need to be scaled at all but just rotated)

I wrote a test, but it doesn't include the case that an image has to be rotated; I'm wondering whether this would be worth the effort as we would probably need to put an image with the rotation-exif-flag into the `test-data` folder, sending it out to get the "actual" image, manually rotating it inside the test to get the "expected" image, and then somehow comparing "actual" and "expected". Also, I'm currently running a little low on time, lots of other things to do.

What speaks in favor of an extra test is that the whole `recode_to_size()` code feels like there could easily be more hidden bugs, there are just so many cases to consider. When implementing #2384, I already rewrote the code some number of times as I was completely un-satisfied or hadn't considered some case.

We could also merge this PR and I write some tests later (and we hope that this time, I actually get to do it, I already planned to do this when merging #2384)