### PR TITLE
prepare 1.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog 
 
+## 1.56.0
+
+- fix downscaling images #2469
+
+- fix outgoing messages popping up in selfchat #2456
+
+- securejoin: display error reason if there is any #2470
+
+- do not allow deleting contacts with ongoing chats #2458
+
+- fix: ignore drafts folder when scanning #2454
+
+- fix: scan folders also when inbox is not watched #2446
+
+- update dependencies #2441 #2438 #2439 #2440 #2447 #2448 #2449 #2452 #2453 #2460 #2464 #2466
+
+- update provider-database #2471
+
+- refactorings #2459 #2457
+
+- improve tests and ci #2445 #2450 #2451
+
+
 ## 1.55.0
 
 - fix panic when receiving some HTML messages #2434

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - fix: scan folders also when inbox is not watched #2446
 
+- more robust In-Reply-To parsing #2182
+
 - update dependencies #2441 #2438 #2439 #2440 #2447 #2448 #2449 #2452 #2453 #2460 #2464 #2466
 
 - update provider-database #2471

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.55.0"
+version = "1.56.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1187,7 +1187,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.55.0"
+version = "1.56.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.55.0"
+version = "1.56.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.55.0"
+version = "1.56.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"


### PR DESCRIPTION
the new core includes some bugfixes that may be considered as being a bit critical, esp. the images that are sent in too high resolutions and the outgoing messages popping up in selfchat for some providers.

~~the changelog already mentions #2471 , so that should be reviewed/approved/merged first.~~ EDIT: done

~~@link2xt @flub shall we also merge in https://github.com/deltachat/deltachat-core-rust/pull/2182 ? - this still lgtm :)~~ EDIT: i merged #2182 in an rebased this pr

after commit, on master make sure to: 

   git tag -a 1.56.0
   git push origin 1.56.0