### PR TITLE
Add socks5 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -325,13 +325,14 @@ dependencies = [
 [[package]]
 name = "async-smtp"
 version = "0.4.0"
-source = "git+https://github.com/async-email/async-smtp?rev=c8800625f7cf29f437143ac7e720ac2730a0962f#c8800625f7cf29f437143ac7e720ac2730a0962f"
+source = "git+https://github.com/async-email/async-smtp?branch=master#2c21f5fb643e9a24c1097f13db4dfcd7818ada06"
 dependencies = [
  "async-native-tls",
  "async-std",
  "async-trait",
  "base64 0.13.0",
  "bufstream",
+ "fast-socks5",
  "hostname 0.1.5",
  "log",
  "nom 5.1.2",
@@ -1142,6 +1143,7 @@ dependencies = [
  "email",
  "encoded-words",
  "escaper",
+ "fast-socks5",
  "futures",
  "futures-lite",
  "hex",
@@ -1514,6 +1516,19 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fast-socks5"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c1955b65d95243f547eb1d1ee6e5ce75ecf6daaeb72b08cd6c66e549d6d88e1"
+dependencies = [
+ "anyhow",
+ "async-std",
+ "futures",
+ "log",
+ "thiserror",
+]
 
 [[package]]
 name = "fast_chemail"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ ansi_term = { version = "0.12.1", optional = true }
 anyhow = "1.0.42"
 async-imap = { git = "https://github.com/async-email/async-imap" }
 async-native-tls = { version = "0.3.3" }
-async-smtp = { git = "https://github.com/async-email/async-smtp", rev="c8800625f7cf29f437143ac7e720ac2730a0962f" }
+async-smtp = { git = "https://github.com/async-email/async-smtp", branch="master", features = ["socks5"] }
 async-std-resolver = "0.20.3"
 async-std = { version = "~1.9.0", features = ["unstable"] }
 async-tar = "0.3.0"
@@ -72,6 +72,7 @@ thiserror = "1.0.26"
 toml = "0.5.6"
 url = "2.2.2"
 uuid = { version = "0.8", features = ["serde", "v4"] }
+fast-socks5 = "0.4.2"
 humansize = "1.1.1"
 
 [dev-dependencies]

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -271,6 +271,11 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  * - `send_port`    = SMTP-port, guessed if left out
  * - `send_security`= SMTP-socket, one of @ref DC_SOCKET, defaults to #DC_SOCKET_AUTO
  * - `server_flags` = IMAP-/SMTP-flags as a combination of @ref DC_LP flags, guessed if left out
+ * - `socks5_enabled` = SOCKS5 enabled
+ * - `socks5_host` = SOCKS5 proxy server host
+ * - `socks5_port` = SOCKS5 proxy server port
+ * - `socks5_user` = SOCKS5 proxy username
+ * - `socks5_password` = SOCKS5 proxy password
  * - `imap_certificate_checks` = how to check IMAP certificates, one of the @ref DC_CERTCK flags, defaults to #DC_CERTCK_AUTO (0)
  * - `smtp_certificate_checks` = how to check SMTP certificates, one of the @ref DC_CERTCK flags, defaults to #DC_CERTCK_AUTO (0)
  * - `displayname`  = Own name to use when sending messages.  MUAs are allowed to spread this way e.g. using CC, defaults to empty

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3614,7 +3614,16 @@ pub unsafe extern "C" fn dc_provider_new_from_email(
         return ptr::null();
     }
     let addr = to_string_lossy(addr);
-    match block_on(provider::get_provider_info(addr.as_str())) {
+
+    let ctx = &*context;
+    let socks5_enabled = block_on(async move {
+        ctx.get_config_bool(config::Config::Socks5Enabled)
+            .await
+            .log_err(ctx, "Can't get config")
+            .unwrap_or_default()
+    });
+
+    match block_on(provider::get_provider_info(addr.as_str(), socks5_enabled)) {
         Some(provider) => provider,
         None => ptr::null_mut(),
     }

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -1168,7 +1168,11 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
         }
         "providerinfo" => {
             ensure!(!arg1.is_empty(), "Argument <addr> missing.");
-            match provider::get_provider_info(arg1).await {
+            let socks5_enabled = context
+                .get_config_bool(config::Config::Socks5Enabled)
+                .await
+                .unwrap_or_default();
+            match provider::get_provider_info(arg1, socks5_enabled).await {
                 Some(info) => {
                     println!("Information for provider belonging to {}:", arg1);
                     println!("status: {}", info.status as u32);

--- a/src/config.rs
+++ b/src/config.rs
@@ -48,6 +48,12 @@ pub enum Config {
     SmtpCertificateChecks,
     ServerFlags,
 
+    Socks5Enabled,
+    Socks5Host,
+    Socks5Port,
+    Socks5User,
+    Socks5Password,
+
     Displayname,
     Selfstatus,
     Selfavatar,

--- a/src/context.rs
+++ b/src/context.rs
@@ -289,6 +289,7 @@ impl Context {
         let request_msgs = message::get_request_msg_cnt(self).await as usize;
         let contacts = Contact::get_real_cnt(self).await? as usize;
         let is_configured = self.get_config_int(Config::Configured).await?;
+        let socks5_enabled = self.get_config_int(Config::Socks5Enabled).await?;
         let dbversion = self
             .sql
             .get_raw_config_int("dbversion")
@@ -357,6 +358,7 @@ impl Context {
                 .unwrap_or_else(|| "<unset>".to_string()),
         );
         res.insert("is_configured", is_configured.to_string());
+        res.insert("socks5_enabled", socks5_enabled.to_string());
         res.insert("entered_account_settings", l.to_string());
         res.insert("used_account_settings", l2.to_string());
         res.insert(
@@ -878,6 +880,10 @@ mod tests {
             "send_security",
             "server_flags",
             "smtp_certificate_checks",
+            "socks5_host",
+            "socks5_port",
+            "socks5_user",
+            "socks5_password",
         ];
         let t = TestContext::new().await;
         let info = t.get_info().await.unwrap();

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -27,6 +27,7 @@ use crate::events::EventType;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
 use crate::job::{self, Action};
 use crate::login_param::{CertificateChecks, LoginParam, ServerLoginParam};
+use crate::login_param::{ServerAddress, Socks5Config};
 use crate::message::{self, update_server_uid, MessageState};
 use crate::mimeparser;
 use crate::oauth2::dc_get_oauth2_access_token;
@@ -142,6 +143,7 @@ impl FolderMeaning {
 struct ImapConfig {
     pub addr: String,
     pub lp: ServerLoginParam,
+    pub socks5_config: Option<Socks5Config>,
     pub strict_tls: bool,
     pub oauth2: bool,
     pub selected_folder: Option<String>,
@@ -165,6 +167,7 @@ impl Imap {
     /// `addr` is used to renew token if OAuth2 authentication is used.
     pub async fn new(
         lp: &ServerLoginParam,
+        socks5_config: Option<Socks5Config>,
         addr: &str,
         oauth2: bool,
         provider_strict_tls: bool,
@@ -183,6 +186,7 @@ impl Imap {
         let config = ImapConfig {
             addr: addr.to_string(),
             lp: lp.clone(),
+            socks5_config,
             strict_tls,
             oauth2,
             selected_folder: None,
@@ -222,6 +226,7 @@ impl Imap {
 
         let imap = Self::new(
             &param.imap,
+            param.socks5_config.clone(),
             &param.addr,
             param.server_flags & DC_LP_AUTH_OAUTH2 != 0,
             param.provider.map_or(false, |provider| provider.strict_tls),
@@ -261,7 +266,20 @@ impl Imap {
             let imap_server: &str = config.lp.server.as_ref();
             let imap_port = config.lp.port;
 
-            match Client::connect_insecure((imap_server, imap_port)).await {
+            let connection = if let Some(socks5_config) = &config.socks5_config {
+                Client::connect_insecure_socks5(
+                    &ServerAddress {
+                        host: imap_server.to_string(),
+                        port: imap_port,
+                    },
+                    socks5_config.clone(),
+                )
+                .await
+            } else {
+                Client::connect_insecure((imap_server, imap_port)).await
+            };
+
+            match connection {
                 Ok(client) => {
                     if config.lp.security == Socket::Starttls {
                         client.secure(imap_server, config.strict_tls).await
@@ -276,7 +294,20 @@ impl Imap {
             let imap_server: &str = config.lp.server.as_ref();
             let imap_port = config.lp.port;
 
-            Client::connect_secure((imap_server, imap_port), imap_server, config.strict_tls).await
+            if let Some(socks5_config) = &config.socks5_config {
+                Client::connect_secure_socks5(
+                    &ServerAddress {
+                        host: imap_server.to_string(),
+                        port: imap_port,
+                    },
+                    config.strict_tls,
+                    socks5_config.clone(),
+                )
+                .await
+            } else {
+                Client::connect_secure((imap_server, imap_port), imap_server, config.strict_tls)
+                    .await
+            }
         };
 
         let login_res = match connection_res {

--- a/src/imap/session.rs
+++ b/src/imap/session.rs
@@ -3,6 +3,7 @@ use std::ops::{Deref, DerefMut};
 use async_imap::Session as ImapSession;
 use async_native_tls::TlsStream;
 use async_std::net::TcpStream;
+use fast_socks5::client::Socks5Stream;
 
 #[derive(Debug)]
 pub(crate) struct Session {
@@ -17,6 +18,7 @@ pub(crate) trait SessionStream:
 impl SessionStream for TlsStream<Box<dyn SessionStream>> {}
 impl SessionStream for TlsStream<TcpStream> {}
 impl SessionStream for TcpStream {}
+impl SessionStream for Socks5Stream<TcpStream> {}
 
 impl Deref for Session {
     type Target = ImapSession<Box<dyn SessionStream>>;

--- a/standards.md
+++ b/standards.md
@@ -5,6 +5,7 @@ Some of the standards Delta Chat is based on:
 Tasks                            | Standards
 ---------------------------------|---------------------------------------------
 Transport                        | IMAP v4 ([RFC 3501](https://tools.ietf.org/html/rfc3501)), SMTP ([RFC 5321](https://tools.ietf.org/html/rfc5321)) and Internet Message Format (IMF, [RFC 5322](https://tools.ietf.org/html/rfc5322))
+Proxy                            | SOCKS5 ([RFC 1928](https://tools.ietf.org/html/rfc1928))
 Embedded media                   | MIME Document Series ([RFC 2045](https://tools.ietf.org/html/rfc2045), [RFC 2046](https://tools.ietf.org/html/rfc2046)), Content-Disposition Header ([RFC 2183](https://tools.ietf.org/html/rfc2183)), Multipart/Related ([RFC 2387](https://tools.ietf.org/html/rfc2387))
 Text and Quote encoding          | Fixed, Flowed ([RFC 3676](https://tools.ietf.org/html/rfc3676))
 Filename encoding                | Encoded Words ([RFC 2047](https://tools.ietf.org/html/rfc2047)), Encoded Word Extensions ([RFC 2231](https://tools.ietf.org/html/rfc2231))


### PR DESCRIPTION
Implements socks5 support. 
This adds following settings:
- Socks5Enabled,
- Socks5Host,
- Socks5Port,
- Socks5User,
- Socks5Password

Currently http requests and dns requests are not getting executed as they currently can't get tunneled through socks5 proxy. Therefore gmail with oauth2 wont work through tor.