### PR TITLE
Improve drafts detection

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -685,11 +685,26 @@ async fn add_parts(
             }
         }
 
-        if !context.is_sentbox(server_folder).await?
+        // If the message is outgoing AND there is no Received header AND it's not in the sentbox,
+        // then ignore the email.
+        //
+        // We only apply this heuristic to classical emails, as it is not reliable (some servers
+        // such as systemli.org in June 2021 remove their own Received headers on incoming mails)
+        // and we know Delta Chat never stores drafts on IMAP servers.
+        let is_draft = !context.is_sentbox(server_folder).await?
             && mime_parser.get(HeaderDef::Received).is_none()
-        {
+            && mime_parser.get(HeaderDef::ChatVersion).is_none();
+
+        // Mozilla Thunderbird does not set \Draft flag on "Templates", but sets
+        // X-Mozilla-Draft-Info header, which can be used to detect both drafts and templates
+        // created by Thunderbird.
+        //
+        // This check is not necessary now, but may become useful if the `Received:` header check
+        // is removed completely later.
+        let is_draft = is_draft || mime_parser.get(HeaderDef::XMozillaDraftInfo).is_some();
+
+        if is_draft {
             // Most mailboxes have a "Drafts" folder where constantly new emails appear but we don't actually want to show them
-            // So: If it's outgoing AND there is no Received header AND it's not in the sentbox, then ignore the email.
             info!(context, "Email is probably just a draft (TRASH)");
             *chat_id = DC_CHAT_ID_TRASH;
             allow_creation = false;

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -25,6 +25,12 @@ pub enum HeaderDef {
     /// we need to check that header as well.
     XMicrosoftOriginalMessageId,
 
+    /// Thunderbird header used to store Draft information.
+    ///
+    /// Thunderbird 78.11.0 does not set \Draft flag on messages saved as "Template", but sets this
+    /// header, so it can be used to ignore such messages.
+    XMozillaDraftInfo,
+
     ListId,
     References,
     InReplyTo,


### PR DESCRIPTION
systemli.org seems not to include Received: header in messages sent to
self, including BCC-self and messages sent to Saved message chat. This
results in all these messages not being displayed on other devices in
multi-device setting. To work around this problem we restrict draft
detection based on Received: header to classical mails.

Delta Chat already implements proper draft detection based on the
\Draft message flag and \Drafts folder flag (#2454). However, Thunderbird does
not set \Draft flag when message is stored as "Template". To make
draft detection for Thunderbird more robust, in case Received: header
check is removed altogether later, we check for X-Mozilla-Draft-Info
header which Thunderbird sets both for "Drafts" and "Templates".