### PR TITLE
avoid creating a default account, adapt tests

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2486,6 +2486,7 @@ dc_context_t*  dc_accounts_get_account          (dc_accounts_t* accounts, uint32
  *     unmanaged account-context as created by dc_context_new().
  *     Once you do no longer need the context-object, you have to call dc_context_unref() on it,
  *     which, however, will not close the account but only decrease a reference counter.
+ *     If there is no selected account, NULL is returned.
  */
 dc_context_t*  dc_accounts_get_selected_account (dc_accounts_t* accounts);
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3695,8 +3695,9 @@ pub unsafe extern "C" fn dc_accounts_get_selected_account(
     }
 
     let accounts = &*accounts;
-    let ctx = block_on(accounts.get_selected_account());
-    Box::into_raw(Box::new(ctx))
+    block_on(accounts.get_selected_account())
+        .map(|ctx| Box::into_raw(Box::new(ctx)))
+        .unwrap_or_else(std::ptr::null_mut)
 }
 
 #[no_mangle]

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -65,14 +65,9 @@ impl Accounts {
     }
 
     /// Get the currently selected account.
-    pub async fn get_selected_account(&self) -> Context {
+    pub async fn get_selected_account(&self) -> Option<Context> {
         let id = self.config.get_selected_account().await;
-        self.accounts
-            .read()
-            .await
-            .get(&id)
-            .cloned()
-            .expect("inconsistent state")
+        self.accounts.read().await.get(&id).cloned()
     }
 
     /// Select the given account.
@@ -509,7 +504,7 @@ mod tests {
         assert_eq!(accounts.accounts.read().await.len(), 1);
         assert_eq!(accounts.config.get_selected_account().await, 1);
 
-        let ctx = accounts.get_selected_account().await;
+        let ctx = accounts.get_selected_account().await.unwrap();
         assert_eq!(
             "me@mail.com",
             ctx.get_config(crate::config::Config::Addr)
@@ -581,7 +576,7 @@ mod tests {
 
         let (id0_reopened, id1_reopened, id2_reopened) = {
             let accounts = Accounts::new("my_os".into(), p.clone()).await?;
-            let ctx = accounts.get_selected_account().await;
+            let ctx = accounts.get_selected_account().await.unwrap();
             assert_eq!(
                 ctx.get_config(crate::config::Config::Addr).await?,
                 Some("two@example.org".to_string())

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -479,6 +479,27 @@ mod tests {
     }
 
     #[async_std::test]
+    async fn test_accounts_remove_last() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let p: PathBuf = dir.path().join("accounts").into();
+
+        let accounts = Accounts::new("my_os".into(), p.clone()).await?;
+        assert!(accounts.get_selected_account().await.is_none());
+        assert_eq!(accounts.config.get_selected_account().await, 0);
+
+        let id = accounts.add_account().await?;
+        assert!(accounts.get_selected_account().await.is_some());
+        assert_eq!(id, 1);
+        assert_eq!(accounts.accounts.read().await.len(), 1);
+        assert_eq!(accounts.config.get_selected_account().await, id);
+
+        accounts.remove_account(id).await?;
+        assert!(accounts.get_selected_account().await.is_none());
+
+        Ok(())
+    }
+
+    #[async_std::test]
     async fn test_migrate_account() {
         let dir = tempfile::tempdir().unwrap();
         let p: PathBuf = dir.path().join("accounts").into();


### PR DESCRIPTION
the default account created by `dc_accounts_new()`
is annoying when doing a migrate/import account;
in this case, you must not forget to remove the default account.
in between you have two account,
and accounts are swiched.

it seems to be better
to just call add_account() on a new account object as needed.