### PR TITLE
move links to angle brackets to avoid rustdoc errors

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -74,7 +74,7 @@ impl<'a> BlobObject<'a> {
 
         // workaround a bug in async-std
         // (the executor does not handle blocking operation in Drop correctly,
-        // see https://github.com/async-rs/async-std/issues/900 )
+        // see <https://github.com/async-rs/async-std/issues/900>)
         let _ = file.flush().await;
 
         let blob = BlobObject {

--- a/src/color.rs
+++ b/src/color.rs
@@ -42,7 +42,7 @@ mod tests {
     #[test]
     fn test_str_to_angle() {
         // Test against test vectors from
-        // https://xmpp.org/extensions/xep-0392.html#testvectors-fullrange-no-cvd
+        // <https://xmpp.org/extensions/xep-0392.html#testvectors-fullrange-no-cvd>
         assert!((str_to_angle("Romeo") - 327.255249).abs() < 1e-6);
         assert!((str_to_angle("juliet@capulet.lit") - 209.410400).abs() < 1e-6);
         assert!((str_to_angle("😺") - 331.199341).abs() < 1e-6);

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -453,7 +453,7 @@ async fn get_autoconfig(
 
     if let Ok(res) = moz_autoconfigure(
         ctx,
-        // the doc does not mention `emailaddress=`, however, Thunderbird adds it, see https://releases.mozilla.org/pub/thunderbird/ ,  which makes some sense
+        // the doc does not mention `emailaddress=`, however, Thunderbird adds it, see <https://releases.mozilla.org/pub/thunderbird/>,  which makes some sense
         &format!(
             "https://{}/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress={}",
             &param_domain, &param_addr_urlencoded

--- a/src/configure/auto_mozilla.rs
+++ b/src/configure/auto_mozilla.rs
@@ -1,6 +1,6 @@
 //! # Thunderbird's Autoconfiguration implementation
 //!
-//! Documentation: https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration
+//! Documentation: <https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration>
 use quick_xml::events::{BytesStart, Event};
 
 use std::io::BufRead;

--- a/src/configure/auto_outlook.rs
+++ b/src/configure/auto_outlook.rs
@@ -15,27 +15,27 @@ use super::{Error, ServerParams};
 
 /// Result of parsing a single `Protocol` tag.
 ///
-/// https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/protocol-pox
+/// <https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/protocol-pox>
 #[derive(Debug)]
 struct ProtocolTag {
     /// Server type, such as "IMAP", "SMTP" or "POP3".
     ///
-    /// https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/type-pox
+    /// <https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/type-pox>
     pub typ: String,
 
     /// Server identifier, hostname or IP address for IMAP and SMTP.
     ///
-    /// https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/server-pox
+    /// <https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/server-pox>
     pub server: String,
 
     /// Network port.
     ///
-    /// https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/port-pox
+    /// <https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/port-pox>
     pub port: u16,
 
     /// Whether connection should be secure, "on" or "off", default is "on".
     ///
-    /// https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/ssl-pox
+    /// <https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/ssl-pox>
     pub ssl: bool,
 }
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -128,7 +128,7 @@ pub(crate) async fn dc_receive_imf_inner(
     // the other To:/Cc: in the 3rd pass)
     // or if From: is equal to SELF (in this case, it is any outgoing messages,
     // we do not check Return-Path any more as this is unreliable, see
-    // https://github.com/deltachat/deltachat-core/issues/150)
+    // <https://github.com/deltachat/deltachat-core/issues/150>)
     //
     // If this is a mailing list email (i.e. list_id_header is some), don't change the displayname because in
     // a mailing list the sender displayname sometimes does not belong to the sender email address.
@@ -1963,7 +1963,7 @@ async fn check_verified_properties(
                 // - use the gossip-key as verified-key if there is no verified-key
                 // - OR if the verified-key does not match public-key or gossip-key
                 //   (otherwise a verified key can _only_ be updated through QR scan which might be annoying,
-                //   see https://github.com/nextleap-project/countermitm/issues/46 for a discussion about this point)
+                //   see <https://github.com/nextleap-project/countermitm/issues/46> for a discussion about this point)
                 if !is_verified
                     || peerstate.verified_key_fingerprint != peerstate.public_key_fingerprint
                         && peerstate.verified_key_fingerprint != peerstate.gossip_key_fingerprint
@@ -4009,7 +4009,7 @@ YEAAAAAA!.
 
     #[async_std::test]
     async fn test_dont_show_all_outgoing_msgs_in_self_chat() {
-        // Regression test for https://github.com/deltachat/deltachat-android/issues/1940:
+        // Regression test for <https://github.com/deltachat/deltachat-android/issues/1940>:
         // Some servers add a `Bcc: <Self>` header, which caused all outgoing messages to
         // be shown in the self-chat.
         let t = TestContext::new_alice().await;

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -666,7 +666,7 @@ pub fn remove_subject_prefix(last_subject: &str) -> String {
         0
     } else {
         // "Antw:" is the longest abbreviation in
-        // https://en.wikipedia.org/wiki/List_of_email_subject_abbreviations#Abbreviations_in_other_languages,
+        // <https://en.wikipedia.org/wiki/List_of_email_subject_abbreviations#Abbreviations_in_other_languages>,
         // so look at the first _5_ characters:
         match last_subject.chars().take(5).position(|c| c == ':') {
             Some(prefix_end) => prefix_end + 1,

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -149,7 +149,7 @@ struct ImapConfig {
     pub can_idle: bool,
 
     /// True if the server has MOVE capability as defined in
-    /// https://tools.ietf.org/html/rfc6851
+    /// <https://tools.ietf.org/html/rfc6851>
     pub can_move: bool,
 }
 
@@ -784,7 +784,7 @@ impl Imap {
         // at least one UID, even if last_seen_uid+1 is past
         // the last UID in the mailbox.  It happens because
         // uid:* is interpreted the same way as *:uid.
-        // See https://tools.ietf.org/html/rfc3501#page-61 for
+        // See <https://tools.ietf.org/html/rfc3501#page-61> for
         // standard reference. Therefore, sometimes we receive
         // already seen messages and have to filter them out.
         let new_msgs = msgs.split_off(&uid_next);
@@ -1372,7 +1372,7 @@ impl Imap {
 // CAVE: if possible, take care not to add a name here that is "sent" in one language
 // but sth. different in others - a hard job.
 fn get_folder_meaning_by_name(folder_name: &str) -> FolderMeaning {
-    // source: https://stackoverflow.com/questions/2185391/localized-gmail-imap-folders
+    // source: <https://stackoverflow.com/questions/2185391/localized-gmail-imap-folders>
     const SENT_NAMES: &[&str] = &[
         "sent",
         "sentmail",
@@ -1702,7 +1702,7 @@ fn get_fallback_folder(delimiter: &str) -> String {
 }
 
 /// uid_next is the next unique identifier value from the last time we fetched a folder
-/// See https://tools.ietf.org/html/rfc3501#section-2.3.1.1
+/// See <https://tools.ietf.org/html/rfc3501#section-2.3.1.1>
 /// This function is used to update our uid_next after fetching messages.
 pub(crate) async fn set_uid_next(context: &Context, folder: &str, uid_next: u32) -> Result<()> {
     context
@@ -1717,7 +1717,7 @@ pub(crate) async fn set_uid_next(context: &Context, folder: &str, uid_next: u32)
 }
 
 /// uid_next is the next unique identifier value from the last time we fetched a folder
-/// See https://tools.ietf.org/html/rfc3501#section-2.3.1.1
+/// See <https://tools.ietf.org/html/rfc3501#section-2.3.1.1>
 /// This method returns the uid_next from the last time we fetched messages.
 /// We can compare this to the current uid_next to find out whether there are new messages
 /// and fetch from this value on to get all new messages.
@@ -1778,7 +1778,7 @@ pub async fn get_config_last_seen_uid<S: AsRef<str>>(
 }
 
 /// Builds a list of sequence/uid sets. The returned sets have each no more than around 1000
-/// characters because according to https://tools.ietf.org/html/rfc2683#section-3.2.1.5
+/// characters because according to <https://tools.ietf.org/html/rfc2683#section-3.2.1.5>
 /// command lines should not be much more than 1000 chars (servers should allow at least 8000 chars)
 fn build_sequence_sets(mut uids: Vec<u32>) -> Vec<String> {
     uids.sort_unstable();

--- a/src/imap/select_folder.rs
+++ b/src/imap/select_folder.rs
@@ -26,7 +26,7 @@ impl Imap {
     /// Issues a CLOSE command to expunge selected folder.
     ///
     /// CLOSE is considerably faster than an EXPUNGE, see
-    /// https://tools.ietf.org/html/rfc3501#section-6.4.2
+    /// <https://tools.ietf.org/html/rfc3501#section-6.4.2>
     pub(super) async fn close_folder(&mut self, context: &Context) -> Result<()> {
         if let Some(ref folder) = self.config.selected_folder {
             info!(context, "Expunge messages in \"{}\".", folder);
@@ -92,7 +92,7 @@ impl Imap {
             if let Some(ref mut session) = &mut self.session {
                 let res = session.select(folder).await;
 
-                // https://tools.ietf.org/html/rfc3501#section-6.3.1
+                // <https://tools.ietf.org/html/rfc3501#section-6.3.1>
                 // says that if the server reports select failure we are in
                 // authenticated (not-select) state.
 

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -184,7 +184,7 @@ pub async fn has_backup_old(context: &Context, dir_name: &Path) -> Result<String
                             "Found backup file {} which could not be opened: {}", name, e
                         );
                         // On some Android devices we can't open sql files that are not in our private directory
-                        // (see https://github.com/deltachat/deltachat-android/issues/1768). So, compare names
+                        // (see <https://github.com/deltachat/deltachat-android/issues/1768>). So, compare names
                         // to still find the newest backup.
                         let name: String = name.into();
                         if newest_backup_time == 0

--- a/src/job.rs
+++ b/src/job.rs
@@ -261,13 +261,13 @@ impl Job {
                         // instead of temporary ones.
                         let maybe_transient = match response.code {
                             // Sometimes servers send a permanent error when actually it is a temporary error
-                            // For documentation see https://tools.ietf.org/html/rfc3463
+                            // For documentation see <https://tools.ietf.org/html/rfc3463>
                             Code {
                                 category: Category::MailSystem,
                                 detail: Detail::Zero,
                                 ..
                             } => {
-                                // Ignore status code 5.5.0, see https://support.delta.chat/t/every-other-message-gets-stuck/877/2
+                                // Ignore status code 5.5.0, see <https://support.delta.chat/t/every-other-message-gets-stuck/877/2>
                                 // Maybe incorrectly configured Postfix milter with "reject" instead of "tempfail", which returns
                                 // "550 5.5.0 Service unavailable" instead of "451 4.7.1 Service unavailable - try again later".
                                 //
@@ -301,7 +301,7 @@ impl Job {
                                 // Sometimes we receive transient errors that should be permanent.
                                 // Any extended smtp status codes like x.1.1, x.1.2 or x.1.3 that we
                                 // receive as a transient error are misconfigurations of the smtp server.
-                                // See https://tools.ietf.org/html/rfc3463#section-3.2
+                                // See <https://tools.ietf.org/html/rfc3463#section-3.2>
                                 info!(context, "Smtp-job #{} Received extended status code {} for a transient error. This looks like a misconfigured smtp server, let's fail immediatly", self.job_id, first_word);
                                 Status::Finished(Err(format_err!("Permanent SMTP error: {}", err)))
                             } else {
@@ -709,7 +709,7 @@ impl Job {
 
         // Make sure that if there now is a chat with a contact (created by an outgoing
         // message), then group contact requests from this contact should also be unblocked.
-        // See https://github.com/deltachat/deltachat-core-rust/issues/2097.
+        // See <https://github.com/deltachat/deltachat-core-rust/issues/2097>.
         for item in job_try!(chat::get_chat_msgs(context, DC_CHAT_ID_DEADDROP, 0, None).await) {
             if let ChatItem::Message { msg_id } = item {
                 let msg = match Message::load_from_db(context, msg_id).await {

--- a/src/log.rs
+++ b/src/log.rs
@@ -76,7 +76,7 @@ where
     /// Once it is, you can add `#[track_caller]` to helper functions that use one of the log helpers here
     /// so that the location of the caller can be seen in the log. (this won't work with the macros,
     /// like warn!(), since the file!() and line!() macros don't work with track_caller)  
-    /// See https://github.com/rust-lang/rust/issues/78840 for progress on this.
+    /// See <https://github.com/rust-lang/rust/issues/78840> for progress on this.
     #[track_caller]
     fn log_err(self, context: &Context, msg: &str) -> Result<T, E> {
         self.log_err_inner(context, Some(msg))

--- a/src/message.rs
+++ b/src/message.rs
@@ -757,7 +757,7 @@ impl Message {
         } else if url.contains("$NOROOM") {
             // there are some usecases where a separate room is not needed to use a service
             // eg. if you let in people manually anyway, see discussion at
-            // https://support.delta.chat/t/videochat-with-webex/1412/4 .
+            // <https://support.delta.chat/t/videochat-with-webex/1412/4>.
             // hacks as hiding the room behind `#` are not reliable, therefore,
             // these services are supported by adding the string `$NOROOM` to the url.
             url.replace("$NOROOM", "")
@@ -1368,7 +1368,7 @@ pub fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)> {
         // before using viewtype other than Viewtype::File,
         // make sure, all target UIs support that type in the context of the used viewer/player.
         // if in doubt, it is better to default to Viewtype::File that passes handing to an external app.
-        // (cmp. https://developer.android.com/guide/topics/media/media-formats )
+        // (cmp. <https://developer.android.com/guide/topics/media/media-formats>)
         "3gp" => (Viewtype::Video, "video/3gpp"),
         "aac" => (Viewtype::Audio, "audio/aac"),
         "avi" => (Viewtype::Video, "video/x-msvideo"),

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -860,7 +860,7 @@ impl<'a> MimeFactory<'a> {
                 // This should prevent automatic replies,
                 // such as non-delivery reports.
                 //
-                // See https://tools.ietf.org/html/rfc3834
+                // See <https://tools.ietf.org/html/rfc3834>
                 //
                 // Adding this header without encryption leaks some
                 // information about the message contents, but it can
@@ -1395,7 +1395,7 @@ mod tests {
             Address::new_mailbox_with_name(display_name.to_string(), addr.to_string())
         );
 
-        // Addresses should not be unnecessarily be encoded, see https://github.com/deltachat/deltachat-core-rust/issues/1575:
+        // Addresses should not be unnecessarily be encoded, see <https://github.com/deltachat/deltachat-core-rust/issues/1575>:
         assert_eq!(s, "a space <x@y.org>");
     }
 
@@ -1859,7 +1859,7 @@ mod tests {
 
     #[test]
     fn test_no_empty_lines_in_header() {
-        // See https://github.com/deltachat/deltachat-core-rust/issues/2118
+        // See <https://github.com/deltachat/deltachat-core-rust/issues/2118>
         let to_tuples = [
             ("Nnnn", "nnn@ttttttttt.de"),
             ("😀 ttttttt", "ttttttt@rrrrrr.net"),

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -198,7 +198,7 @@ impl MimeMessage {
                         }
 
                         // Handle any gossip headers if the mail was encrypted.  See section
-                        // "3.6 Key Gossip" of https://autocrypt.org/autocrypt-spec-1.1.0.pdf
+                        // "3.6 Key Gossip" of <https://autocrypt.org/autocrypt-spec-1.1.0.pdf>
                         // but only if the mail was correctly signed:
                         if !signatures.is_empty() {
                             let gossip_headers =
@@ -220,7 +220,7 @@ impl MimeMessage {
                         let mut throwaway_from = from.clone();
 
                         // We do not want to allow unencrypted subject in encrypted emails because the user might falsely think that the subject is safe.
-                        // See https://github.com/deltachat/deltachat-core-rust/issues/1790.
+                        // See <https://github.com/deltachat/deltachat-core-rust/issues/1790>.
                         headers.remove("subject");
 
                         MimeMessage::merge_headers(
@@ -731,7 +731,7 @@ impl MimeMessage {
                 The second body part contains the control information necessary to
                 verify the digital signature." We simply take the first body part and
                 skip the rest.  (see
-                https://k9mail.github.io/2016/11/24/OpenPGP-Considerations-Part-I.html
+                <https://k9mail.github.io/2016/11/24/OpenPGP-Considerations-Part-I.html>
                 for background information why we use encrypted+signed) */
                 if let Some(first) = mail.subparts.get(0) {
                     any_part_added = self
@@ -1463,7 +1463,7 @@ fn get_mime_type(mail: &mailparse::ParsedMail<'_>) -> Result<(Mime, Viewtype)> {
         mime::VIDEO => Viewtype::Video,
         mime::MULTIPART => Viewtype::Unknown,
         mime::MESSAGE => {
-            // Enacapsulated messages, see https://www.w3.org/Protocols/rfc1341/7_3_Message.html
+            // Enacapsulated messages, see <https://www.w3.org/Protocols/rfc1341/7_3_Message.html>
             // Also used as part "message/disposition-notification" of "multipart/report", which, however, will
             // be handled separatedly.
             // I've not seen any messages using this, so we do not attach these parts (maybe they're used to attach replies,

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -12,7 +12,7 @@ use crate::provider;
 use crate::provider::Oauth2Authorizer;
 
 const OAUTH2_GMAIL: Oauth2 = Oauth2 {
-    // see https://developers.google.com/identity/protocols/OAuth2InstalledApp
+    // see <https://developers.google.com/identity/protocols/OAuth2InstalledApp>
     client_id: "959970109878-4mvtgf6feshskf7695nfln6002mom908.apps.googleusercontent.com",
     get_code: "https://accounts.google.com/o/oauth2/auth?client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&response_type=code&scope=https%3A%2F%2Fmail.google.com%2F%20email&access_type=offline",
     init_token: "https://accounts.google.com/o/oauth2/token?client_id=$CLIENT_ID&redirect_uri=$REDIRECT_URI&code=$CODE&grant_type=authorization_code",
@@ -21,7 +21,7 @@ const OAUTH2_GMAIL: Oauth2 = Oauth2 {
 };
 
 const OAUTH2_YANDEX: Oauth2 = Oauth2 {
-    // see https://tech.yandex.com/oauth/doc/dg/reference/auto-code-client-docpage/
+    // see <https://tech.yandex.com/oauth/doc/dg/reference/auto-code-client-docpage/>
     client_id: "c4d0b6735fc8420a816d7e1303469341",
     get_code: "https://oauth.yandex.com/authorize?client_id=$CLIENT_ID&response_type=code&scope=mail%3Aimap_full%20mail%3Asmtp&force_confirm=true",
     init_token: "https://oauth.yandex.com/token?grant_type=authorization_code&code=$CODE&client_id=$CLIENT_ID&client_secret=58b8c6e94cf44fbe952da8511955dacf",
@@ -41,7 +41,7 @@ struct Oauth2 {
 /// OAuth 2 Access Token Response
 #[derive(Debug, Deserialize)]
 struct Response {
-    // Should always be there according to: https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/
+    // Should always be there according to: <https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/>
     // but previous code handled its abscense.
     access_token: Option<String>,
     token_type: String,
@@ -129,7 +129,7 @@ pub async fn dc_get_oauth2_access_token(
             };
 
         // to allow easier specification of different configurations,
-        // token_url is in GET-method-format, sth. as https://domain?param1=val1&param2=val2 -
+        // token_url is in GET-method-format, sth. as <https://domain?param1=val1&param2=val2> -
         // convert this to POST-format ...
         let mut parts = token_url.splitn(2, '?');
         let post_url = parts.next().unwrap_or_default();

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -86,7 +86,7 @@ impl<'a> PublicKeyTrait for SignedPublicKeyOrSubkey<'a> {
     }
 }
 
-/// Split data from PGP Armored Data as defined in https://tools.ietf.org/html/rfc4880#section-6.2.
+/// Split data from PGP Armored Data as defined in <https://tools.ietf.org/html/rfc4880#section-6.2>.
 ///
 /// Returns (type, headers, base64 encoded body).
 pub fn split_armored_data(buf: &[u8]) -> Result<(BlockType, BTreeMap<String, String>, Vec<u8>)> {

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -247,8 +247,8 @@ fn render_message(lines: &[&str], is_cut_at_end: bool) -> String {
 fn is_empty_line(buf: &str) -> bool {
     buf.chars().all(char::is_whitespace)
     // for some time, this checked for `char <= ' '`,
-    // see discussion at: https://github.com/deltachat/deltachat-core-rust/pull/402#discussion_r317062392
-    // and https://github.com/deltachat/deltachat-core-rust/pull/2104/files#r538973613
+    // see discussion at: <https://github.com/deltachat/deltachat-core-rust/pull/402#discussion_r317062392>
+    // and <https://github.com/deltachat/deltachat-core-rust/pull/2104/files#r538973613>
 }
 
 fn is_quoted_headline(buf: &str) -> bool {
@@ -396,7 +396,7 @@ mod tests {
         assert!(!is_cut);
         assert_eq!(footer, None);
 
-        // Nonstandard footer sent by https://siju.es/
+        // Nonstandard footer sent by <https://siju.es/>
         let input = "Message text here\n---Desde mi teléfono con SIJÚ\n\nQuote here".to_string();
         let (plain, _, is_cut, _, footer) = simplify(input.clone(), false);
         assert_eq!(plain, "Message text here [...]");

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -770,7 +770,7 @@ mod test {
     /// existed and `PRAGMA` returned non-empty result.
     ///
     /// Statements were not finalized due to a bug in sqlx:
-    /// https://github.com/launchbadge/sqlx/issues/1147
+    /// <https://github.com/launchbadge/sqlx/issues/1147>
     #[async_std::test]
     async fn test_db_reopen() -> Result<()> {
         use tempfile::tempdir;


### PR DESCRIPTION
fix rustdoc errors as 

```
Error:   --> src/log.rs:79:13
   |
79 |     /// See https://github.com/rust-lang/rust/issues/78840 for progress on this.
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://github.com/rust-lang/rust/issues/78840>`
   |
   = note: `-D rustdoc::bare-urls` implied by `-D warnings`
   = note: bare URLs are not automatically turned into clickable links

error: this URL is not a hyperlink
```

the errors are probably related to new rust 1.53.

for consistency, i also formatted most links in non-rustdoc comments the same way.