### PR TITLE
Store mime_headers as BLOBs

### DIFF
--- a/deltachat-ffi/src/string.rs
+++ b/deltachat-ffi/src/string.rs
@@ -170,18 +170,30 @@ pub(crate) trait Strdup {
     unsafe fn strdup(&self) -> *mut libc::c_char;
 }
 
-impl<T: AsRef<str>> Strdup for T {
+impl Strdup for str {
     unsafe fn strdup(&self) -> *mut libc::c_char {
-        let tmp = CString::new_lossy(self.as_ref());
+        let tmp = CString::new_lossy(self);
         dc_strdup(tmp.as_ptr())
     }
 }
 
-// We can not implement for AsRef<OsStr> because we already implement
-// AsRev<str> and this conflicts.  So implement for Path directly.
+impl Strdup for String {
+    unsafe fn strdup(&self) -> *mut libc::c_char {
+        let s: &str = self;
+        s.strdup()
+    }
+}
+
 impl Strdup for std::path::Path {
     unsafe fn strdup(&self) -> *mut libc::c_char {
         let tmp = self.to_c_string().unwrap_or_else(|_| CString::default());
+        dc_strdup(tmp.as_ptr())
+    }
+}
+
+impl Strdup for [u8] {
+    unsafe fn strdup(&self) -> *mut libc::c_char {
+        let tmp = CString::new_lossy(self);
         dc_strdup(tmp.as_ptr())
     }
 }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -942,12 +942,12 @@ async fn add_parts(
 
     let mime_headers = if save_mime_headers || save_mime_modified {
         if mime_parser.was_encrypted() && !mime_parser.decoded_data.is_empty() {
-            String::from_utf8_lossy(&mime_parser.decoded_data).to_string()
+            mime_parser.decoded_data.clone()
         } else {
-            String::from_utf8_lossy(imf_raw).to_string()
+            imf_raw.to_vec()
         }
     } else {
-        "".into()
+        Vec::new()
     };
 
     let sent_timestamp = *sent_timestamp;
@@ -1050,9 +1050,9 @@ INSERT INTO msgs
             part.bytes as isize,
             is_hidden,
             if (save_mime_headers || mime_modified) && !trash {
-                mime_headers.to_string()
+                mime_headers.clone()
             } else {
-                "".to_string()
+                Vec::new()
             },
             mime_in_reply_to,
             mime_references,
@@ -3661,8 +3661,9 @@ YEAAAAAA!.
         assert_eq!(msg.get_text(), Some("hi!".to_string()));
         assert!(!msg.get_showpadlock());
         let mime = message::get_mime_headers(&bob, msg.id).await?;
-        assert!(mime.contains("Received:"));
-        assert!(mime.contains("From:"));
+        let mime_str = String::from_utf8_lossy(&mime);
+        assert!(mime_str.contains("Received:"));
+        assert!(mime_str.contains("From:"));
 
         // another one, from bob to alice, that gets encrypted
         let chat_bob = bob.create_chat(&alice).await;
@@ -3672,8 +3673,9 @@ YEAAAAAA!.
         assert_eq!(msg.get_text(), Some("ho!".to_string()));
         assert!(msg.get_showpadlock());
         let mime = message::get_mime_headers(&alice, msg.id).await?;
-        assert!(mime.contains("Received:"));
-        assert!(mime.contains("From:"));
+        let mime_str = String::from_utf8_lossy(&mime);
+        assert!(mime_str.contains("Received:"));
+        assert!(mime_str.contains("From:"));
         Ok(())
     }
 

--- a/src/sql/tables.sql
+++ b/src/sql/tables.sql
@@ -72,6 +72,10 @@ CREATE TABLE msgs (
     timestamp_sent INTEGER DEFAULT 0,
     timestamp_rcvd INTEGER DEFAULT 0,
     hidden INTEGER DEFAULT 0,
+    -- mime_headers column actually contains BLOBs, i.e. it may
+    -- contain non-UTF8 MIME messages.  TEXT was a bad choice, but
+    -- thanks to SQLite 3 being dynamically typed, there is no need to
+    -- change column type.
     mime_headers TEXT,
     mime_in_reply_to TEXT,
     mime_references TEXT,

--- a/test-data/message/cp1252-html.eml
+++ b/test-data/message/cp1252-html.eml
@@ -1,0 +1,18 @@
+Subject: test non-utf8 and dc_get_msg_html()
+To: tunis4 <tunis4@testrun.org>
+From: "B. Petersen" <bpetersen@b44t.com>
+Message-ID: <00007126-1efa-290b-2120-200251f50f23@b44t.com>
+Date: Thu, 27 May 2021 17:33:16 +0200
+MIME-Version: 1.0
+Content-Type: text/plain; charset=windows-1252; format=flowed
+Content-Language: en-US
+Content-Transfer-Encoding: 8bit
+
+foo bar ä ö ü ß
+
+
+-------- Forwarded Message --------
+Subject: 	Foo
+Date: 	Fri, 21 May 2021 08:42:20 +0000
+
+just to force a "more button"


### PR DESCRIPTION
Raw MIME messages may contain non-ASCII characters. Attempting to
store them as TEXT by using String::from_utf8_lossy results in
non-ASCII characters being replaced with Unicode U+FFFD "REPLACEMENT
CHARACTER" which is later incorrectly decoded when attempting to parse
`mime_headers` content into HTML.

Fixes #2455