### PR TITLE
Avoid hiding outgoing classic emails

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -8,7 +8,6 @@ use anyhow::{bail, ensure, format_err, Context as _, Result};
 use async_std::path::{Path, PathBuf};
 use deltachat_derive::{FromSql, ToSql};
 use itertools::Itertools;
-use num_traits::FromPrimitive;
 use serde::{Deserialize, Serialize};
 
 use crate::aheader::EncryptPreference;
@@ -17,7 +16,7 @@ use crate::chatlist::dc_get_archived_cnt;
 use crate::color::str_to_color;
 use crate::config::Config;
 use crate::constants::{
-    Blocked, Chattype, ShowEmails, Viewtype, DC_CHAT_ID_ALLDONE_HINT, DC_CHAT_ID_ARCHIVED_LINK,
+    Blocked, Chattype, Viewtype, DC_CHAT_ID_ALLDONE_HINT, DC_CHAT_ID_ARCHIVED_LINK,
     DC_CHAT_ID_DEADDROP, DC_CHAT_ID_LAST_SPECIAL, DC_CHAT_ID_TRASH, DC_CONTACT_ID_DEVICE,
     DC_CONTACT_ID_INFO, DC_CONTACT_ID_LAST_SPECIAL, DC_CONTACT_ID_SELF, DC_GCM_ADDDAYMARKER,
     DC_GCM_INFO_ONLY, DC_RESEND_USER_AVATAR_DAYS,
@@ -1941,8 +1940,6 @@ pub async fn get_chat_msgs(
     };
 
     let items = if chat_id.is_deaddrop() {
-        let show_emails = ShowEmails::from_i32(context.get_config_int(Config::ShowEmails).await?)
-            .unwrap_or_default();
         context
             .sql
             .query_map(
@@ -1957,13 +1954,8 @@ pub async fn get_chat_msgs(
                 AND m.hidden=0
                 AND chats.blocked=2
                 AND contacts.blocked=0
-                AND m.msgrmsg>=?
               ORDER BY m.timestamp,m.id;",
-                paramsv![if show_emails == ShowEmails::All {
-                    0i32
-                } else {
-                    1i32
-                }],
+                paramsv![],
                 process_row,
                 process_rows,
             )
@@ -4061,6 +4053,52 @@ mod tests {
         let msg = message::Message::load_from_db(&t, msg_id).await?;
         assert_eq!(msg.state, MessageState::InNoticed);
         assert_eq!(t.get_fresh_msgs().await?.len(), 0);
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_classic_deaddrop_chat() -> Result<()> {
+        let alice = TestContext::new_alice().await;
+
+        // Alice enables receiving classic emails.
+        alice
+            .set_config(Config::ShowEmails, Some("2"))
+            .await
+            .unwrap();
+
+        // Alice receives a classic (non-chat) message from Bob.
+        dc_receive_imf(
+            &alice,
+            b"From: bob@example.org\n\
+                 To: alice@example.com\n\
+                 Message-ID: <1@example.org>\n\
+                 Date: Sun, 22 Mar 2021 19:37:57 +0000\n\
+                 \n\
+                 hello\n",
+            "INBOX",
+            1,
+            false,
+        )
+        .await?;
+
+        // There is one message in the contact requests chat.
+        assert_eq!(DC_CHAT_ID_DEADDROP.get_fresh_msg_cnt(&alice).await?, 1);
+
+        let msgs = get_chat_msgs(&alice, DC_CHAT_ID_DEADDROP, 0, None).await?;
+        assert_eq!(msgs.len(), 1);
+
+        // Alice disables receiving classic emails.
+        alice
+            .set_config(Config::ShowEmails, Some("0"))
+            .await
+            .unwrap();
+
+        // Already received classic email should still be in the contact requests.
+        assert_eq!(DC_CHAT_ID_DEADDROP.get_fresh_msg_cnt(&alice).await?, 1);
+
+        let msgs = get_chat_msgs(&alice, DC_CHAT_ID_DEADDROP, 0, None).await?;
+        assert_eq!(msgs.len(), 1);
 
         Ok(())
     }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -587,8 +587,9 @@ impl ChatId {
                     "SELECT COUNT(*)
                     FROM msgs
                     WHERE hidden=0
+                    AND from_id!=?
                     AND chat_id IN (SELECT id FROM chats WHERE blocked=?)",
-                    paramsv![Blocked::Deaddrop],
+                    paramsv![DC_CONTACT_ID_INFO, Blocked::Deaddrop],
                 )
                 .await?
         } else {
@@ -622,8 +623,9 @@ impl ChatId {
                     FROM msgs
                     WHERE state=?
                     AND hidden=0
+                    AND from_id!=?
                     AND chat_id IN (SELECT id FROM chats WHERE blocked=?)",
-                    paramsv![MessageState::InFresh, Blocked::Deaddrop],
+                    paramsv![MessageState::InFresh, DC_CONTACT_ID_INFO, Blocked::Deaddrop],
                 )
                 .await?
         } else {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1949,13 +1949,12 @@ pub async fn get_chat_msgs(
                       ON m.chat_id=chats.id
                LEFT JOIN contacts
                       ON m.from_id=contacts.id
-              WHERE m.from_id!=1  -- 1=DC_CONTACT_ID_SELF
-                AND m.from_id!=2  -- 2=DC_CONTACT_ID_INFO
+              WHERE m.from_id!=?
                 AND m.hidden=0
                 AND chats.blocked=2
                 AND contacts.blocked=0
               ORDER BY m.timestamp,m.id;",
-                paramsv![],
+                paramsv![DC_CONTACT_ID_INFO],
                 process_row,
                 process_rows,
             )


### PR DESCRIPTION
Fixes mainly #2499 and related bugs.

See commit messages for details.

Generally the idea is to ensure that messages stored in the database are displayed at least somewhere. Info messages that go into contact requests are still not shown anywhere, but this will probably be solved by replacing contact request chat with a contact request chatlist later, so info messages will be shown in relevant chats.

