### PR TITLE
withdraw/revive own qr-codes

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2083,30 +2083,73 @@ void            dc_stop_ongoing_process      (dc_context_t* context);
 
 /**
  * Check a scanned QR code.
- * The function should be called after a QR code is scanned.
  * The function takes the raw text scanned and checks what can be done with it.
+ *
+ * The UI is supposed to show the result to the user.
+ * In case there are further actions possible,
+ * the UI has to ask the user before doing further steps.
  *
  * The QR code state is returned in dc_lot_t::state as:
  *
- * - DC_QR_ASK_VERIFYCONTACT with dc_lot_t::id=Contact ID
- * - DC_QR_ASK_VERIFYGROUP withdc_lot_t::text1=Group name
- * - DC_QR_FPR_OK with dc_lot_t::id=Contact ID
- * - DC_QR_FPR_MISMATCH with dc_lot_t::id=Contact ID
+ * - DC_QR_ASK_VERIFYCONTACT with dc_lot_t::id=Contact ID:
+ *   ask whether to verify the contact;
+ *   if so, start the protocol with dc_join_securejoin().
+ *
+ * - DC_QR_ASK_VERIFYGROUP withdc_lot_t::text1=Group name:
+ *   ask whether to join the group;
+ *   if so, start the protocol with dc_join_securejoin().
+ *
+ * - DC_QR_FPR_OK with dc_lot_t::id=Contact ID:
+ *   contact fingerprint verified,
+ *   ask the user if they want to start chatting;
+ *   if so, call dc_create_chat_by_contact_id().
+ *
+ * - DC_QR_FPR_MISMATCH with dc_lot_t::id=Contact ID:
+ *   scanned fingerprint does not match last seen fingerprint.
+ *
  * - DC_QR_FPR_WITHOUT_ADDR with dc_lot_t::test1=Formatted fingerprint
- * - DC_QR_ACCOUNT allows creation of an account, dc_lot_t::text1=domain
- * - DC_QR_WEBRTC_INSTANCE - a shared webrtc-instance
- *   that will be set if dc_set_config_from_qr() is called with the qr-code,
- *   dc_lot_t::text1=domain could be used to ask the user
- * - DC_QR_ADDR with dc_lot_t::id=Contact ID
- * - DC_QR_TEXT with dc_lot_t::text1=Text
- * - DC_QR_URL with dc_lot_t::text1=URL
- * - DC_QR_ERROR with dc_lot_t::text1=Error string
- * - DC_QR_WITHDRAW_VERIFYCONTACT, DC_QR_WITHDRAW_VERIFYGROUP
- *   withdraw own qr-codes, with text1=groupname for groups
- *   to actually withdraw, call dc_set_config_from_qr() with the code.
- * - DC_QR_REVIVE_VERIFYCONTACT, DC_QR_REVIVE_VERIFYGROUP,
- *   revive withdrawn qr-codes, with text1=groupname for groups,
- *   to actually revive, call dc_set_config_from_qr() with the code.
+ *   the scanned QR code contains a fingerprint but no email address;
+ *   suggest the user to establish an encrypted connection first.
+ *
+ * - DC_QR_ACCOUNT dc_lot_t::text1=domain:
+ *   ask the user if they want to create an account on the given domain,
+ *   if so, call dc_set_config_from_qr() and then dc_configure().
+ *
+ * - DC_QR_WEBRTC_INSTANCE with dc_lot_t::text1=domain:
+ *   ask the user if they want to use the given service for video chats;
+ *   if so, call dc_set_config_from_qr().
+ *
+ * - DC_QR_ADDR with dc_lot_t::id=Contact ID:
+ *   email-address scanned,
+ *   ask the user if they want to start chatting;
+ *   if so, call dc_create_chat_by_contact_id()
+ *
+ * - DC_QR_TEXT with dc_lot_t::text1=Text:
+ *   Text scanned,
+ *   ask the user eg. if they want copy to clipboard.
+ *
+ * - DC_QR_URL with dc_lot_t::text1=URL:
+ *   URL scanned,
+ *   ask the user eg. if they want to open a browser or copy to clipboard.
+ *
+ * - DC_QR_ERROR with dc_lot_t::text1=Error string:
+ *   show the error to the user.
+ *
+ * - DC_QR_WITHDRAW_VERIFYCONTACT:
+ *   ask the user if they want to withdraw the their own qr-code;
+ *   if so, call dc_set_config_from_qr().
+ *
+ * - DC_QR_WITHDRAW_VERIFYGROUP with text1=groupname:
+ *   ask the user if they want to withdraw the group-invite code;
+ *   if so, call dc_set_config_from_qr().
+ *
+ * - DC_QR_REVIVE_VERIFYCONTACT:
+ *   ask the user if they want to revive their withdrawn qr-code;
+ *   if so, call dc_set_config_from_qr().
+ *
+ * - DC_QR_REVIVE_VERIFYGROUP with text1=groupname:
+ *   ask the user if they want to revive the withdrawn group-invite code;
+ *   if so, call dc_set_config_from_qr().
  *
  * @memberof dc_context_t
  * @param context The context object.

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2076,6 +2076,10 @@ void            dc_stop_ongoing_process      (dc_context_t* context);
 #define         DC_QR_TEXT                   330 // text1=text
 #define         DC_QR_URL                    332 // text1=URL
 #define         DC_QR_ERROR                  400 // text1=error string
+#define         DC_QR_WITHDRAW_VERIFYCONTACT 500
+#define         DC_QR_WITHDRAW_VERIFYGROUP   502 // text1=groupname
+#define         DC_QR_REVIVE_VERIFYCONTACT   510
+#define         DC_QR_REVIVE_VERIFYGROUP     512 // text1=groupname
 
 /**
  * Check a scanned QR code.
@@ -2097,6 +2101,12 @@ void            dc_stop_ongoing_process      (dc_context_t* context);
  * - DC_QR_TEXT with dc_lot_t::text1=Text
  * - DC_QR_URL with dc_lot_t::text1=URL
  * - DC_QR_ERROR with dc_lot_t::text1=Error string
+ * - DC_QR_WITHDRAW_VERIFYCONTACT, DC_QR_WITHDRAW_VERIFYGROUP
+ *   withdraw own qr-codes, with text1=groupname for groups
+ *   to actually withdraw, call dc_set_config_from_qr() with the code.
+ * - DC_QR_REVIVE_VERIFYCONTACT, DC_QR_REVIVE_VERIFYGROUP,
+ *   revive withdrawn qr-codes, with text1=groupname for groups,
+ *   to actually revive, call dc_set_config_from_qr() with the code.
  *
  * @memberof dc_context_t
  * @param context The context object.

--- a/src/lot.rs
+++ b/src/lot.rs
@@ -110,6 +110,16 @@ pub enum LotState {
     /// text1=error string
     QrError = 400,
 
+    QrWithdrawVerifyContact = 500,
+
+    /// text1=groupname
+    QrWithdrawVerifyGroup = 502,
+
+    QrReviveVerifyContact = 510,
+
+    /// text1=groupname
+    QrReviveVerifyGroup = 512,
+
     // Message States
     MsgInFresh = 10,
     MsgInNoticed = 13,

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -334,16 +334,16 @@ pub async fn set_config_from_qr(context: &Context, qr: &str) -> Result<(), Error
                 context,
                 token::Namespace::InviteNumber,
                 chat_id,
-                lot.invitenumber.unwrap_or_default(),
+                &lot.invitenumber.unwrap_or_default(),
             )
-            .await;
+            .await?;
             token::save(
                 context,
                 token::Namespace::Auth,
                 chat_id,
-                lot.auth.unwrap_or_default(),
+                &lot.auth.unwrap_or_default(),
             )
-            .await;
+            .await?;
             Ok(())
         }
         _ => bail!("qr code does not contain config: {}", qr),

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -202,12 +202,10 @@ async fn decode_openpgp(context: &Context, qr: &str) -> Lot {
                         } else {
                             LotState::QrWithdrawVerifyGroup
                         }
+                    } else if lot.state == LotState::QrAskVerifyContact {
+                        LotState::QrReviveVerifyContact
                     } else {
-                        if lot.state == LotState::QrAskVerifyContact {
-                            LotState::QrReviveVerifyContact
-                        } else {
-                            LotState::QrReviveVerifyGroup
-                        }
+                        LotState::QrReviveVerifyGroup
                     }
             }
         }

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -6,7 +6,7 @@ use percent_encoding::percent_decode_str;
 use serde::Deserialize;
 use std::collections::BTreeMap;
 
-use crate::chat::{self, ChatIdBlocked};
+use crate::chat::{self, get_chat_id_by_grpid, ChatIdBlocked};
 use crate::config::Config;
 use crate::constants::Blocked;
 use crate::contact::{addr_normalize, may_be_valid_addr, Contact, Origin};
@@ -16,6 +16,7 @@ use crate::log::LogExt;
 use crate::lot::{Lot, LotState};
 use crate::message::Message;
 use crate::peerstate::Peerstate;
+use crate::token;
 
 const OPENPGP4FPR_SCHEME: &str = "OPENPGP4FPR:"; // yes: uppercase
 const DCACCOUNT_SCHEME: &str = "DCACCOUNT:";
@@ -189,6 +190,27 @@ async fn decode_openpgp(context: &Context, qr: &str) -> Lot {
         lot.fingerprint = Some(fingerprint);
         lot.invitenumber = invitenumber;
         lot.auth = auth;
+
+        // scanning own qr-code offers withdraw/revive instead of secure-join
+        if context.is_self_addr(&addr).await.unwrap_or_default() {
+            if let Some(ref invitenumber) = lot.invitenumber {
+                lot.state =
+                    if token::exists(context, token::Namespace::InviteNumber, &*invitenumber).await
+                    {
+                        if lot.state == LotState::QrAskVerifyContact {
+                            LotState::QrWithdrawVerifyContact
+                        } else {
+                            LotState::QrWithdrawVerifyGroup
+                        }
+                    } else {
+                        if lot.state == LotState::QrAskVerifyContact {
+                            LotState::QrReviveVerifyContact
+                        } else {
+                            LotState::QrReviveVerifyGroup
+                        }
+                    }
+            }
+        }
     } else {
         return format_err!("Missing address").into();
     }
@@ -275,13 +297,55 @@ async fn set_account_from_qr(context: &Context, qr: &str) -> Result<(), Error> {
 }
 
 pub async fn set_config_from_qr(context: &Context, qr: &str) -> Result<(), Error> {
-    match check_qr(context, qr).await.state {
+    let lot = check_qr(context, qr).await;
+    match lot.state {
         LotState::QrAccount => set_account_from_qr(context, qr).await,
         LotState::QrWebrtcInstance => {
             let val = decode_webrtc_instance(context, qr).text2;
             context
                 .set_config(Config::WebrtcInstance, val.as_deref())
                 .await?;
+            Ok(())
+        }
+        LotState::QrWithdrawVerifyContact | LotState::QrWithdrawVerifyGroup => {
+            token::delete(
+                context,
+                token::Namespace::InviteNumber,
+                lot.invitenumber.unwrap_or_default().as_str(),
+            )
+            .await?;
+            token::delete(
+                context,
+                token::Namespace::Auth,
+                lot.auth.unwrap_or_default().as_str(),
+            )
+            .await?;
+            Ok(())
+        }
+        LotState::QrReviveVerifyContact | LotState::QrReviveVerifyGroup => {
+            let chat_id = if lot.state == LotState::QrReviveVerifyContact {
+                None
+            } else {
+                Some(
+                    get_chat_id_by_grpid(context, &lot.text2.unwrap_or_default())
+                        .await?
+                        .0,
+                )
+            };
+            token::save(
+                context,
+                token::Namespace::InviteNumber,
+                chat_id,
+                lot.invitenumber.unwrap_or_default(),
+            )
+            .await;
+            token::save(
+                context,
+                token::Namespace::Auth,
+                chat_id,
+                lot.auth.unwrap_or_default(),
+            )
+            .await;
             Ok(())
         }
         _ => bail!("qr code does not contain config: {}", qr),

--- a/src/token.rs
+++ b/src/token.rs
@@ -31,8 +31,12 @@ impl Default for Namespace {
 /// Creates a new token and saves it into the database.
 ///
 /// Returns created token.
-pub async fn save(context: &Context, namespace: Namespace, foreign_id: Option<ChatId>) -> String {
-    let token = dc_create_id();
+pub async fn save(
+    context: &Context,
+    namespace: Namespace,
+    foreign_id: Option<ChatId>,
+    token: String,
+) -> String {
     match foreign_id {
         Some(foreign_id) => context
             .sql
@@ -93,7 +97,8 @@ pub async fn lookup_or_new(
         return token;
     }
 
-    save(context, namespace, foreign_id).await
+    let token = dc_create_id();
+    save(context, namespace, foreign_id, token).await
 }
 
 pub async fn exists(context: &Context, namespace: Namespace, token: &str) -> bool {

--- a/src/token.rs
+++ b/src/token.rs
@@ -111,3 +111,14 @@ pub async fn exists(context: &Context, namespace: Namespace, token: &str) -> boo
         .await
         .unwrap_or_default()
 }
+
+pub async fn delete(context: &Context, namespace: Namespace, token: &str) -> Result<()> {
+    context
+        .sql
+        .execute(
+            "DELETE FROM tokens WHERE namespc=? AND token=?;",
+            paramsv![namespace, token],
+        )
+        .await?;
+    Ok(())
+}

--- a/src/token.rs
+++ b/src/token.rs
@@ -69,7 +69,7 @@ pub async fn lookup(
             context
                 .sql
                 .query_get_value(
-                    "SELECT token FROM tokens WHERE namespc=? AND foreign_id=?;",
+                    "SELECT token FROM tokens WHERE namespc=? AND foreign_id=? ORDER BY timestamp DESC LIMIT 1;",
                     paramsv![namespace, chat_id],
                 )
                 .await?
@@ -79,7 +79,7 @@ pub async fn lookup(
             context
                 .sql
                 .query_get_value(
-                    "SELECT token FROM tokens WHERE namespc=? AND foreign_id=0;",
+                    "SELECT token FROM tokens WHERE namespc=? AND foreign_id=0 ORDER BY timestamp DESC LIMIT 1;",
                     paramsv![namespace],
                 )
                 .await?


### PR DESCRIPTION
closes #2511 

this pr adds options to withdraw/revive own qr-codes by simply scanning them.

- `dc_check_qr()` may return one of DC_QR_{WITHDRAW|REVIVE}_VERIFY{CONTACT|GROUP}
- the UI should ask the user, sth. as "This QR code was generated by your for ... do you want to withdraw it?"
- if wanted, one can change the configuration using `dc_set_config_from_qr()` with just the qr-code as paramters.

internally, on withdrawing, the corresponding tokens are deleted or re-inserted.

re-insertion may result in N tokens for a given chat - however, that should not be an issue as the token is verified by exists(token) and not by lookup(chat_id). lookup(), however, makes sure to return only one token and using the newest one.