### PR TITLE
Remove deaddrop chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 ## Unreleased
 
 ### API Changes
+
+- breaking change: removed deaddrop chat #2514
+
+  Contact request chats are not merged into a single virtual
+  "deaddrop" chat anymore. Instead, they are shown in the chatlist the
+  same way as other chats, but sending of messages to them is not
+  allowed and MDNs are not sent automatically until the chat is
+  "accepted" by the user.
+
+  New API:
+  - `dc_chat_is_contact_request()`: returns true if chat is a contact
+    request.  In this case an option to accept the chat via
+    `dc_accept_chat()` should be shown in the UI.
+  - `dc_accept_chat()`: unblock the chat or accept contact request
+  - `dc_block_chat()`: block the chat, currently works only for mailing
+    lists.
+
+  Removed API:
+  - `dc_create_chat_by_msg_id()`: deprecated 2021-02-07 in favor of
+    `dc_decide_on_contact_request()`
+  - `dc_marknoticed_contact()`: deprecated 2021-02-07 in favor of
+    `dc_decide_on_contact_request()`
+  - `dc_decide_on_contact_request()`: this call requires a message ID
+    from deaddrop chat as input. As deaddrop chat is removed, this
+    call can't be used anymore.
+  - `dc_msg_get_real_chat_id()`: use `dc_msg_get_chat_id()` instead, the
+    only difference between these calls was in handling of deaddrop
+    chat
+  - removed `DC_CHAT_ID_DEADDROP` and `DC_STR_DEADDROP` constants
+
 - breaking change: removed `DC_EVENT_ERROR_NETWORK` and `DC_STR_SERVER_RESPONSE`
   Instead, there is a new api `dc_get_connectivity()`
   and `dc_get_connectivity_html()`;

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -167,14 +167,11 @@ const DB_COMMANDS: [&str; 10] = [
     "housekeeping",
 ];
 
-const CHAT_COMMANDS: [&str; 34] = [
+const CHAT_COMMANDS: [&str; 33] = [
     "listchats",
     "listarchived",
     "chat",
     "createchat",
-    "decidestartchat",
-    "decideblock",
-    "decidenotnow",
     "creategroup",
     "createverified",
     "addmember",
@@ -202,6 +199,8 @@ const CHAT_COMMANDS: [&str; 34] = [
     "protect",
     "unprotect",
     "delchat",
+    "accept",
+    "blockchat",
 ];
 const MESSAGE_COMMANDS: [&str; 6] = [
     "listmsgs",

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -330,9 +330,6 @@ class Account(object):
         """ Create a 1:1 chat with Account, Contact or e-mail address. """
         return self.create_contact(obj).create_chat()
 
-    def _create_chat_by_message_id(self, msg_id):
-        return Chat(self, lib.dc_create_chat_by_msg_id(self._dc_context, msg_id))
-
     def create_group_chat(self, name, contacts=None, verified=False):
         """ create a new group chat object.
 
@@ -366,9 +363,6 @@ class Account(object):
             chat_id = lib.dc_chatlist_get_chat_id(dc_chatlist, i)
             chatlist.append(Chat(self, chat_id))
         return chatlist
-
-    def get_deaddrop_chat(self):
-        return Chat(self, const.DC_CHAT_ID_DEADDROP)
 
     def get_device_chat(self):
         return Contact(self, const.DC_CONTACT_ID_DEVICE).create_chat()

--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -50,6 +50,14 @@ class Chat(object):
         """
         lib.dc_delete_chat(self.account._dc_context, self.id)
 
+    def block(self):
+        """Block this chat."""
+        lib.dc_block_chat(self.account._dc_context, self.id)
+
+    def accept(self):
+        """Accept this contact request chat."""
+        lib.dc_accept_chat(self.account._dc_context, self.id)
+
     # ------  chat status/metadata API ------------------------------
 
     def is_group(self):
@@ -59,19 +67,19 @@ class Chat(object):
         """
         return lib.dc_chat_get_type(self._dc_chat) == const.DC_CHAT_TYPE_GROUP
 
-    def is_deaddrop(self):
-        """ return true if this chat is a deaddrop chat.
-
-        :returns: True if chat is the deaddrop chat, False otherwise.
-        """
-        return self.id == const.DC_CHAT_ID_DEADDROP
-
     def is_muted(self):
         """ return true if this chat is muted.
 
         :returns: True if chat is muted, False otherwise.
         """
         return lib.dc_chat_is_muted(self._dc_chat)
+
+    def is_contact_request(self):
+        """ return True if this chat is a contact request chat.
+
+        :returns: True if chat is a contact request chat, False otherwise.
+        """
+        return lib.dc_chat_is_contact_request(self._dc_chat)
 
     def is_promoted(self):
         """ return True if this chat is promoted, i.e.
@@ -84,7 +92,7 @@ class Chat(object):
 
     def can_send(self):
         """Check if messages can be sent to a give chat.
-        This is not true eg. for the deaddrop or for the device-talk
+        This is not true eg. for the contact requests or for the device-talk
 
         :returns: True if the chat is writable, False otherwise
         """

--- a/python/src/deltachat/hookspec.py
+++ b/python/src/deltachat/hookspec.py
@@ -43,7 +43,7 @@ class PerAccount:
 
     @account_hookspec
     def ac_incoming_message(self, message):
-        """ Called on any incoming message (to deaddrop or chat). """
+        """ Called on any incoming message (both existing chats and contact requests). """
 
     @account_hookspec
     def ac_outgoing_message(self, message):

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -61,16 +61,13 @@ class Message(object):
     def create_chat(self):
         """ create or get an existing chat (group) object for this message.
 
-        If the message is a deaddrop contact request
+        If the message is a contact request
         the sender will become an accepted contact.
 
         :returns: a :class:`deltachat.chat.Chat` object.
         """
-        from .chat import Chat
-        chat_id = lib.dc_create_chat_by_msg_id(self.account._dc_context, self.id)
-        ctx = self.account._dc_context
-        self._dc_msg = ffi.gc(lib.dc_get_msg(ctx, self.id), lib.dc_msg_unref)
-        return Chat(self.account, chat_id)
+        self.chat.accept()
+        return self.chat
 
     @props.with_doc
     def id(self):

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -909,12 +909,11 @@ class TestOnlineAccount:
         msg_in = ac2.get_message_by_id(msg_out.id)
         assert msg_in.text == "message2"
 
-        lp.sec("ac2: check that the message arrive in deaddrop")
+        lp.sec("ac2: check that the message arrived in a chat")
         chat2 = msg_in.chat
         assert msg_in in chat2.get_messages()
         assert not msg_in.is_forwarded()
-        assert chat2.is_deaddrop()
-        assert chat2 == ac2.get_deaddrop_chat()
+        assert chat2.is_contact_request()
 
         lp.sec("ac2: create new chat and forward message to it")
         chat3 = ac2.create_group_chat("newgroup")
@@ -979,16 +978,16 @@ class TestOnlineAccount:
         assert not msg2.is_forwarded()
         assert msg2.get_sender_contact().display_name == ac1.get_config("displayname")
 
-        lp.sec("check the message arrived in contact-requests/deaddrop")
+        lp.sec("check the message arrived in contact request chat")
         chat2 = msg2.chat
         assert msg2 in chat2.get_messages()
-        assert chat2.is_deaddrop()
+        assert chat2.is_contact_request()
         assert chat2.count_fresh_messages() == 1
         assert msg2.time_received >= msg1.time_sent
 
         lp.sec("create new chat with contact and verify it's proper")
         chat2b = msg2.create_chat()
-        assert not chat2b.is_deaddrop()
+        assert not chat2b.is_contact_request()
         assert chat2b.count_fresh_messages() == 1
 
         lp.sec("mark chat as noticed")
@@ -1853,7 +1852,7 @@ class TestOnlineAccount:
 
         lp.sec("ac2: wait for receiving message and avatar from ac1")
         msg2 = ac2._evtracker.wait_next_messages_changed()
-        assert msg2.chat.is_deaddrop()
+        assert msg2.chat.is_contact_request()
         received_path = msg2.get_sender_contact().get_profile_image()
         assert open(received_path, "rb").read() == open(p, "rb").read()
 
@@ -1925,6 +1924,8 @@ class TestOnlineAccount:
         # note that if the above create_chat() would not
         # happen we would not receive a proper member_added event
         contact2 = chat.add_contact("devnull@testrun.org")
+        ev = in_list.get(timeout=10)
+        assert ev.action == "chat-modified"
         ev = in_list.get(timeout=10)
         assert ev.action == "chat-modified"
         ev = in_list.get(timeout=10)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -25,7 +25,7 @@ pub static DC_VERSION_STR: Lazy<String> = Lazy::new(|| env!("CARGO_PKG_VERSION")
 pub enum Blocked {
     Not = 0,
     Manually = 1,
-    Deaddrop = 2,
+    Request = 2,
 }
 
 impl Default for Blocked {
@@ -123,8 +123,6 @@ pub const DC_RESEND_USER_AVATAR_DAYS: i64 = 14;
 // do not use too small value that will annoy users checking for nonexistant updates.
 pub const DC_OUTDATED_WARNING_DAYS: i64 = 365;
 
-/// virtual chat showing all messages belonging to chats flagged with chats.blocked=2
-pub const DC_CHAT_ID_DEADDROP: ChatId = ChatId::new(1);
 /// messages that should be deleted get this chat_id; the messages are deleted from the working thread later then. This is also needed as rfc724_mid should be preset as long as the message is not deleted on the server (otherwise it is downloaded again)
 pub const DC_CHAT_ID_TRASH: ChatId = ChatId::new(3);
 /// only an indicator in a chatlist
@@ -404,7 +402,7 @@ mod tests {
         assert_eq!(Blocked::Not, Blocked::default());
         assert_eq!(Blocked::Not, Blocked::from_i32(0).unwrap());
         assert_eq!(Blocked::Manually, Blocked::from_i32(1).unwrap());
-        assert_eq!(Blocked::Deaddrop, Blocked::from_i32(2).unwrap());
+        assert_eq!(Blocked::Request, Blocked::from_i32(2).unwrap());
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -279,8 +279,8 @@ impl Context {
         let l2 = LoginParam::from_database(self, "configured_").await?;
         let displayname = self.get_config(Config::Displayname).await?;
         let chats = get_chat_cnt(self).await? as usize;
-        let real_msgs = message::get_real_msg_cnt(self).await as usize;
-        let deaddrop_msgs = message::get_deaddrop_msg_cnt(self).await as usize;
+        let unblocked_msgs = message::get_unblocked_msg_cnt(self).await as usize;
+        let request_msgs = message::get_request_msg_cnt(self).await as usize;
         let contacts = Contact::get_real_cnt(self).await? as usize;
         let is_configured = self.get_config_int(Config::Configured).await?;
         let dbversion = self
@@ -336,8 +336,8 @@ impl Context {
         // insert values
         res.insert("bot", self.get_config_int(Config::Bot).await?.to_string());
         res.insert("number_of_chats", chats.to_string());
-        res.insert("number_of_chat_messages", real_msgs.to_string());
-        res.insert("messages_in_contact_requests", deaddrop_msgs.to_string());
+        res.insert("number_of_chat_messages", unblocked_msgs.to_string());
+        res.insert("messages_in_contact_requests", request_msgs.to_string());
         res.insert("number_of_contacts", contacts.to_string());
         res.insert("database_dir", self.get_dbfile().display().to_string());
         res.insert("database_version", dbversion.to_string());
@@ -422,7 +422,7 @@ impl Context {
         Ok(res)
     }
 
-    /// Get a list of fresh, unmuted messages in any chat but deaddrop.
+    /// Get a list of fresh, unmuted messages in unblocked chats.
     ///
     /// The list starts with the most recent message
     /// and is typically used to show notifications.

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1806,9 +1806,8 @@ mod tests {
 
         let chats = Chatlist::try_load(context, 0, None, None).await.unwrap();
 
-        let chat_id = chat::create_by_msg_id(context, chats.get_msg_id(0).unwrap().unwrap())
-            .await
-            .unwrap();
+        let chat_id = chats.get_chat_id(0);
+        chat_id.accept(context).await.unwrap();
 
         let mut new_msg = Message::new(Viewtype::Text);
         new_msg.set_text(Some("Hi".to_string()));

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -2793,7 +2793,7 @@ On 2020-10-25, Bob wrote:
         assert_eq!(msg.viewtype, Viewtype::Image);
         assert_eq!(msg.error(), None);
         assert_eq!(msg.is_dc_message, MessengerMessage::No);
-        assert_eq!(msg.chat_blocked, Blocked::Deaddrop);
+        assert_eq!(msg.chat_blocked, Blocked::Request);
         assert_eq!(msg.state, MessageState::InFresh);
         assert_eq!(msg.get_filebytes(&t).await, 2115);
         assert!(msg.get_file(&t).is_some());

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -267,10 +267,9 @@ impl Peerstate {
                 .query_get_value("SELECT id FROM contacts WHERE addr=?;", paramsv![self.addr])
                 .await?
             {
-                let chat_id =
-                    ChatIdBlocked::get_for_contact(context, contact_id, Blocked::Deaddrop)
-                        .await?
-                        .id;
+                let chat_id = ChatIdBlocked::get_for_contact(context, contact_id, Blocked::Request)
+                    .await?
+                    .id;
 
                 let msg = stock_str::contact_setup_changed(context, self.addr.clone()).await;
 

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -156,7 +156,7 @@ async fn decode_openpgp(context: &Context, qr: &str) -> Lot {
                     .map(|(id, _)| id)
                     .unwrap_or_default();
 
-            if let Ok(chat) = ChatIdBlocked::get_for_contact(context, lot.id, Blocked::Deaddrop)
+            if let Ok(chat) = ChatIdBlocked::get_for_contact(context, lot.id, Blocked::Request)
                 .await
                 .log_err(context, "Failed to create (new) chat for contact")
             {

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -501,7 +501,7 @@ pub(crate) async fn handle_securejoin_handshake(
                 )
             })?;
         if chat.blocked != Blocked::Not {
-            chat.id.unblock(context).await;
+            chat.id.unblock(context).await?;
         }
         chat.id
     };
@@ -796,7 +796,7 @@ pub(crate) async fn observe_securejoin_on_other_device(
                 )
             })?;
         if chat.blocked != Blocked::Not {
-            chat.id.unblock(context).await;
+            chat.id.unblock(context).await?;
         }
         chat.id
     };

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -39,9 +39,6 @@ pub enum StockMessage {
     #[strum(props(fallback = "Voice message"))]
     VoiceMessage = 7,
 
-    #[strum(props(fallback = "Contact requests"))]
-    DeadDrop = 8,
-
     #[strum(props(fallback = "Image"))]
     Image = 9,
 
@@ -358,11 +355,6 @@ pub(crate) async fn draft(context: &Context) -> String {
 /// Stock string: `Voice message`.
 pub(crate) async fn voice_message(context: &Context) -> String {
     translated(context, StockMessage::VoiceMessage).await
-}
-
-/// Stock string: `Contact requests`.
-pub(crate) async fn dead_drop(context: &Context) -> String {
-    translated(context, StockMessage::DeadDrop).await
 }
 
 /// Stock string: `Image`.


### PR DESCRIPTION
Contact request chats are not merged into a single virtual "deaddrop"
chat anymore. Instead, they are shown in the chatlist the same way as
other chats, but sending of messages to them is not allowed and MDNs
are not sent automatically until the chat is "accepted" by the user.

New API:
- dc_chat_is_contact_request(): returns true if chat is a contact
  request.  In this case an option to accept the chat via
  dc_accept_chat() should be shown in the UI.
- dc_accept_chat(): unblock the chat or accept contact request
- dc_block_chat(): block the chat, currently works only for mailing
  lists.

Removed API:
- dc_create_chat_by_msg_id(): deprecated 2021-02-07 in favor of
  dc_decide_on_contact_request()
- dc_marknoticed_contact(): deprecated 2021-02-07 in favor of
  dc_decide_on_contact_request()
- dc_decide_on_contact_request(): this call requires a message ID from
  deaddrop chat as input. As deaddrop chat is removed, this call can't
  be used anymore.
- dc_msg_get_real_chat_id(): use dc_msg_get_chat_id() instead, the
  only difference between these calls was in handling of deaddrop chat
- removed DC_CHAT_ID_DEADDROP and DC_STR_DEADDROP constants