### PR TITLE
chatlist: resultify `get_msg_id`, `get_summary` and `get_summary2`

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -551,7 +551,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                         },
                         if chat.is_protected() { "🛡️" } else { "" },
                     );
-                    let lot = chatlist.get_summary(&context, i, Some(&chat)).await;
+                    let lot = chatlist.get_summary(&context, i, Some(&chat)).await?;
                     let statestr = if chat.visibility == ChatVisibility::Archived {
                         " [Archived]"
                     } else {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -86,7 +86,7 @@ async fn main() {
     let chats = Chatlist::try_load(&ctx, 0, None, None).await.unwrap();
 
     for i in 0..chats.len() {
-        let msg = Message::load_from_db(&ctx, chats.get_msg_id(i).unwrap())
+        let msg = Message::load_from_db(&ctx, chats.get_msg_id(i).unwrap().unwrap())
             .await
             .unwrap();
         log::info!("[{}] msg: {:?}", i, msg);

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2295,7 +2295,7 @@ mod tests {
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         assert!(chats.get_chat_id(0).is_deaddrop());
-        let chat_id = chat::create_by_msg_id(&t, chats.get_msg_id(0).unwrap())
+        let chat_id = chat::create_by_msg_id(&t, chats.get_msg_id(0).unwrap().unwrap())
             .await
             .unwrap();
         assert!(!chat_id.is_special());
@@ -2330,7 +2330,7 @@ mod tests {
             .unwrap();
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 2);
-        let chat_id = chat::create_by_msg_id(&t, chats.get_msg_id(0).unwrap())
+        let chat_id = chat::create_by_msg_id(&t, chats.get_msg_id(0).unwrap().unwrap())
             .await
             .unwrap();
         let chat = chat::Chat::load_from_db(&t, chat_id).await.unwrap();
@@ -2351,7 +2351,7 @@ mod tests {
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         assert!(chats.get_chat_id(0).is_deaddrop());
-        let chat_id = chat::create_by_msg_id(&t, chats.get_msg_id(0).unwrap())
+        let chat_id = chat::create_by_msg_id(&t, chats.get_msg_id(0).unwrap().unwrap())
             .await
             .unwrap();
         let chat = chat::Chat::load_from_db(&t, chat_id).await.unwrap();
@@ -2600,7 +2600,7 @@ mod tests {
         assert_eq!(contact.get_display_name(), "h2");
 
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
-        let msg = Message::load_from_db(&t, chats.get_msg_id(0).unwrap())
+        let msg = Message::load_from_db(&t, chats.get_msg_id(0).unwrap().unwrap())
             .await
             .unwrap();
         assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
@@ -2751,7 +2751,7 @@ mod tests {
         .unwrap();
 
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
-        let msg_id = chats.get_msg_id(0).unwrap();
+        let msg_id = chats.get_msg_id(0).unwrap().unwrap();
 
         // Check that the ndn would be downloaded:
         let headers = mailparse::parse_mail(raw_ndn).unwrap().headers;
@@ -2801,7 +2801,7 @@ mod tests {
         .unwrap();
 
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
-        let msg_id = chats.get_msg_id(0).unwrap();
+        let msg_id = chats.get_msg_id(0).unwrap().unwrap();
 
         let raw = include_bytes!("../test-data/message/gmail_ndn_group.eml");
         dc_receive_imf(&t, raw, "INBOX", 1, false).await.unwrap();
@@ -2834,7 +2834,7 @@ mod tests {
             .await
             .unwrap();
         let chats = Chatlist::try_load(context, 0, None, None).await.unwrap();
-        let msg_id = chats.get_msg_id(0).unwrap();
+        let msg_id = chats.get_msg_id(0).unwrap().unwrap();
         Message::load_from_db(context, msg_id).await.unwrap()
     }
 
@@ -2884,7 +2884,7 @@ mod tests {
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
 
-        let chat_id = chat::create_by_msg_id(&t.ctx, chats.get_msg_id(0).unwrap())
+        let chat_id = chat::create_by_msg_id(&t.ctx, chats.get_msg_id(0).unwrap().unwrap())
             .await
             .unwrap();
         let chat = chat::Chat::load_from_db(&t.ctx, chat_id).await.unwrap();
@@ -2957,7 +2957,7 @@ mod tests {
             .await
             .unwrap();
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
-        let chat_id = chat::create_by_msg_id(&t.ctx, chats.get_msg_id(0).unwrap())
+        let chat_id = chat::create_by_msg_id(&t.ctx, chats.get_msg_id(0).unwrap().unwrap())
             .await
             .unwrap();
         let chat = Chat::load_from_db(&t.ctx, chat_id).await.unwrap();

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1806,7 +1806,7 @@ mod tests {
 
         let chats = Chatlist::try_load(context, 0, None, None).await.unwrap();
 
-        let chat_id = chat::create_by_msg_id(context, chats.get_msg_id(0).unwrap())
+        let chat_id = chat::create_by_msg_id(context, chats.get_msg_id(0).unwrap().unwrap())
             .await
             .unwrap();
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -2834,7 +2834,7 @@ On 2020-10-25, Bob wrote:
         .unwrap();
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
-        let msg_id = chats.get_msg_id(0).unwrap();
+        let msg_id = chats.get_msg_id(0).unwrap().unwrap();
         let msg = Message::load_from_db(&t.ctx, msg_id).await.unwrap();
 
         assert_eq!(

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -331,7 +331,7 @@ impl TestContext {
         // The chatlist describes what you see when you open DC, a list of chats and in each of them
         // the first words of the last message. To get the last message overall, we look at the chat at the top of the
         // list, which has the index 0.
-        let msg_id = chats.get_msg_id(0).unwrap();
+        let msg_id = chats.get_msg_id(0).unwrap().unwrap();
         Message::load_from_db(&self.ctx, msg_id)
             .await
             .expect("failed to load msg")


### PR DESCRIPTION
Avoid using MsgId::new(0) in place of `None` in the Rust part.
Zero ID is only used in FFI part now.