### PR TITLE
Fixes for message timestamps

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1535,6 +1535,7 @@ impl ChatIdBlocked {
             _ => (),
         }
 
+        let created_timestamp = dc_create_smeared_timestamp(context).await;
         let chat_id = context
             .sql
             .transaction(move |transaction| {
@@ -1547,7 +1548,7 @@ impl ChatIdBlocked {
                         chat_name,
                         params.to_string(),
                         create_blocked as u8,
-                        time(),
+                        created_timestamp,
                     ],
                 )?;
                 let chat_id = ChatId::new(
@@ -2214,7 +2215,12 @@ pub async fn create_group_chat(
             "INSERT INTO chats
         (type, name, grpid, param, created_timestamp)
         VALUES(?, ?, ?, \'U=1\', ?);",
-            paramsv![Chattype::Group, chat_name, grpid, time(),],
+            paramsv![
+                Chattype::Group,
+                chat_name,
+                grpid,
+                dc_create_smeared_timestamp(context).await,
+            ],
         )
         .await?;
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1797,7 +1797,7 @@ async fn create_multiuser_record(
             grpname.as_ref(),
             grpid.as_ref(),
             create_blocked,
-            time(),
+            dc_create_smeared_timestamp(context).await,
             create_protected,
         ],
     ).await?;


### PR DESCRIPTION
Ensure messages without `Date:` header bump the chat to the top of chatlist.