### PR TITLE
remove dc_accounts_import_account() api

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -467,7 +467,8 @@ char*           dc_get_oauth2_url            (dc_context_t* context, const char*
 
 /**
  * Configure a context.
- * During configuration IO must not be started, if needed stop IO using dc_stop_io() first.
+ * During configuration IO must not be started,
+ * if needed stop IO using dc_accounts_stop_io() or dc_stop_io() first.
  * If the context is already configured,
  * this function will try to change the configuration.
  *
@@ -1878,7 +1879,8 @@ dc_contact_t*   dc_get_contact               (dc_context_t* context, uint32_t co
 
 /**
  * Import/export things.
- * During backup import/export IO must not be started, if needed stop IO using dc_stop_io() first.
+ * During backup import/export IO must not be started,
+ * if needed stop IO using dc_accounts_stop_io() or dc_stop_io() first.
  * What to do is defined by the _what_ parameter which may be one of the following:
  *
  * - **DC_IMEX_EXPORT_BACKUP** (11) - Export a backup to the directory given as `param1`.

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2412,7 +2412,7 @@ void dc_str_unref (char* str);
  * The account manager takes an directory
  * where all context-databases are placed in.
  * To add a context to the account manager,
- * use dc_accounts_add_account(), dc_accounts_import_account or dc_accounts_migrate_account().
+ * use dc_accounts_add_account() or dc_accounts_migrate_account().
  * All account information are persisted.
  * To remove a context from the account manager,
  * use dc_accounts_remove_account().
@@ -2455,21 +2455,6 @@ void           dc_accounts_unref                (dc_accounts_t* accounts);
  *     On errors, 0 is returned.
  */
 uint32_t       dc_accounts_add_account          (dc_accounts_t* accounts);
-
-
-/**
- * Import a tarfile-backup to the account manager.
- * On success, a new account is added to the account-manager,
- * with all the data provided by the backup-file.
- * Moreover, the newly created account will be the selected one.
- *
- * @memberof dc_accounts_t
- * @param accounts Account manager as created by dc_accounts_new().
- * @param tarfile Backup as created by dc_imex().
- * @return Account-id, use dc_accounts_get_account() to get the context object.
- *     On errors, 0 is returned.
- */
-uint32_t       dc_accounts_import_account       (dc_accounts_t* accounts, const char* tarfile);
 
 
 /**

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3800,23 +3800,6 @@ pub unsafe extern "C" fn dc_accounts_get_all(accounts: *mut dc_accounts_t) -> *m
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_accounts_import_account(
-    accounts: *mut dc_accounts_t,
-    file: *const libc::c_char,
-) -> u32 {
-    if accounts.is_null() || file.is_null() {
-        eprintln!("ignoring careless call to dc_accounts_import_account()");
-        return 0;
-    }
-
-    let accounts = &*accounts;
-    let file = to_string_lossy(file);
-    block_on(accounts.import_account(async_std::path::PathBuf::from(file)))
-        .map(|_| 1)
-        .unwrap_or_else(|_| 0)
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn dc_accounts_start_io(accounts: *mut dc_accounts_t) {
     if accounts.is_null() {
         eprintln!("ignoring careless call to dc_accounts_start_io()");

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -179,25 +179,6 @@ impl Accounts {
         self.accounts.read().await.keys().copied().collect()
     }
 
-    /// Import a backup using a new account and selects it.
-    pub async fn import_account(&self, file: PathBuf) -> Result<u32> {
-        let old_id = self.config.get_selected_account().await;
-
-        let id = self.add_account().await?;
-        let ctx = self.get_account(id).await.expect("just added");
-
-        match crate::imex::imex(&ctx, crate::imex::ImexMode::ImportBackup, &file).await {
-            Ok(_) => Ok(id),
-            Err(err) => {
-                // remove temp account
-                self.remove_account(id).await?;
-                // set selection back
-                self.select_account(old_id).await?;
-                Err(err)
-            }
-        }
-    }
-
     pub async fn start_io(&self) {
         let accounts = &*self.accounts.read().await;
         for account in accounts.values() {


### PR DESCRIPTION
in most (all?) UIs, import/export works on an already created account,
so, dc_accounts_import_account() does not really help here -
but adds some noise and confusion
eg. as for the other dc_accounts_t functions,
the corrsponding dc_context_t functions must not be called.

if really a new account is required for import,
it seems to be easier to call add_account() before import.