### PR TITLE
Connectivity view: Only set smtp to "connected" if the last message was actually sent

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -298,6 +298,11 @@ async fn smtp_loop(ctx: Context, started: Sender<()>, smtp_handlers: SmtpConnect
                 None => {
                     // Fake Idle
                     info!(ctx, "smtp fake idle - started");
+                    match &connection.last_send_error {
+                        None => connection.connectivity.set_connected(&ctx).await,
+                        Some(err) => connection.connectivity.set_err(&ctx, err).await,
+                    }
+
                     interrupt_info = idle_interrupt_receiver.recv().await.unwrap_or_default();
                     info!(ctx, "smtp fake idle - interrupted")
                 }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -298,7 +298,6 @@ async fn smtp_loop(ctx: Context, started: Sender<()>, smtp_handlers: SmtpConnect
                 None => {
                     // Fake Idle
                     info!(ctx, "smtp fake idle - started");
-                    connection.connectivity.set_connected(&ctx).await;
                     interrupt_info = idle_interrupt_receiver.recv().await.unwrap_or_default();
                     info!(ctx, "smtp fake idle - interrupted")
                 }

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -54,6 +54,9 @@ pub(crate) struct Smtp {
     last_success: Option<SystemTime>,
 
     pub(crate) connectivity: ConnectivityStore,
+
+    /// If sending the last message failed, contains the error message.
+    pub(crate) last_send_error: Option<String>,
 }
 
 impl Smtp {
@@ -100,20 +103,14 @@ impl Smtp {
 
         self.connectivity.set_connecting(context).await;
         let lp = LoginParam::from_database(context, "configured_").await?;
-        let res = self
-            .connect(
-                context,
-                &lp.smtp,
-                &lp.addr,
-                lp.server_flags & DC_LP_AUTH_OAUTH2 != 0,
-                lp.provider.map_or(false, |provider| provider.strict_tls),
-            )
-            .await;
-
-        if let Err(err) = &res {
-            self.connectivity.set_err(context, err).await;
-        }
-        res
+        self.connect(
+            context,
+            &lp.smtp,
+            &lp.addr,
+            lp.server_flags & DC_LP_AUTH_OAUTH2 != 0,
+            lp.provider.map_or(false, |provider| provider.strict_tls),
+        )
+        .await
     }
 
     /// Connect using the provided login params.


### PR DESCRIPTION
fix #2539

In case you're wondering: It's always a bit ambiguous which function should do `set_err` or set `last_send_error`, I used this rule here:

If some code returns `Status::RetryLater`, then it sets `last_send_error`, because `Status::RetryLater` means that the user won't see the error directly on the message (if we returned `Status::Failed(Err(_))`, then the message would be shown as failed to the user, and it wouldn't be as important that we also show the error message in the connectivity view) Also, `smtp_send` always sets `last_send_error` because, well, sending just failed or succeeded.

Also, remove unused field `pending_error`.