### PR TITLE
mimeparser: use mailparse to parse RFC 2231 filenames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,6 @@ dependencies = [
  "base64 0.13.0",
  "bitflags",
  "byteorder",
- "charset",
  "chrono",
  "criterion",
  "deltachat_derive",
@@ -2185,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "mailparse"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62db73ff1a42b0e3a8858cf0d5c183bdfc23491f7294ae4a8200c83577457386"
+checksum = "c06f526fc13a50f46a3689a6f438cb833c59817c898bb40a3954f341ddf74ce1"
 dependencies = [
  "base64 0.13.0",
  "charset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ backtrace = "0.3.59"
 base64 = "0.13"
 bitflags = "1.1.0"
 byteorder = "1.3.1"
-charset = "0.1"
 chrono = "0.4.6"
 dirs = { version = "3.0.2", optional=true }
 email = { git = "https://github.com/deltachat/rust-email", branch = "master" }
@@ -42,7 +41,7 @@ kamadak-exif = "0.5"
 lettre_email = { git = "https://github.com/deltachat/lettre", branch = "master" }
 libc = "0.2.97"
 log = {version = "0.4.8", optional = true }
-mailparse = "0.13.4"
+mailparse = "0.13.5"
 native-tls = "0.2.3"
 num_cpus = "1.13.0"
 num-derive = "0.3.0"


### PR DESCRIPTION
mailparse supports RFC 2231 since version 0.13.5, so there is no need
for our own code to support it.