### PR TITLE
In dc_maybe_network_lost() directly set the connectivity "Not connected"

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -48,7 +48,7 @@ impl Context {
     pub async fn maybe_network_lost(&self) {
         let lock = self.scheduler.read().await;
         lock.maybe_network_lost().await;
-        connectivity::idle_interrupted(lock).await;
+        connectivity::maybe_network_lost(self, lock).await;
     }
 
     pub(crate) async fn interrupt_inbox(&self, info: InterruptInfo) {

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -20,7 +20,7 @@ pub enum Connectivity {
 // the top) take priority. This means that e.g. if any folder has an error - usually
 // because there is no internet connection - the connectivity for the whole
 // account will be `Notconnected`.
-#[derive(Debug, Clone, PartialEq, Eq, EnumProperty)]
+#[derive(Debug, Clone, PartialEq, Eq, EnumProperty, PartialOrd)]
 enum DetailedConnectivity {
     Error(String),
     Uninitialized,
@@ -200,17 +200,33 @@ pub(crate) async fn maybe_network_lost(
     context: &Context,
     scheduler: RwLockReadGuard<'_, Scheduler>,
 ) {
-    let inbox = match &*scheduler {
-        Scheduler::Running { inbox, .. } => inbox.state.connectivity.clone(),
+    let stores = match &*scheduler {
+        Scheduler::Running {
+            inbox,
+            mvbox,
+            sentbox,
+            ..
+        } => [
+            inbox.state.connectivity.clone(),
+            mvbox.state.connectivity.clone(),
+            sentbox.state.connectivity.clone(),
+        ],
         Scheduler::Stopped => return,
     };
     drop(scheduler);
 
-    let mut connectivity_lock = inbox.0.lock().await;
-    if !matches!(*connectivity_lock, DetailedConnectivity::Error(_)) {
-        *connectivity_lock = DetailedConnectivity::Error("Connection lost".to_string());
+    for store in &stores {
+        let mut connectivity_lock = store.0.lock().await;
+        if !matches!(
+            *connectivity_lock,
+            DetailedConnectivity::Uninitialized
+                | DetailedConnectivity::Error(_)
+                | DetailedConnectivity::NotConfigured,
+        ) {
+            *connectivity_lock = DetailedConnectivity::Error("Connection lost".to_string());
+        }
+        drop(connectivity_lock);
     }
-    drop(connectivity_lock);
     context.emit_event(EventType::ConnectivityChanged);
 }
 


### PR DESCRIPTION
@r10s reported that without doing this, the connectivity would stay at
"Connected" for 16 more seconds after network is gone and
dc_maybe_network_lost() was called.

Not tested as I don't have iOS.