### PR TITLE
allow installing lib and include under different prefixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,11 @@ add_custom_command(
 	"target/release/libdeltachat.a"
 	"target/release/libdeltachat.so"
 	"target/release/pkgconfig/deltachat.pc"
-	COMMAND PREFIX=${CMAKE_INSTALL_PREFIX} ${CARGO} build --release --no-default-features
+        COMMAND
+        PREFIX=${CMAKE_INSTALL_PREFIX}
+        LIBDIR=${CMAKE_INSTALL_FULL_LIBDIR}
+        INCLUDEDIR=${CMAKE_INSTALL_FULL_INCLUDEDIR}
+        ${CARGO} build --release --no-default-features
 
 	# Build in `deltachat-ffi` directory instead of using
 	# `--package deltachat_ffi` to avoid feature resolver version

--- a/deltachat-ffi/build.rs
+++ b/deltachat-ffi/build.rs
@@ -22,7 +22,9 @@ fn main() {
         url = env::var("CARGO_PKG_HOMEPAGE").unwrap_or_else(|_| "".to_string()),
         version = env::var("CARGO_PKG_VERSION").unwrap(),
         libs_priv = libs_priv,
-        prefix = env::var("PREFIX").unwrap_or_else(|_| "/usr/local".to_string()),
+        prefix = env::var("PREFIX").unwrap(),
+        libdir = env::var("LIBDIR").unwrap(),
+        includedir = env::var("INCLUDEDIR").unwrap(),
     );
 
     fs::create_dir_all(target_path.join("pkgconfig")).unwrap();

--- a/deltachat-ffi/build.rs
+++ b/deltachat-ffi/build.rs
@@ -22,9 +22,9 @@ fn main() {
         url = env::var("CARGO_PKG_HOMEPAGE").unwrap_or_else(|_| "".to_string()),
         version = env::var("CARGO_PKG_VERSION").unwrap(),
         libs_priv = libs_priv,
-        prefix = env::var("PREFIX").unwrap(),
-        libdir = env::var("LIBDIR").unwrap(),
-        includedir = env::var("INCLUDEDIR").unwrap(),
+        prefix = env::var("PREFIX").unwrap_or_else(|_| "/usr/local".to_string()),
+        libdir = env::var("LIBDIR").unwrap_or_else(|_| "/usr/local/lib".to_string()),
+        includedir = env::var("INCLUDEDIR").unwrap_or_else(|_| "/usr/local/include".to_string()),
     );
 
     fs::create_dir_all(target_path.join("pkgconfig")).unwrap();

--- a/deltachat-ffi/deltachat.pc.in
+++ b/deltachat-ffi/deltachat.pc.in
@@ -1,6 +1,6 @@
 prefix={prefix}
-libdir=${{prefix}}/lib
-includedir=${{prefix}}/include
+libdir={libdir}
+includedir={includedir}
 
 Name: {name}
 Description: {description}


### PR DESCRIPTION
See https://github.com/jtojnar/cmake-snips#assuming-cmake_install_dir-is-relative-path.

~Since `CMAKE_INSTALL_PREFIX` [defaults to `/usr/local`](https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html), there is no need for `unwrap_or_else()`.~