### PR TITLE
remove archived count suffix

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -12,7 +12,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::aheader::EncryptPreference;
 use crate::blob::{BlobError, BlobObject};
-use crate::chatlist::dc_get_archived_cnt;
 use crate::color::str_to_color;
 use crate::config::Config;
 use crate::constants::{
@@ -892,9 +891,7 @@ impl Chat {
             .context(format!("Failed loading chat {} from database", chat_id))?;
 
         if chat.id.is_archived_link() {
-            let tempname = stock_str::archived_chats(context).await;
-            let cnt = dc_get_archived_cnt(context).await?;
-            chat.name = format!("{} ({})", tempname, cnt);
+            chat.name = stock_str::archived_chats(context).await;
         } else {
             if chat.typ == Chattype::Single {
                 let mut chat_name = "Err [Name not found]".to_owned();
@@ -3033,7 +3030,7 @@ pub(crate) async fn add_info_msg(context: &Context, chat_id: ChatId, text: impl 
 mod tests {
     use super::*;
 
-    use crate::chatlist::Chatlist;
+    use crate::chatlist::{dc_get_archived_cnt, Chatlist};
     use crate::constants::{DC_GCL_ARCHIVED_ONLY, DC_GCL_NO_SPECIALS};
     use crate::contact::Contact;
     use crate::dc_receive_imf::dc_receive_imf;


### PR DESCRIPTION
"Archived Chats" also contain old contact requests now
(an maybe new one if the user archives them),
so, there may be easily some thousands chats in "Archived Chats" -
and the count has no real meaning to the user,
esp. as we not even display the number of "Real Chats".
also, this counter may be confused with "New" or so.

it was never very useful, however, by the added contact requests,
it is even more unuseful :)

Might be that this "Link" will go away anyway sooner or later,
however, for now, it is just fine to remove the badge counter.

example of a useless counter:

<img width=320 src=https://user-images.githubusercontent.com/9800740/127347884-101b562d-ff05-4098-94d2-4006b6a52159.png>

finally, by #2563, we want to have the archive also accessible from eg. the menu -
and there one definitely does not want that info. 