### PR TITLE
add `Accounts::get_selected_account_id` function

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -78,7 +78,7 @@ impl Accounts {
         self.accounts.read().await.get(&id).cloned()
     }
 
-    /// Get the currently selected account's id or None if no account is selected
+    /// Returns the currently selected account's id or None if no account is selected.
     pub async fn get_selected_account_id(&self) -> Option<u32> {
         match self.config.get_selected_account().await {
             0 => None,

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -78,6 +78,14 @@ impl Accounts {
         self.accounts.read().await.get(&id).cloned()
     }
 
+    /// Get the currently selected account's id or None if no account is selected
+    pub async fn get_selected_account_id(&self) -> Option<u32> {
+        match self.config.get_selected_account().await {
+            0 => None,
+            id => Some(id),
+        }
+    }
+
     /// Select the given account.
     pub async fn select_account(&self, id: u32) -> Result<()> {
         self.config.select_account(id).await?;


### PR DESCRIPTION
I don't think this needs a change log entry as this is about a small addition in the rust API which is not much used directly yet.

## Why?

I missed that function and want to use it.
Yes there are other ways to get to this information, but this way is cleaner.