### PR TITLE
also move WAL file when moving database

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -118,6 +118,7 @@ impl Accounts {
     /// Migrate an existing account into this structure.
     pub async fn migrate_account(&self, dbfile: PathBuf) -> Result<u32> {
         let blobdir = Context::derive_blobdir(&dbfile);
+        let walfile = Context::derive_walfile(&dbfile);
 
         ensure!(
             dbfile.exists().await,
@@ -141,6 +142,7 @@ impl Accounts {
 
         let new_dbfile = account_config.dbfile().into();
         let new_blobdir = Context::derive_blobdir(&new_dbfile);
+        let new_walfile = Context::derive_walfile(&new_dbfile);
 
         let res = {
             fs::create_dir_all(&account_config.dir)
@@ -152,6 +154,11 @@ impl Accounts {
             fs::rename(&blobdir, &new_blobdir)
                 .await
                 .context("failed to rename blobdir")?;
+            if walfile.exists().await {
+                fs::rename(&walfile, &new_walfile)
+                    .await
+                    .context("failed to rename walfile")?;
+            }
             Ok(())
         };
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -559,6 +559,13 @@ impl Context {
         blob_fname.push("-blobs");
         dbfile.with_file_name(blob_fname)
     }
+
+    pub fn derive_walfile(dbfile: &PathBuf) -> PathBuf {
+        let mut wal_fname = OsString::new();
+        wal_fname.push(dbfile.file_name().unwrap_or_default());
+        wal_fname.push("-wal");
+        dbfile.with_file_name(wal_fname)
+    }
 }
 
 impl InnerContext {


### PR DESCRIPTION
the WAL files come from sqlite WAL mode,
they have the same name as the database file with an extra `-wal` suffix.

according to https://sqlite.org/wal.html#the_wal_file ,
the WAL file is part of the persistent state of the database
and should be kept with the database if the database is copied or moved.

without moving WAL files,
the database may lose the last records on migrate,
as just experienced in the testing group.

nb: there are much more temporary files in sqlite,
https://sqlite.org/tempfiles.html