### PR TITLE
Set timestamps for system messages

### DIFF
--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -178,7 +178,9 @@ pub async fn try_decrypt(
     let mut signatures = HashSet::default();
 
     if let Some(ref mut peerstate) = peerstate {
-        peerstate.handle_fingerprint_change(context).await?;
+        peerstate
+            .handle_fingerprint_change(context, message_time)
+            .await?;
         if let Some(key) = &peerstate.public_key {
             public_keyring_for_validate.add(key.clone());
         } else if let Some(key) = &peerstate.gossip_key {

--- a/src/location.rs
+++ b/src/location.rs
@@ -190,7 +190,7 @@ impl Kml {
     }
 }
 
-// location streaming
+/// Enables location streaming in chat identified by `chat_id` for `seconds` seconds.
 pub async fn send_locations_to_chat(context: &Context, chat_id: ChatId, seconds: i64) {
     let now = time();
     if !(seconds < 0 || chat_id.is_special()) {
@@ -221,7 +221,7 @@ pub async fn send_locations_to_chat(context: &Context, chat_id: ChatId, seconds:
                     .unwrap_or_default();
             } else if 0 == seconds && is_sending_locations_before {
                 let stock_str = stock_str::msg_location_disabled(context).await;
-                chat::add_info_msg(context, chat_id, stock_str).await;
+                chat::add_info_msg(context, chat_id, stock_str, now).await;
             }
             context.emit_event(EventType::ChatModified(chat_id));
             if 0 != seconds {
@@ -716,7 +716,8 @@ pub(crate) async fn job_maybe_send_locations_ended(
             .await
     );
 
-    if !(send_begin != 0 && time() <= send_until) {
+    let now = time();
+    if !(send_begin != 0 && now <= send_until) {
         // still streaming -
         // may happen as several calls to dc_send_locations_to_chat()
         // do not un-schedule pending DC_MAYBE_SEND_LOC_ENDED jobs
@@ -735,7 +736,7 @@ pub(crate) async fn job_maybe_send_locations_ended(
             );
 
             let stock_str = stock_str::msg_location_disabled(context).await;
-            chat::add_info_msg(context, chat_id, stock_str).await;
+            chat::add_info_msg(context, chat_id, stock_str, now).await;
             context.emit_event(EventType::ChatModified(chat_id));
         }
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -19,8 +19,8 @@ use crate::constants::{
 use crate::contact::{Contact, Origin};
 use crate::context::Context;
 use crate::dc_tools::{
-    dc_get_filebytes, dc_get_filemeta, dc_gm2local_offset, dc_read_file, dc_timestamp_to_str,
-    dc_truncate, time,
+    dc_create_smeared_timestamp, dc_get_filebytes, dc_get_filemeta, dc_gm2local_offset,
+    dc_read_file, dc_timestamp_to_str, dc_truncate, time,
 };
 use crate::ephemeral::Timer as EphemeralTimer;
 use crate::events::EventType;
@@ -1805,7 +1805,13 @@ async fn ndn_maybe_add_info_msg(
                 // Tell the user which of the recipients failed if we know that (because in
                 // a group, this might otherwise be unclear)
                 let text = stock_str::failed_sending_to(context, contact.get_display_name()).await;
-                chat::add_info_msg(context, chat_id, text).await;
+                chat::add_info_msg(
+                    context,
+                    chat_id,
+                    text,
+                    dc_create_smeared_timestamp(context).await,
+                )
+                .await;
                 context.emit_event(EventType::ChatModified(chat_id));
             }
         }

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1347,7 +1347,9 @@ async fn update_gossip_peerstates(
                     peerstate = Some(p);
                 }
                 if let Some(peerstate) = peerstate {
-                    peerstate.handle_fingerprint_change(context).await?;
+                    peerstate
+                        .handle_fingerprint_change(context, message_time)
+                        .await?;
                 }
 
                 gossipped_addr.insert(header.addr.clone());

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -260,7 +260,11 @@ impl Peerstate {
     }
 
     /// Adds a warning to the chat corresponding to peerstate if fingerprint has changed.
-    pub(crate) async fn handle_fingerprint_change(&self, context: &Context) -> Result<()> {
+    pub(crate) async fn handle_fingerprint_change(
+        &self,
+        context: &Context,
+        timestamp: i64,
+    ) -> Result<()> {
         if self.fingerprint_changed {
             if let Some(contact_id) = context
                 .sql
@@ -273,7 +277,7 @@ impl Peerstate {
 
                 let msg = stock_str::contact_setup_changed(context, self.addr.clone()).await;
 
-                chat::add_info_msg(context, chat_id, msg).await;
+                chat::add_info_msg(context, chat_id, msg, timestamp).await;
                 emit_event!(context, EventType::ChatModified(chat_id));
             } else {
                 bail!("contact with peerstate.addr {:?} not found", &self.addr);

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -11,6 +11,7 @@ use crate::config::Config;
 use crate::constants::Blocked;
 use crate::contact::{addr_normalize, may_be_valid_addr, Contact, Origin};
 use crate::context::Context;
+use crate::dc_tools::time;
 use crate::key::Fingerprint;
 use crate::log::LogExt;
 use crate::lot::{Lot, LotState};
@@ -160,7 +161,13 @@ async fn decode_openpgp(context: &Context, qr: &str) -> Lot {
                 .await
                 .log_err(context, "Failed to create (new) chat for contact")
             {
-                chat::add_info_msg(context, chat.id, format!("{} verified.", peerstate.addr)).await;
+                chat::add_info_msg(
+                    context,
+                    chat.id,
+                    format!("{} verified.", peerstate.addr),
+                    time(),
+                )
+                .await;
             }
         } else if let Some(addr) = addr {
             lot.state = LotState::QrFprMismatch;

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -14,6 +14,7 @@ use crate::config::Config;
 use crate::constants::{Blocked, Viewtype, DC_CONTACT_ID_LAST_SPECIAL};
 use crate::contact::{Contact, Origin, VerifiedStatus};
 use crate::context::Context;
+use crate::dc_tools::time;
 use crate::e2ee::ensure_secret_key_exists;
 use crate::events::EventType;
 use crate::headerdef::HeaderDef;
@@ -864,7 +865,7 @@ async fn secure_connection_established(
         "?"
     };
     let msg = stock_str::contact_verified(context, addr).await;
-    chat::add_info_msg(context, contact_chat_id, msg).await;
+    chat::add_info_msg(context, contact_chat_id, msg, time()).await;
     emit_event!(context, EventType::ChatModified(contact_chat_id));
     info!(context, "StockMessage::ContactVerified posted to 1:1 chat");
 
@@ -888,7 +889,7 @@ async fn could_not_establish_secure_connection(
     )
     .await;
 
-    chat::add_info_msg(context, contact_chat_id, &msg).await;
+    chat::add_info_msg(context, contact_chat_id, &msg, time()).await;
     error!(
         context,
         "StockMessage::ContactNotVerified posted to 1:1 chat ({})", details


### PR DESCRIPTION
Previously system messages were always added to the end of the chat,
even if the message triggering them was sent earlier.  This is
especially important for messages about disappearing timer reset
triggered by classic email messages, as they should be placed right
after the message resetting the timer.

Fixes #2263 