### PR TITLE
Fix: Recognize ndns that put the headers into "message/global-headers" part

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2727,6 +2727,18 @@ mod tests {
         .await;
     }
 
+    #[async_std::test]
+    async fn test_parse_ndn_testrun_2() {
+        test_parse_ndn(
+            "alice@example.org",
+            "bob@example.org",
+            "Mr.5xqflwt0YFv.IXDFfHauvWx@testrun.org",
+            include_bytes!("../test-data/message/testrun_ndn_2.eml"),
+            Some("Undelivered Mail Returned to Sender – This is the mail system at host hq5.merlinux.eu.\n\nI'm sorry to have to inform you that your message could not\nbe delivered to one or more recipients. It's attached below.\n\nFor further assistance, please send mail to postmaster.\n\nIf you do so, please include this problem report. You can\ndelete your own text from the attached returned message.\n\n                   The mail system\n\n<bob@example.org>: Host or domain name not found. Name service error for\n    name=echedelyr.tk type=AAAA: Host not found"),
+        )
+        .await;
+    }
+
     // ndn = Non Delivery Notification
     async fn test_parse_ndn(
         self_addr: &str,

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1130,11 +1130,11 @@ impl MimeMessage {
         report: &mailparse::ParsedMail<'_>,
     ) -> Result<Option<FailureReport>> {
         // parse as mailheaders
-        if let Some(original_msg) = report
-            .subparts
-            .iter()
-            .find(|p| p.ctype.mimetype.contains("rfc822") || p.ctype.mimetype == "message/global")
-        {
+        if let Some(original_msg) = report.subparts.iter().find(|p| {
+            p.ctype.mimetype.contains("rfc822")
+                || p.ctype.mimetype == "message/global"
+                || p.ctype.mimetype == "message/global-headers"
+        }) {
             let report_body = original_msg.get_body_raw()?;
             let (report_fields, _) = mailparse::parse_headers(&report_body)?;
 

--- a/test-data/message/testrun_ndn_2.eml
+++ b/test-data/message/testrun_ndn_2.eml
@@ -1,0 +1,97 @@
+Return-Path: <>
+Delivered-To: alice@example.org
+Received: from hq5.merlinux.eu
+	by hq5.merlinux.eu with LMTP
+	id IF/+LHrTFGEQBQAAPzvFDg
+	(envelope-from <>)
+	for <alice@example.org>; Thu, 12 Aug 2021 09:53:30 +0200
+Received: by hq5.merlinux.eu (Postfix)
+	id 9C87727A0006; Thu, 12 Aug 2021 09:53:30 +0200 (CEST)
+Date: Thu, 12 Aug 2021 09:53:30 +0200 (CEST)
+From: MAILER-DAEMON@hq5.merlinux.eu (Mail Delivery System)
+Subject: Undelivered Mail Returned to Sender
+To: alice@example.org
+Auto-Submitted: auto-replied
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="A82D727A0003.1628754810/hq5.merlinux.eu"
+Content-Transfer-Encoding: 8bit
+Message-Id: <20210812075330.9C87727A0006@hq5.merlinux.eu>
+
+This is a MIME-encapsulated message.
+
+--A82D727A0003.1628754810/hq5.merlinux.eu
+Content-Description: Notification
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: 8bit
+
+This is the mail system at host hq5.merlinux.eu.
+
+I'm sorry to have to inform you that your message could not
+be delivered to one or more recipients. It's attached below.
+
+For further assistance, please send mail to postmaster.
+
+If you do so, please include this problem report. You can
+delete your own text from the attached returned message.
+
+                   The mail system
+
+<bob@example.org>: Host or domain name not found. Name service error for
+    name=echedelyr.tk type=AAAA: Host not found
+
+--A82D727A0003.1628754810/hq5.merlinux.eu
+Content-Description: Delivery report
+Content-Type: message/global-delivery-status
+Content-Transfer-Encoding: 8bit
+
+Reporting-MTA: dns; hq5.merlinux.eu
+X-Postfix-Queue-ID: A82D727A0003
+X-Postfix-Sender: rfc822; alice@example.org
+Arrival-Date: Thu, 12 Aug 2021 09:53:29 +0200 (CEST)
+
+Final-Recipient: rfc822; bob@example.org
+Original-Recipient: rfc822;bob@example.org
+Action: failed
+Status: 5.4.4
+Diagnostic-Code: X-Postfix; Host or domain name not found. Name service error
+    for name=echedelyr.tk type=AAAA: Host not found
+
+--A82D727A0003.1628754810/hq5.merlinux.eu
+Content-Description: Undelivered Message Headers
+Content-Type: message/global-headers
+Content-Transfer-Encoding: 8bit
+
+Return-Path: <alice@example.org>
+Chat-Disposition-Notification-To: alice@example.org
+DKIM-Signature: v=1; a=rsa-sha256; c=simple/simple; d=testrun.org;
+	s=testrun; t=1628754810;
+	bh=exDToKrRerWMZ62UQVK/RgNiwDDKe+GqF6zGdG64jl8=;
+	h=Subject:References:Date:To:From:From;
+	b=SNTTDdhkppXqimCSPP+cqDvdzmryYwzurtZdN2XkTVQEeqMMdnGvEA9TOgeZpHqi0
+	 oHSjJ5oD+eUK1ECnfRuxDF9DmFnK7sbw1MaHxIcAVTLPgHrMxv+2Fjq1nmrerzmr1t
+	 z9jOYY8e6gfEBw1uDAfHMmIl4OGuoDSll8haqNF3C2JqdwTtcdtE/w6ERJwSeHhCsR
+	 bknan9Rh75Tr46Zh8WVi9YYRVDGFj7+OlL/67Va+Jxl3c4v4EJ5vF6ncxyJupP9eU2
+	 qndV+g1BbxsARo663codYZRiGh217AI8DG2HUr0rVOPdvWm1kw/NTkp3BxoHkv5q2a
+	 Uak5Jiieur6Hg==
+Subject: Message from Hocuri
+Chat-User-Avatar: 0
+MIME-Version: 1.0
+References: <Mr.5xqflwt0YFv.IXDFfHauvWx@testrun.org>
+Date: Thu, 12 Aug 2021 07:53:28 +0000
+Chat-Version: 1.0
+Autocrypt: addr=alice@example.org;
+	keydata=xjMEX3tmZxYJKwYBBAHaRw8BAQdAl4LKVKPRqxG1ZXEO8e9s1DZWt6f38wSuJnY0mLSOuf
+	7NFTxob2N1cmkxQHRlc3RydW4ub3JnPsKLBBAWCAAzAhkBBQJfe2ZnAhsDBAsJCAcGFQgJCgsCAxYC
+	ARYhBBmltZLxgqC0SHJPEL7qvlxmQUTNAAoJEL7qvlxmQUTNIucBAJkRclHRG7cWpFbMYW+rspEFIQ
+	j1GTKwriiBpk5ffnroAQC3h/scScpG/EeIPL0y80GRS5BoR1Ium3zrlR92EaijDc44BF97ZmcSCisG
+	AQQBl1UBBQEBB0CmxhyX/NuXIlrl0/fdeEseAv6KCbZ4tV3tIvSvnH1KHgMBCAfCeAQYFggAIAUCX3
+	tmZwIbDBYhBBmltZLxgqC0SHJPEL7qvlxmQUTNAAoJEL7qvlxmQUTNnkYA/3qY+e6PrtR1WT7PiVeZ
+	RIQBkkJjWWSx+lBQ5fNb3e92AQCBEG3OnGy4RrxOqWW2ry7ETP33CJeiwAwCvv4LQlwCCw==
+Message-ID: <Mr.5xqflwt0YFv.IXDFfHauvWx@testrun.org>
+To: <bob@example.org>
+From: Hocuri <alice@example.org>
+Content-Type: multipart/mixed; boundary="qtFe0wPDNHWVlvqV0B8ymdWmE6ZmKD"
+
+--A82D727A0003.1628754810/hq5.merlinux.eu--
+


### PR DESCRIPTION
I sent a message, and the ndn (Non Delivery Notification) was not parsed correctly, so here comes
the fix and the test.