### PR TITLE
Add Quota to Connectivity View

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,6 +1145,7 @@ dependencies = [
  "futures",
  "futures-lite",
  "hex",
+ "humansize",
  "image",
  "indexmap",
  "itertools 0.10.1",
@@ -1932,6 +1933,12 @@ dependencies = [
  "toml",
  "uuid",
 ]
+
+[[package]]
+name = "humansize"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 
 [[package]]
 name = "humantime"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,8 +238,7 @@ dependencies = [
 [[package]]
 name = "async-imap"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb2df4b37a99456360a9ab475b723e3a499d51e060ab1bdd8d7565d23dcb74b"
+source = "git+https://github.com/async-email/async-imap#4ce7da455618c387b87b2905a80935107bc69afc"
 dependencies = [
  "async-native-tls",
  "async-std",
@@ -250,7 +249,7 @@ dependencies = [
  "imap-proto",
  "lazy_static",
  "log",
- "nom 5.1.2",
+ "nom 6.2.1",
  "pin-utils",
  "rental",
  "stop-token",
@@ -521,6 +520,18 @@ name = "bitflags"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
+
+[[package]]
+name = "bitvec"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -1587,6 +1598,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
 name = "futures"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,11 +1978,11 @@ dependencies = [
 
 [[package]]
 name = "imap-proto"
-version = "0.11.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3091b99ee5b80f9b010eb6f962af9495ad06561bf662126b077e8ca30e463182"
+checksum = "3ad9b46a79efb6078e578ae04e51463d7c3e8767864687f7e63095b3cbefafbb"
 dependencies = [
- "nom 5.1.2",
+ "nom 6.2.1",
 ]
 
 [[package]]
@@ -2338,6 +2355,19 @@ version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
 dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check 0.9.3",
+]
+
+[[package]]
+name = "nom"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+dependencies = [
+ "bitvec",
+ "funty",
  "lexical-core",
  "memchr",
  "version_check 0.9.3",
@@ -2873,6 +2903,12 @@ dependencies = [
  "r2d2",
  "rusqlite",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "radix_trie"
@@ -3652,6 +3688,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4165,6 +4207,12 @@ checksum = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "x25519-dalek"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ deltachat_derive = { path = "./deltachat_derive" }
 
 ansi_term = { version = "0.12.1", optional = true }
 anyhow = "1.0.42"
-async-imap = "0.5.0"
+async-imap = { git = "https://github.com/async-email/async-imap" }
 async-native-tls = { version = "0.3.3" }
 async-smtp = { git = "https://github.com/async-email/async-smtp", rev="c8800625f7cf29f437143ac7e720ac2730a0962f" }
 async-std-resolver = "0.20.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ thiserror = "1.0.26"
 toml = "0.5.6"
 url = "2.2.2"
 uuid = { version = "0.8", features = ["serde", "v4"] }
+humansize = "1.1.1"
 
 [dev-dependencies]
 ansi_term = "0.12.0"

--- a/src/context.rs
+++ b/src/context.rs
@@ -25,6 +25,8 @@ use crate::message::{self, MessageState, MsgId};
 use crate::scheduler::Scheduler;
 use crate::securejoin::Bob;
 use crate::sql::Sql;
+use async_imap::types::QuotaResource;
+use indexmap::IndexMap;
 
 #[derive(Clone, Debug)]
 pub struct Context {
@@ -61,6 +63,7 @@ pub struct InnerContext {
 
     pub(crate) scheduler: RwLock<Scheduler>,
     pub(crate) ephemeral_task: RwLock<Option<task::JoinHandle<()>>>,
+    pub(crate) recent_quota: RwLock<Option<Result<IndexMap<String, Vec<QuotaResource>>>>>,
 
     pub(crate) last_full_folder_scan: Mutex<Option<Instant>>,
 
@@ -139,6 +142,7 @@ impl Context {
             events: Events::default(),
             scheduler: RwLock::new(Scheduler::Stopped),
             ephemeral_task: RwLock::new(None),
+            recent_quota: RwLock::new(None),
             creation_time: std::time::SystemTime::now(),
             last_full_folder_scan: Mutex::new(None),
         };

--- a/src/context.rs
+++ b/src/context.rs
@@ -64,7 +64,14 @@ pub struct InnerContext {
     pub(crate) scheduler: RwLock<Scheduler>,
     pub(crate) ephemeral_task: RwLock<Option<task::JoinHandle<()>>>,
 
+    /// Recently loaded quota information, if any.
+    /// Set to `None` if quota was never tried to load,
+    /// set to `Some(Err())` if the provider does not support quota or on other errors,
+    /// set to `Some(Ok())` for valid quota information.
+    /// Updated by `Action::UpdateRecentQuota`
     pub(crate) recent_quota: RwLock<Option<Result<IndexMap<String, Vec<QuotaResource>>>>>,
+
+    /// Time when `recent_quota` was modified.
     pub(crate) recent_quota_timestamp: RwLock<i64>,
 
     pub(crate) last_full_folder_scan: Mutex<Option<Instant>>,

--- a/src/context.rs
+++ b/src/context.rs
@@ -22,11 +22,10 @@ use crate::events::{Event, EventEmitter, EventType, Events};
 use crate::key::{DcKey, SignedPublicKey};
 use crate::login_param::LoginParam;
 use crate::message::{self, MessageState, MsgId};
+use crate::quota::QuotaInfo;
 use crate::scheduler::Scheduler;
 use crate::securejoin::Bob;
 use crate::sql::Sql;
-use async_imap::types::QuotaResource;
-use indexmap::IndexMap;
 
 #[derive(Clone, Debug)]
 pub struct Context {
@@ -65,14 +64,8 @@ pub struct InnerContext {
     pub(crate) ephemeral_task: RwLock<Option<task::JoinHandle<()>>>,
 
     /// Recently loaded quota information, if any.
-    /// Set to `None` if quota was never tried to load,
-    /// set to `Some(Err())` if the provider does not support quota or on other errors,
-    /// set to `Some(Ok())` for valid quota information.
-    /// Updated by `Action::UpdateRecentQuota`
-    pub(crate) recent_quota: RwLock<Option<Result<IndexMap<String, Vec<QuotaResource>>>>>,
-
-    /// Time when `recent_quota` was modified.
-    pub(crate) recent_quota_timestamp: RwLock<i64>,
+    /// Set to `None` if quota was never tried to load.
+    pub(crate) quota: RwLock<Option<QuotaInfo>>,
 
     pub(crate) last_full_folder_scan: Mutex<Option<Instant>>,
 
@@ -151,8 +144,7 @@ impl Context {
             events: Events::default(),
             scheduler: RwLock::new(Scheduler::Stopped),
             ephemeral_task: RwLock::new(None),
-            recent_quota: RwLock::new(None),
-            recent_quota_timestamp: RwLock::new(0),
+            quota: RwLock::new(None),
             creation_time: std::time::SystemTime::now(),
             last_full_folder_scan: Mutex::new(None),
         };

--- a/src/context.rs
+++ b/src/context.rs
@@ -63,7 +63,9 @@ pub struct InnerContext {
 
     pub(crate) scheduler: RwLock<Scheduler>,
     pub(crate) ephemeral_task: RwLock<Option<task::JoinHandle<()>>>,
+
     pub(crate) recent_quota: RwLock<Option<Result<IndexMap<String, Vec<QuotaResource>>>>>,
+    pub(crate) recent_quota_timestamp: RwLock<i64>,
 
     pub(crate) last_full_folder_scan: Mutex<Option<Instant>>,
 
@@ -143,6 +145,7 @@ impl Context {
             scheduler: RwLock::new(Scheduler::Stopped),
             ephemeral_task: RwLock::new(None),
             recent_quota: RwLock::new(None),
+            recent_quota_timestamp: RwLock::new(0),
             creation_time: std::time::SystemTime::now(),
             last_full_folder_scan: Mutex::new(None),
         };

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -102,7 +102,7 @@ impl Imap {
     }
 }
 
-async fn get_watched_folders(context: &Context) -> Vec<String> {
+pub(crate) async fn get_watched_folders(context: &Context) -> Vec<String> {
     let mut res = Vec::new();
     let folder_watched_configured = &[
         (Config::SentboxWatch, Config::ConfiguredSentboxFolder),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ pub mod peerstate;
 pub mod pgp;
 pub mod provider;
 pub mod qr;
+pub mod quota;
 pub mod securejoin;
 mod simplify;
 mod smtp;

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -64,6 +64,7 @@ async fn get_unique_quota_roots_and_usage(
 impl Context {
     // Adds a job to update `quota.recent`
     pub(crate) async fn schedule_quota_update(&self) {
+        job::kill_action(self, Action::UpdateRecentQuota).await;
         job::add(
             self,
             job::Job::new(Action::UpdateRecentQuota, 0, Params::new(), 0),

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -4,6 +4,14 @@ use indexmap::IndexMap;
 
 use crate::imap::Imap;
 
+/// warn about a nearly full mailbox after this usage percentage is reached.
+/// quota icon is "yellow".
+pub const QUOTA_WARN_THRESHOLD_PERCENTAGE: u64 = 80;
+
+// warning is already issued at QUOTA_WARN_THRESHOLD_PERCENTAGE,
+// this threshold only makes the quota icon "red".
+pub const QUOTA_ERROR_THRESHOLD_PERCENTAGE: u64 = 99;
+
 pub(crate) async fn get_unique_quota_roots_and_usage(
     folders: Vec<String>,
     imap: &mut Imap,

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -12,6 +12,10 @@ pub const QUOTA_WARN_THRESHOLD_PERCENTAGE: u64 = 80;
 // this threshold only makes the quota icon "red".
 pub const QUOTA_ERROR_THRESHOLD_PERCENTAGE: u64 = 99;
 
+// if recent_quota is older,
+// it is re-fetched on dc_get_connectivity_html()
+pub const QUOTA_MAX_AGE_SECONDS: i64 = 60;
+
 pub(crate) async fn get_unique_quota_roots_and_usage(
     folders: Vec<String>,
     imap: &mut Imap,

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -1,0 +1,32 @@
+use anyhow::{anyhow, Result};
+use async_imap::types::{Quota, QuotaResource};
+use indexmap::IndexMap;
+
+use crate::imap::Imap;
+
+pub(crate) async fn get_unique_quota_roots_and_usage(
+    folders: Vec<String>,
+    imap: &mut Imap,
+) -> Result<IndexMap<String, Vec<QuotaResource>>> {
+    let mut unique_quota_roots: IndexMap<String, Vec<QuotaResource>> = IndexMap::new();
+    for folder in folders {
+        let (quota_roots, quotas) = &imap.get_quota_roots(&folder).await?;
+        // if there are new quota roots found in this imap folder, add them to the list
+        for qr_entries in quota_roots {
+            for quota_root_name in &qr_entries.quota_root_names {
+                // the quota for that quota root
+                let quota: Quota = quotas
+                    .iter()
+                    .find(|q| &q.root_name == quota_root_name)
+                    .cloned()
+                    .ok_or_else(|| anyhow!("quota_root should have a quota"))?;
+                // replace old quotas, because between fetching quotaroots for folders,
+                // messages could be recieved and so the usage could have been changed
+                *unique_quota_roots
+                    .entry(quota_root_name.clone())
+                    .or_insert(vec![]) = quota.resources;
+            }
+        }
+    }
+    Ok(unique_quota_roots)
+}

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -423,6 +423,7 @@ impl Context {
         if let Some(quota) = &*quota {
             match quota {
                 Ok(quota) => {
+                    let roots_cnt = quota.len();
                     for (root_name, resources) in quota {
                         use async_imap::types::QuotaResourceName::*;
                         for resource in resources {
@@ -437,12 +438,13 @@ impl Context {
                                 ret += "<span class=\"green dot\"></span> ";
                             }
 
-                            // root name is empty eg. for gmail.
-                            // not sure, how that is used in the wild, for now, just prepend it to each resource name
-                            // and not use it as a headline or so.
-                            if !root_name.is_empty() {
+                            // root name is empty eg. for gmail and redundant eg. for riseup.
+                            // therefore, use it only if there are really several roots.
+                            if roots_cnt > 1 && !root_name.is_empty() {
                                 ret +=
-                                    &format!("<b>{}:</b> ", &*escaper::encode_minimal(&root_name));
+                                    &format!("<b>{}:</b> ", &*escaper::encode_minimal(root_name));
+                            } else {
+                                info!(self, "connectivity: root name hidden: \"{}\"", root_name);
                             }
 
                             ret += &match &resource.name {

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -307,7 +307,7 @@ impl Context {
         if *self.recent_quota_timestamp.read().await + QUOTA_MAX_AGE_SECONDS < time() {
             job::add(
                 self,
-                job::Job::new(Action::GenerateQuotaUsageReport, 0, Params::new(), 0),
+                job::Job::new(Action::UpdateRecentQuota, 0, Params::new(), 0),
             )
             .await;
         }
@@ -494,7 +494,7 @@ impl Context {
         ret
     }
 
-    pub async fn generate_quota_usage_report(&self, imap: &mut Imap) -> Status {
+    pub async fn update_recent_quota(&self, imap: &mut Imap) -> Status {
         if let Err(err) = imap.prepare(self).await {
             warn!(self, "could not connect: {:?}", err);
             return Status::RetryNow;

--- a/standards.md
+++ b/standards.md
@@ -10,6 +10,7 @@ Text and Quote encoding          | Fixed, Flowed ([RFC 3676](https://tools.ietf.
 Filename encoding                | Encoded Words ([RFC 2047](https://tools.ietf.org/html/rfc2047)), Encoded Word Extensions ([RFC 2231](https://tools.ietf.org/html/rfc2231))
 Identify server folders          | IMAP LIST Extension ([RFC 6154](https://tools.ietf.org/html/rfc6154))
 Push                             | IMAP IDLE ([RFC 2177](https://tools.ietf.org/html/rfc2177))
+Quota                            | IMAP QUOTA extension ([RFC 2087](https://tools.ietf.org/html/rfc2087))
 Authorization                    | OAuth2 ([RFC 6749](https://tools.ietf.org/html/rfc6749))
 End-to-end encryption            | [Autocrypt Level 1](https://autocrypt.org/level1.html), OpenPGP ([RFC 4880](https://tools.ietf.org/html/rfc4880)), Security Multiparts for MIME ([RFC 1847](https://tools.ietf.org/html/rfc1847)) and [“Mixed Up” Encryption repairing](https://tools.ietf.org/id/draft-dkg-openpgp-pgpmime-message-mangling-00.html)
 Configuration assistance         | [Autoconfigure](https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration) and [Autodiscover](https://technet.microsoft.com/library/bb124251(v=exchg.150).aspx)


### PR DESCRIPTION
this pr is based on the work of @Simon-Laux in https://github.com/deltachat/deltachat-core-rust/pull/2462 and https://github.com/async-email/async-imap/pull/47 and adds quota information to the existing connectivity view, more precise to `dc_get_connectivity_html()`.

this is how it looks like on ios using gmai.com and testrun.org:

<img width="300" alt="Screen Shot 2021-08-19 at 13 31 51" src="https://user-images.githubusercontent.com/9800740/130062018-cce42641-37ec-4add-bd65-2596b4f0c3c9.png"> <img width="300" alt="Screen Shot 2021-08-19 at 13 32 18" src="https://user-images.githubusercontent.com/9800740/130062027-1da845b2-06a6-4184-90ab-3bd7c507acab.png">

the connectivity view adds one line per resource and resources are grouped in "quota roots", whatever that is in detail - for gmail, the "quota root name" is just empty - and i did not found another provider providing quota information. the color of the icon beside each quota line changes to yellow/red when things become full.

`dc_get_connectivity_html()` just prints the recently fetched quota and, if recently fetched is older than one minute, starts a job to update that, the ui will be informed about that by DC_EVENT_CONNECTIVITY_CHANGED.

in a subsequent pr, we can maybe add periodic checks and warnings and/or add some nice graphic and translations, however, it would be great to collect some experience first.

closes https://github.com/deltachat/deltachat-core-rust/issues/2534