### PR TITLE
add 'device chat about' to now existing status

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -218,6 +218,7 @@ impl Contact {
         } else if contact_id == DC_CONTACT_ID_DEVICE {
             contact.name = stock_str::device_messages(context).await;
             contact.addr = DC_CONTACT_ID_DEVICE_ADDR.to_string();
+            contact.status = stock_str::device_messages_hint(context).await;
         }
         Ok(contact)
     }

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -897,10 +897,6 @@ impl Context {
 
         // add welcome-messages. by the label, this is done only once,
         // if the user has deleted the message or the chat, it is not added again.
-        let mut msg = Message::new(Viewtype::Text);
-        msg.text = Some(device_messages_hint(self).await);
-        chat::add_device_msg(self, Some("core-about-device-chat"), Some(&mut msg)).await?;
-
         let image = include_bytes!("../assets/welcome-image.jpg");
         let blob = BlobObject::create(self, "welcome-image.jpg", image).await?;
         let mut msg = Message::new(Viewtype::Image);


### PR DESCRIPTION
the 'device chat about' was shown as a single message
as at that time, there was just no 'status'.

meanwhile, we have the status option,
and it feels much more natural to get the information there,
esp. as the subtitle on all UIs already read
'Messages in this chat are generated locally' -
and a tap on that will show the hint, without scrolling or so.

this also teaches the user where to find such information -
and the "welcome" chat is less spammy and really starts with the text
"Welcome to Delta Chat!"

<img width="310" alt="Screen Shot 2021-08-20 at 11 15 39" src="https://user-images.githubusercontent.com/9800740/130210868-377ca2c6-589e-43a5-9930-133142319ccd.png"> <img width="310" alt="Screen Shot 2021-08-20 at 11 14 32" src="https://user-images.githubusercontent.com/9800740/130210878-d0c29bac-a453-4f5f-a87f-efe40a6dca6e.png">
