### PR TITLE
tweak quota display

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -275,7 +275,15 @@ pub unsafe extern "C" fn dc_get_connectivity_html(
         return "".strdup();
     }
     let ctx = &*context;
-    block_on(async move { ctx.get_connectivity_html().await.strdup() })
+    block_on(async move {
+        match ctx.get_connectivity_html().await {
+            Ok(html) => html.strdup(),
+            Err(err) => {
+                error!(ctx, "Failed to get connectivity html: {}", err);
+                "".strdup()
+            }
+        }
+    })
 }
 
 #[no_mangle]

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -514,9 +514,15 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             let file = dirs::home_dir()
                 .unwrap_or_default()
                 .join("connectivity.html");
-            let html = context.get_connectivity_html().await;
-            fs::write(&file, html)?;
-            println!("Report written to: {:#?}", file);
+            match context.get_connectivity_html().await {
+                Ok(html) => {
+                    fs::write(&file, html)?;
+                    println!("Report written to: {:#?}", file);
+                }
+                Err(err) => {
+                    bail!("Failed to get connectivity html: {}", err);
+                }
+            }
         }
         "maybenetwork" => {
             context.maybe_network().await;

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -309,12 +309,28 @@ impl Context {
                         list-style-type: none;
                         padding-left: 1em;
                     }
-
                     .dot {
                         height: 0.9em; width: 0.9em;
+                        border: 1px solid #888;
                         border-radius: 50%;
                         display: inline-block;
                         position: relative; left: -0.1em; top: 0.1em;
+                    }
+                    .bar {
+                        width: 90%;
+                        border: 1px solid #888;
+                        border-radius: .5em;
+                        margin-top: .2em;
+                        margin-bottom: 1em;
+                        position: relative; left: -0.2em;
+                    }
+                    .progress {
+                        min-width:1.8em;
+                        height: 1em;
+                        border-radius: .45em;
+                        color: white;
+                        text-align: center;
+                        padding-bottom: 2px;
                     }
                     .red {
                         background-color: #f33b2d;
@@ -430,15 +446,6 @@ impl Context {
                         for resource in resources {
                             ret += "<li>";
 
-                            let usage_percent = resource.get_usage_percentage();
-                            if usage_percent >= QUOTA_ERROR_THRESHOLD_PERCENTAGE {
-                                ret += "<span class=\"red dot\"></span> ";
-                            } else if usage_percent >= QUOTA_WARN_THRESHOLD_PERCENTAGE {
-                                ret += "<span class=\"yellow dot\"></span> ";
-                            } else {
-                                ret += "<span class=\"green dot\"></span> ";
-                            }
-
                             // root name is empty eg. for gmail and redundant eg. for riseup.
                             // therefore, use it only if there are really several roots.
                             if roots_cnt > 1 && !root_name.is_empty() {
@@ -477,7 +484,16 @@ impl Context {
                                     ret += &format!("{} of {} used", usage, limit)
                                 }
                             };
-                            ret += &format!(" ({}%)", usage_percent);
+
+                            let percent = resource.get_usage_percentage();
+                            let color = if percent >= QUOTA_ERROR_THRESHOLD_PERCENTAGE {
+                                "red"
+                            } else if percent >= QUOTA_WARN_THRESHOLD_PERCENTAGE {
+                                "yellow"
+                            } else {
+                                "green"
+                            };
+                            ret += &format!("<div class=\"bar\"><div class=\"progress {}\" style=\"width: {}%\">{}%</div></div>", color, percent, percent);
 
                             ret += "</li>";
                         }

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -10,6 +10,7 @@ use crate::quota::{
 };
 use crate::{config::Config, scheduler::Scheduler};
 use crate::{context::Context, log::LogExt};
+use anyhow::{anyhow, Result};
 use humansize::{file_size_opts, FileSize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumProperty, PartialOrd, Ord)]
@@ -297,7 +298,7 @@ impl Context {
     ///
     /// This comes as an HTML from the core so that we can easily improve it
     /// and the improvement instantly reaches all UIs.
-    pub async fn get_connectivity_html(&self) -> String {
+    pub async fn get_connectivity_html(&self) -> Result<String> {
         let mut ret = r#"<!DOCTYPE html>
             <html>
             <head>
@@ -358,8 +359,7 @@ impl Context {
                 smtp.state.connectivity.clone(),
             ),
             Scheduler::Stopped => {
-                ret += "Not started</body></html>\n";
-                return ret;
+                return Err(anyhow!("Not started"));
             }
         };
         drop(lock);
@@ -484,7 +484,7 @@ impl Context {
         ret += "</ul>";
 
         ret += "</body></html>\n";
-        ret
+        Ok(ret)
     }
 
     pub async fn all_work_done(&self) -> bool {


### PR DESCRIPTION
- get rid of "Quota" title, many  users and testers do not really understand what this is about - instead, say "Storage on domain.com" - any other suggestions are welcome here, maybe there is sth. even better :)

- ~~the resource-titles are only shown if there are multiple quotas or a single quota that is _not_ "Storage"~~ it is just always skipped, see code-comment for reasoning.

- show the percentage as a bar - margins and paddings are already tweaked a bit, so this screenshot is not totally up-to-date
<img width=300 src=https://user-images.githubusercontent.com/9800740/130335310-b8ef545d-e585-4fa9-a063-8950d28609e9.png>

(the white percentage display also benefits from the additional padding (not on screenshot). using black here does not look good, also, wrt the other background colors) (one could tweak css here further, however, we have to keep things simple to allow good display also on old phones with old webviews ...)

nb: you can test the html also in the repl-tool by the command `connectivity`.