### PR TITLE
download on demand

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5788,6 +5788,22 @@ void dc_event_unref(dc_event_t* event);
 /// `%1$s` will be replaced by the percentage used
 #define DC_STR_QUOTA_EXCEEDING_MSG_BODY   98
 
+/// "%1$s message"
+///
+/// Used as the message body when a message
+/// was not yet downloaded completely
+/// (dc_msg_get_download_state() is eg. @ref DC_DOWNLOAD_AVAILABLE).
+///
+/// `%1$s` will be replaced by human-readable size (eg. "1.2 MiB").
+#define DC_STR_PARTIAL_DOWNLOAD_MSG_BODY  99
+
+/// "Download maximum available until %1$s"
+///
+/// Appended after some separator to @ref DC_STR_PARTIAL_DOWNLOAD_MSG_BODY.
+///
+/// `%1$s` will be replaced by human-readable date and time.
+#define DC_STR_DOWNLOAD_AVAILABILITY      100
+
 /**
  * @}
  */

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1615,7 +1615,7 @@ char*           dc_get_msg_html              (dc_context_t* context, uint32_t ms
   * eg. when an email contains several images
   * that is expanded to several messages.
   *
-  * To reflect these changes a @ref DC_EVENT_MSGS_CHANGED event will be emmitted.
+  * To reflect these changes a @ref DC_EVENT_MSGS_CHANGED event will be emitted.
   *
   * @memberof dc_context_t
   * @param context The context object.

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -351,10 +351,12 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  * - `fetch_existing_msgs` = 1=fetch most recent existing messages on configure (default),
  *                    0=do not fetch existing messages on configure.
  *                    In both cases, existing recipients are added to the contact database.
- * - `download_limit` = Messages up to this number of bytes are downloaded automatically;
- *                    larger messages need to be downloaded manually using dc_download_full_msg().
- *                    The limit is compared against raw message sizes, including headers,
- *                    and must not be too low to not mess up with non-delivery-reports or read-receipts.
+ * - `download_limit` = Messages up to this number of bytes are downloaded automatically.
+ *                    For larger messages, only the header is downloaded and a placeholder is shown.
+ *                    These messages can be downloaded fully using dc_download_full_msg() later.
+ *                    The limit is compared against raw message sizes, including headers.
+ *                    The actually used limit may be corrected
+ *                    to not mess up with non-delivery-reports or read-receipts.
  *                    0=no limit (default).
  *                    Changes affect future messages only.
  *

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1606,9 +1606,9 @@ char*           dc_get_msg_html              (dc_context_t* context, uint32_t ms
   * that is shown by the UI in case dc_msg_get_download_state()
   * returns @ref DC_DOWNLOAD_AVAILABLE or @ref DC_DOWNLOAD_FAILURE.
   *
-  * One success, the type of the message may change.
+  * On success, the @ref DC_MSG "view type of the message" may change.
   * That may happen eg. in cases where the message was encrypted
-  * and the type could not be determinate without fully downloading.
+  * and the type could not be determined without fully downloading.
   * Downloaded content can be accessed as usual after download,
   * eg. using dc_msg_get_file().
   * If may also happen that additional messages appear by downloading,
@@ -1619,7 +1619,7 @@ char*           dc_get_msg_html              (dc_context_t* context, uint32_t ms
   *
   * @memberof dc_context_t
   * @param context The context object.
-  * @param msg_id Message-ID to download the content for.
+  * @param msg_id Message ID to download the content for.
   */
 void dc_download_full_msg (dc_context_t* context, int msg_id);
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1653,6 +1653,22 @@ pub unsafe extern "C" fn dc_get_msg(context: *mut dc_context_t, msg_id: u32) -> 
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_download_full_msg(context: *mut dc_context_t, msg_id: u32) {
+    if context.is_null() {
+        eprintln!("ignoring careless call to dc_download_full_msg()");
+        return;
+    }
+    let ctx = &*context;
+    block_on(async move {
+        MsgId::new(msg_id)
+            .download_full(ctx)
+            .await
+            .log_err(ctx, "Failed to download message fully.")
+            .ok()
+    });
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_may_be_valid_addr(addr: *const libc::c_char) -> libc::c_int {
     if addr.is_null() {
         eprintln!("ignoring careless call to dc_may_be_valid_addr()");
@@ -2789,6 +2805,16 @@ pub unsafe extern "C" fn dc_msg_get_state(msg: *mut dc_msg_t) -> libc::c_int {
     }
     let ffi_msg = &*msg;
     ffi_msg.message.get_state() as libc::c_int
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dc_msg_get_download_state(msg: *mut dc_msg_t) -> libc::c_int {
+    if msg.is_null() {
+        eprintln!("ignoring careless call to dc_msg_get_download_state()");
+        return 0;
+    }
+    let ffi_msg = &*msg;
+    ffi_msg.message.get_download_state() as libc::c_int
 }
 
 #[no_mangle]

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2814,7 +2814,7 @@ pub unsafe extern "C" fn dc_msg_get_download_state(msg: *mut dc_msg_t) -> libc::
         return 0;
     }
     let ffi_msg = &*msg;
-    ffi_msg.message.get_download_state() as libc::c_int
+    ffi_msg.message.download_state() as libc::c_int
 }
 
 #[no_mangle]

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1659,13 +1659,9 @@ pub unsafe extern "C" fn dc_download_full_msg(context: *mut dc_context_t, msg_id
         return;
     }
     let ctx = &*context;
-    block_on(async move {
-        MsgId::new(msg_id)
-            .download_full(ctx)
-            .await
-            .log_err(ctx, "Failed to download message fully.")
-            .ok()
-    });
+    block_on(MsgId::new(msg_id).download_full(ctx))
+        .log_err(ctx, "Failed to download message fully.")
+        .ok();
 }
 
 #[no_mangle]

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -13,6 +13,7 @@ use deltachat::contact::*;
 use deltachat::context::*;
 use deltachat::dc_receive_imf::*;
 use deltachat::dc_tools::*;
+use deltachat::download::DownloadState;
 use deltachat::imex::*;
 use deltachat::location;
 use deltachat::log::LogExt;
@@ -188,10 +189,18 @@ async fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
         MessageState::OutFailed => " !!",
         _ => "",
     };
+
+    let downloadstate = match msg.get_download_state() {
+        DownloadState::Done => "",
+        DownloadState::Available => " [⬇ Download available]",
+        DownloadState::InProgress => " [⬇ Download in progress...]️",
+        DownloadState::Failure => " [⬇ Download failed]",
+    };
+
     let temp2 = dc_timestamp_to_str(msg.get_timestamp());
     let msgtext = msg.get_text();
     println!(
-        "{}{}{}{}: {} (Contact#{}): {} {}{}{}{}{}{} [{}]",
+        "{}{}{}{}: {} (Contact#{}): {} {}{}{}{}{}{}{} [{}]",
         prefix.as_ref(),
         msg.get_id(),
         if msg.get_showpadlock() { "🔒" } else { "" },
@@ -225,6 +234,7 @@ async fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
             ""
         },
         statestr,
+        downloadstate,
         &temp2,
     );
 }
@@ -393,6 +403,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                  ===========================Message commands==\n\
                  listmsgs <query>\n\
                  msginfo <msg-id>\n\
+                 download <msg-id>\n\
                  html <msg-id>\n\
                  listfresh\n\
                  forward <msg-id> <chat-id>\n\
@@ -1027,6 +1038,12 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             let id = MsgId::new(arg1.parse()?);
             let res = message::get_msg_info(&context, id).await?;
             println!("{}", res);
+        }
+        "download" => {
+            ensure!(!arg1.is_empty(), "Argument <msg-id> missing.");
+            let id = MsgId::new(arg1.parse()?);
+            println!("Scheduling download for {:?}", id);
+            id.download_full(&context).await?;
         }
         "html" => {
             ensure!(!arg1.is_empty(), "Argument <msg-id> missing.");

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -190,7 +190,7 @@ async fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
         _ => "",
     };
 
-    let downloadstate = match msg.get_download_state() {
+    let downloadstate = match msg.download_state() {
         DownloadState::Done => "",
         DownloadState::Available => " [⬇ Download available]",
         DownloadState::InProgress => " [⬇ Download in progress...]️",

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -202,13 +202,14 @@ const CHAT_COMMANDS: [&str; 33] = [
     "accept",
     "blockchat",
 ];
-const MESSAGE_COMMANDS: [&str; 6] = [
+const MESSAGE_COMMANDS: [&str; 7] = [
     "listmsgs",
     "msginfo",
     "listfresh",
     "forward",
     "markseen",
     "delmsg",
+    "download",
 ];
 const CONTACT_COMMANDS: [&str; 9] = [
     "listcontacts",

--- a/src/config.rs
+++ b/src/config.rs
@@ -170,6 +170,11 @@ pub enum Config {
     /// To how many seconds to debounce scan_all_folders. Used mainly in tests, to disable debouncing completely.
     #[strum(props(default = "60"))]
     ScanAllFoldersDebounceSecs,
+
+    /// Defines the max. size (in bytes) of messages downloaded automatically.
+    /// 0 = no limit.
+    #[strum(props(default = "0"))]
+    DownloadLimit,
 }
 
 impl Context {

--- a/src/context.rs
+++ b/src/context.rs
@@ -371,6 +371,12 @@ impl Context {
             "show_emails",
             self.get_config_int(Config::ShowEmails).await?.to_string(),
         );
+        res.insert(
+            "download_limit",
+            self.get_config_int(Config::DownloadLimit)
+                .await?
+                .to_string(),
+        );
         res.insert("inbox_watch", inbox_watch.to_string());
         res.insert("sentbox_watch", sentbox_watch.to_string());
         res.insert("mvbox_watch", mvbox_watch.to_string());

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -83,11 +83,7 @@ pub(crate) async fn dc_receive_imf_inner(
 ) -> Result<()> {
     info!(
         context,
-        "Receiving message {}/{}, seen={}, partial={:?}...",
-        server_folder,
-        server_uid,
-        seen,
-        is_partial_download
+        "Receiving message {}/{}, seen={}...", server_folder, server_uid, seen
     );
 
     if std::env::var(crate::DCC_MIME_DEBUG).unwrap_or_default() == "2" {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -135,7 +135,7 @@ pub(crate) async fn dc_receive_imf_inner(
         message::rfc724_mid_exists(context, &rfc724_mid).await?
     {
         let msg = Message::load_from_db(context, old_msg_id).await?;
-        if msg.get_download_state() != DownloadState::Done && is_partial_download.is_none() {
+        if msg.download_state() != DownloadState::Done && is_partial_download.is_none() {
             // the mesage was partially downloaded before and is fully downloaded now.
             info!(
                 context,

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -287,7 +287,7 @@ pub(crate) async fn dc_receive_imf_inner(
     let delete_server_after = context.get_config_delete_server_after().await?;
 
     if !created_db_entries.is_empty() {
-        if needs_delete_job || delete_server_after == Some(0) {
+        if needs_delete_job || (delete_server_after == Some(0) && is_partial_download.is_none()) {
             for db_entry in &created_db_entries {
                 job::add(
                     context,

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1031,7 +1031,7 @@ INSERT INTO msgs
     txt, subject, txt_raw, param, 
     bytes, hidden, mime_headers, mime_in_reply_to,
     mime_references, mime_modified, error, ephemeral_timer,
-    ephemeral_timestamp
+    ephemeral_timestamp, download_state
   )
   VALUES (
     ?, ?, ?, ?,
@@ -1040,7 +1040,7 @@ INSERT INTO msgs
     ?, ?, ?, ?,
     ?, ?, ?, ?,
     ?, ?, ?, ?,
-    ?
+    ?, ?
   );
 "#,
         )?;
@@ -1119,7 +1119,12 @@ INSERT INTO msgs
             mime_modified,
             part.error.take().unwrap_or_default(),
             ephemeral_timer,
-            ephemeral_timestamp
+            ephemeral_timestamp,
+            if is_partial_download.is_some() {
+                DownloadState::Available
+            } else {
+                DownloadState::Done
+            },
         ])?;
         let row_id = conn.last_insert_rowid();
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -130,7 +130,7 @@ pub(crate) async fn dc_receive_imf_inner(
     );
 
     // check, if the mail is already in our database.
-    // make sure, this check is done eg. before securejoin-processing)
+    // make sure, this check is done eg. before securejoin-processing.
     let replace_partial_download = if let Some((old_server_folder, old_server_uid, old_msg_id)) =
         message::rfc724_mid_exists(context, &rfc724_mid).await?
     {

--- a/src/download.rs
+++ b/src/download.rs
@@ -22,6 +22,11 @@ use std::cmp::max;
 /// they're catched by `MIN_DOWNLOAD_LIMIT`.
 const MIN_DOWNLOAD_LIMIT: u32 = 32768;
 
+/// If `delete_server_after` is set to small timeouts (eg. "at once"),
+/// the user might have no chance to actually download a message.
+/// `MIN_DELETE_SERVER_AFTER` increases the timeout in this case.
+pub const MIN_DELETE_SERVER_AFTER: i64 = 48 * 60 * 60;
+
 #[derive(
     Debug,
     Display,

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,0 +1,220 @@
+//! # Download large messages manually.
+
+use anyhow::{anyhow, Result};
+use deltachat_derive::{FromSql, ToSql};
+use num_traits::{FromPrimitive, ToPrimitive};
+use serde::{Deserialize, Serialize};
+
+use crate::config::Config;
+use crate::context::Context;
+use crate::imap::{Imap, ImapActionResult};
+use crate::job::{self, Action, Job, Status};
+use crate::message::{Message, MsgId};
+use crate::param::{Param, Params};
+use crate::{job_try, EventType};
+use std::cmp::max;
+
+/// Download limits should not be used below `MIN_DOWNLOAD_LIMIT`.
+///
+/// Some messages as non-delivery-reports (NDN) or read-receipts (MDN)
+/// need to be downloaded completely to handle them correctly,
+/// eg. to assign them to the correct chat.
+/// As these messages are typically small,
+/// they're catched by `MIN_DOWNLOAD_LIMIT`.
+const MIN_DOWNLOAD_LIMIT: u32 = 32768;
+
+#[derive(
+    Debug,
+    Display,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    FromPrimitive,
+    ToPrimitive,
+    FromSql,
+    ToSql,
+    Serialize,
+    Deserialize,
+)]
+#[repr(u32)]
+pub enum DownloadState {
+    Done = 0,
+    Available = 10,
+    Failure = 20,
+    InProgress = 1000,
+}
+
+impl Default for DownloadState {
+    fn default() -> Self {
+        DownloadState::Done
+    }
+}
+
+impl Context {
+    // Gets validated download limit or 0 for "no limit".
+    pub(crate) async fn get_download_limit(&self) -> Result<u32> {
+        let download_limit = self.get_config_int(Config::DownloadLimit).await?;
+        if download_limit <= 0 {
+            Ok(0)
+        } else {
+            Ok(max(MIN_DOWNLOAD_LIMIT, download_limit as u32))
+        }
+    }
+}
+
+impl MsgId {
+    /// Adds the job `Action::DownloadMsg` to download a message.
+    pub async fn download_full(self, context: &Context) -> Result<()> {
+        let msg = Message::load_from_db(context, self).await?;
+        match msg.get_download_state() {
+            DownloadState::Done => return Err(anyhow!("Nothing to download.")),
+            DownloadState::InProgress => return Err(anyhow!("Download already in progress.")),
+            DownloadState::Available | DownloadState::Failure => {
+                self.update_download_state(context, DownloadState::InProgress)
+                    .await?;
+                job::add(
+                    context,
+                    Job::new(Action::DownloadMsg, self.to_u32(), Params::new(), 0),
+                )
+                .await;
+            }
+        }
+        Ok(())
+    }
+
+    async fn update_download_state(
+        self,
+        context: &Context,
+        download_state: DownloadState,
+    ) -> Result<()> {
+        let mut msg = Message::load_from_db(context, self).await?;
+        msg.param.set_int(
+            Param::DownloadState,
+            download_state.to_i32().unwrap_or_default(),
+        );
+        msg.update_param(context).await;
+        context.emit_event(EventType::MsgsChanged {
+            chat_id: msg.chat_id,
+            msg_id: self,
+        });
+        Ok(())
+    }
+}
+
+impl Message {
+    /// Gets the download state of the message.
+    pub fn get_download_state(&self) -> DownloadState {
+        DownloadState::from_i32(self.param.get_int(Param::DownloadState).unwrap_or_default())
+            .unwrap_or_default()
+    }
+}
+
+impl Job {
+    /// Actually download a message.
+    /// Called in response to `Action::DownloadMsg`.
+    pub(crate) async fn download_msg(&self, context: &Context, imap: &mut Imap) -> Status {
+        if let Err(err) = imap.prepare(context).await {
+            warn!(context, "download: could not connect: {:?}", err);
+            return Status::RetryNow;
+        }
+
+        let msg = job_try!(Message::load_from_db(context, MsgId::new(self.foreign_id)).await);
+        let server_folder = msg.server_folder.unwrap_or_default();
+        match imap
+            .fetch_single_msg(context, &server_folder, msg.server_uid)
+            .await
+        {
+            ImapActionResult::RetryLater | ImapActionResult::Failed => {
+                job_try!(
+                    msg.id
+                        .update_download_state(context, DownloadState::Failure)
+                        .await
+                );
+                Status::Finished(Err(anyhow!("Call download_full() again to try over.")))
+            }
+            ImapActionResult::Success | ImapActionResult::AlreadyDone => {
+                // update_download_state() not needed as receive_imf() already
+                // set the state and emitted the event.
+                Status::Finished(Ok(()))
+            }
+        }
+    }
+}
+
+impl Imap {
+    /// Download a single message and pipe it to receive_imf().
+    ///
+    /// receive_imf() is not directly aware that this is a result of a call to download_msg(),
+    /// however, implicitly knows that as the existing message is flagged as being partly.
+    async fn fetch_single_msg(
+        &mut self,
+        context: &Context,
+        folder: &str,
+        uid: u32,
+    ) -> ImapActionResult {
+        if let Some(imapresult) = self
+            .prepare_imap_operation_on_msg(context, folder, uid)
+            .await
+        {
+            return imapresult;
+        }
+
+        // we are connected, and the folder is selected
+        info!(context, "Downloading message {}/{} fully...", folder, uid);
+
+        let (_, error_cnt) = self
+            .fetch_many_msgs(context, folder, vec![uid], false, false)
+            .await;
+        if error_cnt > 0 {
+            return ImapActionResult::Failed;
+        }
+
+        ImapActionResult::Success
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::TestContext;
+
+    #[test]
+    fn test_downloadstate_values() {
+        // values may be written to disk and must not change
+        assert_eq!(DownloadState::Done, DownloadState::default());
+        assert_eq!(DownloadState::Done, DownloadState::from_i32(0).unwrap());
+        assert_eq!(
+            DownloadState::Available,
+            DownloadState::from_i32(10).unwrap()
+        );
+        assert_eq!(DownloadState::Failure, DownloadState::from_i32(20).unwrap());
+        assert_eq!(
+            DownloadState::InProgress,
+            DownloadState::from_i32(1000).unwrap()
+        );
+    }
+
+    #[async_std::test]
+    async fn test_download_limit() -> Result<()> {
+        let t = TestContext::new_alice().await;
+
+        assert_eq!(t.get_download_limit().await?, 0);
+
+        t.set_config(Config::DownloadLimit, Some("200000")).await?;
+        assert_eq!(t.get_download_limit().await?, 200000);
+
+        t.set_config(Config::DownloadLimit, Some("20000")).await?;
+        assert_eq!(t.get_download_limit().await?, MIN_DOWNLOAD_LIMIT);
+
+        t.set_config(Config::DownloadLimit, None).await?;
+        assert_eq!(t.get_download_limit().await?, 0);
+
+        for val in &["0", "-1", "-100", "", "foo"] {
+            t.set_config(Config::DownloadLimit, Some(val)).await?;
+            assert_eq!(t.get_download_limit().await?, 0);
+        }
+
+        Ok(())
+    }
+}

--- a/src/download.rs
+++ b/src/download.rs
@@ -184,6 +184,13 @@ impl Imap {
 }
 
 impl MimeMessage {
+    /// Creates a placeholder part and add that to `parts`.
+    ///
+    /// To create the placeholder, only the outermost header can be used,
+    /// the mime-structure itself is not available.
+    ///
+    /// The placeholder part currently contains a text with size and availability of the message;
+    /// in the future, we may do more advanced things as previews here.
     pub(crate) async fn create_stub_from_partial_download(
         &mut self,
         context: &Context,
@@ -314,6 +321,10 @@ mod tests {
         let msg = t.get_last_msg().await;
         assert_eq!(msg.download_state(), DownloadState::Available);
         assert_eq!(msg.get_subject(), "foo");
+        assert!(msg
+            .get_text()
+            .unwrap()
+            .contains(&stock_str::partial_download_msg_body(&t, 100000).await));
 
         dc_receive_imf_inner(
             &t,

--- a/src/download.rs
+++ b/src/download.rs
@@ -22,10 +22,11 @@ use std::cmp::max;
 /// they're catched by `MIN_DOWNLOAD_LIMIT`.
 const MIN_DOWNLOAD_LIMIT: u32 = 32768;
 
-/// If `delete_server_after` is set to small timeouts (eg. "at once"),
-/// the user might have no chance to actually download a message.
+/// If a message is downloaded only partially
+/// and `delete_server_after` is set to small timeouts (eg. "at once"),
+/// the user might have no chance to actually download that message.
 /// `MIN_DELETE_SERVER_AFTER` increases the timeout in this case.
-pub const MIN_DELETE_SERVER_AFTER: i64 = 48 * 60 * 60;
+pub(crate) const MIN_DELETE_SERVER_AFTER: i64 = 48 * 60 * 60;
 
 #[derive(
     Debug,
@@ -68,7 +69,7 @@ impl Context {
 }
 
 impl MsgId {
-    /// Adds the job `Action::DownloadMsg` to download a message.
+    /// Schedules full message download for partially downloaded message.
     pub async fn download_full(self, context: &Context) -> Result<()> {
         let msg = Message::load_from_db(context, self).await?;
         match msg.get_download_state() {

--- a/src/download.rs
+++ b/src/download.rs
@@ -87,7 +87,7 @@ impl MsgId {
         Ok(())
     }
 
-    async fn update_download_state(
+    pub(crate) async fn update_download_state(
         self,
         context: &Context,
         download_state: DownloadState,

--- a/src/download.rs
+++ b/src/download.rs
@@ -303,7 +303,7 @@ mod tests {
 
         dc_receive_imf_inner(
             &t,
-            &header.as_bytes(),
+            header.as_bytes(),
             "INBOX",
             1,
             false,

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -705,10 +705,15 @@ impl Imap {
             )
             .await
             {
-                if download_limit > 0 && msg.size.unwrap_or_default() > download_limit {
-                    uids_fetch_partially.push(current_uid);
-                } else {
-                    uids_fetch_fully.push(current_uid);
+                match download_limit {
+                    Some(download_limit) => {
+                        if msg.size.unwrap_or_default() > download_limit {
+                            uids_fetch_partially.push(current_uid);
+                        } else {
+                            uids_fetch_fully.push(current_uid)
+                        }
+                    }
+                    None => uids_fetch_fully.push(current_uid),
                 }
             } else if read_errors == 0 {
                 // If there were errors (`read_errors != 0`), stop updating largest_uid_skipped so that uid_next will

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -655,7 +655,7 @@ impl Imap {
     ) -> Result<bool> {
         let show_emails = ShowEmails::from_i32(context.get_config_int(Config::ShowEmails).await?)
             .unwrap_or_default();
-        let download_limit = context.get_download_limit().await?;
+        let download_limit = context.download_limit().await?;
 
         let new_emails = self
             .select_with_uidvalidity(context, folder.as_ref())

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -65,7 +65,7 @@ pub enum ImapActionResult {
 /// - Chat-Version to check if a message is a chat message
 /// - Autocrypt-Setup-Message to check if a message is an autocrypt setup message,
 ///   not necessarily sent by Delta Chat.
-const PREFETCH_FLAGS: &str = "(UID BODY.PEEK[HEADER.FIELDS (\
+const PREFETCH_FLAGS: &str = "(UID RFC822.SIZE BODY.PEEK[HEADER.FIELDS (\
                               MESSAGE-ID \
                               FROM \
                               IN-REPLY-TO REFERENCES \
@@ -81,7 +81,8 @@ const RFC724MID_UID: &str = "(UID BODY.PEEK[HEADER.FIELDS (\
                              X-MICROSOFT-ORIGINAL-MESSAGE-ID\
                              )])";
 const JUST_UID: &str = "(UID)";
-const BODY_FLAGS: &str = "(FLAGS BODY.PEEK[])";
+const BODY_FULL: &str = "(FLAGS BODY.PEEK[])";
+const BODY_PARTIAL: &str = "(FLAGS RFC822.SIZE BODY.PEEK[HEADER])";
 
 #[derive(Debug)]
 pub struct Imap {
@@ -654,6 +655,7 @@ impl Imap {
     ) -> Result<bool> {
         let show_emails = ShowEmails::from_i32(context.get_config_int(Config::ShowEmails).await?)
             .unwrap_or_default();
+        let download_limit = context.get_download_limit().await?;
 
         let new_emails = self
             .select_with_uidvalidity(context, folder.as_ref())
@@ -675,7 +677,8 @@ impl Imap {
         let folder: &str = folder.as_ref();
 
         let mut read_errors = 0;
-        let mut uids = Vec::with_capacity(msgs.len());
+        let mut uids_fetch_fully = Vec::with_capacity(msgs.len());
+        let mut uids_fetch_partially = Vec::with_capacity(msgs.len());
         let mut largest_uid_skipped = None;
 
         for (current_uid, msg) in msgs.into_iter() {
@@ -702,7 +705,11 @@ impl Imap {
             )
             .await
             {
-                uids.push(current_uid);
+                if download_limit > 0 && msg.size.unwrap_or_default() > download_limit {
+                    uids_fetch_partially.push(current_uid);
+                } else {
+                    uids_fetch_fully.push(current_uid);
+                }
             } else if read_errors == 0 {
                 // If there were errors (`read_errors != 0`), stop updating largest_uid_skipped so that uid_next will
                 // not be updated and we will retry prefetching next time
@@ -710,12 +717,29 @@ impl Imap {
             }
         }
 
-        if !uids.is_empty() {
+        if !uids_fetch_fully.is_empty() || !uids_fetch_partially.is_empty() {
             self.connectivity.set_working(context).await;
         }
 
-        let (largest_uid_processed, error_cnt) = self
-            .fetch_many_msgs(context, folder, uids, fetch_existing_msgs)
+        let (largest_uid_fully_fetched, error_cnt) = self
+            .fetch_many_msgs(
+                context,
+                folder,
+                uids_fetch_fully,
+                false,
+                fetch_existing_msgs,
+            )
+            .await;
+        read_errors += error_cnt;
+
+        let (largest_uid_partially_fetched, error_cnt) = self
+            .fetch_many_msgs(
+                context,
+                folder,
+                uids_fetch_partially,
+                true,
+                fetch_existing_msgs,
+            )
             .await;
         read_errors += error_cnt;
 
@@ -726,7 +750,10 @@ impl Imap {
         // So: Update the uid_next to the largest uid that did NOT recoverably fail. Not perfect because if there was
         // another message afterwards that succeeded, we will not retry. The upside is that we will not retry an infinite amount of times.
         let largest_uid_without_errors = max(
-            largest_uid_processed.unwrap_or(0),
+            max(
+                largest_uid_fully_fetched.unwrap_or(0),
+                largest_uid_partially_fetched.unwrap_or(0),
+            ),
             largest_uid_skipped.unwrap_or(0),
         );
         let new_uid_next = largest_uid_without_errors + 1;
@@ -863,11 +890,12 @@ impl Imap {
     /// Fetches a list of messages by server UID.
     ///
     /// Returns the last uid fetch successfully and an error count.
-    async fn fetch_many_msgs(
+    pub(crate) async fn fetch_many_msgs(
         &mut self,
         context: &Context,
         folder: &str,
         server_uids: Vec<u32>,
+        fetch_partially: bool,
         fetching_existing_messages: bool,
     ) -> (Option<u32>, usize) {
         if server_uids.is_empty() {
@@ -888,7 +916,17 @@ impl Imap {
         let mut last_uid = None;
 
         for set in sets.iter() {
-            let mut msgs = match session.uid_fetch(&set, BODY_FLAGS).await {
+            let mut msgs = match session
+                .uid_fetch(
+                    &set,
+                    if fetch_partially {
+                        BODY_PARTIAL
+                    } else {
+                        BODY_FULL
+                    },
+                )
+                .await
+            {
                 Ok(msgs) => msgs,
                 Err(err) => {
                     // TODO: maybe differentiate between IO and input/parsing problems
@@ -923,7 +961,13 @@ impl Imap {
                 count += 1;
 
                 let is_deleted = msg.flags().any(|flag| flag == Flag::Deleted);
-                if is_deleted || msg.body().is_none() {
+                let (body, partial) = if fetch_partially {
+                    (msg.header(), msg.size) // `BODY.PEEK[HEADER]` goes to header() ...
+                } else {
+                    (msg.body(), None) // ... while `BODY.PEEK[]` goes to body() - and includes header()
+                };
+
+                if is_deleted || body.is_none() {
                     info!(
                         context,
                         "Not processing deleted or empty msg {}", server_uid
@@ -937,7 +981,7 @@ impl Imap {
                 let folder = folder.clone();
 
                 // safe, as we checked above that there is a body.
-                let body = msg.body().unwrap();
+                let body = body.unwrap();
                 let is_seen = msg.flags().any(|flag| flag == Flag::Seen);
 
                 match dc_receive_imf_inner(
@@ -946,6 +990,7 @@ impl Imap {
                     &folder,
                     server_uid,
                     is_seen,
+                    partial,
                     fetching_existing_messages,
                 )
                 .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ mod configure;
 pub mod constants;
 pub mod contact;
 pub mod context;
+pub mod download;
 mod e2ee;
 pub mod ephemeral;
 mod imap;

--- a/src/message.rs
+++ b/src/message.rs
@@ -21,6 +21,7 @@ use crate::dc_tools::{
     dc_create_smeared_timestamp, dc_get_filebytes, dc_get_filemeta, dc_gm2local_offset,
     dc_read_file, dc_timestamp_to_str, dc_truncate, time,
 };
+use crate::download::DownloadState;
 use crate::ephemeral::Timer as EphemeralTimer;
 use crate::events::EventType;
 use crate::job::{self, Action};
@@ -296,6 +297,7 @@ pub struct Message {
     pub(crate) chat_id: ChatId,
     pub(crate) viewtype: Viewtype,
     pub(crate) state: MessageState,
+    pub(crate) download_state: DownloadState,
     pub(crate) hidden: bool,
     pub(crate) timestamp_sort: i64,
     pub(crate) timestamp_sent: i64,
@@ -350,6 +352,7 @@ impl Message {
                     "    m.ephemeral_timestamp AS ephemeral_timestamp,",
                     "    m.type AS type,",
                     "    m.state AS state,",
+                    "    m.download_state AS download_state,",
                     "    m.error AS error,",
                     "    m.msgrmsg AS msgrmsg,",
                     "    m.mime_modified AS mime_modified,",
@@ -401,6 +404,7 @@ impl Message {
                         ephemeral_timestamp: row.get("ephemeral_timestamp")?,
                         viewtype: row.get("type")?,
                         state: row.get("state")?,
+                        download_state: row.get("download_state")?,
                         error: Some(row.get::<_, String>("error")?)
                             .filter(|error| !error.is_empty()),
                         is_dc_message: row.get("msgrmsg")?,

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -8,7 +8,6 @@ use anyhow::{bail, Result};
 use deltachat_derive::{FromSql, ToSql};
 use lettre_email::mime::{self, Mime};
 use mailparse::{addrparse_header, DispositionType, MailHeader, MailHeaderMap, SingleInfo};
-use num_traits::ToPrimitive;
 use once_cell::sync::Lazy;
 
 use crate::aheader::Aheader;
@@ -18,7 +17,6 @@ use crate::contact::addr_normalize;
 use crate::context::Context;
 use crate::dc_tools::{dc_get_filemeta, dc_truncate};
 use crate::dehtml::dehtml;
-use crate::download::DownloadState;
 use crate::e2ee;
 use crate::events::EventType;
 use crate::format_flowed::unformat_flowed;
@@ -291,11 +289,6 @@ impl MimeMessage {
                 parser.parse_mime_recursive(context, &mail, false).await?;
             }
             Some(org_bytes) => {
-                let mut params = Params::new();
-                params.set_int(
-                    Param::DownloadState,
-                    DownloadState::Available.to_i32().unwrap_or_default(),
-                );
                 parser.parts.push(Part {
                     typ: Viewtype::Text,
                     msg: format!(
@@ -304,7 +297,6 @@ impl MimeMessage {
                             .file_size(file_size_opts::BINARY)
                             .unwrap_or_default()
                     ),
-                    param: params,
                     ..Default::default()
                 });
             }

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -17,6 +17,7 @@ use crate::contact::addr_normalize;
 use crate::context::Context;
 use crate::dc_tools::{dc_get_filemeta, dc_timestamp_to_str, dc_truncate, time};
 use crate::dehtml::dehtml;
+use crate::download::MIN_DELETE_SERVER_AFTER;
 use crate::e2ee;
 use crate::events::EventType;
 use crate::format_flowed::unformat_flowed;
@@ -29,6 +30,7 @@ use crate::peerstate::Peerstate;
 use crate::simplify::simplify;
 use crate::stock_str;
 use humansize::{file_size_opts, FileSize};
+use std::cmp::max;
 
 /// A parsed MIME message.
 ///
@@ -300,7 +302,9 @@ impl MimeMessage {
                         .unwrap_or_default()
                 );
                 if let Some(delete_server_after) = context.get_config_delete_server_after().await? {
-                    let until = dc_timestamp_to_str(time() + delete_server_after);
+                    let until = dc_timestamp_to_str(
+                        time() + max(delete_server_after, MIN_DELETE_SERVER_AFTER),
+                    );
                     text += &*format!(" [Download maximum available until {}]", until);
                 };
                 parser.parts.push(Part {

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -140,6 +140,10 @@ impl MimeMessage {
         MimeMessage::from_bytes_with_partial(context, body, None).await
     }
 
+    /// Parse a mime message.
+    ///
+    /// If `partial` is set, it contains the full message size in bytes
+    /// and `body` contains the header only.
     pub async fn from_bytes_with_partial(
         context: &Context,
         body: &[u8],

--- a/src/param.rs
+++ b/src/param.rs
@@ -160,9 +160,6 @@ pub enum Param {
 
     /// For Chats: timestamp of protection settings update.
     ProtectionSettingsTimestamp = b'L',
-
-    /// For Messages: a value from `DownloadState` enum.
-    DownloadState = b'z',
 }
 
 /// An object for handling key=value parameter lists.

--- a/src/param.rs
+++ b/src/param.rs
@@ -160,6 +160,9 @@ pub enum Param {
 
     /// For Chats: timestamp of protection settings update.
     ProtectionSettingsTimestamp = b'L',
+
+    /// For Messages: a value from `DownloadState` enum.
+    DownloadState = b'z',
 }
 
 /// An object for handling key=value parameter lists.

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -477,6 +477,16 @@ paramsv![]
         sql.execute_migration("UPDATE chats SET archived=1 WHERE blocked=2;", 78)
             .await?;
     }
+    if dbversion < 79 {
+        info!(context, "[migration] v79");
+        sql.execute_migration(
+            r#"
+        ALTER TABLE msgs ADD COLUMN download_state INTEGER DEFAULT 0;
+        "#,
+            79,
+        )
+        .await?;
+    }
 
     Ok((
         recalc_fingerprints,

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -1076,6 +1076,14 @@ mod tests {
     }
 
     #[async_std::test]
+    async fn test_partial_download_msg_body() -> anyhow::Result<()> {
+        let t = TestContext::new().await;
+        let str = partial_download_msg_body(&t, 1024 * 1024).await;
+        assert_eq!(str, "1 MiB message");
+        Ok(())
+    }
+
+    #[async_std::test]
     async fn test_update_device_chats() {
         let t = TestContext::new().await;
         t.update_device_chats().await.ok();

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -13,8 +13,10 @@ use crate::config::Config;
 use crate::constants::{Viewtype, DC_CONTACT_ID_SELF};
 use crate::contact::{Contact, Origin};
 use crate::context::Context;
+use crate::dc_tools::dc_timestamp_to_str;
 use crate::message::Message;
 use crate::param::Param;
+use humansize::{file_size_opts, FileSize};
 
 /// Stock strings
 ///
@@ -267,6 +269,12 @@ pub enum StockMessage {
                     You can check your current storage usage anytime at \"Settings / Connectivity\"."
     ))]
     QuotaExceedingMsgBody = 98,
+
+    #[strum(props(fallback = "%1$s message"))]
+    PartialDownloadMsgBody = 99,
+
+    #[strum(props(fallback = "Download maximum available until %1$s"))]
+    DownloadAvailability = 100,
 }
 
 impl StockMessage {
@@ -855,6 +863,23 @@ pub(crate) async fn quota_exceeding(context: &Context, highest_usage: u64) -> St
         .await
         .replace1(format!("{}", highest_usage))
         .replace("%%", "%")
+}
+
+/// Stock string: `%1$s message` with placeholder replaced by human-readable size.
+pub(crate) async fn partial_download_msg_body(context: &Context, org_bytes: u32) -> String {
+    let size = org_bytes
+        .file_size(file_size_opts::BINARY)
+        .unwrap_or_default();
+    translated(context, StockMessage::PartialDownloadMsgBody)
+        .await
+        .replace1(size)
+}
+
+/// Stock string: `Download maximum available until %1$s`.
+pub(crate) async fn download_availability(context: &Context, timestamp: i64) -> String {
+    translated(context, StockMessage::DownloadAvailability)
+        .await
+        .replace1(dc_timestamp_to_str(timestamp))
 }
 
 impl Context {


### PR DESCRIPTION
this pr allows large messages not being downloaded automatically. instead, only the header is downloaded and the body is skipped. goal is to save traffic.

# at a glance

- messages that are not downloaded completely have the status `DC_DOWNLOAD_AVAILABLE` returned by `dc_msg_get_download_status()`. in the easiest case, the message only has a text saying "This is a 10 MiB message", full download will replace the message by eg.  a video then.  
(in more advanced scenarios, the type of the message would be known already, maybe there is even some low-res image or so - that would be harder core-wise, the api would already make this possible)
- `dc_schedule_download()` will allow downloading the incomplete message; 
- with `dc_set_config("download_limit")` the limit can be adapted, changes affect future downloads only. this option can be exposed to the ui, however, it is also possible to  per-provider defaults.

more details are in the comments of `deltachat.h`

we also discussed some "large file transfer" at some point, this is currently not goal of this approach, however, ui-wise, if would be pretty much the same, cmp. https://github.com/deltachat/deltachat-core-rust/pull/2630

# todo

- [x] basic implementation
- [x] on downloading full messages, make sure not to overwrite things that may have been updated later.  
pr #2642 targets this point and should be merged first
- [x] make sure, auto-delete-from-server is not done before the message is actually downloaded 
- [x] otoh, messages should not occupy space on the server "forever" in case they are not downloaded

# further points that came up during development

- the messages get a new message-ids after full-download,  they may even expand to multiple messages. the position in the chat, however, stays the same.  
this adding of messages inside a chat is a thing UI have to deal with anyway as that also happens for other purposes.  
if it turns out that existing refresh issues become more visible on some platforms (currently, only android is checked, there it is fine), we can try to keep the id; but maybe do that in a subsequent pr and if needed only.

- encrypted messages are not shown as such. reason is that we cannot check the signature and the  padlock is usually shown if the message is encrypted _and_ correctly signed. of course, once the message is downloaded, the padlock is shown if things are okay.

- currently, MDN are sent also for partially downloaded messages, maybe, this is okay - also for videos there is no guarantee that he message is actually _played_. esp. when it comes to nicer/partial previews, delayed MDN may raise a lot of issues, so, maybe better send them just on initial download, even when partial.

- short timespans for disappearing messages should be okay as the timeout only starts when the message is actually viewed. 