### PR TITLE
update chat/contact data only when there was no newer update

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1590,39 +1590,49 @@ async fn create_or_lookup_group(
 
     // add members to group/check members
     if recreate_member_list {
-        if !chat::is_contact_in_chat(context, chat_id, DC_CONTACT_ID_SELF).await {
-            // Members could have been removed while we were
-            // absent. We can't use existing member list and need to
-            // start from scratch.
-            context
-                .sql
-                .execute(
-                    "DELETE FROM chats_contacts WHERE chat_id=?;",
-                    paramsv![chat_id],
-                )
-                .await
-                .ok();
-
-            chat::add_to_chat_contacts_table(context, chat_id, DC_CONTACT_ID_SELF).await;
-        }
-        if from_id > DC_CONTACT_ID_LAST_SPECIAL
-            && !Contact::addr_equals_contact(context, &self_addr, from_id).await
-            && !chat::is_contact_in_chat(context, chat_id, from_id).await
+        if chat_id
+            .update_timestamp(context, Param::MemberListTimestamp, sent_timestamp)
+            .await?
         {
-            chat::add_to_chat_contacts_table(context, chat_id, from_id).await;
-        }
-        for &to_id in to_ids.iter() {
-            info!(context, "adding to={:?} to chat id={}", to_id, chat_id);
-            if !Contact::addr_equals_contact(context, &self_addr, to_id).await
-                && !chat::is_contact_in_chat(context, chat_id, to_id).await
-            {
-                chat::add_to_chat_contacts_table(context, chat_id, to_id).await;
+            if !chat::is_contact_in_chat(context, chat_id, DC_CONTACT_ID_SELF).await {
+                // Members could have been removed while we were
+                // absent. We can't use existing member list and need to
+                // start from scratch.
+                context
+                    .sql
+                    .execute(
+                        "DELETE FROM chats_contacts WHERE chat_id=?;",
+                        paramsv![chat_id],
+                    )
+                    .await
+                    .ok();
+
+                chat::add_to_chat_contacts_table(context, chat_id, DC_CONTACT_ID_SELF).await;
             }
+            if from_id > DC_CONTACT_ID_LAST_SPECIAL
+                && !Contact::addr_equals_contact(context, &self_addr, from_id).await
+                && !chat::is_contact_in_chat(context, chat_id, from_id).await
+            {
+                chat::add_to_chat_contacts_table(context, chat_id, from_id).await;
+            }
+            for &to_id in to_ids.iter() {
+                info!(context, "adding to={:?} to chat id={}", to_id, chat_id);
+                if !Contact::addr_equals_contact(context, &self_addr, to_id).await
+                    && !chat::is_contact_in_chat(context, chat_id, to_id).await
+                {
+                    chat::add_to_chat_contacts_table(context, chat_id, to_id).await;
+                }
+            }
+            send_EVENT_CHAT_MODIFIED = true;
         }
-        send_EVENT_CHAT_MODIFIED = true;
     } else if let Some(contact_id) = removed_id {
-        chat::remove_from_chat_contacts_table(context, chat_id, contact_id).await;
-        send_EVENT_CHAT_MODIFIED = true;
+        if chat_id
+            .update_timestamp(context, Param::MemberListTimestamp, sent_timestamp)
+            .await?
+        {
+            chat::remove_from_chat_contacts_table(context, chat_id, contact_id).await;
+            send_EVENT_CHAT_MODIFIED = true;
+        }
     }
 
     if send_EVENT_CHAT_MODIFIED {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1134,7 +1134,7 @@ INSERT INTO msgs
         // This way, `LastSubject` actually refers to the most recent message _shown_ in the chat.
         if chat
             .param
-            .set_timestamp(Param::SubjectTimestamp, sort_timestamp)?
+            .update_timestamp(Param::SubjectTimestamp, sort_timestamp)?
         {
             // write the last subject even if empty -
             // otherwise a reply may get an outdated subject.
@@ -1590,7 +1590,7 @@ async fn create_or_lookup_group(
         if let Ok(mut chat) = Chat::load_from_db(context, chat_id).await {
             if chat
                 .param
-                .set_timestamp(Param::AvatarTimestamp, sent_timestamp)?
+                .update_timestamp(Param::AvatarTimestamp, sent_timestamp)?
             {
                 match avatar_action {
                     AvatarAction::Change(profile_image) => {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1444,9 +1444,7 @@ async fn create_or_lookup_group(
             if value == "group-avatar-changed" {
                 if let Some(avatar_action) = &mime_parser.group_avatar {
                     // this is just an explicit message containing the group-avatar,
-                    // apart from that, the group-avatar is send along with various other messages.
-                    // we do not check Param::AvatarTimestamp here:
-                    // even if the avatar is already outdated, text/type of the message should be correct.
+                    // apart from that, the group-avatar is send along with various other messages
                     mime_parser.is_system_message = SystemMessage::GroupImageChanged;
                     better_msg = match avatar_action {
                         AvatarAction::Delete => {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -210,9 +210,10 @@ pub(crate) async fn dc_receive_imf_inner(
     }
 
     if let Some(avatar_action) = &mime_parser.user_avatar {
-        if context
-            .update_contacts_timestamp(from_id, Param::AvatarTimestamp, sent_timestamp)
-            .await?
+        if from_id != 0
+            && context
+                .update_contacts_timestamp(from_id, Param::AvatarTimestamp, sent_timestamp)
+                .await?
         {
             match contact::set_profile_image(
                 context,
@@ -236,6 +237,7 @@ pub(crate) async fn dc_receive_imf_inner(
     //
     // Ignore MDNs though, as they never contain the signature even if user has set it.
     if mime_parser.mdn_reports.is_empty()
+        && from_id != 0
         && context
             .update_contacts_timestamp(from_id, Param::StatusTimestamp, sent_timestamp)
             .await?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ mod simplify;
 mod smtp;
 pub mod stock_str;
 mod token;
+mod update_helper;
 #[macro_use]
 mod dehtml;
 mod color;

--- a/src/param.rs
+++ b/src/param.rs
@@ -374,7 +374,7 @@ impl Params {
 
     /// Set the given paramter to the passed in `i64`.
     pub fn set_i64(&mut self, key: Param, value: i64) -> &mut Self {
-        self.set(key, format!("{}", value));
+        self.set(key, value.to_string());
         self
     }
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -154,6 +154,9 @@ pub enum Param {
 
     /// For Chats: timestamp of group name update.
     GroupNameTimestamp = b'g',
+
+    /// For Chats: timestamp of group name update.
+    MemberListTimestamp = b'k',
 }
 
 /// An object for handling key=value parameter lists.

--- a/src/param.rs
+++ b/src/param.rs
@@ -151,6 +151,9 @@ pub enum Param {
 
     /// For Chats: timestamp of subject update.
     SubjectTimestamp = b'C',
+
+    /// For Chats: timestamp of group name update.
+    GroupNameTimestamp = b'g',
 }
 
 /// An object for handling key=value parameter lists.

--- a/src/param.rs
+++ b/src/param.rs
@@ -157,6 +157,9 @@ pub enum Param {
 
     /// For Chats: timestamp of group name update.
     MemberListTimestamp = b'k',
+
+    /// For Chats: timestamp of protection settings update.
+    ProtectionSettingsTimestamp = b'L',
 }
 
 /// An object for handling key=value parameter lists.

--- a/src/param.rs
+++ b/src/param.rs
@@ -139,6 +139,18 @@ pub enum Param {
 
     /// For MDN-sending job
     MsgId = b'I',
+
+    /// For Contacts: timestamp of status (aka signature or footer) update.
+    StatusTimestamp = b'j',
+
+    /// For Contacts and Chats: timestamp of avatar update.
+    AvatarTimestamp = b'J',
+
+    /// For Chats: timestamp of status/signature/footer update.
+    EphemeralSettingsTimestamp = b'B',
+
+    /// For Chats: timestamp of subject update.
+    SubjectTimestamp = b'C',
 }
 
 /// An object for handling key=value parameter lists.
@@ -245,6 +257,11 @@ impl Params {
         self.get(key).and_then(|s| s.parse().ok())
     }
 
+    /// Get the given parameter and parse as `i64`.
+    pub fn get_i64(&self, key: Param) -> Option<i64> {
+        self.get(key).and_then(|s| s.parse().ok())
+    }
+
     /// Get the given parameter and parse as `bool`.
     pub fn get_bool(&self, key: Param) -> Option<bool> {
         self.get_int(key).map(|v| v != 0)
@@ -342,6 +359,12 @@ impl Params {
 
     /// Set the given paramter to the passed in `i32`.
     pub fn set_int(&mut self, key: Param, value: i32) -> &mut Self {
+        self.set(key, format!("{}", value));
+        self
+    }
+
+    /// Set the given paramter to the passed in `i64`.
+    pub fn set_i64(&mut self, key: Param, value: i64) -> &mut Self {
         self.set(key, format!("{}", value));
         self
     }

--- a/src/update_helper.rs
+++ b/src/update_helper.rs
@@ -1,0 +1,87 @@
+//! # Functions to update timestamps.
+
+use crate::chat::{Chat, ChatId};
+use crate::contact::Contact;
+use crate::context::Context;
+use crate::param::{Param, Params};
+use anyhow::Result;
+
+impl Context {
+    /// Updates a contact's timestamp, if reasonable.
+    /// Returns true if the caller shall update the settings belonging to the scope.
+    /// (if we have a ContactId type at some point, the function should go there)
+    pub(crate) async fn update_contacts_timestamp(
+        &self,
+        contact_id: u32,
+        scope: Param,
+        new_timestamp: i64,
+    ) -> Result<bool> {
+        if let Ok(mut contact) = Contact::load_from_db(self, contact_id).await {
+            if contact.param.set_timestamp(scope, new_timestamp)? {
+                contact.update_param(self).await?;
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+impl ChatId {
+    /// Updates a chat id's timestamp on disk, if reasonable.
+    /// Returns true if the caller shall update the settings belonging to the scope.
+    pub(crate) async fn update_timestamp(
+        &self,
+        context: &Context,
+        scope: Param,
+        new_timestamp: i64,
+    ) -> Result<bool> {
+        if let Ok(mut chat) = Chat::load_from_db(context, *self).await {
+            if chat.param.set_timestamp(scope, new_timestamp)? {
+                chat.update_param(context).await?;
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+impl Params {
+    /// Updates a param's timestamp in memory, if reasonable.
+    /// Returns true if the caller shall update the settings belonging to the scope.
+    pub(crate) fn set_timestamp(&mut self, scope: Param, new_timestamp: i64) -> Result<bool> {
+        let old_timestamp = self.get_i64(scope).unwrap_or_default();
+        if new_timestamp >= old_timestamp {
+            self.set_i64(scope, new_timestamp);
+            return Ok(true);
+        }
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dc_tools::time;
+
+    #[async_std::test]
+    async fn test_params_set_timestamp() -> Result<()> {
+        let mut params = Params::new();
+        let ts = time();
+
+        assert!(params.set_timestamp(Param::LastSubject, ts)?);
+        assert!(params.set_timestamp(Param::LastSubject, ts)?); // same timestamp -> update
+        assert!(params.set_timestamp(Param::LastSubject, ts + 10)?);
+        assert!(!params.set_timestamp(Param::LastSubject, ts)?); // `ts` is now too old
+        assert!(!params.set_timestamp(Param::LastSubject, 0)?);
+        assert_eq!(params.get_i64(Param::LastSubject).unwrap(), ts + 10);
+
+        assert!(params.set_timestamp(Param::GroupNameTimestamp, 0)?); // stay unset -> update ...
+        assert!(params.set_timestamp(Param::GroupNameTimestamp, 0)?); // ... also on multiple calls
+        assert_eq!(params.get_i64(Param::GroupNameTimestamp).unwrap(), 0);
+
+        assert!(!params.set_timestamp(Param::AvatarTimestamp, -1)?);
+        assert_eq!(params.get_i64(Param::AvatarTimestamp), None);
+
+        Ok(())
+    }
+}

--- a/src/update_helper.rs
+++ b/src/update_helper.rs
@@ -16,11 +16,10 @@ impl Context {
         scope: Param,
         new_timestamp: i64,
     ) -> Result<bool> {
-        if let Ok(mut contact) = Contact::load_from_db(self, contact_id).await {
-            if contact.param.set_timestamp(scope, new_timestamp)? {
-                contact.update_param(self).await?;
-                return Ok(true);
-            }
+        let mut contact = Contact::load_from_db(self, contact_id).await?;
+        if contact.param.set_timestamp(scope, new_timestamp)? {
+            contact.update_param(self).await?;
+            return Ok(true);
         }
         Ok(false)
     }
@@ -35,11 +34,10 @@ impl ChatId {
         scope: Param,
         new_timestamp: i64,
     ) -> Result<bool> {
-        if let Ok(mut chat) = Chat::load_from_db(context, *self).await {
-            if chat.param.set_timestamp(scope, new_timestamp)? {
-                chat.update_param(context).await?;
-                return Ok(true);
-            }
+        let mut chat = Chat::load_from_db(context, *self).await?;
+        if chat.param.set_timestamp(scope, new_timestamp)? {
+            chat.update_param(context).await?;
+            return Ok(true);
         }
         Ok(false)
     }


### PR DESCRIPTION
this is a preparation for the download-on-demand-feature of #2631 - i suggest to review/merge this pr first, to make #2631 easier to review/merge.

this pr makes sure, older messages do not overwrite chat- or contact-"items" [1] set by newer messages. 

this could _always_ been happening by messages received out-of-order - however, it happens _much more_ when we start with download-on-demand in #2631

to simplify checking, there is a new module `update_helper.rs` that does the timestamp checks. timestamps given to the helper are already "effective dates" [2].

separate items targeted:

- [x] ephemeral-setting 
- [x] signature
- [x] user-avatars
- [x] group-avatars
- [x] group-memberlist
- [x] group-name
- [x] last subject
- [x] chat-protection

things checked, no modification seems to be needed:

- [x] autocrypt-key - this is always placed in the outer, unencrypted header and can be processed without body-download. moreover, [this already checks the timestamps](https://github.com/deltachat/deltachat-core-rust/blob/master/src/peerstate.rs#L294).
- [x] autocrypt-gossip - also [already checks the timestamps](https://github.com/deltachat/deltachat-core-rust/blob/master/src/peerstate.rs#L319)

some items have some initial protection as they are sent in separate messages that are small enough to be downloaded directly - however, even then, it seems reasonable to use a timestamp.

for review, best is to hide whitespace changes.

[1] an "item" here is a part of a chat- or contact-record - a column, a file, a param, whatever.
[2] "effective dates" are not in the future from the view of the receiver (a simple min(sent_timestamp, now)), see eg. https://autocrypt.org/level1.html#effective-date - that way, these "effective dates" would fail only when sender _and_ receivers clocks are far in the future.