### PR TITLE
better readable code fragments on c.delta.chat

### DIFF
--- a/deltachat-ffi/Doxyfile.css
+++ b/deltachat-ffi/Doxyfile.css
@@ -5,3 +5,13 @@ div.fragment {
 	border: 0;
 	padding: 1em;
 }
+
+code {
+	background-color: #e0e0e0;
+	padding-left: .5em;
+	padding-right: .5em;
+}
+
+li {
+	margin-bottom: .5em;
+}

--- a/deltachat-ffi/Doxyfile.css
+++ b/deltachat-ffi/Doxyfile.css
@@ -4,12 +4,14 @@ div.fragment {
 	background-color: #e0e0e0;
 	border: 0;
 	padding: 1em;
+	border-radius: 6px;
 }
 
 code {
 	background-color: #e0e0e0;
 	padding-left: .5em;
 	padding-right: .5em;
+	border-radius: 6px;
 }
 
 li {


### PR DESCRIPTION
esp. lists as used for [dc_get_config()](https://c.delta.chat/classdc__context__t.html#aff3b894f6cfca46cab5248fdffdf083d) are hard to read otherwise 

# before

<img width="716" alt="Screen Shot 2021-09-02 at 11 10 49" src="https://user-images.githubusercontent.com/9800740/131817227-7da105f6-5faa-44db-8961-7007462234a6.png">

# after

<img width="716" alt="Screen Shot 2021-09-02 at 11 26 11" src="https://user-images.githubusercontent.com/9800740/131819242-c0f7f790-a9af-4dc9-ad5b-26c16619a7d0.png">

nb: seems as if rebuild of c.delta.chat was not triggered recently, [dc_get_config()](https://c.delta.chat/classdc__context__t.html#aff3b894f6cfca46cab5248fdffdf083d) lacks the new [socks5-options](https://github.com/deltachat/deltachat-core-rust/blob/master/deltachat-ffi/deltachat.h#L274). we'll see on merging this pr if this is a general issue.