### PR TITLE
Always check certificate when connecting over SOCKS5 in Automatic mode

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -319,7 +319,9 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
         .filter(|params| params.protocol == Protocol::Smtp)
         .cloned()
         .collect();
-    let provider_strict_tls = param.provider.map_or(false, |provider| provider.strict_tls);
+    let provider_strict_tls = param
+        .provider
+        .map_or(socks5_config.is_some(), |provider| provider.strict_tls);
 
     let smtp_config_task = task::spawn(async move {
         let mut smtp_configured = false;

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -228,7 +228,11 @@ impl Imap {
             param.socks5_config.clone(),
             &param.addr,
             param.server_flags & DC_LP_AUTH_OAUTH2 != 0,
-            param.provider.map_or(false, |provider| provider.strict_tls),
+            param
+                .provider
+                .map_or(param.socks5_config.is_some(), |provider| {
+                    provider.strict_tls
+                }),
             idle_interrupt,
         )
         .await?;

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -109,7 +109,8 @@ impl Smtp {
             &lp.socks5_config,
             &lp.addr,
             lp.server_flags & DC_LP_AUTH_OAUTH2 != 0,
-            lp.provider.map_or(false, |provider| provider.strict_tls),
+            lp.provider
+                .map_or(lp.socks5_config.is_some(), |provider| provider.strict_tls),
         )
         .await
     }


### PR DESCRIPTION
There is a real risk of an active attack when connecting to non-.onion
servers over Tor, as bad Tor exit nodes are cheap to set up.

It's probably not needed for .onion domains, but we don't make an
exception for now.