### PR TITLE
get correct names of .xt.local mailinglists

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1713,14 +1713,17 @@ async fn create_or_lookup_mailinglist(
     }
 
     // if we do not have a name yet and `From` indicates, that this is a notification list,
-    // a usable name is often in the `From` header.
-    // this pattern was seen for parcel service notifications
-    // and is similar to mailchimp above, however, with weaker conditions.
+    // a usable name is often in the `From` header (seen for several parcel service notifications).
+    // same, if we do not have a name yet and `List-Id` has a known suffix (`.xt.local`)
+    //
+    // this pattern is similar to mailchimp above, however,
+    // with weaker conditions and does not overwrite existing names.
     if name.is_empty() {
         if let Some(from) = mime_parser.from.first() {
             if from.addr.contains("noreply")
                 || from.addr.contains("no-reply")
                 || from.addr.starts_with("notifications@")
+                || listid.ends_with(".xt.local")
             {
                 if let Some(display_name) = &from.display_name {
                     name = display_name.clone();
@@ -3333,7 +3336,7 @@ mod tests {
             1,
             false,
         )
-            .await?;
+        .await?;
         let chat = Chat::load_from_db(&t, t.get_last_msg().await.chat_id).await?;
         assert_eq!(chat.typ, Chattype::Mailinglist);
         assert_eq!(chat.grpid, "96540.xt.local");

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3322,6 +3322,40 @@ mod tests {
     }
 
     #[async_std::test]
+    async fn test_xt_local_mailing_list() -> Result<()> {
+        let t = TestContext::new_alice().await;
+        t.set_config(Config::ShowEmails, Some("2")).await?;
+
+        dc_receive_imf(
+            &t,
+            include_bytes!("../test-data/message/mailinglist_xt_local_microsoft.eml"),
+            "INBOX",
+            1,
+            false,
+        )
+            .await?;
+        let chat = Chat::load_from_db(&t, t.get_last_msg().await.chat_id).await?;
+        assert_eq!(chat.typ, Chattype::Mailinglist);
+        assert_eq!(chat.grpid, "96540.xt.local");
+        assert_eq!(chat.name, "Microsoft Store");
+
+        dc_receive_imf(
+            &t,
+            include_bytes!("../test-data/message/mailinglist_xt_local_spiegel.eml"),
+            "INBOX",
+            2,
+            false,
+        )
+        .await?;
+        let chat = Chat::load_from_db(&t, t.get_last_msg().await.chat_id).await?;
+        assert_eq!(chat.typ, Chattype::Mailinglist);
+        assert_eq!(chat.grpid, "121231234.xt.local");
+        assert_eq!(chat.name, "DER SPIEGEL Kundenservice");
+
+        Ok(())
+    }
+
+    #[async_std::test]
     async fn test_mailing_list_with_mimepart_footer() {
         let t = TestContext::new_alice().await;
         t.set_config(Config::ShowEmails, Some("2")).await.unwrap();

--- a/test-data/message/mailinglist_xt_local_microsoft.eml
+++ b/test-data/message/mailinglist_xt_local_microsoft.eml
@@ -1,0 +1,164 @@
+Return-Path: <bounce-889884_HTML-1111111111-2222222-33333333-4444@bounce.microsoftstoreemail.com>
+X-Original-To: me@foobar.com
+Delivered-To: m111111f@dd22222.kasserver.com
+X-policyd-weight:  NOT_IN_SPAMCOP=-1.5 NOT_IN_IX_MANITU=-1.5 CL_IP_EQ_HELO_MX=-3.1 (check from: .microsoftstoreemail. - helo: .merlinux. - helo-domain: .merlinux.)  FROM/MX_MATCHES_NOT_HELO(DOMAIN)=1; rate: -5.1
+Authentication-Results: dd22222.kasserver.com;
+	dkim=pass (1024-bit key; unprotected) header.d=microsoftstoreemail.com header.i=microsoftstore@microsoftstoreemail.com header.b="XV8jLprF";
+	dkim-atps=neutral
+Received: from merlin.eu (hq6.merlin.eu [95.217.159.152])
+	by dd22222.kasserver.com (Postfix) with ESMTPS id BAD2E53C0541
+	for <me@foobar.com>; Mon, 30 Aug 2021 20:29:57 +0200 (CEST)
+Received: from [127.0.0.1] (localhost [127.0.0.1])
+	(using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+	(No client certificate requested)
+	by merlin.eu (Postfix) with ESMTPS id 40DA541C7E
+	for <me@merlin.eu>; Mon, 30 Aug 2021 20:29:55 +0200 (CEST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; s=200608; d=microsoftstoreemail.com;
+ h=From:To:Subject:Date:List-Help:MIME-Version:List-ID:X-CSA-Complaints:
+ Message-ID:Content-Type; i=microsoftstore@microsoftstoreemail.com;
+ bh=dvrsbCk+3USZNtvsQRvPSo2qpqsG0det56Snu0/Vz7I=;
+ b=XV8jLprFcPv/OmruNBYNRrau26cDZYl4EchN88fJa3q49VpWwom5Pakcw2fkj1i63acBRpyVOBEr
+   M3rZ/p/S3c+n5wkqcQJO/ruWPR16GacnfwYq3zGFIEs5HVjFLbMF+26YuCD7u6GEJC559yD7kWje
+   1RCh9UZqYxBOsdYhkyk=
+Received: by mta16.microsoftstoreemail.com id h1111111111v for <me@merlin.eu>; Mon, 30 Aug 2021 18:14:50 +0000 (envelope-from <bounce-889884_HTML-1111111111-2222222-33333333-4444@bounce.microsoftstoreemail.com>)
+From: "Microsoft Store" <microsoftstore@microsoftstoreemail.com>
+To: <me@merlin.eu>
+Subject: Notice of Update to Microsoft Store Marketing Disclosure Document
+Date: Mon, 30 Aug 2021 12:14:50 -0600
+List-Help: <https://click.microsoftstoreemail.com/subscription_center.aspx?jwt=123.123.123>
+x-CSA-Compliance-Source: SFMC
+MIME-Version: 1.0
+List-ID: <96540.xt.local>
+X-CSA-Complaints: csa-complaints@eco.de
+X-SFMC-Stack: 1
+x-job: 10359607_7641603
+Message-ID: <9b806dd3-1234-1234-1234-49603f588b2c@ind1s01mta720.xt.local>
+Content-Type: multipart/alternative;
+	boundary="x28u2yBkExvV=_?:"
+X-Spamd-Bar: ++++
+X-Spam-Level: ****
+X-Rspamd-Server: hq6
+Authentication-Results: merlin.eu;
+	dkim=pass header.d=microsoftstoreemail.com;
+	dmarc=pass (policy=none) header.from=microsoftstoreemail.com;
+	spf=pass smtp.mailfrom=bounce-889884_HTML-1111111111-2222222-33333333-4444@bounce.microsoftstoreemail.com
+X-Rspamd-Queue-Id: 40DA541C7E
+X-Spamd-Result: default: False [4.17 / 15.00];
+	 ARC_NA(0.00)[];
+	 R_DKIM_ALLOW(-0.20)[microsoftstoreemail.com];
+	 FROM_HAS_DN(0.00)[];
+	 R_SPF_ALLOW(-0.20)[+ip4:64.132.88.0/23];
+	 TO_MATCH_ENVRCPT_ALL(0.00)[];
+	 R_BAD_CTE_7BIT(1.05)[7bit,utf8];
+	 PREVIOUSLY_DELIVERED(0.00)[me@merlin.eu];
+	 TO_DN_NONE(0.00)[];
+	 MIME_GOOD(-0.10)[multipart/alternative,text/plain];
+	 URI_COUNT_ODD(1.00)[63];
+	 RCPT_COUNT_ONE(0.00)[1];
+	 MANY_INVISIBLE_PARTS(0.10)[2];
+	 IP_SCORE(-0.47)[asn: 22606(-2.23), country: US(-0.10)];
+	 DKIM_TRACE(0.00)[microsoftstoreemail.com:+];
+	 HTML_SHORT_LINK_IMG_2(1.00)[];
+	 DMARC_POLICY_ALLOW(-0.50)[microsoftstoreemail.com,none];
+	 MX_GOOD(-0.01)[cached: inbound.s1.exacttarget.com];
+	 FORGED_SENDER(0.30)[microsoftstore@microsoftstoreemail.com,bounce-889884_HTML-1111111111-2222222-33333333-4444@bounce.microsoftstoreemail.com];
+	 RWL_MAILSPIKE_POSSIBLE(0.00)[177.89.132.64.rep.mailspike.net : 127.0.0.17];
+	 RCVD_TLS_LAST(0.00)[];
+	 HFILTER_URL_ONLY(2.20)[1];
+	 ASN(0.00)[asn:22606, ipnet:64.132.89.0/24, country:US];
+	 FROM_NEQ_ENVFROM(0.00)[microsoftstore@microsoftstoreemail.com,bounce-889884_HTML-1111111111-2222222-33333333-4444@bounce.microsoftstoreemail.com];
+	 GREYLIST(0.00)[pass,body];
+	 RCVD_COUNT_TWO(0.00)[2]
+X-KasLoop: m111111f
+
+This is a multi-part message in MIME format.
+
+--x28u2yBkExvV=_?:
+Content-Type: text/plain;
+	charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+
+
+
+<!--
+    en_us
+
+    @templateVersion = "Templates_v01"
+-->
+<span style="display: none"></span>
+<html lang="en">
+<head>
+    <title>Notice of Update to Microsoft Store Marketing Disclosure Document</title>
+    <style media="all" type="text/css">
+
+        div.preheader {
+            display: none !important;
+        }
+
+        ...
+
+    </style>
+</head>
+<body>
+    <!-- Wrapper -->
+    <div style="display: none; max-height: 0px; overflow: hidden;">Please read these important updates&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+
+... 100 or so more of these lines - and yes, this is really in a `text/plain` part ...
+
+</body>
+</html>
+
+
+--x28u2yBkExvV=_?:
+Content-Type: text/html;
+	charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+
+
+<!-- Template Top -->
+<!--
+    en_us
+
+    @templateVersion = "Templates_v01"
+-->
+<span style="display: none"></span>
+<html lang="en">
+<head>
+    <title>Notice of Update to Microsoft Store Marketing Disclosure Document</title>
+    <style media="all" type="text/css">
+
+        div.preheader {
+            display: none !important;
+        }
+
+        ...
+
+    </style>
+</head>
+<body>
+    <!-- Wrapper -->
+    <div style="display: none; max-height: 0px; overflow: hidden;">Please read these important updates&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;
+
+
+... 100 or so more of these lines ...
+
+</body>
+</html>
+
+
+--x28u2yBkExvV=_?:--
+

--- a/test-data/message/mailinglist_xt_local_spiegel.eml
+++ b/test-data/message/mailinglist_xt_local_spiegel.eml
@@ -1,0 +1,70 @@
+Return-Path: <bounce-155_HTML-111111111-222222-333333333-1234@bounce.angebote.spiegel.de>
+X-Original-To: me@foobar.com
+Delivered-To: m000002f@dd22222.kasserver.com
+X-policyd-weight:  NOT_IN_SPAMCOP=-1.5 NOT_IN_IX_MANITU=-1.5 CL_IP_EQ_HELO_IP=-2 (check from: .spiegel. - helo: .mta.angebote.spiegel. - helo-domain: .spiegel.)  FROM/MX_MATCHES_HELO(DOMAIN)=-2; rate: -7
+Authentication-Results: dd22222.kasserver.com;
+	dkim=pass (2048-bit key; unprotected) header.d=angebote.spiegel.de header.i=service@angebote.spiegel.de header.b="EO7/nr7w";
+	dkim-atps=neutral
+Received: from mta.angebote.spiegel.de (mta.angebote.spiegel.de [13.111.60.76])
+	by dd22222.kasserver.com (Postfix) with ESMTPS id 5667B53C0576
+	for <me@foobar.com>; Mon,  6 Sep 2021 13:27:43 +0200 (CEST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; s=10dkim1; d=angebote.spiegel.de;
+ h=From:To:Subject:Date:List-Unsubscribe:List-Unsubscribe-Post:MIME-Version:
+ Reply-To:List-ID:X-CSA-Complaints:Message-ID:Content-Type;
+ i=service@angebote.spiegel.de;
+ bh=OgZoChKe0M5AaHNMVEyCAZ9jK0q01BajqQhtcqP22/Q=;
+ b=EO7/nr7w54xd68XV1+qUteycqAN63r7HH4QAw60wImD4rE76J4+vWAcf8TNYayM/vPefcM7zcfFk
+   ERwrlR/aT4BoRAWghyQHKgAZ0lwVKpqWGuYe9cF8wjLuYJOwPCoYIiry/GgOSXIVwazlXE2FRN9V
+   Y8m8OStmH3KbVZC55j1Ta6OXMMHEyvwZ+/OHbJ2CLW3jinw84NevP2aMDoI60TidBS5HYVclUT9W
+   IT4bs1o6a659LeVw/ViitQULL7c2P/UWPv0gm5w5IRci6jmdCOzfa+rvFmxSGIlfalTJ/VVG4V+V
+   PlbJl49RrPBuXl62ub6f1EPjFGtbJD8Gy3BliQ==
+Received: by mta.angebote.spiegel.de id h6ntj42fmd4o for <me@foobar.com>; Mon, 6 Sep 2021 11:27:41 +0000 (envelope-from <bounce-155_HTML-111111111-222222-333333333-1234@bounce.angebote.spiegel.de>)
+From: "DER SPIEGEL Kundenservice" <service@angebote.spiegel.de>
+To: <me@foobar.com>
+Subject: subject here
+Date: Mon, 06 Sep 2021 05:27:41 -0600
+List-Unsubscribe: <https://click.angebote.spiegel.de/subscription_center.aspx?jwt=123.123.123-123-123>, <mailto:leave-123-123-123-123-123@leave.angebote.spiegel.de>
+List-Unsubscribe-Post: List-Unsubscribe=One-Click
+x-CSA-Compliance-Source: SFMC
+MIME-Version: 1.0
+Reply-To: "DER SPIEGEL Kundenservice" <reply-123-123-123-123-123@angebote.spiegel.de>
+List-ID: <121231234.xt.local>
+X-CSA-Complaints: csa-complaints@eco.de
+X-SFMC-Stack: 10
+x-job: 100006074_884883
+Message-ID: <123-123-123-123-123@dfw123123a96.xt.local>
+Content-Type: multipart/alternative;
+	boundary="NwnF3UJtimpn=_?:"
+X-KasLoop: m000002f
+
+This is a multi-part message in MIME format.
+
+--NwnF3UJtimpn=_?:
+Content-Type: text/plain;
+	charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+
+  
+ 
+
+ 
+plain text here
+
+ 
+ 
+
+
+  
+ 
+
+
+--NwnF3UJtimpn=_?:
+Content-Type: text/html;
+	charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+<p>html text here</p>
+
+--NwnF3UJtimpn=_?:--
+


### PR DESCRIPTION
these mailinglist probably come from the xt:Commerce system and are pretty widely used.
    
i have not seen an .xt.local mailinglist with name set in `List-Id:`, however, if that happens, it will still be taken.

only if the `List-Id:`-name is unset, we use the name from the `From:`-header.