### PR TITLE
implement `set/get_ui_config()` resurrection

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -359,6 +359,11 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    to not mess up with non-delivery-reports or read-receipts.
  *                    0=no limit (default).
  *                    Changes affect future messages only.
+ * - `ui.*`         = All keys prefixed by `ui.` can be used by the user-interfaces for system-specific purposes.
+ *                    The prefix should be followed by the system and maybe subsystem,
+ *                    eg. `ui.desktop.foo`, `ui.desktop.linux.bar`, `ui.android.foo`, `ui.dc40.bar`, `ui.bot.simplebot.baz`.
+ *                    These keys go to backups and allow easy per-account settings when using @ref dc_accounts_t,
+ *                    however, are not handled by the core otherwise.
  *
  * If you want to retrieve a value, use dc_get_config().
  *

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 //! # Key-value configuration management.
 
-use anyhow::{anyhow, Result};
+use anyhow::{ensure, Result};
 use strum::{EnumProperty, IntoEnumIterator};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumProperty, EnumString};
 
@@ -340,20 +340,16 @@ impl Context {
 
     /// Sets an ui-specific key-value pair.
     /// Keys must be prefixed by `ui.`
-    /// and should be followe by the name of the system and maybe subsystem,
+    /// and should be followed by the name of the system and maybe subsystem,
     /// eg. `ui.desktop.linux.foo`, `ui.desktop.macos.bar`, `ui.ios.foobar`.
     pub async fn set_ui_config(&self, key: &str, value: Option<&str>) -> Result<()> {
-        if !key.starts_with("ui.") {
-            return Err(anyhow!("ui-prefix missing on setting ui-config."));
-        }
+        ensure!(key.starts_with("ui."), "set_ui_config(): prefix missing.");
         self.sql.set_raw_config(key, value).await
     }
 
     /// Gets an ui-specific value set by set_ui_config().
     pub async fn get_ui_config(&self, key: &str) -> Result<Option<String>> {
-        if !key.starts_with("ui.") {
-            return Err(anyhow!("ui-prefix missing on getting ui-config."));
-        }
+        ensure!(key.starts_with("ui."), "get_ui_config(): prefix missing.");
         self.sql.get_raw_config(key).await
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 //! # Key-value configuration management.
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use strum::{EnumProperty, IntoEnumIterator};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumProperty, EnumString};
 
@@ -337,6 +337,25 @@ impl Context {
             .await?;
         Ok(())
     }
+
+    /// Sets an ui-specific key-value pair.
+    /// Keys must be prefixed by `ui.`
+    /// and should be followe by the name of the system and maybe subsystem,
+    /// eg. `ui.desktop.linux.foo`, `ui.desktop.macos.bar`, `ui.ios.foobar`.
+    pub async fn set_ui_config(&self, key: &str, value: Option<&str>) -> Result<()> {
+        if !key.starts_with("ui.") {
+            return Err(anyhow!("ui-prefix missing on setting ui-config."));
+        }
+        self.sql.set_raw_config(key, value).await
+    }
+
+    /// Gets an ui-specific value set by set_ui_config().
+    pub async fn get_ui_config(&self, key: &str) -> Result<Option<String>> {
+        if !key.starts_with("ui.") {
+            return Err(anyhow!("ui-prefix missing on getting ui-config."));
+        }
+        self.sql.get_raw_config(key).await
+    }
 }
 
 /// Returns all available configuration keys concated together.
@@ -388,5 +407,26 @@ mod tests {
         assert_eq!(constants::MediaQuality::Worse as i32, 1);
         let media_quality = constants::MediaQuality::from_i32(media_quality).unwrap_or_default();
         assert_eq!(media_quality, constants::MediaQuality::Worse);
+    }
+
+    #[async_std::test]
+    async fn test_ui_config() -> Result<()> {
+        let t = TestContext::new().await;
+
+        assert_eq!(t.get_ui_config("ui.desktop.linux.systray").await?, None);
+
+        t.set_ui_config("ui.android.screen_security", Some("safe"))
+            .await?;
+        assert_eq!(
+            t.get_ui_config("ui.android.screen_security").await?,
+            Some("safe".to_string())
+        );
+
+        t.set_ui_config("ui.android.screen_security", None).await?;
+        assert_eq!(t.get_ui_config("ui.android.screen_security").await?, None);
+
+        assert!(t.set_ui_config("configured", Some("bar")).await.is_err());
+
+        Ok(())
     }
 }


### PR DESCRIPTION
this pr allows UIs to store own config settings in the database. as multi-account, becomes more a thing, this gets much more important.

also, that way, ui settings go to the backup, this is also a thing that was requested several times - resp. ppl are wondering why on export/import not everything is restored.

the ui settings are stored in the same database as the other config, however, must be prefixed by ' ui.`.

the pr is a revival of #503, targeting most comments made there.

to the [idea of adding `Ui(String)`](https://github.com/deltachat/deltachat-core-rust/pull/503#issuecomment-531183450) to the `Config` enum - well, i tried that, however, all my attempts result in lots of rust issues (missing Copy-trait or complicated lifetimes).  
if someone has a concrete idea here, feel free to commit :)

but i also do not think, this is a blocker, it can be done later as needed.

**CAVE:** UIs has to be carefully on reading the ui-settings. eg. saving a notification sound to the database at `ui.android.sound` is reasonable - but on import, it may be that the destination system has a complete different set of sounds.  
also, many settings are still better treated as global so, we should not "just" port all settings.