### PR TITLE
simpler subject of Autocrypt-Setup-Message

### DIFF
--- a/src/imex.rs
+++ b/src/imex.rs
@@ -234,7 +234,7 @@ async fn do_initiate_key_transfer(context: &Context) -> Result<String> {
     msg = Message::default();
     msg.viewtype = Viewtype::File;
     msg.param.set(Param::File, setup_file_blob.as_name());
-
+    msg.subject = stock_str::ac_setup_msg_subject(context).await;
     msg.param
         .set(Param::MimeType, "application/autocrypt-setup");
     msg.param.set_cmd(SystemMessage::AutocryptSetupMessage);

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -388,10 +388,6 @@ impl<'a> MimeFactory<'a> {
 
         let subject = match self.loaded {
             Loaded::Message { ref chat } => {
-                if self.msg.param.get_cmd() == SystemMessage::AutocryptSetupMessage {
-                    return Ok(stock_str::ac_setup_msg_subject(context).await);
-                }
-
                 if !self.msg.subject.is_empty() {
                     return Ok(self.msg.subject.clone());
                 }


### PR DESCRIPTION
since some time, core handles per-message-subjects
and Mimefactory also picks that up.

therefore, we can remove the old special handling.

came over that bit on checking things out wrt sync-messages #2669