### PR TITLE
Use saturating addition for ephemeral timers

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1222,7 +1222,7 @@ impl Chat {
         };
         let ephemeral_timestamp = match ephemeral_timer {
             EphemeralTimer::Disabled => 0,
-            EphemeralTimer::Enabled { duration } => time() + i64::from(duration),
+            EphemeralTimer::Enabled { duration } => time().saturating_add(duration.into()),
         };
 
         let new_mime_headers = if msg.has_html() {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1046,7 +1046,9 @@ INSERT INTO msgs
         } else {
             match ephemeral_timer {
                 EphemeralTimer::Disabled => 0,
-                EphemeralTimer::Enabled { duration } => rcvd_timestamp + i64::from(duration),
+                EphemeralTimer::Enabled { duration } => {
+                    rcvd_timestamp.saturating_add(duration.into())
+                }
             }
         };
 

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -279,7 +279,7 @@ impl MsgId {
     /// Starts ephemeral message timer for the message if it is not started yet.
     pub(crate) async fn start_ephemeral_timer(self, context: &Context) -> anyhow::Result<()> {
         if let Timer::Enabled { duration } = self.ephemeral_timer(context).await? {
-            let ephemeral_timestamp = time() + i64::from(duration);
+            let ephemeral_timestamp = time().saturating_add(duration.into());
 
             context
                 .sql


### PR DESCRIPTION
Integer overflows crash the application by default.

On a first sight this is only a potential crash that can't be
triggered, because timestamps are stored as i64 and ephemeral timer
duration is u32.