### PR TITLE
better names for more mailinglist-types

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1768,6 +1768,7 @@ async fn create_or_lookup_mailinglist(
     // as a last resort, use the ListId as the name
     // but strip some known, long hash prefixes
     if name.is_empty() {
+        // 51231231231231231231231232869f58.xing.com -> xing.com
         static PREFIX_32_CHARS_HEX: Lazy<Regex> =
             Lazy::new(|| Regex::new(r"([0-9a-fA-F]{32})\.(.{6,})").unwrap());
         if let Some(cap) = PREFIX_32_CHARS_HEX.captures(&listid) {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1755,6 +1755,7 @@ async fn create_or_lookup_mailinglist(
             if from.addr.contains("noreply")
                 || from.addr.contains("no-reply")
                 || from.addr.starts_with("notifications@")
+                || from.addr.starts_with("newsletter@")
                 || listid.ends_with(".xt.local")
             {
                 if let Some(display_name) = &from.display_name {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1768,12 +1768,12 @@ async fn create_or_lookup_mailinglist(
     // as a last resort, use the ListId as the name
     // but strip some known, long hash prefixes
     if name.is_empty() {
-        name = listid.clone();
-
         static PREFIX_32_CHARS_HEX: Lazy<Regex> =
-            Lazy::new(|| Regex::new("([0-9a-fA-F]{32})\\.(.{6,})").unwrap());
-        if let Some(cap) = PREFIX_32_CHARS_HEX.captures(&name) {
+            Lazy::new(|| Regex::new(r"([0-9a-fA-F]{32})\.(.{6,})").unwrap());
+        if let Some(cap) = PREFIX_32_CHARS_HEX.captures(&listid) {
             name = cap[2].to_string();
+        } else {
+            name = listid.clone();
         }
     }
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1765,8 +1765,15 @@ async fn create_or_lookup_mailinglist(
     }
 
     // as a last resort, use the ListId as the name
+    // but strip some known, long hash prefixes
     if name.is_empty() {
         name = listid.clone();
+
+        static PREFIX_32_CHARS_HEX: Lazy<Regex> =
+            Lazy::new(|| Regex::new("([0-9a-fA-F]{32})\\.(.{6,})").unwrap());
+        if let Some(cap) = PREFIX_32_CHARS_HEX.captures(&name) {
+            name = cap[2].to_string();
+        }
     }
 
     if allow_creation {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3403,6 +3403,29 @@ mod tests {
     }
 
     #[async_std::test]
+    async fn test_xing_mailing_list() -> Result<()> {
+        let t = TestContext::new_alice().await;
+        t.set_config(Config::ShowEmails, Some("2")).await?;
+
+        dc_receive_imf(
+            &t,
+            include_bytes!("../test-data/message/mailinglist_xing.eml"),
+            "INBOX",
+            1,
+            false,
+        )
+        .await?;
+        let msg = t.get_last_msg().await;
+        assert_eq!(msg.subject, "Kennst Du Dr. Mabuse?");
+        let chat = Chat::load_from_db(&t, msg.chat_id).await?;
+        assert_eq!(chat.typ, Chattype::Mailinglist);
+        assert_eq!(chat.grpid, "51231231231231231231231232869f58.xing.com");
+        assert_eq!(chat.name, "xing.com");
+
+        Ok(())
+    }
+
+    #[async_std::test]
     async fn test_mailing_list_with_mimepart_footer() {
         let t = TestContext::new_alice().await;
         t.set_config(Config::ShowEmails, Some("2")).await.unwrap();

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3433,6 +3433,29 @@ mod tests {
     }
 
     #[async_std::test]
+    async fn test_ttline_mailing_list() -> Result<()> {
+        let t = TestContext::new_alice().await;
+        t.set_config(Config::ShowEmails, Some("2")).await?;
+
+        dc_receive_imf(
+            &t,
+            include_bytes!("../test-data/message/mailinglist_ttline.eml"),
+            "INBOX",
+            1,
+            false,
+        )
+        .await?;
+        let msg = t.get_last_msg().await;
+        assert_eq!(msg.subject, "Unsere Sommerangebote an Bord ⚓");
+        let chat = Chat::load_from_db(&t, msg.chat_id).await?;
+        assert_eq!(chat.typ, Chattype::Mailinglist);
+        assert_eq!(chat.grpid, "39123123-1BBQXPY.t.ttline.com");
+        assert_eq!(chat.name, "TT-Line - Die Schwedenfähren");
+
+        Ok(())
+    }
+
+    #[async_std::test]
     async fn test_mailing_list_with_mimepart_footer() {
         let t = TestContext::new_alice().await;
         t.set_config(Config::ShowEmails, Some("2")).await.unwrap();

--- a/test-data/message/mailinglist_ttline.eml
+++ b/test-data/message/mailinglist_ttline.eml
@@ -1,0 +1,60 @@
+Return-Path: <return@t.ttline.com>
+X-Original-To: pdetersen@b123.com
+Delivered-To: m123123f@d123123.kasserver.com
+X-policyd-weight:  NOT_IN_SPAMCOP=-1.5 NOT_IN_IX_MANITU=-1.5 CL_IP_EQ_HELO_IP=-2 (check from: .ttline. - helo: .mail18-212.srv2. - helo-domain: .srv2.)  FROM/MX_MATCHES_HELO(DOMAIN)=-2; rate: -7
+Authentication-Results: d123123.kasserver.com;
+	dkim=pass (1024-bit key; unprotected) header.d=ttline.com header.i=newsletter@ttline.com header.b="SEFAAx0a";
+	dkim=pass (1024-bit key; unprotected) header.d=srv2.de header.i=@srv2.de header.b="UqUBlHLF";
+	dkim-atps=neutral
+Received: from mail18-212.srv2.de (mail18-212.srv2.de [193.169.181.212])
+	by d123123.kasserver.com (Postfix) with ESMTPS id 4216753C0228
+	for <pdetersen@b123.com>; Mon, 12 Jul 2021 18:00:55 +0200 (CEST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed; s=mailing; d=ttline.com;
+ h=Date:From:Reply-To:To:Message-ID:Subject:MIME-Version:Content-Type:X-ulpe:
+ List-Id:X-CSA-Complaints:List-Unsubscribe:List-Unsubscribe-Post:Feedback-ID;
+ i=newsletter@ttline.com;
+ bh=s/Rjfns4gt9JjcDSSsqHZctvWTOtocDJRpEVs80pElM=;
+ b=SEFAAx0aG2fD5fytZ1z0WI2elUpWh5J+ekno+UQE/PDqc4bwz5xEUGRXuBszhV9vh3UJVq9HL0Lz
+   40Bcjzcoob+Iza9KKnl0spLKMPgQNpoCerBCdE/v/DmiWus/gs2MOE+xE5dTM6A8kK0K4ukDoDjr
+   mnkjezkK8iuh5wwjPqA=
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed; s=mailing; d=srv2.de;
+ h=Date:From:Reply-To:To:Message-ID:Subject:MIME-Version:Content-Type:X-ulpe:
+ List-Id:X-CSA-Complaints:List-Unsubscribe:List-Unsubscribe-Post:Feedback-ID;
+ bh=s/Rjfns4gt9JjcDSSsqHZctvWTOtocDJRpEVs80pElM=;
+ b=UqUBlHLFoluhBzwmQDgHdd9OdiyI9Cy8Y5zqJqfyhmdV34Owpvu1Vx7HnlljqxlUTSVSPtL6Ldoe
+   bjWHA8yBc0lFKnF7Kt8a2Wd2ac0aHsLgQvwVmoM0T9Av8Hgx4qyRhaTQIho2IbcKcP0IEwEUKVou
+   KwU4tfT8MLuZHX4rkWc=
+Date: Mon, 12 Jul 2021 18:00:54 +0200 (CEST)
+From: =?UTF-8?Q?TT-Line_-_Die_Schwedenf=C3=A4hren?= <newsletter@ttline.com>
+Reply-To: 
+	=?UTF-8?Q?TT-Line_-_Die_Schwedenf=C3=A4hren?= <newsletter@ttline.com>
+To: pdetersen@b123.com
+Message-ID: <re-p123123123123123123123123-41231231-4J123123-1123123@t.ttline.com>
+Subject: =?UTF-8?Q?Unsere_Sommerangebote_an_Bord_=E2=9A=93?=
+MIME-Version: 1.0
+Content-Type: multipart/alternative; 
+	boundary="----=_Part_15756440_1404911700.1626105654088"
+X-ulpe: re-p123123123123123123123123-41231231-4J123123-1123123@t.ttline.com
+List-Id: <39123123-1BBQXPY.t.ttline.com>
+X-Report-Spam: complaints@episerver.com
+X-CSA-Complaints: csa-complaints@eco.de
+X-sender: =?UTF-8?Q?TT-Line_-_Die_Schwedenf=C3=A4hren?= <newsletter@ttline.com>
+List-Unsubscribe: <mailto:listoff-41231231-4J123123-5M123@t.ttline.com?subject=unsubscribe>,<https://t.ttline.com/go/0/41231231-4J123123-39123123-A9E123-UL.html>
+List-Unsubscribe-Post: List-Unsubscribe=One-Click
+Feedback-ID: 39123123:4J123123:episerver
+X-KasLoop: m123123f
+
+------=_Part_15756440_1404911700.1626105654088
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+
+plain...
+------=_Part_15756440_1404911700.1626105654088
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Content-Disposition: inline
+
+html...
+------=_Part_15756440_1404911700.1626105654088--
+

--- a/test-data/message/mailinglist_xing.eml
+++ b/test-data/message/mailinglist_xing.eml
@@ -1,0 +1,75 @@
+Return-Path: <mailrobot@mail.xing.com>
+X-Original-To: pbetersen@b123.com
+Delivered-To: m123123f@dd12312.kasserver.com
+X-policyd-weight: using cached result; rate: -7
+Authentication-Results: dd12312.kasserver.com;
+	dkim=pass (1024-bit key; unprotected) header.d=mail.xing.com header.i=@mail.xing.com header.b="o123123j";
+	dkim-atps=neutral
+Received: from mailout1-107.xing.com (mailout1-107.xing.com [109.233.158.107])
+	by dd12312.kasserver.com (Postfix) with ESMTPS id DCB9D53C055C
+	for <pbetersen@b123.com>; Tue, 14 Sep 2021 12:11:17 +0200 (CEST)
+DKIM-Signature: v=1; a=rsa-sha256; d=mail.xing.com; s=main; c=relaxed/simple;
+	q=dns/txt; i=@mail.xing.com; t=1631614277;
+	h=From:Subject:Date:To:Mime-Version:Content-Type:X-CSA-Complaints:List-Help;
+	bh=bc0sqvXhKYO4cLpVn9ZYqLQQYPgPysrjt9/f6mx2BQI=;
+	b=o123123jtfoTCEiqaRZ3ax7h17rGfXP1ZQ3sjbdaBguPy5q1k+EpuXYdCwFq7S7z
+	yRjbK+VvTSKDn4Dxqk/wA9hFyGrO6XuYdJt3NEZ3Yye7W222dNR58ww3XCavjSpY
+	pzhJdAEo9Zw1sG3fhtm2eI60Oe1hLOr6G657sAo2ubQ=;
+X-MSFBL: SwzhdcKRUcljkfTYaEiSU28Q3a0pxO+Z9dY1NMgWyq4=|eyJnIjoibWFpbG91dDE
+	iLCJiIjoibWFpbG91dDEtMTA3IiwidSI6ImNvbnRhY3RzL215bWs7RzhMWjI0RlR
+	SSUItdVkxaXRaa1EiLCJyIjoiYnBldGVyc2VuQGI0NHQuY29tIn0=
+Received: from [10.12.225.241] ([10.12.225.241:27696])
+	by mta-6.mail.ams1.xing.com (envelope-from <mailrobot@mail.xing.com>)
+	(ecelerity 4.2.1.51128 r(Core:4.2.1.5)) with REST
+	id 82/69-03094-54570416; Tue, 14 Sep 2021 12:11:17 +0200
+Date: Tue, 14 Sep 2021 12:11:17 +0200
+From: =?UTF-8?B?WElORyBLb250YWt0dm9yc2NobMOkZ2U=?= <mailrobot@mail.xing.com>
+Reply-To: no-reply@mail.xing.com
+To: =?UTF-8?B?QmrDtnJuIFBldGVyc2Vu?= <pbetersen@b123.com>
+Message-ID: <6123123123123_5123123123123@hermes-worker-5123123123-7lcmp.mail>
+Subject: Kennst Du Dr. Mabuse?
+Mime-Version: 1.0
+Content-Type: multipart/alternative;
+ boundary="--==_mimepart_614075452ac33_5ed3cc13386fc";
+ charset=UTF-8
+Content-Transfer-Encoding: 7bit
+List-Help: <https://www.xing.com/settings/notifications>,
+ <mailto:fbl@xing.com>
+List-Id: <51231231231231231231231232869f58.xing.com>
+X-CSA-Complaints: csa-complaints@eco.de
+X-KasLoop: m123123f
+
+
+----==_mimepart_614075452ac33_5ed3cc13386fc
+Content-Type: text/plain;
+ charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+**********************************************************
+* unfortunately:
+*
+* - xing mailinglists do not have a name in `List-Id:`
+*   so we cannot get the name from there
+*
+* - different senders may use the same `List-Id:`,
+*   at least i found that two times,
+*   maybe it is a bug on xing's side as most times `List-Id:` differs,
+*   however, so we cannot get the name from `From:`.
+*
+* to avoid chat names as `51231231231231231231231232869f58.xing.com`,
+* we detect the hash prefix and strip that;
+* as the sender, we have "xing.com" then, which is fine.
+*
+* that approach should also work for other mailinglist.
+**********************************************************
+
+
+----==_mimepart_614075452ac33_5ed3cc13386fc
+Content-Type: text/html;
+ charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+html ...
+
+----==_mimepart_614075452ac33_5ed3cc13386fc--
+


### PR DESCRIPTION
this pr improves finding out names of mailing lists:

- if there is no name set for the mailinglist, as a last resort, we already use the `List-Id:` as the name (we cannot just always use `From:` as that may refer to the sender, not to the chat, see xing example).  
however, this `List-Id:` may be prefixed by a "long hash", sth. as `1234567890abcdef1234567890abcdef.company.com`.  
this pr removes that "long hash" and adds a test for a real-life mailinglist.

- if there is no name set for the mailing list, for `From:` addresses starting with `newsletter@`, we use the `From:` name as the mailing list name -  sth. similar is already done for other prefixes.