### PR TITLE
make connectivity and quota views translatable

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5900,6 +5900,70 @@ void dc_event_unref(dc_event_t* event);
 /// `%1$s` will be replaced by human-readable date and time.
 #define DC_STR_DOWNLOAD_AVAILABILITY      100
 
+/// "Inbox"
+///
+/// Used as a headline in the connectivity view.
+#define DC_STR_INBOX                      103
+
+/// "Outbox"
+///
+/// Used as a headline in the connectivity view.
+#define DC_STR_OUTBOX                     104
+
+/// "Storage on %1$s"
+///
+/// Used as a headline in the connectivity view.
+///
+/// `%1$s` will be replaced by the domain of the configured email-address.
+#define DC_STR_STORAGE_ON_DOMAIN          105
+
+/// "One moment…"
+///
+/// Used in the connectivity view when some information are not yet there.
+#define DC_STR_ONE_MOMENT                 106
+
+/// "Connected"
+///
+/// Used as status in the connectivity view.
+#define DC_STR_CONNECTED                  107
+
+/// "Connecting…"
+///
+/// Used as status in the connectivity view.
+#define DC_STR_CONNTECTING                108
+
+/// "Updating…"
+///
+/// Used as status in the connectivity view.
+#define DC_STR_UPDATING                   109
+
+/// "Sending…"
+///
+/// Used as status in the connectivity view.
+#define DC_STR_SENDING                    110
+
+/// "Your last message was sent successfully."
+///
+/// Used as status in the connectivity view.
+#define DC_STR_LAST_MSG_SENT_SUCCESSFULLY 111
+
+/// "Error: %1$s"
+///
+/// Used as status in the connectivity view.
+///
+/// `%1$s` will be replaced by a possibly more detailed, typically english, error description.
+#define DC_STR_ERROR                      112
+
+/// "Quota not supported by your provider."
+///
+/// Used in the connectivity view.
+#define DC_STR_QUOTA_NOT_SUPPORTED        113
+
+/// "Messages"
+///
+/// Used as a subtitle in quota context; can be plural always.
+#define DC_STR_MESSAGES                   114
+
 /**
  * @}
  */

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5954,7 +5954,7 @@ void dc_event_unref(dc_event_t* event);
 /// `%1$s` will be replaced by a possibly more detailed, typically english, error description.
 #define DC_STR_ERROR                      112
 
-/// "Quota not supported by your provider."
+/// "Your provider does not support reading quota information."
 ///
 /// Used in the connectivity view.
 #define DC_STR_QUOTA_NOT_SUPPORTED        113

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5954,10 +5954,10 @@ void dc_event_unref(dc_event_t* event);
 /// `%1$s` will be replaced by a possibly more detailed, typically english, error description.
 #define DC_STR_ERROR                      112
 
-/// "Your provider does not support reading quota information."
+/// "Not supported by your provider."
 ///
 /// Used in the connectivity view.
-#define DC_STR_QUOTA_NOT_SUPPORTED        113
+#define DC_STR_NOT_SUPPORTED_BY_PROVIDER  113
 
 /// "Messages"
 ///

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5900,15 +5900,15 @@ void dc_event_unref(dc_event_t* event);
 /// `%1$s` will be replaced by human-readable date and time.
 #define DC_STR_DOWNLOAD_AVAILABILITY      100
 
-/// "Inbox"
+/// "Incoming Messages"
 ///
 /// Used as a headline in the connectivity view.
-#define DC_STR_INBOX                      103
+#define DC_STR_INCOMING_MESSAGES          103
 
-/// "Outbox"
+/// "Outgoing Messages"
 ///
 /// Used as a headline in the connectivity view.
-#define DC_STR_OUTBOX                     104
+#define DC_STR_OUTGOING_MESSAGES          104
 
 /// "Storage on %1$s"
 ///

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -128,7 +128,7 @@ impl Context {
             let folders = get_watched_folders(self).await;
             get_unique_quota_roots_and_usage(folders, imap).await
         } else {
-            Err(anyhow!(stock_str::quota_not_supported(self).await))
+            Err(anyhow!(stock_str::not_supported_by_provider(self).await))
         };
 
         if let Ok(quota) = &quota {

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -128,7 +128,7 @@ impl Context {
             let folders = get_watched_folders(self).await;
             get_unique_quota_roots_and_usage(folders, imap).await
         } else {
-            Err(anyhow!("Quota not supported by your provider."))
+            Err(anyhow!(stock_str::quota_not_supported(self).await))
         };
 
         if let Ok(quota) = &quota {

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -8,7 +8,7 @@ use crate::events::EventType;
 use crate::quota::{
     QUOTA_ERROR_THRESHOLD_PERCENTAGE, QUOTA_MAX_AGE_SECONDS, QUOTA_WARN_THRESHOLD_PERCENTAGE,
 };
-use crate::{config::Config, dc_tools, scheduler::Scheduler};
+use crate::{config::Config, dc_tools, scheduler::Scheduler, stock_str};
 use crate::{context::Context, log::LogExt};
 use anyhow::{anyhow, Result};
 use humansize::{file_size_opts, FileSize};
@@ -73,33 +73,33 @@ impl DetailedConnectivity {
         }
     }
 
-    fn to_string_imap(&self, _context: &Context) -> String {
+    async fn to_string_imap(&self, context: &Context) -> String {
         match self {
-            DetailedConnectivity::Error(e) => format!("Error: {}", e),
+            DetailedConnectivity::Error(e) => stock_str::error(context, e).await,
             DetailedConnectivity::Uninitialized => "Not started".to_string(),
-            DetailedConnectivity::Connecting => "Connecting…".to_string(),
-            DetailedConnectivity::Working => "Getting new messages…".to_string(),
+            DetailedConnectivity::Connecting => stock_str::connecting(context).await,
+            DetailedConnectivity::Working => stock_str::updating(context).await,
             DetailedConnectivity::InterruptingIdle | DetailedConnectivity::Connected => {
-                "Connected".to_string()
+                stock_str::connected(context).await
             }
             DetailedConnectivity::NotConfigured => "Not configured".to_string(),
         }
     }
 
-    fn to_string_smtp(&self, _context: &Context) -> String {
+    async fn to_string_smtp(&self, context: &Context) -> String {
         match self {
-            DetailedConnectivity::Error(e) => format!("Error: {}", e),
+            DetailedConnectivity::Error(e) => stock_str::error(context, e).await,
             DetailedConnectivity::Uninitialized => {
-                "(You did not try to send a message recently)".to_string()
+                "You did not try to send a message recently.".to_string()
             }
-            DetailedConnectivity::Connecting => "Connecting…".to_string(),
-            DetailedConnectivity::Working => "Sending…".to_string(),
+            DetailedConnectivity::Connecting => stock_str::connecting(context).await,
+            DetailedConnectivity::Working => stock_str::sending(context).await,
 
             // We don't know any more than that the last message was sent successfully;
             // since sending the last message, connectivity could have changed, which we don't notice
             // until another message is sent
             DetailedConnectivity::InterruptingIdle | DetailedConnectivity::Connected => {
-                "Your last message was sent successfully".to_string()
+                stock_str::last_msg_sent_successfully(context).await
             }
             DetailedConnectivity::NotConfigured => "Not configured".to_string(),
         }
@@ -251,7 +251,7 @@ impl Context {
     /// One of:
     /// - DC_CONNECTIVITY_NOT_CONNECTED (1000-1999): Show e.g. the string "Not connected" or a red dot
     /// - DC_CONNECTIVITY_CONNECTING (2000-2999): Show e.g. the string "Connecting…" or a yellow dot
-    /// - DC_CONNECTIVITY_WORKING (3000-3999): Show e.g. the string "Getting new messages" or a spinning wheel
+    /// - DC_CONNECTIVITY_WORKING (3000-3999): Show e.g. the string "Updating…" or a spinning wheel
     /// - DC_CONNECTIVITY_CONNECTED (>=4000): Show e.g. the string "Connected" or a green dot
     ///
     /// We don't use exact values but ranges here so that we can split up
@@ -380,7 +380,7 @@ impl Context {
         };
         drop(lock);
 
-        ret += "<h3>Incoming messages</h3><ul>";
+        ret += &format!("<h3>{}</h3><ul>", stock_str::inbox(self).await);
         for (folder, watch, state) in &folders_states {
             let w = self.get_config(*watch).await.ok_or_log(self);
 
@@ -395,7 +395,7 @@ impl Context {
                     ret += " <b>";
                     ret += &*escaper::encode_minimal(&foldername);
                     ret += ":</b> ";
-                    ret += &*escaper::encode_minimal(&*detailed.to_string_imap(self));
+                    ret += &*escaper::encode_minimal(&*detailed.to_string_imap(self).await);
                     ret += "</li>";
 
                     folder_added = true;
@@ -410,18 +410,18 @@ impl Context {
                     ret += "<li>";
                     ret += &*detailed.to_icon();
                     ret += " ";
-                    ret += &*escaper::encode_minimal(&detailed.to_string_imap(self));
+                    ret += &*escaper::encode_minimal(&detailed.to_string_imap(self).await);
                     ret += "</li>";
                 }
             }
         }
         ret += "</ul>";
 
-        ret += "<h3>Outgoing messages</h3><ul><li>";
+        ret += &format!("<h3>{}</h3><ul><li>", stock_str::outbox(self).await);
         let detailed = smtp.get_detailed().await;
         ret += &*detailed.to_icon();
         ret += " ";
-        ret += &*escaper::encode_minimal(&detailed.to_string_smtp(self));
+        ret += &*escaper::encode_minimal(&detailed.to_string_smtp(self).await);
         ret += "</li></ul>";
 
         let domain = dc_tools::EmailAddress::new(
@@ -431,7 +431,10 @@ impl Context {
                 .unwrap_or_default(),
         )?
         .domain;
-        ret += &format!("<h3>Storage on {}</h3><ul>", domain);
+        ret += &format!(
+            "<h3>{}</h3><ul>",
+            stock_str::storage_on_domain(self, domain).await
+        );
         let quota = self.quota.read().await;
         if let Some(quota) = &*quota {
             match &quota.recent {
@@ -462,7 +465,8 @@ impl Context {
                                 }
                                 Message => {
                                     format!(
-                                        "<b>Messages:</b> {} of {} used",
+                                        "<b>{}:</b> {} of {} used",
+                                        stock_str::messages(self).await,
                                         resource.usage.to_string(),
                                         resource.limit.to_string(),
                                     )
@@ -507,7 +511,7 @@ impl Context {
                 self.schedule_quota_update().await?;
             }
         } else {
-            ret += "<li>One moment...</li>";
+            ret += &format!("<li>{}</li>", stock_str::one_moment(self).await);
             self.schedule_quota_update().await?;
         }
         ret += "</ul>";

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -380,7 +380,7 @@ impl Context {
         };
         drop(lock);
 
-        ret += &format!("<h3>{}</h3><ul>", stock_str::inbox(self).await);
+        ret += &format!("<h3>{}</h3><ul>", stock_str::incoming_messages(self).await);
         for (folder, watch, state) in &folders_states {
             let w = self.get_config(*watch).await.ok_or_log(self);
 
@@ -417,7 +417,10 @@ impl Context {
         }
         ret += "</ul>";
 
-        ret += &format!("<h3>{}</h3><ul><li>", stock_str::outbox(self).await);
+        ret += &format!(
+            "<h3>{}</h3><ul><li>",
+            stock_str::outgoing_messages(self).await
+        );
         let detailed = smtp.get_detailed().await;
         ret += &*detailed.to_icon();
         ret += " ";

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -306,7 +306,7 @@ pub enum StockMessage {
     #[strum(props(fallback = "Error: %1$s"))]
     Error = 112,
 
-    #[strum(props(fallback = "Quota not supported by your provider."))]
+    #[strum(props(fallback = "Your provider does not support reading quota information."))]
     QuotaNotSupported = 113,
 
     #[strum(props(fallback = "Messages"))]
@@ -975,7 +975,7 @@ pub(crate) async fn error(context: &Context, error: impl AsRef<str>) -> String {
         .replace1(error)
 }
 
-/// Stock string: `Quota not supported by your provider.`.
+/// Stock string: `Your provider does not support reading quota information.`.
 pub(crate) async fn quota_not_supported(context: &Context) -> String {
     translated(context, StockMessage::QuotaNotSupported).await
 }

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -275,6 +275,42 @@ pub enum StockMessage {
 
     #[strum(props(fallback = "Download maximum available until %1$s"))]
     DownloadAvailability = 100,
+
+    #[strum(props(fallback = "Inbox"))]
+    Inbox = 103,
+
+    #[strum(props(fallback = "Outbox"))]
+    Outbox = 104,
+
+    #[strum(props(fallback = "Storage on %1$s"))]
+    StorageOnDomain = 105,
+
+    #[strum(props(fallback = "One moment…"))]
+    OneMoment = 106,
+
+    #[strum(props(fallback = "Connected"))]
+    Connected = 107,
+
+    #[strum(props(fallback = "Connecting…"))]
+    Connecting = 108,
+
+    #[strum(props(fallback = "Updating…"))]
+    Updating = 109,
+
+    #[strum(props(fallback = "Sending…"))]
+    Sending = 110,
+
+    #[strum(props(fallback = "Your last message was sent successfully."))]
+    LastMsgSentSuccessfully = 111,
+
+    #[strum(props(fallback = "Error: %1$s"))]
+    Error = 112,
+
+    #[strum(props(fallback = "Quota not supported by your provider."))]
+    QuotaNotSupported = 113,
+
+    #[strum(props(fallback = "Messages"))]
+    Messages = 114,
 }
 
 impl StockMessage {
@@ -880,6 +916,74 @@ pub(crate) async fn download_availability(context: &Context, timestamp: i64) -> 
     translated(context, StockMessage::DownloadAvailability)
         .await
         .replace1(dc_timestamp_to_str(timestamp))
+}
+
+/// Stock string: `Inbox`.
+pub(crate) async fn inbox(context: &Context) -> String {
+    translated(context, StockMessage::Inbox).await
+}
+
+/// Stock string: `Outbox`.
+pub(crate) async fn outbox(context: &Context) -> String {
+    translated(context, StockMessage::Outbox).await
+}
+
+/// Stock string: `Storage on %1$s`.
+/// `%1$s` will be replaced by the domain of the configured email-address.
+pub(crate) async fn storage_on_domain(context: &Context, domain: impl AsRef<str>) -> String {
+    translated(context, StockMessage::Inbox)
+        .await
+        .replace1(domain)
+}
+
+/// Stock string: `One moment…`.
+pub(crate) async fn one_moment(context: &Context) -> String {
+    translated(context, StockMessage::OneMoment).await
+}
+
+/// Stock string: `Connected`.
+pub(crate) async fn connected(context: &Context) -> String {
+    translated(context, StockMessage::Connected).await
+}
+
+/// Stock string: `Connecting…`.
+pub(crate) async fn connecting(context: &Context) -> String {
+    translated(context, StockMessage::Connecting).await
+}
+
+/// Stock string: `Updating…`.
+pub(crate) async fn updating(context: &Context) -> String {
+    translated(context, StockMessage::Updating).await
+}
+
+/// Stock string: `Sending…`.
+pub(crate) async fn sending(context: &Context) -> String {
+    translated(context, StockMessage::Sending).await
+}
+
+
+/// Stock string: `Your last message was sent successfully.`.
+pub(crate) async fn last_msg_sent_successfully(context: &Context) -> String {
+    translated(context, StockMessage::LastMsgSentSuccessfully).await
+}
+
+/// Stock string: `Error: %1$s…`.
+/// `%1$s` will be replaced by a possibly more detailed, typically english, error description.
+pub(crate) async fn error(context: &Context, error: impl AsRef<str>) -> String {
+    translated(context, StockMessage::Error)
+        .await
+        .replace1(error)
+}
+
+/// Stock string: `Quota not supported by your provider.`.
+pub(crate) async fn quota_not_supported(context: &Context) -> String {
+    translated(context, StockMessage::QuotaNotSupported).await
+}
+
+/// Stock string: `Messages`.
+/// Used as a subtitle in quota context; can be plural always.
+pub(crate) async fn messages(context: &Context) -> String {
+    translated(context, StockMessage::Messages).await
 }
 
 impl Context {

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -276,11 +276,11 @@ pub enum StockMessage {
     #[strum(props(fallback = "Download maximum available until %1$s"))]
     DownloadAvailability = 100,
 
-    #[strum(props(fallback = "Inbox"))]
-    Inbox = 103,
+    #[strum(props(fallback = "Incoming Messages"))]
+    IncomingMessages = 103,
 
-    #[strum(props(fallback = "Outbox"))]
-    Outbox = 104,
+    #[strum(props(fallback = "Outgoing Messages"))]
+    OutgoingMessages = 104,
 
     #[strum(props(fallback = "Storage on %1$s"))]
     StorageOnDomain = 105,
@@ -918,20 +918,20 @@ pub(crate) async fn download_availability(context: &Context, timestamp: i64) -> 
         .replace1(dc_timestamp_to_str(timestamp))
 }
 
-/// Stock string: `Inbox`.
-pub(crate) async fn inbox(context: &Context) -> String {
-    translated(context, StockMessage::Inbox).await
+/// Stock string: `Incoming Messages`.
+pub(crate) async fn incoming_messages(context: &Context) -> String {
+    translated(context, StockMessage::IncomingMessages).await
 }
 
-/// Stock string: `Outbox`.
-pub(crate) async fn outbox(context: &Context) -> String {
-    translated(context, StockMessage::Outbox).await
+/// Stock string: `Outgoing Messages`.
+pub(crate) async fn outgoing_messages(context: &Context) -> String {
+    translated(context, StockMessage::OutgoingMessages).await
 }
 
 /// Stock string: `Storage on %1$s`.
 /// `%1$s` will be replaced by the domain of the configured email-address.
 pub(crate) async fn storage_on_domain(context: &Context, domain: impl AsRef<str>) -> String {
-    translated(context, StockMessage::Inbox)
+    translated(context, StockMessage::StorageOnDomain)
         .await
         .replace1(domain)
 }
@@ -960,7 +960,6 @@ pub(crate) async fn updating(context: &Context) -> String {
 pub(crate) async fn sending(context: &Context) -> String {
     translated(context, StockMessage::Sending).await
 }
-
 
 /// Stock string: `Your last message was sent successfully.`.
 pub(crate) async fn last_msg_sent_successfully(context: &Context) -> String {

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -306,8 +306,8 @@ pub enum StockMessage {
     #[strum(props(fallback = "Error: %1$s"))]
     Error = 112,
 
-    #[strum(props(fallback = "Your provider does not support reading quota information."))]
-    QuotaNotSupported = 113,
+    #[strum(props(fallback = "Not supported by your provider."))]
+    NotSupportedByProvider = 113,
 
     #[strum(props(fallback = "Messages"))]
     Messages = 114,
@@ -974,9 +974,9 @@ pub(crate) async fn error(context: &Context, error: impl AsRef<str>) -> String {
         .replace1(error)
 }
 
-/// Stock string: `Your provider does not support reading quota information.`.
-pub(crate) async fn quota_not_supported(context: &Context) -> String {
-    translated(context, StockMessage::QuotaNotSupported).await
+/// Stock string: `Not supported by your provider.`.
+pub(crate) async fn not_supported_by_provider(context: &Context) -> String {
+    translated(context, StockMessage::NotSupportedByProvider).await
 }
 
 /// Stock string: `Messages`.


### PR DESCRIPTION
- i picked up the "Updating..." wording we agreed on in the ui, "Receiving messages..." is not always correct from the user's point of view as there may be no visible message received at the end
- server errors and errors that are a result of library misuse are not translated.
- ~~for the "Inbox" and "Outbox" titles, i think we should use the same wording as already present in configuration screen~~ in general true, but the existing wording in the connectivity view seems to be better, so configuration should be adapted, if at all.
- wrt #2626 - i am just leaving things as is - "Storage on used-domain.com" is not that bad, and there were not much complains about that