### PR TITLE
emit `MsgsChanged(chat_id, 0)` on full downloads

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5136,8 +5136,8 @@ void dc_event_unref(dc_event_t* event);
  * - Chats created, deleted or archived
  * - A draft has been set
  *
- * @param data1 (int) chat_id for single added messages
- * @param data2 (int) msg_id for single added messages
+ * @param data1 (int) chat_id if only a single chat is affected by the changes, otherwise 0
+ * @param data2 (int) msg_id if only a single message is affected by the changes, otherwise 0
  */
 #define DC_EVENT_MSGS_CHANGED             2000
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -327,7 +327,12 @@ pub(crate) async fn dc_receive_imf_inner(
         }
     }
 
-    if let Some(create_event_to_send) = create_event_to_send {
+    if replace_partial_download {
+        context.emit_event(EventType::MsgsChanged {
+            msg_id: MsgId::new(0),
+            chat_id,
+        });
+    } else if let Some(create_event_to_send) = create_event_to_send {
         for (chat_id, msg_id) in created_db_entries {
             let event = match create_event_to_send {
                 CreateEvent::MsgsChanged => EventType::MsgsChanged { msg_id, chat_id },

--- a/src/events.rs
+++ b/src/events.rs
@@ -203,7 +203,8 @@ pub enum EventType {
     /// - Chats created, deleted or archived
     /// - A draft has been set
     ///
-    /// The `chat_id` and `msg_id` values will be 0 if more than one message is changed.
+    /// `chat_id` is set if only a single chat is affected by the changes, otherwise 0.
+    /// `msg_id` is set if only a single message is affected by the changes, otherwise 0.
     #[strum(props(id = "2000"))]
     MsgsChanged { chat_id: ChatId, msg_id: MsgId },
 


### PR DESCRIPTION
before, `MsgsChanged(chat_id, new_msg_id)`  was emitted,
but that does not cover the deleted message.

in theory, we could emit both,
however, that would just be a waste of refresh in uis.

also before, events were used this way,
however, also the documentations are updated to
reflect reality better.

needed to fix a bug on ios, that does not delete the old message if only  `MsgsChanged(chat_id, new_msg_id)` is emitted; android does not really care and always does the same :)