### PR TITLE
set message-state OutMdnRcvd on first read-receipt

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2758,17 +2758,6 @@ pub async fn forward_msgs(context: &Context, msg_ids: &[MsgId], chat_id: ChatId)
     Ok(())
 }
 
-pub(crate) async fn get_chat_contact_cnt(context: &Context, chat_id: ChatId) -> Result<usize> {
-    let count = context
-        .sql
-        .count(
-            "SELECT COUNT(*) FROM chats_contacts WHERE chat_id=?;",
-            paramsv![chat_id],
-        )
-        .await?;
-    Ok(count as usize)
-}
-
 pub(crate) async fn get_chat_cnt(context: &Context) -> Result<usize> {
     if context.sql.is_open().await {
         // no database, no chats - this is no error (needed eg. for information)


### PR DESCRIPTION
in the past, group-messages were marked as "read by recipient"
only when at least 50% of the group members have send a read receipt -
in practise, this does happen never or much too late esp. in larger groups.

setting the state OutMdnRcvd already on the first read-receipt
seems to be much more intuitive and useful as you at least know
one person has read the message.

this is also what other messengers as telegram are doing here.

moreover, this fixes a bug that did not add all read-receipts
to the "Info" screen - once "enough" read-receipts were received,
and the state was already set to OutMdnRcvd, subsequent read-receipts
were ignored.
probably because the "Info" screen did not show the read-receipts since forever -
and for the second tick, the additional read-receipts are not needed.

