### PR TITLE
add parameter description for DC_EVENT_CHAT_EPHEMERAL_TIMER_MODIFIED

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5218,6 +5218,9 @@ void dc_event_unref(dc_event_t* event);
 
 /**
  * Chat ephemeral timer changed.
+ *
+ * @param data1 (int) chat_id
+ * @param data2 0
  */
 #define DC_EVENT_CHAT_EPHEMERAL_TIMER_MODIFIED 2021
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5220,7 +5220,7 @@ void dc_event_unref(dc_event_t* event);
  * Chat ephemeral timer changed.
  *
  * @param data1 (int) chat_id
- * @param data2 0
+ * @param data2 (int) Timer value in seconds or 0 for disabled timer
  */
 #define DC_EVENT_CHAT_EPHEMERAL_TIMER_MODIFIED 2021
 


### PR DESCRIPTION
see title

DC_EVENT_CHAT_EPHEMERAL_TIMER_MODIFIED already sends the chat id, but this was not yet documented.