### PR TITLE
Emit events from account manager

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4993,7 +4993,7 @@ char* dc_event_get_data2_str(dc_event_t* event);
  *
  * @memberof dc_event_t
  * @param event Event object as returned from dc_accounts_get_next_event().
- * @return account-id belonging to the event or 0 for errors.
+ * @return account-id belonging to the event, 0 for account manager errors.
  */
 uint32_t dc_event_get_account_id(dc_event_t* event);
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -62,10 +62,6 @@ impl Events {
 pub struct EventEmitter(Receiver<Event>);
 
 impl EventEmitter {
-    pub(crate) fn into_inner(self) -> Receiver<Event> {
-        self.0
-    }
-
     /// Blocking recv of an event. Return `None` if the `Sender` has been droped.
     pub fn recv_sync(&self) -> Option<Event> {
         async_std::task::block_on(self.recv())


### PR DESCRIPTION
Errors and warnings are emitted with a special 0 account ID.