### PR TITLE
make string `123 MiB of 456 MiB used` translatable

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -6014,6 +6014,11 @@ void dc_event_unref(dc_event_t* event);
 /// Used as the default name for broadcast lists; a number may be added.
 #define DC_STR_BROADCAST_LIST             115
 
+/// "%1$s of %2$s used"
+///
+/// Used for describing resource usage, resulting string will be eg. "1.2 GiB of 3 GiB used".
+#define DC_STR_PART_OF_TOTAL_USED         116
+
 /**
  * @}
  */

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -460,18 +460,26 @@ impl Context {
                             ret += &match &resource.name {
                                 Atom(resource_name) => {
                                     format!(
-                                        "<b>{}:</b> {} of {} used",
+                                        "<b>{}:</b> {}",
                                         &*escaper::encode_minimal(resource_name),
-                                        resource.usage.to_string(),
-                                        resource.limit.to_string(),
+                                        stock_str::part_of_total_used(
+                                            self,
+                                            resource.usage.to_string(),
+                                            resource.limit.to_string()
+                                        )
+                                        .await,
                                     )
                                 }
                                 Message => {
                                     format!(
-                                        "<b>{}:</b> {} of {} used",
+                                        "<b>{}:</b> {}",
                                         stock_str::messages(self).await,
-                                        resource.usage.to_string(),
-                                        resource.limit.to_string(),
+                                        stock_str::part_of_total_used(
+                                            self,
+                                            resource.usage.to_string(),
+                                            resource.limit.to_string()
+                                        )
+                                        .await,
                                     )
                                 }
                                 Storage => {
@@ -487,7 +495,7 @@ impl Context {
                                     let limit = (resource.limit * 1024)
                                         .file_size(file_size_opts::BINARY)
                                         .unwrap_or_default();
-                                    format!("{} of {} used", usage, limit)
+                                    stock_str::part_of_total_used(self, usage, limit).await
                                 }
                             };
 

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -314,6 +314,9 @@ pub enum StockMessage {
 
     #[strum(props(fallback = "Broadcast List"))]
     BroadcastList = 115,
+
+    #[strum(props(fallback = "%1$s of %2$s used"))]
+    PartOfTotallUsed = 116,
 }
 
 impl StockMessage {
@@ -986,6 +989,18 @@ pub(crate) async fn not_supported_by_provider(context: &Context) -> String {
 /// Used as a subtitle in quota context; can be plural always.
 pub(crate) async fn messages(context: &Context) -> String {
     translated(context, StockMessage::Messages).await
+}
+
+/// Stock string: `%1$s of %2$s used`.
+pub(crate) async fn part_of_total_used(
+    context: &Context,
+    part: impl AsRef<str>,
+    total: impl AsRef<str>,
+) -> String {
+    translated(context, StockMessage::PartOfTotallUsed)
+        .await
+        .replace1(part)
+        .replace2(total)
 }
 
 /// Stock string: `Broadcast List`.


### PR DESCRIPTION
that was just forgotten in https://github.com/deltachat/deltachat-core-rust/pull/2694

once that is merged, a corresponding string should be added to transifex and passed to core by the UIs.