### PR TITLE
fix "QR process failed" error and add a test

### DIFF
--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -1297,7 +1297,7 @@ mod tests {
 
         // do a scan that is not working as claire is never responding
         let qr_stale = "OPENPGP4FPR:1234567890123456789012345678901234567890#a=claire%40foo.de&n=&i=12345678901&s=23456789012";
-        let claire_id = dc_join_securejoin(&bob, &qr_stale).await?;
+        let claire_id = dc_join_securejoin(&bob, qr_stale).await?;
         let chat = Chat::load_from_db(&bob, claire_id).await?;
         assert!(!claire_id.is_special());
         assert_eq!(chat.typ, Chattype::Single);

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -248,19 +248,25 @@ async fn get_self_fingerprint(context: &Context) -> Option<Fingerprint> {
 pub enum JoinError {
     #[error("Unknown QR-code: {0}")]
     QrCode(#[from] QrError),
+
     #[error("A setup-contact/secure-join protocol is already running")]
     AlreadyRunning,
+
     #[error("An \"ongoing\" process is already running")]
     OngoingRunning,
+
     #[error("Failed to send handshake message: {0}")]
     SendMessage(#[from] SendMsgError),
+
     // Note that this can currently only occur if there is a bug in the QR/Lot code as this
     // is supposed to create a contact for us.
     #[error("Unknown contact (this is a bug): {0}")]
     UnknownContact(#[source] anyhow::Error),
+
     // Note that this can only occur if we failed to create the chat correctly.
     #[error("Ongoing sender dropped (this is a bug)")]
     OngoingSenderDropped,
+
     #[error("Other")]
     Other(#[from] anyhow::Error),
 }

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -105,7 +105,8 @@ impl Bob {
     ) -> Result<StartedProtocolVariant, JoinError> {
         let mut guard = self.inner.lock().await;
         if guard.is_some() {
-            return Err(JoinError::AlreadyRunning);
+            warn!(context, "The new securejoin will replace the ongoing one.");
+            *guard = None;
         }
         let variant = match invite {
             QrInvite::Group { ref grpid, .. } => {

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -250,9 +250,6 @@ pub enum JoinError {
     #[error("Unknown QR-code: {0}")]
     QrCode(#[from] QrError),
 
-    #[error("A setup-contact/secure-join protocol is already running")]
-    AlreadyRunning,
-
     #[error("An \"ongoing\" process is already running")]
     OngoingRunning,
 


### PR DESCRIPTION
as already pointed out at #2611, the issue was that a stale/running secure-join/setup-contact made any subsequent joins unusable.

this pr aborts any existing secure-join/setup-contact, as it is also described [in the docs ("Subsequent calls of dc_join_securejoin() will abort unfinished tasks")](https://c.delta.chat/classdc__context__t.html#ae49176cbc26d4d40d52de4f5301d1fa7)

nb: calls to stop_ongoing_process() does not help, however, in case of setup-contact the function is not blocking anyway (and the same is [planned for secure-join](https://github.com/deltachat/deltachat-core-rust/pull/2508))

fixes #2611