### PR TITLE
Fix: Don't update quota in an endless loop

### DIFF
--- a/src/quota.rs
+++ b/src/quota.rs
@@ -110,12 +110,13 @@ pub fn needs_quota_warning(curr_percentage: u64, warned_at_percentage: u64) -> b
 impl Context {
     // Adds a job to update `quota.recent`
     pub(crate) async fn schedule_quota_update(&self) -> Result<()> {
-        job::kill_action(self, Action::UpdateRecentQuota).await?;
-        job::add(
-            self,
-            job::Job::new(Action::UpdateRecentQuota, 0, Params::new(), 0),
-        )
-        .await?;
+        if !job::action_exists(self, Action::UpdateRecentQuota).await? {
+            job::add(
+                self,
+                job::Job::new(Action::UpdateRecentQuota, 0, Params::new(), 0),
+            )
+            .await?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
The problem was:
When opening the connectivity view while there is no network,
get_connectivity_html() calls schedule_quota_update(), which schedules a
UpdateRecentQuota job. But in update_recent_quota(), connecting fails
and a ConnectivityChanged event is emitted (connectivity changes from
Error to Connecting and back). Therefore the UI calls
get_connectivity_html() again, and the loop is complete.

This made the UI completely unresponsible. To reproduce, just turn wi-fi
off and open the connectivity view.

The fix is:
schedule_quota_update() now only schedules a new job if there is no old
job. To prevent the possible (though probably unlikely) problem that an
old quota update job has a backoff of, like, a day and therefore quota
is not updated, I reduced the backoff time for quota jobs to 10s.

Fixes possibly https://github.com/deltachat/deltachat-android/issues/2043, but we should "re-try" this