### PR TITLE
Start making it possible to write to mailing lists

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1063,11 +1063,12 @@ impl Chat {
 
     /// Returns true if user can send messages to this chat.
     pub async fn can_send(&self, context: &Context) -> Result<bool> {
-        Ok(!self.id.is_special()
-            && !self.is_device_talk()
-            && !self.is_contact_request()
-            && !(self.is_mailing_list() && self.param.get(Param::ListPost).is_none_or_empty())
-            && self.is_self_in_chat(context).await?)
+        let cannot_send = self.id.is_special()
+            || self.is_device_talk()
+            || self.is_contact_request()
+            || (self.is_mailing_list() && self.param.get(Param::ListPost).is_none_or_empty())
+            || !self.is_self_in_chat(context).await?;
+        Ok(!cannot_send)
     }
 
     /// Checks if the user is part of a chat

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1066,7 +1066,7 @@ impl Chat {
         Ok(!self.id.is_special()
             && !self.is_device_talk()
             && !self.is_contact_request()
-            && (!self.is_mailing_list() || self.param.get(Param::ListPost).is_some())
+            && !(self.is_mailing_list() && self.param.get(Param::ListPost).is_none_or_empty())
             && self.is_self_in_chat(context).await?)
     }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -225,10 +225,11 @@ impl ChatId {
         grpname: impl AsRef<str>,
         create_blocked: Blocked,
         create_protected: ProtectionStatus,
+        param: Option<String>,
     ) -> Result<Self> {
         let row_id =
             context.sql.insert(
-                "INSERT INTO chats (type, name, grpid, blocked, created_timestamp, protected) VALUES(?, ?, ?, ?, ?, ?);",
+                "INSERT INTO chats (type, name, grpid, blocked, created_timestamp, protected, param) VALUES(?, ?, ?, ?, ?, ?, ?);",
                 paramsv![
                     chattype,
                     grpname.as_ref(),
@@ -236,6 +237,7 @@ impl ChatId {
                     create_blocked,
                     dc_create_smeared_timestamp(context).await,
                     create_protected,
+                    param.unwrap_or_default(),
                 ],
             ).await?;
 
@@ -1063,8 +1065,8 @@ impl Chat {
     pub async fn can_send(&self, context: &Context) -> Result<bool> {
         Ok(!self.id.is_special()
             && !self.is_device_talk()
-            && !self.is_mailing_list()
             && !self.is_contact_request()
+            && (!self.is_mailing_list() || self.param.get(Param::ListPost).is_some())
             && self.is_self_in_chat(context).await?)
     }
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3124,7 +3124,7 @@ mod tests {
         chat_id.accept(&t).await.unwrap();
         let chat = Chat::load_from_db(&t.ctx, chat_id).await.unwrap();
         assert_eq!(chat.name, "delta-dev");
-        assert!(chat.can_send(&t).await.unwrap());
+        assert!(chat.can_send(&t).await?);
 
         let msg = get_chat_msg(&t, chat_id, 0, 1).await;
         let contact1 = Contact::load_from_db(&t.ctx, msg.from_id).await.unwrap();

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3005,6 +3005,7 @@ mod tests {
     Subject: Let's put some [brackets here that] have nothing to do with the topic\n\
     Message-ID: <3333@example.org>\n\
     List-ID: deltachat/deltachat-core-rust <deltachat-core-rust.deltachat.github.com>\n\
+    List-Post: <mailto:reply+ELERNSHSETUSHOYSESHETIHSEUSAFERUHSEDTISNEU@reply.github.com>
     Precedence: list\n\
     Date: Sun, 22 Mar 2020 22:37:57 +0000\n\
     \n\
@@ -3017,6 +3018,7 @@ mod tests {
     Subject: [deltachat/deltachat-core-rust] PR run failed\n\
     Message-ID: <3334@example.org>\n\
     List-ID: deltachat/deltachat-core-rust <deltachat-core-rust.deltachat.github.com>\n\
+    List-Post: <mailto:reply+EGELITBABIHXSITUZIEPAKYONASITEPUANERGRUSHE@reply.github.com>
     Precedence: list\n\
     Date: Sun, 22 Mar 2020 22:37:57 +0000\n\
     \n\
@@ -3042,6 +3044,9 @@ mod tests {
         assert_eq!(chat::get_chat_contacts(&t.ctx, chat_id).await?.len(), 1);
 
         dc_receive_imf(&t.ctx, GH_MAILINGLIST2, "INBOX", false).await?;
+
+        let chat = chat::Chat::load_from_db(&t.ctx, chat_id).await?;
+        assert!(!chat.can_send(&t.ctx).await?);
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await?;
         assert_eq!(chats.len(), 1);
@@ -3128,6 +3133,12 @@ Hello mailinglist!\r\n\
 -- \r\n\
 Sent with my Delta Chat Messenger: https://delta.chat\r\n"
         ));
+
+        dc_receive_imf(&t.ctx, DC_MAILINGLIST2, "INBOX", 2, false).await?;
+
+        let chat = chat::Chat::load_from_db(&t.ctx, chat_id).await?;
+        assert!(chat.can_send(&t.ctx).await?);
+
         Ok(())
     }
 
@@ -3263,6 +3274,8 @@ Sent with my Delta Chat Messenger: https://delta.chat\r\n"
 
         let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0, None).await.unwrap();
         assert_eq!(msgs.len(), 2);
+        let chat = chat::Chat::load_from_db(&t.ctx, chat_id).await.unwrap();
+        assert!(chat.can_send(&t.ctx).await.unwrap());
     }
 
     #[async_std::test]

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1766,8 +1766,10 @@ async fn create_or_lookup_mailinglist(
         let (contact_id, _) =
             Contact::add_or_lookup(context, "", list_post, Origin::Hidden).await?;
         let mut contact = Contact::load_from_db(context, contact_id).await?;
-        contact.param.set(Param::ListPost, &listid);
-        contact.update_param(context).await?;
+        if contact.param.get(Param::ListPost) != Some(&listid) {
+            contact.param.set(Param::ListPost, &listid);
+            contact.update_param(context).await?;
+        }
     }
 
     if let Some((chat_id, _, blocked)) = chat::get_chat_id_by_grpid(context, &listid).await? {

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -796,7 +796,7 @@ async fn add_parts(
                 } else {
                     Blocked::Request
                 };
-                if let Some(list_id) = to_contact.param.get(Param::ListPost) {
+                if let Some(list_id) = to_contact.param.get(Param::ListId) {
                     if let Some((id, _, blocked)) =
                         chat::get_chat_id_by_grpid(context, list_id).await?
                     {
@@ -1872,8 +1872,8 @@ async fn apply_mailinglist_changes(
         let (contact_id, _) =
             Contact::add_or_lookup(context, "", list_post, Origin::Hidden).await?;
         let mut contact = Contact::load_from_db(context, contact_id).await?;
-        if contact.param.get(Param::ListPost) != Some(listid) {
-            contact.param.set(Param::ListPost, &listid);
+        if contact.param.get(Param::ListId) != Some(listid) {
+            contact.param.set(Param::ListId, &listid);
             contact.update_param(context).await?;
         }
     }
@@ -3199,7 +3199,7 @@ Sent with my Delta Chat Messenger: https://delta.chat\r\n"
                 .unwrap();
         let list_post_contact = Contact::load_from_db(&t, list_post_contact_id).await?;
         assert_eq!(
-            list_post_contact.param.get(Param::ListPost).unwrap(),
+            list_post_contact.param.get(Param::ListId).unwrap(),
             "delta.codespeak.net"
         );
         assert_eq!(
@@ -3695,7 +3695,7 @@ Sent with my Delta Chat Messenger: https://delta.chat\r\n"
         .unwrap();
         let contact = Contact::load_from_db(&t, contact_id).await.unwrap();
         assert_eq!(
-            contact.param.get(Param::ListPost).unwrap(),
+            contact.param.get(Param::ListId).unwrap(),
             "deltachat-core-rust.deltachat.github.com"
         )
     }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1780,9 +1780,12 @@ async fn create_or_lookup_mailinglist(
                 if list_post != old_list_post {
                     // Apparently the mailing list is using a different List-Post header in each message.
                     // Make the mailing list read-only because we would't know which message the user wants to reply to.
-                    chat.param.remove(Param::ListPost);
+                    chat.param.set(Param::ListPost, "");
                     chat.update_param(context).await?;
                 }
+            } else {
+                chat.param.set(Param::ListPost, list_post);
+                chat.update_param(context).await?;
             }
         }
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3140,7 +3140,7 @@ mod tests {
         assert!(mime.contains("In-Reply-To: <38942@posteo.org>\r\n"));
         assert!(mime.contains("Chat-Version: 1.0\r\n"));
         assert!(mime.contains("To: <delta@codespeak.net>\r\n"));
-        assert!(mime.contains("From: <alice@example.com>\r\n"));
+        assert!(mime.contains("From: <alice@example.org>\r\n"));
         assert!(mime.contains(
             "\r\n\
 \r\n\
@@ -3191,10 +3191,10 @@ Sent with my Delta Chat Messenger: https://delta.chat\r\n"
         dc_receive_imf(
             &t,
             b"Received: (Postfix, from userid 1000); Mon, 4 Dec 2006 14:51:39 +0100 (CET)\n\
-            From: Alice <alice@example.com>\n\
+            From: Alice <alice@example.org>\n\
             To: delta@codespeak.net\n\
             Subject: [delta-dev] Subject\n\
-            Message-ID: <0476@example.com>\n\
+            Message-ID: <0476@example.org>\n\
             Date: Sun, 22 Mar 2020 22:37:57 +0000\n\
             \n\
             body 4\n",

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -3042,7 +3042,7 @@ mod tests {
     Subject: Let's put some [brackets here that] have nothing to do with the topic\n\
     Message-ID: <3333@example.org>\n\
     List-ID: deltachat/deltachat-core-rust <deltachat-core-rust.deltachat.github.com>\n\
-    List-Post: <mailto:reply+ELERNSHSETUSHOYSESHETIHSEUSAFERUHSEDTISNEU@reply.github.com>
+    List-Post: <mailto:reply+ELERNSHSETUSHOYSESHETIHSEUSAFERUHSEDTISNEU@reply.github.com>\n\
     Precedence: list\n\
     Date: Sun, 22 Mar 2020 22:37:57 +0000\n\
     \n\
@@ -3055,7 +3055,7 @@ mod tests {
     Subject: [deltachat/deltachat-core-rust] PR run failed\n\
     Message-ID: <3334@example.org>\n\
     List-ID: deltachat/deltachat-core-rust <deltachat-core-rust.deltachat.github.com>\n\
-    List-Post: <mailto:reply+EGELITBABIHXSITUZIEPAKYONASITEPUANERGRUSHE@reply.github.com>
+    List-Post: <mailto:reply+EGELITBABIHXSITUZIEPAKYONASITEPUANERGRUSHE@reply.github.com>\n\
     Precedence: list\n\
     Date: Sun, 22 Mar 2020 22:37:57 +0000\n\
     \n\
@@ -3076,7 +3076,7 @@ mod tests {
         let chat = chat::Chat::load_from_db(&t.ctx, chat_id).await?;
 
         assert!(chat.is_mailing_list());
-        assert_eq!(chat.can_send(&t.ctx).await?, false);
+        assert!(chat.can_send(&t.ctx).await?);
         assert_eq!(chat.name, "deltachat/deltachat-core-rust");
         assert_eq!(chat::get_chat_contacts(&t.ctx, chat_id).await?.len(), 1);
 
@@ -3171,7 +3171,7 @@ Hello mailinglist!\r\n\
 Sent with my Delta Chat Messenger: https://delta.chat\r\n"
         ));
 
-        dc_receive_imf(&t.ctx, DC_MAILINGLIST2, "INBOX", 2, false).await?;
+        dc_receive_imf(&t.ctx, DC_MAILINGLIST2, "INBOX", false).await?;
 
         let chat = chat::Chat::load_from_db(&t.ctx, chat_id).await?;
         assert!(chat.can_send(&t.ctx).await?);
@@ -3183,7 +3183,7 @@ Sent with my Delta Chat Messenger: https://delta.chat\r\n"
     async fn test_other_device_writes_to_mailinglist() -> Result<()> {
         let t = TestContext::new_alice().await;
         t.set_config(Config::ShowEmails, Some("2")).await?;
-        dc_receive_imf(&t, DC_MAILINGLIST, "INBOX", 1, false)
+        dc_receive_imf(&t, DC_MAILINGLIST, "INBOX", false)
             .await
             .unwrap();
         let first_msg = t.get_last_msg().await;
@@ -3220,7 +3220,6 @@ Sent with my Delta Chat Messenger: https://delta.chat\r\n"
             \n\
             body 4\n",
             "INBOX",
-            2,
             false,
         )
         .await

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1872,7 +1872,7 @@ async fn apply_mailinglist_changes(
         let (contact_id, _) =
             Contact::add_or_lookup(context, "", list_post, Origin::Hidden).await?;
         let mut contact = Contact::load_from_db(context, contact_id).await?;
-        if contact.param.get(Param::ListPost) != Some(&listid) {
+        if contact.param.get(Param::ListPost) != Some(listid) {
             contact.param.set(Param::ListPost, &listid);
             contact.update_param(context).await?;
         }

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -33,6 +33,7 @@ pub enum HeaderDef {
     XMozillaDraftInfo,
 
     ListId,
+    ListPost,
     References,
     InReplyTo,
     Precedence,

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -2,7 +2,7 @@
 
 use std::convert::TryInto;
 
-use anyhow::{bail, ensure, format_err, Result};
+use anyhow::{bail, ensure, format_err, Context as _, Result};
 use chrono::TimeZone;
 use lettre_email::{mime, Address, Header, MimeMultipartType, PartBuilder};
 
@@ -154,6 +154,12 @@ impl<'a> MimeFactory<'a> {
 
         if chat.is_self_talk() {
             recipients.push((from_displayname.to_string(), from_addr.to_string()));
+        } else if chat.is_mailing_list() {
+            let list_post = chat
+                .param
+                .get(Param::ListPost)
+                .context("Can't write to mailinglist without ListPost param")?;
+            recipients.push(("".to_string(), list_post.to_string()));
         } else {
             context
                 .sql

--- a/src/param.rs
+++ b/src/param.rs
@@ -113,6 +113,9 @@ pub enum Param {
     /// For Jobs: space-separated list of message recipients
     Recipients = b'R',
 
+    /// For MDN-sending job
+    MsgId = b'I',
+
     /// For Groups
     ///
     /// An unpromoted group has not had any messages sent to it and thus only exists on the
@@ -125,19 +128,6 @@ pub enum Param {
     /// For Groups and Contacts
     ProfileImage = b'i',
 
-    /// For Chats and Contacts
-    ///
-    /// For Chats: If this is a mailing list chat, contains the List-Post address.
-    /// None if there simply is no `List-Post` header in the mailing list.
-    /// Some("") if the mailing list is using multiple different List-Post headers.
-    ///
-    /// For Contacts: If this is the List-Post address of a mailing list, contains
-    /// the List-Id of the mailing list (which is also used as the group id of the chat).
-    ///
-    /// The List-Post address is the email address where the user can write to in order to
-    /// post something to the mailing list.
-    ListPost = b'p',
-
     /// For Chats
     Selftalk = b'K',
 
@@ -149,8 +139,17 @@ pub enum Param {
     /// For Chats
     Devicetalk = b'D',
 
-    /// For MDN-sending job
-    MsgId = b'I',
+    /// For Chats: If this is a mailing list chat, contains the List-Post address.
+    /// None if there simply is no `List-Post` header in the mailing list.
+    /// Some("") if the mailing list is using multiple different List-Post headers.
+    ///
+    /// The List-Post address is the email address where the user can write to in order to
+    /// post something to the mailing list.
+    ListPost = b'p',
+
+    /// For Contacts: If this is the List-Post address of a mailing list, contains
+    /// the List-Id of the mailing list (which is also used as the group id of the chat).
+    ListId = b's',
 
     /// For Contacts: timestamp of status (aka signature or footer) update.
     StatusTimestamp = b'j',

--- a/src/param.rs
+++ b/src/param.rs
@@ -125,6 +125,18 @@ pub enum Param {
     /// For Groups and Contacts
     ProfileImage = b'i',
 
+    /// For Chats and Contacts
+    ///
+    /// For Chats: If this is a mailing list chat, contains the List-Post address.
+    /// If it's empty, the mailing list is read-only.
+    ///
+    /// For Contacts: If this is the List-Post address of a mailing list, contains
+    /// the List-Id of the mailing list (which is also used as the group id of the chat).
+    ///
+    /// The List-Post address is the email address where the user can write to in order to
+    /// post something to the mailing list.
+    ListPost = b'p',
+
     /// For Chats
     Selftalk = b'K',
 
@@ -159,11 +171,6 @@ pub enum Param {
 
     /// For Chats: timestamp of protection settings update.
     ProtectionSettingsTimestamp = b'L',
-
-    /// For Chats: If this is a mailing list chat, contains the email address
-    /// the user can write to in order to post something to the mailing list.
-    /// If it's empty, the mailing list is read-only.
-    ListPost = b'p',
 }
 
 /// An object for handling key=value parameter lists.

--- a/src/param.rs
+++ b/src/param.rs
@@ -128,7 +128,8 @@ pub enum Param {
     /// For Chats and Contacts
     ///
     /// For Chats: If this is a mailing list chat, contains the List-Post address.
-    /// If it's empty, the mailing list is read-only.
+    /// None if there simply is no `List-Post` header in the mailing list.
+    /// Some("") if the mailing list is using multiple different List-Post headers.
     ///
     /// For Contacts: If this is the List-Post address of a mailing list, contains
     /// the List-Id of the mailing list (which is also used as the group id of the chat).

--- a/src/param.rs
+++ b/src/param.rs
@@ -159,6 +159,11 @@ pub enum Param {
 
     /// For Chats: timestamp of protection settings update.
     ProtectionSettingsTimestamp = b'L',
+
+    /// For Chats: If this is a mailing list chat, contains the email address
+    /// the user can write to in order to post something to the mailing list.
+    /// If it's empty, the mailing list is read-only.
+    ListPost = b'p',
 }
 
 /// An object for handling key=value parameter lists.

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -326,6 +326,7 @@ async fn securejoin(context: &Context, qr: &str) -> Result<ChatId, JoinError> {
                     group_name,
                     Blocked::Not,
                     ProtectionStatus::Unprotected, // protection is added later as needed
+                    None,
                 )
                 .await?
             };


### PR DESCRIPTION
See https://github.com/deltachat/deltachat-core-rust/issues/748, https://github.com/deltachat/deltachat-core-rust/pull/1964 and https://github.com/deltachat/deltachat-core-rust/blob/3ba4c6718e31fe89e3f921e12dc547cc61907c0c/draft/mailing_list_managers.md


---

Also fix https://github.com/deltachat/deltachat-core-rust/issues/2735

Currently there remains a small "bug", #2735 is not completely fixed, do you think we should fix this? -> @r10s said no
1. You need a mailing list where you never received an email from before. Write to this mailing list address using a normal MUA -> a 1:1 chat will be created
2. later receive a message from this mailing list -> a mailing list will be created
3. write to the mailing list again using a normal MUA or DC

Expected: The outgoing messages from step 1 should be moved into the mailing list chat created in step 2
Actual: The new outgoing messages from step 3 will now be shown in the mailing list chat, but the ones from step 1 will be stay in the 1:1 chat