### PR TITLE
Remove get_summarytext_by_raw to simplify api

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -30,7 +30,7 @@ use crate::mimeparser::{parse_message_id, FailureReport, SystemMessage};
 use crate::param::{Param, Params};
 use crate::pgp::split_armored_data;
 use crate::stock_str;
-use crate::summary::{get_summarytext_by_raw, Summary};
+use crate::summary::Summary;
 
 /// Message ID, including reserved IDs.
 ///
@@ -592,7 +592,7 @@ impl Message {
     }
 
     /// Returns message summary for display in the search results.
-    pub async fn get_summary(&mut self, context: &Context, chat: Option<&Chat>) -> Result<Summary> {
+    pub async fn get_summary(&self, context: &Context, chat: Option<&Chat>) -> Result<Summary> {
         let chat_loaded: Chat;
         let chat = if let Some(chat) = chat {
             chat
@@ -614,18 +614,6 @@ impl Message {
         };
 
         Ok(Summary::new(context, self, chat, contact.as_ref()).await)
-    }
-
-    pub async fn get_summarytext(&self, context: &Context, approx_characters: usize) -> String {
-        get_summarytext_by_raw(
-            self.viewtype,
-            self.text.as_ref(),
-            self.is_forwarded(),
-            &self.param,
-            approx_characters,
-            context,
-        )
-        .await
     }
 
     // It's a little unfortunate that the UI has to first call dc_msg_get_override_sender_name() and then if it was NULL, call
@@ -871,7 +859,11 @@ impl Message {
             Param::Quote,
             if text.is_empty() {
                 // Use summary, similar to "Image" to avoid sending empty quote.
-                quote.get_summarytext(context, 500).await
+                quote
+                    .get_summary(context, None)
+                    .await
+                    .unwrap_or_default()
+                    .text
             } else {
                 text
             },

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -12,10 +12,9 @@ use crate::config::Config;
 use crate::constants::{Chattype, Viewtype, DC_FROM_HANDSHAKE};
 use crate::contact::Contact;
 use crate::context::{get_version_str, Context};
-use crate::dc_tools::IsNoneOrEmpty;
 use crate::dc_tools::{
     dc_create_outgoing_rfc724_mid, dc_create_smeared_timestamp, dc_get_filebytes,
-    remove_subject_prefix, time,
+    remove_subject_prefix, time, IsNoneOrEmpty,
 };
 use crate::e2ee::EncryptHelper;
 use crate::ephemeral::Timer as EphemeralTimer;
@@ -1157,7 +1156,12 @@ impl<'a> MimeFactory<'a> {
         {
             stock_str::encrypted_msg(context).await
         } else {
-            self.msg.get_summarytext(context, 32).await
+            self.msg
+                .get_summary(context, None)
+                .await
+                .unwrap_or_default()
+                .truncated_text(32)
+                .into_owned()
         };
         let p2 = stock_str::read_rcpt_mail_body(context, p1).await;
         let message_text = format!("{}\r\n", format_flowed(&p2));

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -10,6 +10,7 @@ use crate::mimeparser::SystemMessage;
 use crate::param::{Param, Params};
 use crate::stock_str;
 use itertools::Itertools;
+use std::borrow::Cow;
 use std::fmt;
 
 // In practice, the user additionally cuts the string themselves
@@ -106,10 +107,21 @@ impl Summary {
             state: msg.state,
         }
     }
+
+    /// Returns the [`Summary::text`] attribute truncated to an approximate length.
+    pub fn truncated_text(&self, approx_chars: usize) -> Cow<str> {
+        if approx_chars >= SUMMARY_CHARACTERS {
+            // This is a micro-optimisation, without it dc_truncate() would have to count
+            // the chars in the text.
+            Cow::Borrowed(&self.text)
+        } else {
+            dc_truncate(&self.text, approx_chars)
+        }
+    }
 }
 
 /// Returns a summary text.
-pub async fn get_summarytext_by_raw(
+async fn get_summarytext_by_raw(
     viewtype: Viewtype,
     text: Option<impl AsRef<str>>,
     was_forwarded: bool,


### PR DESCRIPTION
This is an alternative to #2740.

There is little need for this function now, so reduce the API surface
instead.  Because the dc_truncate() function is not public the
truncate_text() method is needed for the FFI to keep offering the
interface with custom truncating.