### PR TITLE
Optimize Autocrypt gossip

### DIFF
--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -3,7 +3,7 @@
 import mimetypes
 import calendar
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 from .cutil import as_dc_charpointer, from_dc_charpointer, iter_array
 from .capi import lib, ffi
@@ -512,8 +512,9 @@ class Chat(object):
                 latitude=lib.dc_array_get_latitude(dc_array, i),
                 longitude=lib.dc_array_get_longitude(dc_array, i),
                 accuracy=lib.dc_array_get_accuracy(dc_array, i),
-                timestamp=datetime.utcfromtimestamp(
-                    lib.dc_array_get_timestamp(dc_array, i)
+                timestamp=datetime.fromtimestamp(
+                    lib.dc_array_get_timestamp(dc_array, i),
+                    timezone.utc
                 ),
                 marker=from_dc_charpointer(lib.dc_array_get_marker(dc_array, i)),
             )

--- a/python/src/deltachat/cutil.py
+++ b/python/src/deltachat/cutil.py
@@ -1,6 +1,6 @@
 from .capi import lib
 from .capi import ffi
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 def as_dc_charpointer(obj):
@@ -44,4 +44,4 @@ class DCLot:
         ts = lib.dc_lot_get_timestamp(self._dc_lot)
         if ts == 0:
             return None
-        return datetime.utcfromtimestamp(ts)
+        return datetime.fromtimestamp(ts, timezone.utc)

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -6,7 +6,7 @@ from . import props
 from .cutil import from_dc_charpointer, as_dc_charpointer
 from .capi import lib, ffi
 from . import const
-from datetime import datetime
+from datetime import datetime, timezone
 
 
 class Message(object):
@@ -170,7 +170,7 @@ class Message(object):
         :returns: naive datetime.datetime() object.
         """
         ts = lib.dc_msg_get_timestamp(self._dc_msg)
-        return datetime.utcfromtimestamp(ts)
+        return datetime.fromtimestamp(ts, timezone.utc)
 
     @props.with_doc
     def time_received(self):
@@ -180,7 +180,7 @@ class Message(object):
         """
         ts = lib.dc_msg_get_received_timestamp(self._dc_msg)
         if ts:
-            return datetime.utcfromtimestamp(ts)
+            return datetime.fromtimestamp(ts, timezone.utc)
 
     @props.with_doc
     def ephemeral_timer(self):
@@ -200,7 +200,7 @@ class Message(object):
         """
         ts = lib.dc_msg_get_ephemeral_timestamp(self._dc_msg)
         if ts:
-            return datetime.utcfromtimestamp(ts)
+            return datetime.fromtimestamp(ts, timezone.utc)
 
     @property
     def quoted_text(self):

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -10,7 +10,7 @@ from deltachat.tracker import ImexTracker
 from deltachat.hookspec import account_hookimpl
 from deltachat.capi import ffi, lib
 from deltachat.cutil import iter_array
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 
 @pytest.mark.parametrize("msgtext,res", [
@@ -447,7 +447,7 @@ class TestOfflineChat:
         contact1.create_chat().send_text("hello")
 
     def test_chat_message_distinctions(self, ac1, chat1):
-        past1s = datetime.utcnow() - timedelta(seconds=1)
+        past1s = datetime.now(timezone.utc) - timedelta(seconds=1)
         msg = chat1.send_text("msg1")
         ts = msg.time_sent
         assert msg.time_received is None
@@ -2163,7 +2163,7 @@ class TestOnlineAccount:
                 break  # DC is done with reading messages
 
     def test_send_receive_locations(self, acfactory, lp):
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         ac1, ac2 = acfactory.get_two_online_accounts()
 
         lp.sec("ac1: create chat with ac2")

--- a/src/job.rs
+++ b/src/job.rs
@@ -991,7 +991,7 @@ pub async fn send_msg_job(context: &Context, msg_id: MsgId) -> Result<Option<Job
     }
 
     if rendered_msg.is_gossiped {
-        chat::set_gossiped_timestamp(context, msg.chat_id, time()).await?;
+        msg.chat_id.set_gossiped_timestamp(context, time()).await?;
     }
 
     if 0 != rendered_msg.last_added_location_id {

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -361,7 +361,7 @@ impl<'a> MimeFactory<'a> {
         match &self.loaded {
             Loaded::Message { chat } => {
                 // beside key- and member-changes, force re-gossip every 48 hours
-                let gossiped_timestamp = chat.get_gossiped_timestamp(context).await?;
+                let gossiped_timestamp = chat.id.get_gossiped_timestamp(context).await?;
                 if time() > gossiped_timestamp + (2 * 24 * 60 * 60) {
                     Ok(true)
                 } else {


### PR DESCRIPTION
Update gossiped_timestamp when someone else sends autocrypt gossip in
the group, so we postpone sending gossip again ourselves.

- Warn about failures to parse Autocrypt-Gossip header
- Move gossip-related methods into ChatId impl
- Fix a "gossi_pp_ed" typo

Closes #1027