### PR TITLE
priorize CertificateChecks setting from user over the one from provider-db

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -280,8 +280,6 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
     progress!(ctx, 500);
 
     let mut servers = param_autoconfig.unwrap_or_default();
-
-    // in case of missing servers, add the ones given as function parameters
     if !servers
         .iter()
         .any(|server| server.protocol == Protocol::Imap)


### PR DESCRIPTION
before, `set_config("imap_certificate_checks")` or `set_config("smtp_certificate_checks")` were ignored in case something was loaded from the provider-db.

targets one point of https://github.com/deltachat/deltachat-core-rust/issues/2748