### PR TITLE
Get back stack traces and error messages when tests fail

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -108,12 +108,15 @@ impl TestContext {
         let (evtracker_sender, evtracker_receiver) = channel::unbounded();
 
         async_std::task::spawn(async move {
-            // Make sure that the test fails if there is a panic on this thread here:
-            let current_id = task::current().id();
+            // Make sure that the test fails if there is a panic on this thread here
+            // (but not if there is a panic on another thread)
+            let looptask_id = task::current().id();
             let orig_hook = panic::take_hook();
             panic::set_hook(Box::new(move |panic_info| {
-                if task::current().id() == current_id {
-                    poison_sender.try_send(panic_info.to_string()).ok();
+                if let Some(panicked_task) = task::try_current() {
+                    if panicked_task.id() == looptask_id {
+                        poison_sender.try_send(panic_info.to_string()).ok();
+                    }
                 }
                 orig_hook(panic_info);
             }));


### PR DESCRIPTION
Before this PR, when a test failed, we often got:

```
thread panicked while processing panic. aborting.
error: test failed, to rerun pass '-p deltachat --lib'

Caused by:
  process didn't exit successfully: `/home/user/deltachat-android/jni/deltachat-core-rust/target/debug/deps/deltachat-33648fc4aaad608c 'contact::tests::test_selfavatar_changed_event' --nocapture` (signal: 4, SIGILL: illegal instruction)
```

instead of the error message and stack trace.

This PR fixes this.

The problem was that `task::current()` panics if it is not within something async, and therefore we had a panic while handling a panic.