### PR TITLE
Modernize python setup

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2", "cffi>=1.0.0"]
+
+[tool.setuptools-scm]
+root = ".."
+tag_regex = '^(?P<prefix>py-)?(?P<version>[^\+]+)(?P<suffix>.*)?$'
+git_describe_command = "git describe --dirty --tags --long --match py-*.*"

--- a/python/setup.py
+++ b/python/setup.py
@@ -8,13 +8,6 @@ def main():
         long_description = f.read()
     setuptools.setup(
         name='deltachat',
-        setup_requires=['setuptools_scm', 'cffi>=1.0.0'],
-        use_scm_version = {
-            "root": "..",
-            "relative_to": __file__,
-            'tag_regex': r'^(?P<prefix>py-)?(?P<version>[^\+]+)(?P<suffix>.*)?$',
-            'git_describe_command': "git describe --dirty --tags --long --match py-*.*",
-        },
         description='Python bindings for the Delta Chat Core library using CFFI against the Rust-implemented libdeltachat',
         long_description=long_description,
         author='holger krekel, Floris Bruynooghe, Bjoern Petersen and contributors',

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -45,9 +45,8 @@ commands =
 [testenv:doc]
 changedir=doc
 deps =
-    # Pin dependencies to the versions which actually work with Python 3.5.
-    sphinx==3.4.3
-    breathe==4.28.0
+    sphinx
+    breathe
 commands =
     sphinx-build -Q -w toxdoc-warnings.log -b html . _build/html
 


### PR DESCRIPTION
Use pyproject.toml instead of deprecated setup.py arguments and unpin dependencies in tox.ini.