### PR TITLE
Stop using the `hidden` column for incoming messages

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -497,9 +497,11 @@ async fn add_parts(
             securejoin_seen = false;
         }
 
-        let test_normal_chat = ChatIdBlocked::lookup_by_contact(context, from_id)
-            .await
-            .unwrap_or_default();
+        let test_normal_chat = if from_id == 0 {
+            Default::default()
+        } else {
+            ChatIdBlocked::lookup_by_contact(context, from_id).await?
+        };
 
         if chat_id.is_none() && mime_parser.failure_report.is_some() {
             chat_id = Some(DC_CHAT_ID_TRASH);

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -854,11 +854,12 @@ async fn add_parts(
 
     // Apply ephemeral timer changes to the chat.
     //
-    // Only non-hidden timers are applied. Timers from hidden
-    // messages such as read receipts can be useful to detect
-    // ephemeral timer support, but timer changes without visible
-    // received messages may be confusing to the user.
-    if !location_kml_is && !is_mdn && chat_id.get_ephemeral_timer(context).await? != ephemeral_timer
+    // Only apply the timer when there are visible parts (e.g., the message does not consist only
+    // of `location.kml` attachment).  Timer changes without visible received messages may be
+    // confusing to the user.
+    if !chat_id.is_special()
+        && !mime_parser.parts.is_empty()
+        && chat_id.get_ephemeral_timer(context).await? != ephemeral_timer
     {
         info!(
             context,


### PR DESCRIPTION
See commit messages for description, there are multiple commits further refactoring `dc_receive_imf` module.

Outgoing messages still use the `hidden` column, e.g, in `send_handshake_message` and `send_sync_msg`.