### PR TITLE
Fix dc_truncate proptest

### DIFF
--- a/proptest-regressions/dc_tools.txt
+++ b/proptest-regressions/dc_tools.txt
@@ -7,3 +7,5 @@
 cc c310754465ee0261807b96fa9bcc4861ff9aa286e94667524b5960c69f9b6620 # shrinks to buf = "", approx_chars = 0, do_unwrap = false
 cc 5fd8d730b0a9cdf7308ce58818ca9aefc0255c9ba2a0878944fc48d43a67315b # shrinks to buf = "𑒀ὐ￠🜀\u{1e01b}A a🟠", approx_chars = 0, do_unwrap = false
 cc c6a0029a54137a4b9efc9ef2ea6d9a7dd1d60d1c937bb472b66a174618ba8013 # shrinks to buf = "𐠈0Aᝮa𫝀®!ꫛa¡0A𐢧00𐹠®A  丽ⷐએ  ", approx_chars = 0, do_unwrap = false
+cc 9796807baeda701227dcdcfc9fdaa93ddd556da2bb1630381bfe2e037bee73f6 # shrinks to buf = " ꫛ®a\u{11300}a", approx_chars = 0
+cc 063a4c42ac1ec9aa37af54521b210ba9cd82dcc9cc3be296ca2fedf8240072d4 # shrinks to buf = "a᪠  0A", approx_chars = 0

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -844,22 +844,18 @@ mod tests {
         #[test]
         fn test_dc_truncate(
             buf: String,
-            approx_chars in 0..10000usize
+            approx_chars in 0..100usize
         ) {
             let res = dc_truncate(&buf, approx_chars);
             let el_len = 5;
             let l = res.chars().count();
-            if approx_chars > 0 {
-                assert!(
-                    l <= approx_chars + el_len,
-                    "buf: '{}' - res: '{}' - len {}, approx {}",
-                    &buf, &res, res.len(), approx_chars
-                );
-            } else {
-                assert_eq!(&res, &buf);
-            }
+            assert!(
+                l <= approx_chars + el_len,
+                "buf: '{}' - res: '{}' - len {}, approx {}",
+                &buf, &res, res.len(), approx_chars
+            );
 
-            if approx_chars > 0 && buf.chars().count() > approx_chars + el_len {
+            if buf.chars().count() > approx_chars + el_len {
                 let l = res.len();
                 assert_eq!(&res[l-5..l], "[...]", "missing ellipsis in {}", &res);
             }


### PR DESCRIPTION
It was failing for approx_chars = 0.

Also reduce approx_chars range so approx_chars = 0 is tested more frequently.