### PR TITLE
fix permanently hiding of one-to-one chats after secure-join

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -266,7 +266,7 @@ impl ChatId {
     /// Updates chat blocked status.
     ///
     /// Returns true if the value was modified.
-    async fn set_blocked(self, context: &Context, new_blocked: Blocked) -> Result<bool> {
+    pub(crate) async fn set_blocked(self, context: &Context, new_blocked: Blocked) -> Result<bool> {
         if self.is_special() {
             bail!("ignoring setting of Block-status for {}", self);
         }

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -664,11 +664,12 @@ async fn add_parts(
             }
 
             if let Some(chat_id) = chat_id {
-                if Blocked::Not != chat_id_blocked {
-                    if Blocked::Not == create_blocked {
-                        chat_id.unblock(context).await?;
-                        chat_id_blocked = Blocked::Not;
-                    } else if parent.is_some() {
+                if chat_id_blocked != Blocked::Not {
+                    if chat_id_blocked != create_blocked {
+                        chat_id.set_blocked(context, create_blocked).await?;
+                        chat_id_blocked = create_blocked;
+                    }
+                    if create_blocked == Blocked::Request && parent.is_some() {
                         // we do not want any chat to be created implicitly.  Because of the origin-scale-up,
                         // the contact requests will pop up and this should be just fine.
                         Contact::scaleup_origin_by_id(context, from_id, Origin::IncomingReplyTo)
@@ -806,9 +807,9 @@ async fn add_parts(
                 }
 
                 if let Some(chat_id) = chat_id {
-                    if Blocked::Not != chat_id_blocked && Blocked::Not == create_blocked {
-                        chat_id.unblock(context).await?;
-                        chat_id_blocked = Blocked::Not;
+                    if chat_id_blocked != Blocked::Not && chat_id_blocked != create_blocked {
+                        chat_id.set_blocked(context, create_blocked).await?;
+                        chat_id_blocked = create_blocked;
                     }
                 }
             }

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -930,7 +930,7 @@ mod tests {
     use async_std::prelude::*;
 
     use crate::chat;
-    use crate::chat::{send_text_msg, ProtectionStatus};
+    use crate::chat::ProtectionStatus;
     use crate::chatlist::Chatlist;
     use crate::constants::Chattype;
     use crate::events::Event;
@@ -939,7 +939,7 @@ mod tests {
     use std::time::Duration;
 
     #[async_std::test]
-    async fn test_setup_contact_x() -> Result<()> {
+    async fn test_setup_contact() -> Result<()> {
         let alice = TestContext::new_alice().await;
         let bob = TestContext::new_bob().await;
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
@@ -1471,8 +1471,7 @@ mod tests {
 
         // If Bob then sends a direct message to alice, however, the one-to-one with Alice should appear.
         let bobs_chat_with_alice = bob.create_chat(&alice).await;
-        send_text_msg(&bob, bobs_chat_with_alice.id, "Hello".to_string()).await?;
-        let sent = bob.pop_sent_msg().await;
+        let sent = bob.send_text(bobs_chat_with_alice.id, "Hello").await;
         alice.recv_msg(&sent).await;
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 2);
         assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 2);

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -499,6 +499,12 @@ pub(crate) async fn handle_securejoin_handshake(
 
             inviter_progress!(context, contact_id, 300);
 
+            // for setup-contact, make Alice's one-to-one chat with Bob visible
+            // (secure-join-information are shown in the group chat)
+            if !join_vg {
+                ChatId::create_for_contact(context, contact_id).await?;
+            }
+
             // Alice -> Bob
             send_alice_handshake_msg(
                 context,
@@ -933,7 +939,7 @@ mod tests {
     use std::time::Duration;
 
     #[async_std::test]
-    async fn test_setup_contact() -> Result<()> {
+    async fn test_setup_contact_x() -> Result<()> {
         let alice = TestContext::new_alice().await;
         let bob = TestContext::new_bob().await;
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);


### PR DESCRIPTION
fixes #2790 

see commit messages for detailed information and reasoning.