### PR TITLE
Factor `apply_group_changes` out of `create_or_lookup_group`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- prioritize In-Reply-To: and References: headers over group IDs when assigning
+  messages to chats to fix incorrect assignment of Delta Chat replies to
+  classic email threads #2795
+
+
 ## 1.63.0
 
 ### API changes


### PR DESCRIPTION
`apply_group_changes` is executed regardless of whether the group is
created via `create_or_lookup_group` or found via
`lookup_chat_by_reply`. This change removes the need for
`lookup_chat_by_reply` to return `None` when group ID exists in the
database to let `create_or_lookup_group` run. As a side effect of this
Delta Chat replies to ad hoc groups are now correctly assigned to
chats when there are multiple groups with the same group ID, such as
ad hoc groups with the same member lists.

Fixes #2573