### PR TITLE
prepare 1.63

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.63.0
+
+### API changes
+- `dc_get_last_error()` added #2788
+
+### Changes
+- Optimize Autocrypt gossip #2743
+
+### Fixes
+- fix permanently hiding of one-to-one chats after secure-join #2791
+
+
 ## 1.62.0
 
 ### API Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.62.0"
+version = "1.63.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.62.0"
+version = "1.63.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.62.0"
+version = "1.63.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"


### PR DESCRIPTION
bug-fix-release of core62, mainly because of #2791

after commit, on master make sure to: 

   git tag -a 1.63.0
   git push origin 1.63.0
   git tag -a py-1.63.0
   git push origin py-1.63.0