### PR TITLE
prepare 1.64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## Unreleased
+## 1.64.0
 
 ### Fixes
+- add 'waiting for being added to the group' only for group-joins,
+  not for setup-contact #2797
 - prioritize In-Reply-To: and References: headers over group IDs when assigning
   messages to chats to fix incorrect assignment of Delta Chat replies to
   classic email threads #2795

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.63.0"
+version = "1.64.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.63.0"
+version = "1.64.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.63.0"
+version = "1.64.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.63.0"
+version = "1.64.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"


### PR DESCRIPTION
this is a bugfix release for 1.63 and is mainly needed for the fix #2797, which is quite user-visible.

for the refactoring of the other commits between 1.63 an 1.64 - i think, that needs some testing. however, an 1.24.3 that is first released for the testers only is planned anyway (because of several android changes and fixes), so it is probably fine.

afaik, no further blocking core-bugs were found during the first testing round of 1.24.

after commit, on master make sure to: 

   git tag -a 1.64.0
   git push origin 1.64.0
   git tag -a py-1.64.0
   git push origin py-1.64.0