### PR TITLE
Fix: Only show the "Cannot login" device message if it's actually authentication that failed

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -361,6 +361,7 @@ impl Imap {
 
                 let lock = context.wrong_pw_warning_mutex.lock().await;
                 if self.login_failed_once
+                    && err.to_string().to_lowercase().contains("authentication")
                     && context.get_config_bool(Config::NotifyAboutWrongPw).await?
                 {
                     if let Err(e) = context.set_config(Config::NotifyAboutWrongPw, None).await {


### PR DESCRIPTION
It happened twice to me now that this device message was shown even though my password is correct.

Generally we could also just remove the device message as we have the
connectivity view, OTOH if you are not using DC a lot, it may be useful
to be notified without opening DC.

And apart from this one bug it's working fine.