### PR TITLE
python: add mypy support and some type hints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,4 +150,4 @@ jobs:
         DCC_RS_TARGET: debug
         DCC_RS_DEV: ${{ github.workspace }}
       working-directory: python
-      run: tox -e lint,doc,py3
+      run: tox -e lint,mypy,doc,py3

--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -1,0 +1,19 @@
+[mypy]
+
+[mypy-deltachat.capi.*]
+ignore_missing_imports = True
+
+[mypy-pluggy.*]
+ignore_missing_imports = True
+
+[mypy-cffi.*]
+ignore_missing_imports = True
+
+[mypy-imapclient.*]
+ignore_missing_imports = True
+
+[mypy-pytest.*]
+ignore_missing_imports = True
+
+[mypy-_pytest.*]
+ignore_missing_imports = True

--- a/python/src/deltachat/__init__.py
+++ b/python/src/deltachat/__init__.py
@@ -19,9 +19,9 @@ except DistributionNotFound:
 
 def get_dc_event_name(integer, _DC_EVENTNAME_MAP={}):
     if not _DC_EVENTNAME_MAP:
-        for name, val in vars(const).items():
+        for name in dir(const):
             if name.startswith("DC_EVENT_"):
-                _DC_EVENTNAME_MAP[val] = name
+                _DC_EVENTNAME_MAP[getattr(const, name)] = name
     return _DC_EVENTNAME_MAP[integer]
 
 

--- a/python/src/deltachat/const.py
+++ b/python/src/deltachat/const.py
@@ -1,7 +1,13 @@
+from typing import Any, List
+
 from .capi import lib
 
 
-for name in dir(lib):
+def __getattr__(name: str) -> Any:
     if name.startswith("DC_"):
-        globals()[name] = getattr(lib, name)
-del name
+        return getattr(lib, name)
+    return globals()[name]
+
+
+def __dir__() -> List[str]:
+    return sorted(name for name in dir(lib) if name.startswith("DC_"))

--- a/python/src/deltachat/cutil.py
+++ b/python/src/deltachat/cutil.py
@@ -1,6 +1,9 @@
 from .capi import lib
 from .capi import ffi
 from datetime import datetime, timezone
+from typing import Optional, TypeVar, Generator, Callable
+
+T = TypeVar('T')
 
 
 def as_dc_charpointer(obj):
@@ -11,21 +14,22 @@ def as_dc_charpointer(obj):
     return obj
 
 
-def iter_array(dc_array_t, constructor):
+def iter_array(dc_array_t, constructor: Callable[[int], T]) -> Generator[T, None, None]:
     for i in range(0, lib.dc_array_get_cnt(dc_array_t)):
         yield constructor(lib.dc_array_get_id(dc_array_t, i))
 
 
-def from_dc_charpointer(obj):
+def from_dc_charpointer(obj) -> Optional[str]:
     if obj != ffi.NULL:
         return ffi.string(ffi.gc(obj, lib.dc_str_unref)).decode("utf8")
+    return None
 
 
 class DCLot:
-    def __init__(self, dc_lot):
+    def __init__(self, dc_lot) -> None:
         self._dc_lot = dc_lot
 
-    def id(self):
+    def id(self) -> int:
         return lib.dc_lot_get_id(self._dc_lot)
 
     def state(self):

--- a/python/src/deltachat/direct_imap.py
+++ b/python/src/deltachat/direct_imap.py
@@ -11,7 +11,7 @@ from imapclient import IMAPClient
 from imapclient.exceptions import IMAPClientError
 import imaplib
 import deltachat
-from deltachat import const
+from deltachat import const, Account
 
 
 SEEN = b'\\Seen'
@@ -62,7 +62,7 @@ def dc_account_after_shutdown(account):
 
 
 class DirectImap:
-    def __init__(self, account):
+    def __init__(self, account: Account) -> None:
         self.account = account
         self.logid = account.get_config("displayname") or id(account)
         self._idling = False

--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -13,7 +13,7 @@ from .cutil import from_dc_charpointer
 
 
 class FFIEvent:
-    def __init__(self, name, data1, data2):
+    def __init__(self, name: str, data1, data2):
         self.name = name
         self.data1 = data1
         self.data2 = data2
@@ -29,13 +29,13 @@ class FFIEventLogger:
     # to prevent garbled logging
     _loglock = threading.RLock()
 
-    def __init__(self, account):
+    def __init__(self, account) -> None:
         self.account = account
         self.logid = self.account.get_config("displayname")
         self.init_time = time.time()
 
     @account_hookimpl
-    def ac_process_ffi_event(self, ffi_event):
+    def ac_process_ffi_event(self, ffi_event: FFIEvent) -> None:
         self.account.log(str(ffi_event))
 
     @account_hookimpl
@@ -69,7 +69,7 @@ class FFIEventTracker:
         self._event_queue = Queue()
 
     @account_hookimpl
-    def ac_process_ffi_event(self, ffi_event):
+    def ac_process_ffi_event(self, ffi_event: FFIEvent):
         self._event_queue.put(ffi_event)
 
     def set_timeout(self, timeout):
@@ -96,7 +96,7 @@ class FFIEventTracker:
             if rex.match(ev.name):
                 return ev
 
-    def get_info_contains(self, regex):
+    def get_info_contains(self, regex: str) -> FFIEvent:
         rex = re.compile(regex)
         while 1:
             ev = self.get_matching("DC_EVENT_INFO")
@@ -176,6 +176,7 @@ class FFIEventTracker:
         ev = self.get_matching("DC_EVENT_MSGS_CHANGED")
         if ev.data2 > 0:
             return self.account.get_message_by_id(ev.data2)
+        return None
 
     def wait_msg_delivered(self, msg):
         ev = self.get_matching("DC_EVENT_MSG_DELIVERED")
@@ -189,7 +190,7 @@ class EventThread(threading.Thread):
 
     With each Account init this callback thread is started.
     """
-    def __init__(self, account):
+    def __init__(self, account) -> None:
         self.account = account
         super(EventThread, self).__init__(name="events")
         self.setDaemon(True)
@@ -202,17 +203,17 @@ class EventThread(threading.Thread):
         yield
         self.account.log(message + " FINISHED")
 
-    def mark_shutdown(self):
+    def mark_shutdown(self) -> None:
         self._marked_for_shutdown = True
 
-    def wait(self, timeout=None):
+    def wait(self, timeout=None) -> None:
         if self == threading.current_thread():
             # we are in the callback thread and thus cannot
             # wait for the thread-loop to finish.
             return
         self.join(timeout=timeout)
 
-    def run(self):
+    def run(self) -> None:
         """ get and run events until shutdown. """
         with self.log_execution("EVENT THREAD"):
             self._inner_run()
@@ -250,7 +251,7 @@ class EventThread(threading.Thread):
                 if self.account._dc_context is not None:
                     raise
 
-    def _map_ffi_event(self, ffi_event):
+    def _map_ffi_event(self, ffi_event: FFIEvent):
         name = ffi_event.name
         account = self.account
         if name == "DC_EVENT_CONFIGURE_PROGRESS":

--- a/python/src/deltachat/provider.py
+++ b/python/src/deltachat/provider.py
@@ -14,7 +14,7 @@ class Provider(object):
     :param domain: The email to get the provider info for.
     """
 
-    def __init__(self, account, addr):
+    def __init__(self, account, addr) -> None:
         provider = ffi.gc(
             lib.dc_provider_new_from_email(account._dc_context, as_dc_charpointer(addr)),
             lib.dc_provider_unref,

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -3,6 +3,7 @@ isolated_build = true
 envlist =
     py3
     lint
+    mypy
     auditwheels
 
 [testenv]
@@ -42,6 +43,15 @@ commands =
     flake8 src/deltachat
     flake8 tests/ examples/
     rst-lint --encoding 'utf-8' README.rst
+
+[testenv:mypy]
+deps =
+    mypy
+    typing
+    types-setuptools
+    types-requests
+commands =
+    mypy --no-incremental src/
 
 [testenv:doc]
 changedir=doc


### PR DESCRIPTION
`deltachat.const` module now defines `__getattr__` and `__dir__` as
suggested by https://www.python.org/dev/peps/pep-0562/
mypy detects that `__getattr__` is defined and does not show errors
for `DC_*` constants which cannot be detected statically.
mypy is added to `tox.ini`, so type check can be run with `tox -e mypy`.