### PR TITLE
contact: use `last_seen` column

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4383,6 +4383,16 @@ uint32_t        dc_contact_get_color         (const dc_contact_t* contact);
 char*           dc_contact_get_status        (const dc_contact_t* contact);
 
 /**
+ * Get the contact's last seen timestamp.
+ *
+ * @memberof dc_contact_t
+ * @param contact The contact object.
+ * @return Last seen timestamp.
+ *     0 on error or if the contact was never seen.
+ */
+int64_t         dc_contact_get_last_seen     (const dc_contact_t* contact);
+
+/**
  * Check if a contact is blocked.
  *
  * To block or unblock a contact, use dc_block_contact().

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3545,6 +3545,16 @@ pub unsafe extern "C" fn dc_contact_get_status(contact: *mut dc_contact_t) -> *m
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_contact_get_last_seen(contact: *mut dc_contact_t) -> i64 {
+    if contact.is_null() {
+        eprintln!("ignoring careless call to dc_contact_get_last_seen()");
+        return 0;
+    }
+    let ffi_contact = &*contact;
+    ffi_contact.contact.last_seen()
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_contact_is_blocked(contact: *mut dc_contact_t) -> libc::c_int {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_is_blocked()");

--- a/python/src/deltachat/contact.py
+++ b/python/src/deltachat/contact.py
@@ -1,11 +1,12 @@
 """ Contact object. """
 
-from . import props
-from .cutil import from_dc_charpointer, from_optional_dc_charpointer
-from .capi import lib, ffi
-from .chat import Chat
-from . import const
+from datetime import date, datetime, timezone
 from typing import Optional
+
+from . import const, props
+from .capi import ffi, lib
+from .chat import Chat
+from .cutil import from_dc_charpointer, from_optional_dc_charpointer
 
 
 class Contact(object):
@@ -47,6 +48,13 @@ class Contact(object):
 
     # deprecated alias
     display_name = name
+
+    @props.with_doc
+    def last_seen(self) -> date:
+        """Last seen timestamp."""
+        return datetime.fromtimestamp(
+            lib.dc_contact_get_last_seen(self._dc_contact), timezone.utc
+        )
 
     def is_blocked(self):
         """ Return True if the contact is blocked. """

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -216,6 +216,10 @@ pub(crate) async fn dc_receive_imf_inner(
     .await
     .map_err(|err| err.context("add_parts error"))?;
 
+    if from_id > DC_CONTACT_ID_LAST_SPECIAL {
+        contact::update_last_seen(context, from_id, sent_timestamp).await?;
+    }
+
     // Update gossiped timestamp for the chat if someone else or our other device sent
     // Autocrypt-Gossip for all recipients in the chat to avoid sending Autocrypt-Gossip ourselves
     // and waste traffic.


### PR DESCRIPTION
It was there since the C core, labeled with "/* last_seen is for
future use */" but never actually used. The comment was lost during
the translation from C to Rust.