### PR TITLE
tweak qr svg

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -755,7 +755,12 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
         "groupname" => {
             ensure!(sel_chat.is_some(), "No chat selected.");
             ensure!(!arg1.is_empty(), "Argument <name> missing.");
-            chat::set_chat_name(&context, sel_chat.as_ref().unwrap().get_id(), arg1).await?;
+            chat::set_chat_name(
+                &context,
+                sel_chat.as_ref().unwrap().get_id(),
+                &format!("{} {}", arg1, arg2).trim(),
+            )
+            .await?;
 
             println!("Chat name set");
         }

--- a/src/qr_code_generator.rs
+++ b/src/qr_code_generator.rs
@@ -146,7 +146,7 @@ fn inner_generate_secure_join_qr_code(
         } else {
             BIG_TEXT_CHARS_PER_LINE
         };
-        let lines = textwrap::fill(&qrcode_description, chars_per_line);
+        let lines = textwrap::fill(qrcode_description, chars_per_line);
         let (text_font_size, text_y_shift) = if lines.split('\n').count() <= 2 {
             (27.0, 0.0)
         } else {

--- a/src/qr_code_generator.rs
+++ b/src/qr_code_generator.rs
@@ -80,11 +80,6 @@ fn inner_generate_secure_join_qr_code(
     let qr_code_size = 400.0;
     let qr_translate_up = 40.0;
     let text_y_pos = ((height - qr_code_size) / 2.0) + qr_code_size;
-    let (text_font_size, max_text_width) = if qrcode_description.len() <= 75 {
-        (27.0, 32)
-    } else {
-        (19.0, 38)
-    };
     let avatar_border_size = 9.0;
     let card_border_size = 2.0;
     let card_roundness = 40.0;
@@ -142,10 +137,22 @@ fn inner_generate_secure_join_qr_code(
                     .attr("transform", format!("scale({})", scale));
             });
         });
+
         // Text
-        for (count, line) in textwrap::fill(qrcode_description, max_text_width)
-            .split('\n')
-            .enumerate()
+        const BIG_TEXT_CHARS_PER_LINE: usize = 32;
+        const SMALL_TEXT_CHARS_PER_LINE: usize = 38;
+        let chars_per_line = if qrcode_description.len() > SMALL_TEXT_CHARS_PER_LINE*2 {
+            SMALL_TEXT_CHARS_PER_LINE
+        } else {
+            BIG_TEXT_CHARS_PER_LINE
+        };
+        let lines = textwrap::fill(&qrcode_description, chars_per_line);
+        let text_font_size = if lines.split('\n').count() <= 2 {
+            27.0
+        } else {
+            19.0
+        };
+        for (count, line) in lines.split('\n').enumerate()
         {
             w.elem("text", |d| {
                 d.attr("y", (count as f32 * (text_font_size * 1.2)) + text_y_pos)

--- a/src/qr_code_generator.rs
+++ b/src/qr_code_generator.rs
@@ -147,15 +147,15 @@ fn inner_generate_secure_join_qr_code(
             BIG_TEXT_CHARS_PER_LINE
         };
         let lines = textwrap::fill(&qrcode_description, chars_per_line);
-        let text_font_size = if lines.split('\n').count() <= 2 {
-            27.0
+        let (text_font_size, text_y_shift) = if lines.split('\n').count() <= 2 {
+            (27.0, 0.0)
         } else {
-            19.0
+            (19.0, -10.0)
         };
         for (count, line) in lines.split('\n').enumerate()
         {
             w.elem("text", |d| {
-                d.attr("y", (count as f32 * (text_font_size * 1.2)) + text_y_pos)
+                d.attr("y", (count as f32 * (text_font_size * 1.2)) + text_y_pos + text_y_shift)
                     .attr("x", width / 2.0)
                     .attr("text-anchor", "middle")
                     .attr(
@@ -256,7 +256,7 @@ fn inner_generate_secure_join_qr_code(
                 format!(
                     "translate({},{})",
                     (width - FOOTER_WIDTH) / 2.0,
-                    height - logo_offset - FOOTER_HEIGHT
+                    height - logo_offset - FOOTER_HEIGHT - text_y_shift
                 ),
             );
         })


### PR DESCRIPTION
closes #2837, see commit messages for details

things are fine in most common cases now, even yggmail addresses with longer names. 

if things get to more than 4 lines (yggmail-plus :) the text runs over the watermark, however, well, then the watermark is a watermark :)