### PR TITLE
Add option to force E2EE encryption preference

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -287,6 +287,8 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    To save traffic, however, the avatar is attached only as needed
  *                    and also recoded to a reasonable size.
  * - `e2ee_enabled` = 0=no end-to-end-encryption, 1=prefer end-to-end-encryption (default)
+ * - `e2ee_force`   = 1=ignore encryption preferences of others,
+ *                    0=use majority vote when deciding whether to encrypt (default).
  * - `mdns_enabled` = 0=do not send or request read receipts,
  *                    1=send and request read receipts (default)
  * - `bcc_self`     = 0=do not send a copy of outgoing messages to self (default),

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,13 @@ pub enum Config {
     #[strum(props(default = "1"))]
     E2eeEnabled,
 
+    /// Ignore Autocrypt recommendation for message encryption if possible.
+    ///
+    /// The only expection is when recommendation is "disable", i.e. encryption is not possible
+    /// because some recipient has no OpenPGP key.
+    #[strum(props(default = "0"))]
+    E2eeForce,
+
     #[strum(props(default = "1"))]
     MdnsEnabled,
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -307,6 +307,7 @@ impl Context {
             .await?
             .unwrap_or_else(|| "unknown".to_string());
         let e2ee_enabled = self.get_config_int(Config::E2eeEnabled).await?;
+        let e2ee_force = self.get_config_int(Config::E2eeForce).await?;
         let mdns_enabled = self.get_config_int(Config::MdnsEnabled).await?;
         let bcc_self = self.get_config_int(Config::BccSelf).await?;
         let send_sync_msgs = self.get_config_int(Config::SendSyncMsgs).await?;
@@ -394,6 +395,7 @@ impl Context {
         res.insert("configured_mvbox_folder", configured_mvbox_folder);
         res.insert("mdns_enabled", mdns_enabled.to_string());
         res.insert("e2ee_enabled", e2ee_enabled.to_string());
+        res.insert("e2ee_force", e2ee_force.to_string());
         res.insert(
             "key_gen_type",
             self.get_config_int(Config::KeyGenType).await?.to_string(),


### PR DESCRIPTION
Enabling this option ignores Autocrypt recommendation taking others encryption preferences into account and overrides it with our own encryption preference when possible.

This is similar to user always manually enabling/disabling encryption manually in a classic Autocrypt-capable MUA UI whenever the control is not disabled.

The goal is to allow encrypting responses to MUAs which can send Autocrypt header but don't support setting encryption preference, such as Thunderbird 91: https://support.delta.chat/t/fyi-receiving-encrypted-autocrypt-messages-without-prefer-encrypt-set-to-anything/1923