### PR TITLE
Add `dc_msg_force_plaintext()` API for bots

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4217,6 +4217,15 @@ char*           dc_msg_get_quoted_text        (const dc_msg_t* msg);
  */
 dc_msg_t*       dc_msg_get_quoted_msg         (const dc_msg_t* msg);
 
+/**
+ * Force the message to be sent in plain text.
+ *
+ * This API is for bots, there is no need to expose it in the UI.
+ *
+ * @memberof dc_msg_t
+ * @param msg The message object.
+ */
+void            dc_msg_force_plaintext        (dc_msg_t* msg);
 
 /**
  * @class dc_contact_t

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3435,6 +3435,16 @@ pub unsafe extern "C" fn dc_msg_get_quoted_msg(msg: *const dc_msg_t) -> *mut dc_
     }
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn dc_msg_force_plaintext(msg: *mut dc_msg_t) {
+    if msg.is_null() {
+        eprintln!("ignoring careless call to dc_msg_force_plaintext()");
+        return;
+    }
+    let ffi_msg = &mut *msg;
+    ffi_msg.message.force_plaintext();
+}
+
 // dc_contact_t
 
 /// FFI struct for [dc_contact_t]

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -225,6 +225,10 @@ class Message(object):
         """Quote setter"""
         lib.dc_msg_set_quote(self._dc_msg, quoted_message._dc_msg)
 
+    def force_plaintext(self) -> None:
+        """Force the message to be sent in plain text."""
+        lib.dc_msg_force_plaintext(self._dc_msg)
+
     def get_mime_headers(self):
         """ return mime-header object for an incoming message.
 

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -502,7 +502,7 @@ Sent with my Delta Chat Messenger: https://delta.chat";
 
         // Alice sends plaintext message with Autocrypt header.
         let mut msg = Message::new(Viewtype::Text);
-        msg.param.set_int(Param::ForcePlaintext, 1);
+        msg.force_plaintext();
         chat::prepare_msg(&alice.ctx, chat_alice, &mut msg).await?;
         chat::send_msg(&alice.ctx, chat_alice, &mut msg).await?;
         let sent = alice.pop_sent_msg().await;
@@ -516,7 +516,7 @@ Sent with my Delta Chat Messenger: https://delta.chat";
 
         // Alice sends plaintext message without Autocrypt header.
         let mut msg = Message::new(Viewtype::Text);
-        msg.param.set_int(Param::ForcePlaintext, 1);
+        msg.force_plaintext();
         msg.param.set_int(Param::SkipAutocrypt, 1);
         chat::prepare_msg(&alice.ctx, chat_alice, &mut msg).await?;
         chat::send_msg(&alice.ctx, chat_alice, &mut msg).await?;

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -238,7 +238,7 @@ async fn do_initiate_key_transfer(context: &Context) -> Result<String> {
     msg.param
         .set(Param::MimeType, "application/autocrypt-setup");
     msg.param.set_cmd(SystemMessage::AutocryptSetupMessage);
-    msg.param.set_int(Param::ForcePlaintext, 1);
+    msg.force_plaintext();
     msg.param.set_int(Param::SkipAutocrypt, 1);
 
     let msg_id = chat::send_msg(context, chat_id, &mut msg).await?;

--- a/src/message.rs
+++ b/src/message.rs
@@ -893,6 +893,11 @@ impl Message {
         Ok(None)
     }
 
+    /// Force the message to be sent in plain text.
+    pub fn force_plaintext(&mut self) {
+        self.param.set_int(Param::ForcePlaintext, 1);
+    }
+
     pub async fn update_param(&self, context: &Context) {
         context
             .sql

--- a/src/securejoin/bobstate.rs
+++ b/src/securejoin/bobstate.rs
@@ -422,7 +422,7 @@ impl BobState {
             BobHandshakeMsg::Request => {
                 // Sends the Secure-Join-Invitenumber header in mimefactory.rs.
                 msg.param.set(Param::Arg2, self.invite.invitenumber());
-                msg.param.set_int(Param::ForcePlaintext, 1);
+                msg.force_plaintext();
             }
             BobHandshakeMsg::RequestWithAuth => {
                 // Sends the Secure-Join-Auth header in mimefactory.rs.


### PR DESCRIPTION
This will allow implementing a special command for download bot to request that it sends back the downloaded file unencrypted.