### PR TITLE
fix missing MX resolver eg. on android

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3753,7 +3753,11 @@ pub unsafe extern "C" fn dc_provider_new_from_email(
 
     match socks5_enabled {
         Ok(socks5_enabled) => {
-            match block_on(provider::get_provider_info(addr.as_str(), socks5_enabled)) {
+            match block_on(provider::get_provider_info(
+                ctx,
+                addr.as_str(),
+                socks5_enabled,
+            )) {
                 Some(provider) => provider,
                 None => ptr::null_mut(),
             }

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -1185,7 +1185,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             let socks5_enabled = context
                 .get_config_bool(config::Config::Socks5Enabled)
                 .await?;
-            match provider::get_provider_info(arg1, socks5_enabled).await {
+            match provider::get_provider_info(&context, arg1, socks5_enabled).await {
                 Some(info) => {
                     println!("Information for provider belonging to {}:", arg1);
                     println!("status: {}", info.status as u32);

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -221,7 +221,9 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
             "checking internal provider-info for offline autoconfig"
         );
 
-        if let Some(provider) = provider::get_provider_info(&param_domain, socks5_enabled).await {
+        if let Some(provider) =
+            provider::get_provider_info(ctx, &param_domain, socks5_enabled).await
+        {
             param.provider = Some(provider);
             match provider.status {
                 provider::Status::Ok | provider::Status::Preparation => {

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -4,7 +4,9 @@ mod data;
 
 use crate::config::Config;
 use crate::provider::data::{PROVIDER_DATA, PROVIDER_IDS, PROVIDER_UPDATED};
-use async_std_resolver::resolver_from_system_conf;
+use async_std_resolver::{
+    config, resolver, resolver_from_system_conf, AsyncStdResolver, ResolveError,
+};
 use chrono::{NaiveDateTime, NaiveTime};
 
 #[derive(Debug, Display, Copy, Clone, PartialEq, FromPrimitive, ToPrimitive)]
@@ -81,6 +83,22 @@ pub struct Provider {
     pub oauth2_authorizer: Option<Oauth2Authorizer>,
 }
 
+/// Get resolver to query MX records.
+///
+/// We first try resolver_from_system_conf() which reads the system's resolver from `/etc/resolv.conf`.
+/// This does not work at least on some Androids, therefore we use use ResolverConfig::default()
+/// which default eg. to google's 8.8.8.8 or 8.8.4.4 as a fallback.
+async fn get_resolver() -> Result<AsyncStdResolver, ResolveError> {
+    if let Ok(resolver) = resolver_from_system_conf().await {
+        return Ok(resolver);
+    }
+    resolver(
+        config::ResolverConfig::default(),
+        config::ResolverOpts::default(),
+    )
+    .await
+}
+
 /// Returns provider for the given domain.
 ///
 /// This function looks up domain in offline database first. If not
@@ -118,7 +136,7 @@ pub fn get_provider_by_domain(domain: &str) -> Option<&'static Provider> {
 ///
 /// For security reasons, only Gmail can be configured this way.
 pub async fn get_provider_by_mx(domain: &str) -> Option<&'static Provider> {
-    if let Ok(resolver) = resolver_from_system_conf().await {
+    if let Ok(resolver) = get_resolver().await {
         let mut fqdn: String = domain.to_string();
         if !fqdn.ends_with('.') {
             fqdn.push('.');
@@ -169,6 +187,7 @@ mod tests {
 
     use super::*;
     use crate::dc_tools::time;
+    use anyhow::Result;
     use chrono::NaiveDate;
 
     #[test]
@@ -241,5 +260,11 @@ mod tests {
             / 1_000;
         assert!(get_provider_update_timestamp() <= time());
         assert!(get_provider_update_timestamp() > timestamp_past);
+    }
+
+    #[async_std::test]
+    async fn test_get_resolver() -> Result<()> {
+        assert!(get_resolver().await.is_ok());
+        Ok(())
     }
 }


### PR DESCRIPTION
switching completely to /etc/resolv.conf (see #2780)
does not work at least on some Androids
(see https://github.com/deltachat/deltachat-android/issues/2151 )

therefore, we use the old approach as a fallback.

fixes https://github.com/deltachat/deltachat-android/issues/2151

@link2xt i am not deep in that stuff, maybe there is a more elegant solution or sth. to tweak upstream, however, this one works :) (tested on android)

for review: the fix is in the first commit, the second one only adds a warning - and introduces some noise as we have to pass context around.