### PR TITLE
use anyhow-result for get_resolver

### DIFF
--- a/src/provider.rs
+++ b/src/provider.rs
@@ -5,8 +5,9 @@ mod data;
 use crate::config::Config;
 use crate::context::Context;
 use crate::provider::data::{PROVIDER_DATA, PROVIDER_IDS, PROVIDER_UPDATED};
+use anyhow::Result;
 use async_std_resolver::{
-    config, resolver, resolver_from_system_conf, AsyncStdResolver, ResolveError,
+    config, resolver, resolver_from_system_conf, AsyncStdResolver,
 };
 use chrono::{NaiveDateTime, NaiveTime};
 
@@ -89,7 +90,7 @@ pub struct Provider {
 /// We first try resolver_from_system_conf() which reads the system's resolver from `/etc/resolv.conf`.
 /// This does not work at least on some Androids, therefore we use use ResolverConfig::default()
 /// which default eg. to google's 8.8.8.8 or 8.8.4.4 as a fallback.
-async fn get_resolver() -> Result<AsyncStdResolver, ResolveError> {
+async fn get_resolver() -> Result<AsyncStdResolver> {
     if let Ok(resolver) = resolver_from_system_conf().await {
         return Ok(resolver);
     }
@@ -98,6 +99,7 @@ async fn get_resolver() -> Result<AsyncStdResolver, ResolveError> {
         config::ResolverOpts::default(),
     )
     .await
+    .map_err(|err| err.into())
 }
 
 /// Returns provider for the given domain.
@@ -195,7 +197,6 @@ mod tests {
     use super::*;
     use crate::dc_tools::time;
     use crate::test_utils::TestContext;
-    use anyhow::Result;
     use chrono::NaiveDate;
 
     #[test]

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -6,9 +6,7 @@ use crate::config::Config;
 use crate::context::Context;
 use crate::provider::data::{PROVIDER_DATA, PROVIDER_IDS, PROVIDER_UPDATED};
 use anyhow::Result;
-use async_std_resolver::{
-    config, resolver, resolver_from_system_conf, AsyncStdResolver,
-};
+use async_std_resolver::{config, resolver, resolver_from_system_conf, AsyncStdResolver};
 use chrono::{NaiveDateTime, NaiveTime};
 
 #[derive(Debug, Display, Copy, Clone, PartialEq, FromPrimitive, ToPrimitive)]
@@ -94,12 +92,12 @@ async fn get_resolver() -> Result<AsyncStdResolver> {
     if let Ok(resolver) = resolver_from_system_conf().await {
         return Ok(resolver);
     }
-    resolver(
+    let resolver = resolver(
         config::ResolverConfig::default(),
         config::ResolverOpts::default(),
     )
-    .await
-    .map_err(|err| err.into())
+    .await?;
+    Ok(resolver)
 }
 
 /// Returns provider for the given domain.


### PR DESCRIPTION
successor of https://github.com/deltachat/deltachat-core-rust/pull/2852 to focus more on that: @link2xt is `map_err()` the correct way to convert to an Anyhow result? or better use `?` (seems more handy to me, indeed :)

(tbh, i also like to have one pr for myself as reference for anyhow :)

(i know, that it may also be better to log the error at another level, but that may need larger changes)