### PR TITLE
Fix unread count

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1429,15 +1429,16 @@ class TestOnlineAccount:
         ac1_clone.create_chat(ac2)
 
         lp.sec("Send a first message from ac2 to ac1 and check that it's 'fresh'")
-        ac2.create_chat(ac1).send_text("Hi")
+        first_msg_id = ac2.create_chat(ac1).send_text("Hi")
         ac1._evtracker.wait_next_incoming_message()
         assert ac1.create_chat(ac2).count_fresh_messages() == 1
         assert len(list(ac1.get_fresh_messages())) == 1
 
         lp.sec("Send a message from ac1_clone to ac2 and check that ac1 marks the first message as 'noticed'")
         ac1_clone.create_chat(ac2).send_text("Hi back")
-        ac1._evtracker.get_matching("DC_EVENT_MSGS_NOTICED")
+        ev = ac1._evtracker.get_matching("DC_EVENT_MSGS_NOTICED")
 
+        assert ev.data1 == first_msg_id.id
         assert ac1.create_chat(ac2).count_fresh_messages() == 0
         assert len(list(ac1.get_fresh_messages())) == 0
 

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1413,6 +1413,34 @@ class TestOnlineAccount:
         assert msg2.text == "subj – message in Drafts that is moved to Sent later"
         assert len(msg.chat.get_messages()) == 2
 
+    def test_no_old_msg_is_fresh(self, acfactory, lp):
+        ac1 = acfactory.get_online_configuring_account()
+        ac2 = acfactory.get_online_configuring_account()
+        ac1_clone = acfactory.clone_online_account(ac1)
+        acfactory.wait_configure_and_start_io()
+
+        ac1.set_config("e2ee_enabled", "0")
+        ac1_clone.set_config("e2ee_enabled", "0")
+        ac2.set_config("e2ee_enabled", "0")
+
+        ac1_clone.set_config("bcc_self", "1")
+
+        ac1.create_chat(ac2)
+        ac1_clone.create_chat(ac2)
+
+        lp.sec("Send a first message from ac2 to ac1 and check that it's 'fresh'")
+        ac2.create_chat(ac1).send_text("Hi")
+        ac1._evtracker.wait_next_incoming_message()
+        assert ac1.create_chat(ac2).count_fresh_messages() == 1
+        assert len(list(ac1.get_fresh_messages())) == 1
+
+        lp.sec("Send a message from ac1_clone to ac2 and check that ac1 marks the first message as 'noticed'")
+        ac1_clone.create_chat(ac2).send_text("Hi back")
+        ac1._evtracker.get_matching("DC_EVENT_MSGS_NOTICED")
+
+        assert ac1.create_chat(ac2).count_fresh_messages() == 0
+        assert len(list(ac1.get_fresh_messages())) == 0
+
     def test_prefer_encrypt(self, acfactory, lp):
         """Test quorum rule for encryption preference in 1:1 and group chat."""
         ac1, ac2, ac3 = acfactory.get_many_online_accounts(3)

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2151,9 +2151,12 @@ pub(crate) async fn mark_old_messages_as_noticed(
     context: &Context,
     mut msgs: Vec<ReceivedMsg>,
 ) -> Result<()> {
-    let mut msgs_by_chat: HashMap<ChatId, ReceivedMsg> = HashMap::new();
-
     msgs.retain(|m| m.state.is_outgoing());
+    if msgs.is_empty() {
+        return Ok(());
+    }
+
+    let mut msgs_by_chat: HashMap<ChatId, ReceivedMsg> = HashMap::new();
     for msg in msgs {
         let chat_id = msg.chat_id;
         if let Some(existing_msg) = msgs_by_chat.get(&chat_id) {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2147,6 +2147,12 @@ pub async fn marknoticed_chat(context: &Context, chat_id: ChatId) -> Result<()> 
     Ok(())
 }
 
+/// Marks messages preceding outgoing messages as noticed.
+///
+/// In a chat, if there is an outgoing message, it can be assumed that all previous
+/// messages were noticed. So, this function takes a Vec of messages that were
+/// just received, and for all the outgoing messages, it marks all
+/// previous messages as noticed.
 pub(crate) async fn mark_old_messages_as_noticed(
     context: &Context,
     mut msgs: Vec<ReceivedMsg>,

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -42,9 +42,10 @@ enum CreateEvent {
     IncomingMsg,
 }
 
-/// Return type of dc_receive_imf() and dc_receive_imf_inner().
-/// Contains exactly the information about the received message
-/// that's useful for its callers to know.
+/// This is the struct that is returned after receiving one email (aka MIME message).
+///
+/// One email with multiple attachments can end up as multiple chat messages, but they
+/// all have the same chat_id, state and sort_timestamp.
 #[derive(Debug)]
 pub struct ReceivedMsg {
     pub chat_id: ChatId,

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -231,15 +231,12 @@ pub(crate) async fn dc_receive_imf_inner(
         contact::update_last_seen(context, from_id, sent_timestamp).await?;
     }
 
-    let received_msg = match received_msg {
-        Some(m) => m,
-        None => return Ok(None),
-    };
-
     // Update gossiped timestamp for the chat if someone else or our other device sent
     // Autocrypt-Gossip for all recipients in the chat to avoid sending Autocrypt-Gossip ourselves
     // and waste traffic.
-    let chat_id = received_msg.chat_id;
+    let chat_id = received_msg
+        .as_ref()
+        .map_or(DC_CHAT_ID_TRASH, |received_msg| received_msg.chat_id);
     if !chat_id.is_special()
         && mime_parser
             .recipients
@@ -389,7 +386,7 @@ pub(crate) async fn dc_receive_imf_inner(
         .handle_reports(context, from_id, sent_timestamp, &mime_parser.parts)
         .await;
 
-    Ok(Some(received_msg))
+    Ok(received_msg)
 }
 
 /// Converts "From" field to contact id.

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -56,8 +56,14 @@ pub struct ReceivedMsg {
 /// Receive a message and add it to the database.
 ///
 /// Returns an error on recoverable errors, e.g. database errors. In this case,
-/// message parsing should be retried later. If message itself is wrong, logs
-/// the error and returns success.
+/// message parsing should be retried later.
+///
+/// If message itself is wrong, logs
+/// the error and returns success:
+/// - If possible, creates a database entry to prevent the message from being
+///   downloaded again, sets `chat_id=DC_CHAT_ID_TRASH` and returns `Ok(Some(…))`
+/// - If the message is so wrong that we didn't even create a database entry,
+///   returns `Ok(None)`
 pub async fn dc_receive_imf(
     context: &Context,
     imf_raw: &[u8],

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -50,7 +50,7 @@ pub struct ReceivedMsg {
     pub chat_id: ChatId,
     pub state: MessageState,
     pub sort_timestamp: i64,
-    // Feel free to add more fiedlds here
+    // Feel free to add more fields here
 }
 
 /// Receive a message and add it to the database.

--- a/src/download.rs
+++ b/src/download.rs
@@ -173,7 +173,7 @@ impl Imap {
         info!(context, "Downloading message {}/{} fully...", folder, uid);
 
         let (_, error_cnt) = self
-            .fetch_many_msgs(context, folder, vec![uid], false, false)
+            .fetch_many_msgs(context, folder, vec![uid], false, false, &mut Vec::new())
             .await;
         if error_cnt > 0 {
             return ImapActionResult::Failed;

--- a/src/download.rs
+++ b/src/download.rs
@@ -172,8 +172,8 @@ impl Imap {
         // we are connected, and the folder is selected
         info!(context, "Downloading message {}/{} fully...", folder, uid);
 
-        let (_, error_cnt) = self
-            .fetch_many_msgs(context, folder, vec![uid], false, false, &mut Vec::new())
+        let (_, error_cnt, _) = self
+            .fetch_many_msgs(context, folder, vec![uid], false, false)
             .await;
         if error_cnt > 0 {
             return ImapActionResult::Failed;

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -776,12 +776,7 @@ impl Imap {
             );
         }
 
-        let ctx = context.clone();
-        async_std::task::spawn(async move {
-            chat::mark_old_messages_as_noticed(&ctx, received_msgs)
-                .await
-                .log_err(&ctx, "Failed to mark old messages as noticed");
-        });
+        chat::mark_old_messages_as_noticed(&ctx, received_msgs).await?;
 
         Ok(read_cnt > 0)
     }

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -25,7 +25,6 @@ use crate::dc_tools::dc_extract_grpid_from_rfc724_mid;
 use crate::events::EventType;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
 use crate::job::{self, Action};
-use crate::log::LogExt;
 use crate::login_param::{CertificateChecks, LoginParam, ServerLoginParam};
 use crate::login_param::{ServerAddress, Socks5Config};
 use crate::message::{self, update_server_uid, MessageState};
@@ -776,7 +775,7 @@ impl Imap {
             );
         }
 
-        chat::mark_old_messages_as_noticed(&ctx, received_msgs).await?;
+        chat::mark_old_messages_as_noticed(context, received_msgs).await?;
 
         Ok(read_cnt > 0)
     }


### PR DESCRIPTION
When there is an outgoing message in a chat, mark all older messages in this chat as seen.

Android already has a similar behavior, however, this led to the issue https://github.com/deltachat/deltachat-android/issues/2163 and should be changed back.

--

From the issue description at https://github.com/deltachat/deltachat-android/issues/2163, I implemented these fixes:
> Core should take care that if the last message in a chat is not fresh|noticed, no messages in the chat can be fresh. [...] Do this [...] in a function that's called at the end of fetch_new_messages(). Then dc_receive_imf() wouldn't get slower by this and we could re-use the same function for migration.

So, I didn't do this inside `dc_receive_imf()` in order not to make it take even longer. This obviously has the downside of higher complexity.

And I think we should implement this:
> On Androd, show the unread badge when unread!=0 again (see deltachat/deltachat-android@618af02). Then the user can see that there is a chat with an unread message and click it to get rid of it. 

because it shouldn't be the UI's job to decide whether an unread badge is shown, but the core's.