### PR TITLE
Remove wrong comment in add_parts

### DIFF
--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -912,8 +912,6 @@ async fn add_parts(
         EphemeralTimer::Disabled
     };
 
-    // correct message_timestamp, it should not be used before,
-    // however, we cannot do this earlier as we need chat_id to be set
     let in_fresh = state == MessageState::InFresh;
     let sort_timestamp = calc_sort_timestamp(context, sent_timestamp, chat_id, in_fresh).await?;
 


### PR DESCRIPTION
There is no mutable `message_timestamp` variable anymore, it's obvious now that `sort_timestamp` isn't used before, and no one will try to compute the `sort_timestamp` before we have the `chat_id` because this would give a compiler error.