### PR TITLE
do not change the draft's message-id on updates and sending

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3369,7 +3369,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_delete_draft() -> Result<()> {
-        let t = TestContext::new().await;
+        let t = TestContext::new_alice().await;
         let chat_id = create_group_chat(&t, ProtectionStatus::Unprotected, "abc").await?;
 
         let mut msg = Message::new(Viewtype::Text);

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1853,9 +1853,6 @@ async fn prepare_msg_common(
     msg: &mut Message,
     change_state_to: MessageState,
 ) -> Result<MsgId> {
-    prepare_msg_blob(context, msg).await?;
-    chat_id.unarchive(context).await?;
-
     let mut chat = Chat::load_from_db(context, chat_id).await?;
     ensure!(chat.can_send(context).await?, "cannot send to {}", chat_id);
 
@@ -1874,6 +1871,8 @@ async fn prepare_msg_common(
     // ... then change the MessageState in the message object
     msg.state = change_state_to;
 
+    prepare_msg_blob(context, msg).await?;
+    chat_id.unarchive(context).await?;
     msg.id = chat
         .prepare_msg_raw(
             context,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3004,11 +3004,10 @@ pub async fn forward_msgs(context: &Context, msg_ids: &[MsgId], chat_id: ChatId)
 
             let new_msg_id: MsgId;
             if msg.state == MessageState::OutPreparing {
-                let fresh9 = curr_timestamp;
-                curr_timestamp += 1;
                 new_msg_id = chat
-                    .prepare_msg_raw(context, &mut msg, None, fresh9)
+                    .prepare_msg_raw(context, &mut msg, None, curr_timestamp)
                     .await?;
+                curr_timestamp += 1;
                 let save_param = msg.param.clone();
                 msg.param = original_param;
                 msg.id = src_msg_id;
@@ -3025,11 +3024,10 @@ pub async fn forward_msgs(context: &Context, msg_ids: &[MsgId], chat_id: ChatId)
                 msg.param = save_param;
             } else {
                 msg.state = MessageState::OutPending;
-                let fresh10 = curr_timestamp;
-                curr_timestamp += 1;
                 new_msg_id = chat
-                    .prepare_msg_raw(context, &mut msg, None, fresh10)
+                    .prepare_msg_raw(context, &mut msg, None, curr_timestamp)
                     .await?;
+                curr_timestamp += 1;
                 if let Some(send_job) = job::send_msg_job(context, new_msg_id).await? {
                     job::add(context, send_job).await?;
                 }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2978,6 +2978,10 @@ pub async fn forward_msgs(context: &Context, msg_ids: &[MsgId], chat_id: ChatId)
         for id in ids {
             let src_msg_id: MsgId = id;
             let mut msg = Message::load_from_db(context, src_msg_id).await?;
+            if msg.state == MessageState::OutDraft {
+                bail!("cannot forward drafts.");
+            }
+
             let original_param = msg.param.clone();
 
             // we tested a sort of broadcast
@@ -2999,9 +3003,7 @@ pub async fn forward_msgs(context: &Context, msg_ids: &[MsgId], chat_id: ChatId)
             msg.subject = "".to_string();
 
             let new_msg_id: MsgId;
-            if msg.state == MessageState::OutDraft {
-                bail!("cannot forward drafts.");
-            } else if msg.state == MessageState::OutPreparing {
+            if msg.state == MessageState::OutPreparing {
                 let fresh9 = curr_timestamp;
                 curr_timestamp += 1;
                 new_msg_id = chat

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3285,6 +3285,27 @@ mod tests {
     }
 
     #[async_std::test]
+    async fn test_delete_draft() -> Result<()> {
+        let t = TestContext::new().await;
+        let chat_id = create_group_chat(&t, ProtectionStatus::Unprotected, "abc").await?;
+
+        let mut msg = Message::new(Viewtype::Text);
+        msg.set_text(Some("hi!".to_string()));
+        chat_id.set_draft(&t, Some(&mut msg)).await?;
+        assert!(chat_id.get_draft(&t).await?.is_some());
+
+        let mut msg = Message::new(Viewtype::Text);
+        msg.set_text(Some("another".to_string()));
+        chat_id.set_draft(&t, Some(&mut msg)).await?;
+        assert!(chat_id.get_draft(&t).await?.is_some());
+
+        chat_id.set_draft(&t, None).await?;
+        assert!(chat_id.get_draft(&t).await?.is_none());
+
+        Ok(())
+    }
+
+    #[async_std::test]
     async fn test_draft_stable_ids() -> Result<()> {
         let t = TestContext::new().await;
         let chat_id = &t.get_self_chat().await.id;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -627,7 +627,7 @@ impl ChatId {
     }
 
     /// Set provided message as draft message for specified chat.
-    /// Returns true on changes.
+    /// Returns true if the draft was added or updated in place.
     async fn do_set_draft(self, context: &Context, msg: &mut Message) -> Result<bool> {
         match msg.viewtype {
             Viewtype::Unknown => bail!("Can not set draft of unknown type."),
@@ -1210,6 +1210,11 @@ impl Chat {
         }
     }
 
+    /// Adds missing values to the msg object,
+    /// writes the record to the database and returns its msg_id.
+    ///
+    /// If `update_msg_id` is set, that record is reused;
+    /// if `update_msg_id` is None, a new record is created.
     async fn prepare_msg_raw(
         &mut self,
         context: &Context,


### PR DESCRIPTION
needed for #2826 

in short, web30 needs the msg_id not to change when finally sending a draft - this is because already in draft-mode, updates are assigned to the msg_id.

however, that seems to be a good idea in general, eg. there were always thoughts about adding blob-meta-data to a special table - that would run into the same issues as w30.

the single commit messages show some more details and the pr also adds some tests wrt drafts.

for review, it makes sense to hide whitespace.

- [x] do not change message-id on updating drafts
- [x] do not change message-id on finally sending drafts