### PR TITLE
add more links to the language bindings in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ $ cargo test -- --ignored
 
 Language bindings are available for:
 
-- [C](https://c.delta.chat)
-- [Node.js](https://www.npmjs.com/package/deltachat-node)
-- [Python](https://py.delta.chat)
-- [Go](https://github.com/deltachat/go-deltachat/)
-- [Free Pascal](https://github.com/deltachat/deltachat-fp/)
+- C \[[📂 source](./deltachat-ffi) | [📚 docs](https://c.delta.chat)\]
+- Node.js \[[📂 source](https://github.com/deltachat/deltachat-node) | [📦 npm](https://www.npmjs.com/package/deltachat-node) | [📚 docs](https://js.delta.chat)\]
+- Python \[[📂 source](./python) | [📦 pypi](https://pypi.org/project/deltachat) | [📚 docs](https://py.delta.chat)\]
+- Go \[[📂 source](https://github.com/deltachat/go-deltachat/)\]
+- Free Pascal \[[📂 source](https://github.com/deltachat/deltachat-fp/)\]
 - **Java** and **Swift** (contained in the Android/iOS repos)
 
 The following "frontend" projects make use of the Rust-library

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ $ cargo test -- --ignored
 
 Language bindings are available for:
 
-- C \[[📂 source](./deltachat-ffi) | [📚 docs](https://c.delta.chat)\]
-- Node.js \[[📂 source](https://github.com/deltachat/deltachat-node) | [📦 npm](https://www.npmjs.com/package/deltachat-node) | [📚 docs](https://js.delta.chat)\]
-- Python \[[📂 source](./python) | [📦 pypi](https://pypi.org/project/deltachat) | [📚 docs](https://py.delta.chat)\]
-- Go \[[📂 source](https://github.com/deltachat/go-deltachat/)\]
-- Free Pascal \[[📂 source](https://github.com/deltachat/deltachat-fp/)\]
+- **C** \[[📂 source](./deltachat-ffi) | [📚 docs](https://c.delta.chat)\]
+- **Node.js** \[[📂 source](https://github.com/deltachat/deltachat-node) | [📦 npm](https://www.npmjs.com/package/deltachat-node) | [📚 docs](https://js.delta.chat)\]
+- **Python** \[[📂 source](./python) | [📦 pypi](https://pypi.org/project/deltachat) | [📚 docs](https://py.delta.chat)\]
+- **Go** \[[📂 source](https://github.com/deltachat/go-deltachat/)\]
+- **Free Pascal** \[[📂 source](https://github.com/deltachat/deltachat-fp/)\]
 - **Java** and **Swift** (contained in the Android/iOS repos)
 
 The following "frontend" projects make use of the Rust-library


### PR DESCRIPTION
I'm not sure about the emojis, but I think the extra links are going to be helpful for new devs.

when reviewing I recommend looking at it in the "rich diff" or at https://github.com/deltachat/deltachat-core-rust/tree/add_more_links_to_language_bindings#language-bindings-and-frontend-projects