### PR TITLE
Allow using secondary email addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Changes
 
+- introduce multiple self addresses with the "configured" address always
+  being the primary one. 
 - Further improve finding the correct server after logging in #3208
 - `get_connectivity_html()` returns HTML as non-scalable #3213
 - add update-serial to `DC_EVENT_WEBXDC_STATUS_UPDATE` #3215

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3049,7 +3049,7 @@ pub async fn forward_msgs(context: &Context, msg_ids: &[MsgId], chat_id: ChatId)
             .query_map(
                 format!(
                     "SELECT id FROM msgs WHERE id IN({}) ORDER BY timestamp,id",
-                    sql::repeat_vars(msg_ids.len())?
+                    sql::repeat_vars(msg_ids.len())
                 ),
                 rusqlite::params_from_iter(msg_ids),
                 |row| row.get::<_, MsgId>(0),

--- a/src/config.rs
+++ b/src/config.rs
@@ -376,7 +376,7 @@ impl Context {
     pub(crate) async fn get_all_self_addrs(&self) -> Result<Vec<String>> {
         let mut ret = Vec::new();
 
-        ret.push(self.get_primary_self_addr().await.unwrap_or_default());
+        ret.extend(self.get_primary_self_addr().await.into_iter());
         ret.extend(self.get_secondary_self_addrs().await?.into_iter());
 
         Ok(ret)

--- a/src/config.rs
+++ b/src/config.rs
@@ -381,12 +381,10 @@ impl Context {
 
     /// Returns all primary and secondary self addresses.
     pub(crate) async fn get_all_self_addrs(&self) -> Result<Vec<String>> {
-        let mut ret = Vec::new();
+        let primary_addrs = self.get_primary_self_addr().await.into_iter();
+        let secondary_addrs = self.get_secondary_self_addrs().await?.into_iter();
 
-        ret.extend(self.get_primary_self_addr().await.into_iter());
-        ret.extend(self.get_secondary_self_addrs().await?.into_iter());
-
-        Ok(ret)
+        Ok(primary_addrs.chain(secondary_addrs).collect())
     }
 
     /// Returns all secondary self addresses.

--- a/src/config.rs
+++ b/src/config.rs
@@ -338,8 +338,8 @@ impl Context {
     /// determine whether the specified addr maps to the/a self addr
     pub(crate) async fn is_self_addr(&self, addr: &str) -> Result<bool> {
         Ok(self
-            .get_primary_self_addr()
-            .await
+            .get_config(Config::ConfiguredAddr)
+            .await?
             .iter()
             .any(|a| addr_cmp(addr, a))
             || self
@@ -372,7 +372,7 @@ impl Context {
 
     /// Returns all primary and secondary self addresses.
     pub(crate) async fn get_all_self_addrs(&self) -> Result<Vec<String>> {
-        let primary_addrs = self.get_primary_self_addr().await.into_iter();
+        let primary_addrs = self.get_config(Config::ConfiguredAddr).await?.into_iter();
         let secondary_addrs = self.get_secondary_self_addrs().await?.into_iter();
 
         Ok(primary_addrs.chain(secondary_addrs).collect())
@@ -391,6 +391,7 @@ impl Context {
     }
 
     /// Returns the primary self address.
+    /// Returns an error if no self addr is configured.
     pub async fn get_primary_self_addr(&self) -> Result<String> {
         self.get_config(Config::ConfiguredAddr)
             .await?

--- a/src/config.rs
+++ b/src/config.rs
@@ -351,6 +351,13 @@ impl Context {
     pub(crate) async fn set_primary_self_addr(&self, primary_new: &str) -> Result<()> {
         let primary_new = addr_normalize(primary_new).to_lowercase();
 
+        if self.get_primary_self_addr().await.ok().as_deref() != Some(&primary_new) {
+            // Make sure that all server UIDs will be resynced
+            self.sql
+                .execute("DELETE FROM imap_sync;", paramsv![])
+                .await?;
+        }
+
         // add old primary address (if exists) to secondary addresses
         let mut secondary_addrs = self.get_all_self_addrs().await?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -335,7 +335,8 @@ impl Context {
 
 // Separate impl block for self address handling
 impl Context {
-    /// determine whether the specified addr maps to the/a self addr
+    /// Determine whether the specified addr maps to the/a self addr.
+    /// Returns `false` if no addresses are configured.
     pub(crate) async fn is_self_addr(&self, addr: &str) -> Result<bool> {
         Ok(self
             .get_config(Config::ConfiguredAddr)

--- a/src/config.rs
+++ b/src/config.rs
@@ -351,13 +351,6 @@ impl Context {
     pub(crate) async fn set_primary_self_addr(&self, primary_new: &str) -> Result<()> {
         let primary_new = addr_normalize(primary_new).to_lowercase();
 
-        if self.get_primary_self_addr().await.ok().as_deref() != Some(&primary_new) {
-            // Make sure that all server UIDs will be resynced
-            self.sql
-                .execute("DELETE FROM imap_sync;", paramsv![])
-                .await?;
-        }
-
         // add old primary address (if exists) to secondary addresses
         let mut secondary_addrs = self.get_all_self_addrs().await?;
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -454,7 +454,7 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
 
     progress!(ctx, 910);
 
-    if ctx.get_primary_self_addr().await.ok().as_deref() != Some(&param.addr) {
+    if ctx.get_config(Config::ConfiguredAddr).await?.as_deref() != Some(&param.addr) {
         // Switched account, all server UIDs we know are invalid
         job::schedule_resync(ctx).await?;
     }

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -453,6 +453,12 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
     drop(imap);
 
     progress!(ctx, 910);
+
+    if ctx.get_primary_self_addr().await.ok().as_deref() != Some(&param.addr) {
+        // Switched account, all server UIDs we know are invalid
+        job::schedule_resync(ctx).await?;
+    }
+
     // the trailing underscore is correct
     param.save_as_configured_params(ctx).await?;
     ctx.set_config(Config::ConfiguredTimestamp, Some(&time().to_string()))

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1509,6 +1509,8 @@ mod tests {
     async fn test_get_contacts() -> Result<()> {
         let context = TestContext::new().await;
 
+        assert!(context.get_all_self_addrs().await?.is_empty());
+
         // Bob is not in the contacts yet.
         let contacts = Contact::get_all(&context.ctx, 0, Some("bob")).await?;
         assert_eq!(contacts.len(), 0);

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -706,7 +706,7 @@ impl Contact {
                  AND (iif(c.name='',c.authname,c.name) LIKE ? OR c.addr LIKE ?) \
                  AND (1=? OR LENGTH(ps.verified_key_fingerprint)!=0)  \
                  ORDER BY LOWER(iif(c.name='',c.authname,c.name)||c.addr),c.id;",
-                        sql::repeat_vars(self_addrs.len())?
+                        sql::repeat_vars(self_addrs.len())
                     ),
                     rusqlite::params_from_iter(params_iter(&self_addrs).chain(params_iterv![
                         ContactId::LAST_SPECIAL,
@@ -755,7 +755,7 @@ impl Contact {
                  AND origin>=?
                  AND blocked=0
                  ORDER BY LOWER(iif(name='',authname,name)||addr),id;",
-                        sql::repeat_vars(self_addrs.len())?
+                        sql::repeat_vars(self_addrs.len())
                     ),
                     rusqlite::params_from_iter(params_iter(&self_addrs).chain(params_iterv![
                         ContactId::LAST_SPECIAL,

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -297,7 +297,10 @@ impl Contact {
             .await?;
         if contact_id == ContactId::SELF {
             contact.name = stock_str::self_msg(context).await;
-            contact.addr = context.get_primary_self_addr().await.unwrap_or_default();
+            contact.addr = context
+                .get_config(Config::ConfiguredAddr)
+                .await?
+                .unwrap_or_default();
             contact.status = context
                 .get_config(Config::Selfstatus)
                 .await?
@@ -726,7 +729,10 @@ impl Contact {
                 .await?;
 
             if let Some(query) = query {
-                let self_addr = context.get_primary_self_addr().await.unwrap_or_default();
+                let self_addr = context
+                    .get_config(Config::ConfiguredAddr)
+                    .await?
+                    .unwrap_or_default();
                 let self_name = context
                     .get_config(Config::Displayname)
                     .await?

--- a/src/context.rs
+++ b/src/context.rs
@@ -336,6 +336,7 @@ impl Context {
         let unset = "0";
         let l = LoginParam::load_candidate_params(self).await?;
         let l2 = LoginParam::load_configured_params(self).await?;
+        let secondary_addrs = self.get_secondary_self_addrs().await?.join(", ");
         let displayname = self.get_config(Config::Displayname).await?;
         let chats = get_chat_cnt(self).await? as usize;
         let unblocked_msgs = message::get_unblocked_msg_cnt(self).await as usize;
@@ -420,6 +421,7 @@ impl Context {
         res.insert("socks5_enabled", socks5_enabled.to_string());
         res.insert("entered_account_settings", l.to_string());
         res.insert("used_account_settings", l2.to_string());
+        res.insert("secondary_addrs", secondary_addrs);
         res.insert(
             "fetch_existing_msgs",
             self.get_config_int(Config::FetchExistingMsgs)

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1967,7 +1967,7 @@ async fn create_adhoc_grp_id(context: &Context, member_ids: &[ContactId]) -> Res
     let member_cs = context.get_primary_self_addr().await?.to_lowercase();
     let query = format!(
         "SELECT addr FROM contacts WHERE id IN({}) AND id!=?",
-        sql::repeat_vars(member_ids.len())?
+        sql::repeat_vars(member_ids.len())
     );
     let mut params = Vec::new();
     params.extend_from_slice(member_ids);
@@ -2065,7 +2065,7 @@ async fn check_verified_properties(
             format!(
                 "SELECT c.addr, LENGTH(ps.verified_key_fingerprint)  FROM contacts c  \
              LEFT JOIN acpeerstates ps ON c.addr=ps.addr  WHERE c.id IN({}) ",
-                sql::repeat_vars(to_ids.len())?
+                sql::repeat_vars(to_ids.len())
             ),
             rusqlite::params_from_iter(to_ids),
             |row| {

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -28,7 +28,7 @@ impl EncryptHelper {
         let prefer_encrypt =
             EncryptPreference::from_i32(context.get_config_int(Config::E2eeEnabled).await?)
                 .unwrap_or_default();
-        let addr = context.get_configured_addr().await?;
+        let addr = context.get_primary_self_addr().await?;
         let public_key = SignedPublicKey::load_self(context).await?;
 
         Ok(EncryptHelper {
@@ -381,7 +381,7 @@ fn contains_report(mail: &ParsedMail<'_>) -> bool {
 /// [Config::ConfiguredAddr] is configured, this address is returned.
 // TODO, remove this once deltachat::key::Key no longer exists.
 pub async fn ensure_secret_key_exists(context: &Context) -> Result<String> {
-    let self_addr = context.get_configured_addr().await?;
+    let self_addr = context.get_primary_self_addr().await?;
     SignedPublicKey::load_self(context).await?;
     Ok(self_addr)
 }

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -315,7 +315,7 @@ pub(crate) async fn start_ephemeral_timers_msgids(
                 "UPDATE msgs SET ephemeral_timestamp = ? + ephemeral_timer
          WHERE (ephemeral_timestamp == 0 OR ephemeral_timestamp > ? + ephemeral_timer) AND ephemeral_timer > 0
          AND id IN ({})",
-                sql::repeat_vars(msg_ids.len())?
+                sql::repeat_vars(msg_ids.len())
             ),
             rusqlite::params_from_iter(
                 std::iter::once(&now as &dyn crate::ToSql)

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -2170,7 +2170,7 @@ async fn get_modseq(context: &Context, folder: &str) -> Result<u64> {
 }
 
 /// Compute the imap search expression for all self-sent mails (for all self addresses)
-pub async fn get_imap_self_sent_search_command(context: &Context) -> Result<String> {
+pub(crate) async fn get_imap_self_sent_search_command(context: &Context) -> Result<String> {
     // See https://www.rfc-editor.org/rfc/rfc3501#section-6.4.4 for syntax of SEARCH and OR
     let mut search_command = format!("FROM {}", context.get_primary_self_addr().await?);
 

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -912,7 +912,7 @@ impl Imap {
             .execute(
                 format!(
                     "DELETE FROM imap WHERE id IN ({})",
-                    sql::repeat_vars(row_ids.len())?
+                    sql::repeat_vars(row_ids.len())
                 ),
                 rusqlite::params_from_iter(row_ids),
             )
@@ -949,7 +949,7 @@ impl Imap {
                         .execute(
                             format!(
                                 "DELETE FROM imap WHERE id IN ({})",
-                                sql::repeat_vars(row_ids.len())?
+                                sql::repeat_vars(row_ids.len())
                             ),
                             rusqlite::params_from_iter(row_ids),
                         )
@@ -991,7 +991,7 @@ impl Imap {
                     .execute(
                         format!(
                             "UPDATE imap SET target='' WHERE id IN ({})",
-                            sql::repeat_vars(row_ids.len())?
+                            sql::repeat_vars(row_ids.len())
                         ),
                         rusqlite::params_from_iter(row_ids),
                     )
@@ -1103,7 +1103,7 @@ impl Imap {
                     .execute(
                         format!(
                             "DELETE FROM imap_markseen WHERE id IN ({})",
-                            sql::repeat_vars(rowid_set.len())?
+                            sql::repeat_vars(rowid_set.len())
                         ),
                         rusqlite::params_from_iter(rowid_set),
                     )

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -2172,10 +2172,10 @@ async fn get_modseq(context: &Context, folder: &str) -> Result<u64> {
 /// Compute the imap search expression for all self-sent mails (for all self addresses)
 pub(crate) async fn get_imap_self_sent_search_command(context: &Context) -> Result<String> {
     // See https://www.rfc-editor.org/rfc/rfc3501#section-6.4.4 for syntax of SEARCH and OR
-    let mut search_command = format!("FROM {}", context.get_primary_self_addr().await?);
+    let mut search_command = format!("FROM \"{}\"", context.get_primary_self_addr().await?);
 
     for item in context.get_secondary_self_addrs().await? {
-        search_command = format!("OR ({}) (FROM {})", search_command, item);
+        search_command = format!("OR ({}) (FROM \"{}\")", search_command, item);
     }
 
     Ok(search_command)
@@ -2555,19 +2555,19 @@ mod tests {
         let t = TestContext::new_alice().await;
         assert_eq!(
             get_imap_self_sent_search_command(&t.ctx).await?,
-            "FROM alice@example.org"
+            r#"FROM "alice@example.org""#
         );
 
         t.ctx.set_primary_self_addr("alice@another.com").await?;
         assert_eq!(
             get_imap_self_sent_search_command(&t.ctx).await?,
-            "OR (FROM alice@another.com) (FROM alice@example.org)"
+            r#"OR (FROM "alice@another.com") (FROM "alice@example.org")"#
         );
 
         t.ctx.set_primary_self_addr("alice@third.com").await?;
         assert_eq!(
             get_imap_self_sent_search_command(&t.ctx).await?,
-            "OR (OR (FROM alice@third.com) (FROM alice@another.com)) (FROM alice@example.org)"
+            r#"OR (OR (FROM "alice@third.com") (FROM "alice@another.com")) (FROM "alice@example.org")"#
         );
 
         Ok(())

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -351,7 +351,7 @@ async fn set_self_key(
         }
     };
 
-    let self_addr = context.get_configured_addr().await?;
+    let self_addr = context.get_primary_self_addr().await?;
     let addr = EmailAddress::new(&self_addr)?;
     let keypair = pgp::KeyPair {
         addr,

--- a/src/job.rs
+++ b/src/job.rs
@@ -399,7 +399,7 @@ async fn kill_ids(context: &Context, job_ids: &[u32]) -> Result<()> {
     }
     let q = format!(
         "DELETE FROM jobs WHERE id IN({})",
-        sql::repeat_vars(job_ids.len())?
+        sql::repeat_vars(job_ids.len())
     );
     context
         .sql

--- a/src/key.rs
+++ b/src/key.rs
@@ -198,7 +198,7 @@ impl DcSecretKey for SignedSecretKey {
 }
 
 async fn generate_keypair(context: &Context) -> Result<KeyPair> {
-    let addr = context.get_configured_addr().await?;
+    let addr = context.get_primary_self_addr().await?;
     let addr = EmailAddress::new(&addr)?;
     let _guard = context.generating_key_mutex.lock().await;
 

--- a/src/location.rs
+++ b/src/location.rs
@@ -423,7 +423,7 @@ pub async fn delete_all(context: &Context) -> Result<()> {
 pub async fn get_kml(context: &Context, chat_id: ChatId) -> Result<(String, u32)> {
     let mut last_added_location_id = 0;
 
-    let self_addr = context.get_configured_addr().await?;
+    let self_addr = context.get_primary_self_addr().await?;
 
     let (locations_send_begin, locations_send_until, locations_last_sent) = context.sql.query_row(
         "SELECT locations_send_begin, locations_send_until, locations_last_sent  FROM chats  WHERE id=?;",

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -256,8 +256,7 @@ impl LoginParam {
         let prefix = "configured_";
         let sql = &context.sql;
 
-        let key = format!("{}addr", prefix);
-        sql.set_raw_config(key, Some(&self.addr)).await?;
+        context.set_primary_self_addr(&self.addr).await?;
 
         let key = format!("{}mail_server", prefix);
         sql.set_raw_config(key, Some(&self.imap.server)).await?;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1296,7 +1296,7 @@ pub async fn markseen_msgs(context: &Context, msg_ids: Vec<MsgId>) -> Result<()>
                     c.blocked AS blocked
                  FROM msgs m LEFT JOIN chats c ON c.id=m.chat_id
                  WHERE m.id IN ({}) AND m.chat_id>9",
-                sql::repeat_vars(msg_ids.len())?
+                sql::repeat_vars(msg_ids.len())
             ),
             rusqlite::params_from_iter(&msg_ids),
             |row| {

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -271,13 +271,13 @@ impl<'a> MimeFactory<'a> {
         &self,
         context: &Context,
     ) -> Result<Vec<(Option<Peerstate>, &str)>> {
-        let self_addrs = context.get_all_self_addrs().await?;
+        let self_addr = context.get_primary_self_addr().await?;
 
         let mut res = Vec::new();
         for (_, addr) in self
             .recipients
             .iter()
-            .filter(|(_, addr)| !self_addrs.contains(addr))
+            .filter(|(_, addr)| addr != &self_addr)
         {
             res.push((Peerstate::from_addr(context, addr).await?, addr.as_str()));
         }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -133,7 +133,7 @@ impl<'a> MimeFactory<'a> {
     ) -> Result<MimeFactory<'a>> {
         let chat = Chat::load_from_db(context, msg.chat_id).await?;
 
-        let from_addr = context.get_configured_addr().await?;
+        let from_addr = context.get_primary_self_addr().await?;
         let config_displayname = context
             .get_config(Config::Displayname)
             .await?
@@ -233,7 +233,7 @@ impl<'a> MimeFactory<'a> {
         ensure!(!msg.chat_id.is_special(), "Invalid chat id");
 
         let contact = Contact::load_from_db(context, msg.from_id).await?;
-        let from_addr = context.get_configured_addr().await?;
+        let from_addr = context.get_primary_self_addr().await?;
         let from_displayname = context
             .get_config(Config::Displayname)
             .await?
@@ -271,12 +271,13 @@ impl<'a> MimeFactory<'a> {
         &self,
         context: &Context,
     ) -> Result<Vec<(Option<Peerstate>, &str)>> {
-        let self_addr = context.get_configured_addr().await?;
+        let self_addrs = context.get_all_self_addrs().await?;
+
         let mut res = Vec::new();
         for (_, addr) in self
             .recipients
             .iter()
-            .filter(|(_, addr)| addr != &self_addr)
+            .filter(|(_, addr)| !self_addrs.contains(addr))
         {
             res.push((Peerstate::from_addr(context, addr).await?, addr.as_str()));
         }

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -449,7 +449,7 @@ impl Context {
         //                                [======67%=====       ]
         // =============================================================================================
 
-        let domain = dc_tools::EmailAddress::new(&self.get_configured_addr().await?)?.domain;
+        let domain = dc_tools::EmailAddress::new(&self.get_primary_self_addr().await?)?.domain;
         ret += &format!(
             "<h3>{}</h3><ul>",
             stock_str::storage_on_domain(self, domain).await

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -66,7 +66,7 @@ pub async fn dc_get_securejoin_qr(context: &Context, group: Option<ChatId>) -> R
         .is_none();
     let invitenumber = token::lookup_or_new(context, Namespace::InviteNumber, group).await;
     let auth = token::lookup_or_new(context, Namespace::Auth, group).await;
-    let self_addr = context.get_configured_addr().await?;
+    let self_addr = context.get_primary_self_addr().await?;
     let self_name = context
         .get_config(Config::Displayname)
         .await?

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -844,9 +844,6 @@ async fn prune_tombstones(sql: &Sql) -> Result<()> {
 /// Use this together with [`rusqlite::ParamsFromIter`] to use dynamically generated
 /// parameter lists.
 pub fn repeat_vars(count: usize) -> Result<String> {
-    if count == 0 {
-        bail!("Must have at least one repeat variable");
-    }
     let mut s = "?,".repeat(count);
     s.pop(); // Remove trailing comma
     Ok(s)

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -843,10 +843,10 @@ async fn prune_tombstones(sql: &Sql) -> Result<()> {
 ///
 /// Use this together with [`rusqlite::ParamsFromIter`] to use dynamically generated
 /// parameter lists.
-pub fn repeat_vars(count: usize) -> Result<String> {
+pub fn repeat_vars(count: usize) -> String {
     let mut s = "?,".repeat(count);
     s.pop(); // Remove trailing comma
-    Ok(s)
+    s
 }
 
 #[cfg(test)]

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -34,6 +34,17 @@ macro_rules! paramsv {
     };
 }
 
+#[macro_export]
+macro_rules! params_iterv {
+    ($($param:expr),+ $(,)?) => {
+        vec![$(&$param as &dyn $crate::ToSql),+]
+    };
+}
+
+pub(crate) fn params_iter(iter: &[impl crate::ToSql]) -> impl Iterator<Item = &dyn crate::ToSql> {
+    iter.iter().map(|item| item as &dyn crate::ToSql)
+}
+
 mod migrations;
 
 /// A wrapper around the underlying Sqlite3 object.

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -395,7 +395,7 @@ UPDATE chats SET protected=1, type=120 WHERE type=130;"#,
 
     if dbversion < 71 {
         info!(context, "[migration] v71");
-        if let Ok(addr) = context.get_configured_addr().await {
+        if let Ok(addr) = context.get_primary_self_addr().await {
             if let Ok(domain) = addr.parse::<EmailAddress>().map(|email| email.domain) {
                 context
                     .set_config(

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -407,7 +407,7 @@ impl TestContext {
             .await
             .unwrap_or_default()
             .unwrap_or_default();
-        let addr = other.ctx.get_configured_addr().await.unwrap();
+        let addr = other.ctx.get_primary_self_addr().await.unwrap();
         // MailinglistAddress is the lowest allowed origin, we'd prefer to not modify the
         // origin when creating this contact.
         let (contact_id, modified) =


### PR DESCRIPTION
That's a prerequesite for automatic email address porting (AEAP) because after porting, the user will have two email addresses