### PR TITLE
Make test output appear in the correct failing test

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -2029,7 +2029,7 @@ CCCB 5AA9 F6E1 141C 9431
 
         alice1
             .evtracker
-            .get_matching(|e| e == EventType::SelfavatarChanged)
+            .get_matching(|e| matches!(e, EventType::SelfavatarChanged))
             .await;
 
         // Bob sends a message so that Alice can encrypt to him.
@@ -2059,7 +2059,7 @@ CCCB 5AA9 F6E1 141C 9431
         assert!(alice2.get_config(Config::Selfavatar).await?.is_some());
         alice2
             .evtracker
-            .get_matching(|e| e == EventType::SelfavatarChanged)
+            .get_matching(|e| matches!(e, EventType::SelfavatarChanged))
             .await;
 
         Ok(())

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1525,9 +1525,9 @@ mod tests {
         let t = TestContext::new().await;
         assert_eq!(t.is_self_addr("me@me.org").await?, false);
 
-        let addr = t.configure_alice().await;
+        t.configure_addr("you@you.net").await;
         assert_eq!(t.is_self_addr("me@me.org").await?, false);
-        assert_eq!(t.is_self_addr(&addr).await?, true);
+        assert_eq!(t.is_self_addr("you@you.net").await?, true);
 
         Ok(())
     }

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -417,7 +417,10 @@ mod tests {
         #[async_std::test]
         async fn test_prexisting() {
             let t = TestContext::new_alice().await;
-            assert_eq!(ensure_secret_key_exists(&t).await.unwrap(), "alice@example.com");
+            assert_eq!(
+                ensure_secret_key_exists(&t).await.unwrap(),
+                "alice@example.org"
+            );
         }
 
         #[async_std::test]

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -416,9 +416,8 @@ mod tests {
 
         #[async_std::test]
         async fn test_prexisting() {
-            let t = TestContext::new().await;
-            let test_addr = t.configure_alice().await;
-            assert_eq!(ensure_secret_key_exists(&t).await.unwrap(), test_addr);
+            let t = TestContext::new_alice().await;
+            assert_eq!(ensure_secret_key_exists(&t).await.unwrap(), "alice@example.com");
         }
 
         #[async_std::test]

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -936,9 +936,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_render_setup_file() {
-        let t = TestContext::new().await;
-
-        t.configure_alice().await;
+        let t = TestContext::new_alice().await;
         let msg = render_setup_file(&t, "hello").await.unwrap();
         println!("{}", &msg);
         // Check some substrings, indicating things got substituted.
@@ -955,11 +953,10 @@ mod tests {
 
     #[async_std::test]
     async fn test_render_setup_file_newline_replace() {
-        let t = TestContext::new().await;
+        let t = TestContext::new_alice().await;
         t.set_stock_translation(StockMessage::AcSetupMsgBody, "hello\r\nthere".to_string())
             .await
             .unwrap();
-        t.configure_alice().await;
         let msg = render_setup_file(&t, "pw").await.unwrap();
         println!("{}", &msg);
         assert!(msg.contains("<p>hello<br>there</p>"));
@@ -1012,15 +1009,13 @@ mod tests {
 
     #[async_std::test]
     async fn test_export_and_import_key() {
-        let context = TestContext::new().await;
-        context.configure_alice().await;
+        let context = TestContext::new_alice().await;
         let blobdir = context.ctx.get_blobdir();
         if let Err(err) = imex(&context.ctx, ImexMode::ExportSelfKeys, blobdir).await {
             panic!("got error on export: {:?}", err);
         }
 
-        let context2 = TestContext::new().await;
-        context2.configure_alice().await;
+        let context2 = TestContext::new_alice().await;
         if let Err(err) = imex(&context2.ctx, ImexMode::ImportSelfKeys, blobdir).await {
             panic!("got error on import: {:?}", err);
         }

--- a/src/key.rs
+++ b/src/key.rs
@@ -510,8 +510,7 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
     #[async_std::test]
     async fn test_load_self_existing() {
         let alice = alice_keypair();
-        let t = TestContext::new().await;
-        t.configure_alice().await;
+        let t = TestContext::new_alice().await;
         let pubkey = SignedPublicKey::load_self(&t).await.unwrap();
         assert_eq!(alice.public, pubkey);
         let seckey = SignedSecretKey::load_self(&t).await.unwrap();

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -79,8 +79,7 @@ mod tests {
     #[async_std::test]
     async fn test_keyring_load_self() {
         // new_self() implies load_self()
-        let t = TestContext::new().await;
-        t.configure_alice().await;
+        let t = TestContext::new_alice().await;
         let alice = alice_keypair();
 
         let pub_ring: Keyring<SignedPublicKey> = Keyring::new_self(&t).await.unwrap();

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -941,12 +941,21 @@ mod tests {
     use crate::chatlist::Chatlist;
     use crate::constants::Chattype;
     use crate::peerstate::Peerstate;
-    use crate::test_utils::TestContext;
+    use crate::test_utils::{LogSink, TestContext};
 
     #[async_std::test]
     async fn test_setup_contact() -> Result<()> {
-        let alice = TestContext::new_alice().await;
-        let bob = TestContext::new_bob().await;
+        let (log_tx, _log_sink) = LogSink::create();
+        let alice = TestContext::builder()
+            .configure_alice()
+            .with_log_sink(log_tx.clone())
+            .build()
+            .await;
+        let bob = TestContext::builder()
+            .configure_bob()
+            .with_log_sink(log_tx)
+            .build()
+            .await;
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
         assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 0);
 
@@ -1133,8 +1142,17 @@ mod tests {
 
     #[async_std::test]
     async fn test_setup_contact_bob_knows_alice() -> Result<()> {
-        let alice = TestContext::new_alice().await;
-        let bob = TestContext::new_bob().await;
+        let (log_tx, _log_sink) = LogSink::create();
+        let alice = TestContext::builder()
+            .configure_alice()
+            .with_log_sink(log_tx.clone())
+            .build()
+            .await;
+        let bob = TestContext::builder()
+            .configure_bob()
+            .with_log_sink(log_tx)
+            .build()
+            .await;
 
         // Ensure Bob knows Alice_FP
         let alice_pubkey = SignedPublicKey::load_self(&alice.ctx).await?;
@@ -1257,8 +1275,17 @@ mod tests {
 
     #[async_std::test]
     async fn test_setup_contact_concurrent_calls() -> Result<()> {
-        let alice = TestContext::new_alice().await;
-        let bob = TestContext::new_bob().await;
+        let (log_tx, _log_sink) = LogSink::create();
+        let alice = TestContext::builder()
+            .configure_alice()
+            .with_log_sink(log_tx.clone())
+            .build()
+            .await;
+        let bob = TestContext::builder()
+            .configure_bob()
+            .with_log_sink(log_tx)
+            .build()
+            .await;
 
         // do a scan that is not working as claire is never responding
         let qr_stale = "OPENPGP4FPR:1234567890123456789012345678901234567890#a=claire%40foo.de&n=&i=12345678901&s=23456789012";
@@ -1287,8 +1314,17 @@ mod tests {
 
     #[async_std::test]
     async fn test_secure_join() -> Result<()> {
-        let alice = TestContext::new_alice().await;
-        let bob = TestContext::new_bob().await;
+        let (log_tx, _log_sink) = LogSink::create();
+        let alice = TestContext::builder()
+            .configure_alice()
+            .with_log_sink(log_tx.clone())
+            .build()
+            .await;
+        let bob = TestContext::builder()
+            .configure_bob()
+            .with_log_sink(log_tx)
+            .build()
+            .await;
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
         assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 0);
 

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -936,15 +936,12 @@ fn encrypted_and_signed(
 mod tests {
     use super::*;
 
-    use async_std::prelude::*;
-
     use crate::chat;
     use crate::chat::ProtectionStatus;
     use crate::chatlist::Chatlist;
     use crate::constants::Chattype;
     use crate::peerstate::Peerstate;
     use crate::test_utils::TestContext;
-    use std::time::Duration;
 
     #[async_std::test]
     async fn test_setup_contact() -> Result<()> {
@@ -952,10 +949,6 @@ mod tests {
         let bob = TestContext::new_bob().await;
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
         assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 0);
-
-        // Setup JoinerProgress sinks.
-        let (joiner_progress_tx, joiner_progress_rx) = async_std::channel::unbounded();
-        bob.add_event_sender(joiner_progress_tx).await;
 
         // Step 1: Generate QR-code, ChatId(0) indicates setup-contact
         let qr = dc_get_securejoin_qr(&alice.ctx, None).await?;
@@ -988,33 +981,25 @@ mod tests {
         bob.recv_msg(&sent).await;
 
         // Check Bob emitted the JoinerProgress event.
-        async {
-            loop {
-                let event = joiner_progress_rx.recv().await.unwrap();
-                match event.typ {
-                    EventType::SecurejoinJoinerProgress {
-                        contact_id,
-                        progress,
-                    } => {
-                        let alice_contact_id = Contact::lookup_id_by_addr(
-                            &bob.ctx,
-                            "alice@example.org",
-                            Origin::Unknown,
-                        )
+        let event = bob
+            .evtracker
+            .get_matching(|evt| matches!(evt, EventType::SecurejoinJoinerProgress { .. }))
+            .await;
+        match event {
+            EventType::SecurejoinJoinerProgress {
+                contact_id,
+                progress,
+            } => {
+                let alice_contact_id =
+                    Contact::lookup_id_by_addr(&bob.ctx, "alice@example.org", Origin::Unknown)
                         .await
                         .expect("Error looking up contact")
                         .expect("Contact not found");
-                        assert_eq!(contact_id, alice_contact_id);
-                        assert_eq!(progress, 400);
-                        break;
-                    }
-                    _ => {}
-                }
+                assert_eq!(contact_id, alice_contact_id);
+                assert_eq!(progress, 400);
             }
+            _ => unreachable!(),
         }
-        .timeout(Duration::from_secs(10))
-        .await
-        .expect("timeout waiting for JoinerProgress event");
 
         // Check Bob sent the right message.
         let sent = bob.pop_sent_msg().await;
@@ -1151,10 +1136,6 @@ mod tests {
         let alice = TestContext::new_alice().await;
         let bob = TestContext::new_bob().await;
 
-        // Setup JoinerProgress sinks.
-        let (joiner_progress_tx, joiner_progress_rx) = async_std::channel::unbounded();
-        bob.add_event_sender(joiner_progress_tx).await;
-
         // Ensure Bob knows Alice_FP
         let alice_pubkey = SignedPublicKey::load_self(&alice.ctx).await?;
         let peerstate = Peerstate {
@@ -1181,34 +1162,25 @@ mod tests {
         dc_join_securejoin(&bob.ctx, &qr).await.unwrap();
 
         // Check Bob emitted the JoinerProgress event.
-        async {
-            loop {
-                let event = joiner_progress_rx.recv().await.unwrap();
-                match event.typ {
-                    EventType::SecurejoinJoinerProgress {
-                        contact_id,
-                        progress,
-                    } => {
-                        let alice_contact_id = Contact::lookup_id_by_addr(
-                            &bob.ctx,
-                            "alice@example.org",
-                            Origin::Unknown,
-                        )
+        let event = bob
+            .evtracker
+            .get_matching(|evt| matches!(evt, EventType::SecurejoinJoinerProgress { .. }))
+            .await;
+        match event {
+            EventType::SecurejoinJoinerProgress {
+                contact_id,
+                progress,
+            } => {
+                let alice_contact_id =
+                    Contact::lookup_id_by_addr(&bob.ctx, "alice@example.org", Origin::Unknown)
                         .await
                         .expect("Error looking up contact")
                         .expect("Contact not found");
-                        assert_eq!(contact_id, alice_contact_id);
-                        assert_eq!(progress, 400);
-                        break;
-                    }
-                    _ => {}
-                }
+                assert_eq!(contact_id, alice_contact_id);
+                assert_eq!(progress, 400);
             }
+            _ => unreachable!(),
         }
-        .timeout(Duration::from_secs(10))
-        .await
-        .expect("timeout waiting for JoinerProgress event");
-        assert!(!bob.ctx.has_ongoing().await);
 
         // Check Bob sent the right handshake message.
         let sent = bob.pop_sent_msg().await;
@@ -1320,10 +1292,6 @@ mod tests {
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
         assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 0);
 
-        // Setup JoinerProgress sinks.
-        let (joiner_progress_tx, joiner_progress_rx) = async_std::channel::unbounded();
-        bob.add_event_sender(joiner_progress_tx).await;
-
         let chatid =
             chat::create_group_chat(&alice.ctx, ProtectionStatus::Protected, "the chat").await?;
 
@@ -1359,33 +1327,25 @@ mod tests {
         let sent = bob.pop_sent_msg().await;
 
         // Check Bob emitted the JoinerProgress event.
-        async {
-            loop {
-                let event = joiner_progress_rx.recv().await.unwrap();
-                match event.typ {
-                    EventType::SecurejoinJoinerProgress {
-                        contact_id,
-                        progress,
-                    } => {
-                        let alice_contact_id = Contact::lookup_id_by_addr(
-                            &bob.ctx,
-                            "alice@example.org",
-                            Origin::Unknown,
-                        )
+        let event = bob
+            .evtracker
+            .get_matching(|evt| matches!(evt, EventType::SecurejoinJoinerProgress { .. }))
+            .await;
+        match event {
+            EventType::SecurejoinJoinerProgress {
+                contact_id,
+                progress,
+            } => {
+                let alice_contact_id =
+                    Contact::lookup_id_by_addr(&bob.ctx, "alice@example.org", Origin::Unknown)
                         .await
                         .expect("Error looking up contact")
                         .expect("Contact not found");
-                        assert_eq!(contact_id, alice_contact_id);
-                        assert_eq!(progress, 400);
-                        break;
-                    }
-                    _ => {}
-                }
+                assert_eq!(contact_id, alice_contact_id);
+                assert_eq!(progress, 400);
             }
+            _ => unreachable!(),
         }
-        .timeout(Duration::from_secs(10))
-        .await
-        .expect("timeout waiting for JoinerProgress event");
 
         // Check Bob sent the right handshake message.
         let msg = alice.parse_msg(&sent).await;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -829,17 +829,24 @@ mod tests {
         assert!(!disable_server_delete);
         assert!(!recode_avatar);
 
-        info!(&t, "test_migration_flags: XXX");
+        info!(&t, "test_migration_flags: XXX END MARKER");
 
         loop {
-            if let EventType::Info(info) = t.evtracker.recv().await.unwrap() {
-                assert!(
-                    !info.contains("[migration]"),
-                    "Migrations were run twice, you probably forgot to update the db version"
-                );
-                if info.contains("test_migration_flags: XXX") {
-                    break;
+            let evt = t
+                .evtracker
+                .get_matching(|evt| matches!(evt, EventType::Info(_)))
+                .await;
+            match evt {
+                EventType::Info(msg) => {
+                    assert!(
+                        !msg.contains("[migration]"),
+                        "Migrations were run twice, you probably forgot to update the db version"
+                    );
+                    if msg.contains("test_migration_flags: XXX END MARKER") {
+                        break;
+                    }
                 }
+                _ => unreachable!(),
             }
         }
 

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -678,11 +678,12 @@ async fn prune_tombstones(sql: &Sql) -> Result<()> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
+    use async_std::channel;
     use async_std::fs::File;
 
     use crate::config::Config;
-    use crate::{test_utils::TestContext, Event, EventType};
+    use crate::{test_utils::TestContext, EventType};
 
     use super::*;
 
@@ -743,18 +744,8 @@ mod test {
             .await
             .unwrap();
 
-        t.add_event_sink(move |event: Event| async move {
-            match event.typ {
-                EventType::Info(s) => assert!(
-                    !s.contains("Keeping new unreferenced file"),
-                    "File {} was almost deleted, only reason it was kept is that it was created recently (as the tests don't run for a long time)",
-                    s
-                ),
-                EventType::Error(s) => panic!("{}", s),
-                _ => {}
-            }
-        })
-        .await;
+        let (event_sink, event_source) = channel::unbounded();
+        t.add_event_sender(event_sink).await;
 
         let a = t.get_config(Config::Selfavatar).await.unwrap().unwrap();
         assert_eq!(avatar_bytes, &async_std::fs::read(&a).await.unwrap()[..]);
@@ -765,6 +756,18 @@ mod test {
 
         let a = t.get_config(Config::Selfavatar).await.unwrap().unwrap();
         assert_eq!(avatar_bytes, &async_std::fs::read(&a).await.unwrap()[..]);
+
+        while let Ok(event) = event_source.try_recv() {
+            match event.typ {
+                EventType::Info(s) => assert!(
+                    !s.contains("Keeping new unreferenced file"),
+                    "File {} was almost deleted, only reason it was kept is that it was created recently (as the tests don't run for a long time)",
+                    s
+                ),
+                EventType::Error(s) => panic!("{}", s),
+                _ => {}
+            }
+        }
     }
 
     /// Regression test.

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -570,7 +570,7 @@ pub struct LogSink {
 
 impl LogSink {
     /// Creates a new [`LogSink`] and returns the attached event sink.
-    fn create() -> (Sender<Event>, Self) {
+    pub fn create() -> (Sender<Event>, Self) {
         let (tx, rx) = channel::unbounded();
         (tx, Self { events: rx })
     }


### PR DESCRIPTION
Tests made sure to log their events, however when you have multiple failures the results were all over the place.  This introduces a LogSink to ensure the test failures look good and each has their own log reports.  If you only have a single context nothing changes since the TestContext keeps a reference to the LogSink and since the TestContext is dropped at the end of each test this works correctly.  If you have multiple TestContexts in a test and want to see the logs intermingled, both TestContexts need to use the same LogSink and you need to create it explicitly.

It is best to review this commit-by-commit, because one thing led to another:

- With the LogSink having to be injected early, the ways to create the TestContext exploded and creating a builder for it seemed much more sane.
- The EventSink type was a generic callback, this was awkward mostly because it can not be cloned, there is nothing you could do with the EventSink that you can't do by spawning a receiver and making it receive events over a channel.  So let's do that and switch over EventSink users.
- The EvTracker really didn't need to be special cased anymore now, it is just another event sender.
- Switch over the securejoin test to use EventTracker and LogSink