### PR TITLE
Add `imap` table to keep track of message UIDs

### DIFF
--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -101,7 +101,7 @@ async fn reset_tables(context: &Context, bits: i32) {
 async fn poke_eml_file(context: &Context, filename: impl AsRef<Path>) -> Result<()> {
     let data = dc_read_file(context, filename).await?;
 
-    if let Err(err) = dc_receive_imf(context, &data, "import", 0, false).await {
+    if let Err(err) = dc_receive_imf(context, &data, "import", false).await {
         println!("dc_receive_imf errored: {:?}", err);
     }
     Ok(())

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4369,7 +4369,7 @@ mod tests {
         assert_eq!(msg.match_indices("Gr.").count(), 1);
 
         // Bob receives this message, he may detect group by `References:`- or `Chat-Group:`-header
-        dc_receive_imf(&bob, msg.as_bytes(), "INBOX", 1, false)
+        dc_receive_imf(&bob, msg.as_bytes(), "INBOX", false)
             .await
             .unwrap();
         let msg = bob.get_last_msg().await;
@@ -4389,7 +4389,7 @@ mod tests {
         assert_eq!(msg.match_indices("Chat-").count(), 0);
 
         // Alice receives this message - she can still detect the group by the `References:`-header
-        dc_receive_imf(&alice, msg.as_bytes(), "INBOX", 2, false)
+        dc_receive_imf(&alice, msg.as_bytes(), "INBOX", false)
             .await
             .unwrap();
         let msg = alice.get_last_msg().await;
@@ -4417,7 +4417,6 @@ mod tests {
                  \n\
                  hello\n",
             "INBOX",
-            1,
             false,
         )
         .await?;
@@ -4466,7 +4465,6 @@ mod tests {
                  \n\
                  hello\n",
             "INBOX",
-            1,
             false,
         )
         .await?;
@@ -4515,7 +4513,6 @@ mod tests {
                  \n\
                  hello\n",
             "INBOX",
-            1,
             false,
         )
         .await?;
@@ -4563,7 +4560,6 @@ mod tests {
                  \n\
                  hello\n",
             "INBOX",
-            1,
             false,
         )
         .await?;

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -507,7 +507,6 @@ mod tests {
                  \n\
                  hello foo\n",
             "INBOX",
-            1,
             false,
         )
         .await?;
@@ -569,7 +568,6 @@ mod tests {
                  \n\
                  hello foo\n",
             "INBOX",
-            1,
             false,
         )
         .await?;

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -2084,7 +2084,7 @@ Chat-Version: 1.0
 Date: Sun, 22 Mar 2020 22:37:55 +0000
 
 Hi."#;
-        dc_receive_imf(&alice, mime, "Inbox", 1, false).await?;
+        dc_receive_imf(&alice, mime, "Inbox", false).await?;
         let msg = alice.get_last_msg().await;
 
         let timestamp = msg.get_timestamp();

--- a/src/context.rs
+++ b/src/context.rs
@@ -676,7 +676,7 @@ mod tests {
             dc_create_outgoing_rfc724_mid(None, contact.get_addr())
         );
         println!("{}", msg);
-        dc_receive_imf(t, msg.as_bytes(), "INBOX", 1, false)
+        dc_receive_imf(t, msg.as_bytes(), "INBOX", false)
             .await
             .unwrap();
     }

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -776,7 +776,6 @@ mod tests {
 hi
 
 Message-ID: 2dfdbde7@example.org
-Last seen as: INBOX/1
 
 Hop: From: localhost; By: hq5.merlinux.eu; Date: Sat, 14 Sep 2019 17:00:22 +0000
 Hop: From: hq5.merlinux.eu; By: hq5.merlinux.eu; Date: Sat, 14 Sep 2019 17:00:25 +0000";
@@ -793,7 +792,6 @@ hi back\r\n\
 Sent with my Delta Chat Messenger: https://delta.chat
 
 Message-ID: Mr.adQpEwndXLH.LPDdlFVJ7wG@example.net
-Last seen as: INBOX/1
 
 Hop: From: [127.0.0.1]; By: mail.example.org; Date: Mon, 27 Dec 2021 11:21:21 +0000
 Hop: From: mout.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22 +0000
@@ -804,7 +802,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
     async fn check_parse_receive_headers_integration(raw: &[u8], expected: &str) {
         let t = TestContext::new_alice().await;
         t.set_config(Config::ShowEmails, Some("2")).await.unwrap();
-        dc_receive_imf(&t, raw, "INBOX", 1, false).await.unwrap();
+        dc_receive_imf(&t, raw, "INBOX", false).await.unwrap();
         let msg = t.get_last_msg().await;
         let msg_info = get_msg_info(&t, msg.id).await.unwrap();
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -440,9 +440,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
             .create_chat_with_contact("", "sender@testrun.org")
             .await;
         let raw = include_bytes!("../test-data/message/text_alt_plain_html.eml");
-        dc_receive_imf(&alice, raw, "INBOX", 1, false)
-            .await
-            .unwrap();
+        dc_receive_imf(&alice, raw, "INBOX", false).await.unwrap();
         let msg = alice.get_last_msg_in(chat.get_id()).await;
         assert_ne!(msg.get_from_id(), DC_CONTACT_ID_SELF);
         assert_eq!(msg.is_dc_message, MessengerMessage::No);
@@ -491,9 +489,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
             .create_chat_with_contact("", "sender@testrun.org")
             .await;
         let raw = include_bytes!("../test-data/message/text_alt_plain_html.eml");
-        dc_receive_imf(&alice, raw, "INBOX", 1, false)
-            .await
-            .unwrap();
+        dc_receive_imf(&alice, raw, "INBOX", false).await.unwrap();
         let msg = alice.get_last_msg_in(chat.get_id()).await;
 
         // forward the message to saved-messages,
@@ -560,7 +556,6 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
             &t,
             include_bytes!("../test-data/message/cp1252-html.eml"),
             "INBOX",
-            0,
             false,
         )
         .await?;

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -10,7 +10,7 @@ use async_std::prelude::*;
 use super::{get_folder_meaning, get_folder_meaning_by_name};
 
 impl Imap {
-    pub async fn scan_folders(&mut self, context: &Context) -> Result<()> {
+    pub(crate) async fn scan_folders(&mut self, context: &Context) -> Result<()> {
         // First of all, debounce to once per minute:
         let mut last_scan = context.last_full_folder_scan.lock().await;
         if let Some(last_scan) = *last_scan {
@@ -74,7 +74,7 @@ impl Imap {
                 self.server_sent_unsolicited_exists(context);
 
                 loop {
-                    self.fetch_new_messages(context, folder.name(), false)
+                    self.fetch_move_delete(context, folder.name())
                         .await
                         .ok_or_log_msg(context, "Can't fetch new msgs in scanned folder");
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1637,7 +1637,6 @@ mod tests {
             \n\
             hello\n",
             "INBOX",
-            1,
             false,
         )
         .await
@@ -1731,7 +1730,6 @@ mod tests {
             )
             .as_bytes(),
             "INBOX",
-            5,
             false,
         )
         .await?;
@@ -1843,7 +1841,6 @@ mod tests {
                     \n\
                     Some other, completely unrelated content\n",
                 "INBOX",
-                2,
                 false,
             )
             .await
@@ -1868,7 +1865,7 @@ mod tests {
             .await
             .unwrap();
 
-        dc_receive_imf(context, imf_raw, "INBOX", 1, false)
+        dc_receive_imf(context, imf_raw, "INBOX", false)
             .await
             .unwrap();
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -2855,7 +2855,6 @@ On 2020-10-25, Bob wrote:
             &t.ctx,
             include_bytes!("../test-data/message/subj_with_multimedia_msg.eml"),
             "INBOX",
-            1,
             false,
         )
         .await
@@ -3004,7 +3003,7 @@ Subject: ...
 
 Some quote.
 "###;
-        dc_receive_imf(&t, raw, "INBOX", 1, false).await?;
+        dc_receive_imf(&t, raw, "INBOX", false).await?;
 
         // Delta Chat generates In-Reply-To with a starting tab when Message-ID is too long.
         let raw = br###"In-Reply-To:
@@ -3021,7 +3020,7 @@ Subject: ...
 Some reply
 "###;
 
-        dc_receive_imf(&t, raw, "INBOX", 2, false).await?;
+        dc_receive_imf(&t, raw, "INBOX", false).await?;
 
         let msg = t.get_last_msg().await;
         assert_eq!(msg.get_text().unwrap(), "Some reply");
@@ -3049,13 +3048,13 @@ Message.
 "###;
 
         // Bob receives message.
-        dc_receive_imf(&bob, raw, "INBOX", 1, false).await?;
+        dc_receive_imf(&bob, raw, "INBOX", false).await?;
         let msg = bob.get_last_msg().await;
         // Message is incoming.
         assert!(msg.param.get_bool(Param::WantsMdn).unwrap());
 
         // Alice receives copy-to-self.
-        dc_receive_imf(&alice, raw, "INBOX", 1, false).await?;
+        dc_receive_imf(&alice, raw, "INBOX", false).await?;
         let msg = alice.get_last_msg().await;
         // Message is outgoing, don't send read receipt to self.
         assert!(msg.param.get_bool(Param::WantsMdn).is_none());
@@ -3082,7 +3081,6 @@ Message.
                  hello\n"
                 .as_bytes(),
             "INBOX",
-            1,
             false,
         )
         .await?;
@@ -3121,7 +3119,6 @@ Message.
                  --SNIPP--"
             .as_bytes(),
             "INBOX",
-            2,
             false,
         )
         .await?;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -666,9 +666,11 @@ async fn maybe_add_from_param(
 /// have a server UID.
 async fn prune_tombstones(sql: &Sql) -> Result<()> {
     sql.execute(
-        "DELETE FROM msgs \
-         WHERE (chat_id = ? OR hidden) \
-         AND server_uid = 0",
+        "DELETE FROM msgs
+         WHERE (chat_id=? OR hidden)
+         AND NOT EXISTS (
+         SELECT * FROM imap WHERE msgs.rfc724_mid=rfc724_mid AND target!=''
+         )",
         paramsv![DC_CHAT_ID_TRASH],
     )
     .await?;

--- a/src/update_helper.rs
+++ b/src/update_helper.rs
@@ -100,7 +100,6 @@ mod tests {
                  \n\
                  second message\n",
             "INBOX",
-            1,
             false,
         )
         .await?;
@@ -115,7 +114,6 @@ mod tests {
                  \n\
                  first message\n",
             "INBOX",
-            2,
             false,
         )
         .await?;
@@ -146,7 +144,6 @@ mod tests {
                  \n\
                  first message\n",
             "INBOX",
-            1,
             false,
         )
         .await?;
@@ -167,7 +164,6 @@ mod tests {
                  \n\
                  third message\n",
             "INBOX",
-            2,
             false,
         )
         .await?;
@@ -184,7 +180,6 @@ mod tests {
                  \n\
                  second message\n",
             "INBOX",
-            3,
             false,
         )
         .await?;


### PR DESCRIPTION
`imap` table maps Message-IDs to UIDs on the server. `dc_receive_imf`
no longer gets the UID of the message as an argument and does not
insert the folder and UID of the message into the `msgs`
table. `server_folder` and `server_uid` columns in `msgs` table are
deprecated.

MoveMsg and DeleteMsgOnImap jobs are removed. Now messages are moved
and deleted only in the `fetch_move_delete` procedure that consults
the `target` column of the `imap` table to determine where the message
should go.

Where the message should go is determined after prefetching by the
`imap::target_folder()` procedure.  Messages are only downloaded once
they reach their target folder to avoid race conditions in multidevice
setting, such as:

1. One device trying to FETCH the message while the other tries to
MOVE it.

2. One device marking the message as \Seen in the Inbox while the
other has already copied unseen message to the Movebox and is going to
delete the \Seen message in the Inbox.

3. Device downloads the message from the Inbox while there are newer
messages in the Movebox placed there by the other device, thus
processing the messages out of order.

Closes #1334
Closes #2163 