### PR TITLE
change SVG Viewtype to Image, again

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1232,7 +1232,7 @@ pub fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)> {
         "rar" => (Viewtype::File, "application/vnd.rar"),
         "rtf" => (Viewtype::File, "application/rtf"),
         "spx" => (Viewtype::File, "audio/ogg"), // Ogg Speex Profile
-        "svg" => (Viewtype::File, "image/svg+xml"),
+        "svg" => (Viewtype::Image, "image/svg+xml"),
         "tgs" => (Viewtype::Sticker, "application/x-tgsticker"),
         "tiff" => (Viewtype::File, "image/tiff"),
         "tif" => (Viewtype::File, "image/tiff"),

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1537,7 +1537,6 @@ fn get_mime_type(mail: &mailparse::ParsedMail<'_>) -> Result<(Mime, Viewtype)> {
         }
         mime::IMAGE => match mimetype.subtype() {
             mime::GIF => Viewtype::Gif,
-            mime::SVG => Viewtype::File,
             _ => Viewtype::Image,
         },
         mime::AUDIO => Viewtype::Audio,


### PR DESCRIPTION
SVG viewtype was changed to file because Android app didn't supported SVG but now it is added in https://github.com/deltachat/deltachat-android/pull/2179 and Desktop & iOS already supported SVG in the past