### PR TITLE
Securejoin: store bobstate in database instead of context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changes
 - add more SMTP logging #3093
 - place common headers like `From:` before the large `Autocrypt:` header #3079
-
+- keep track of securejoin joiner status in database to survive restarts #2920
 
 ## 1.76.0
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -175,7 +175,7 @@ impl ChatId {
     /// Returns the unblocked 1:1 chat with `contact_id`.
     ///
     /// This should be used when **a user action** creates a chat 1:1, it ensures the chat
-    /// exists and is unblocked and scales the [`Contact`]'s origin.
+    /// exists, is unblocked and scales the [`Contact`]'s origin.
     pub async fn create_for_contact(context: &Context, contact_id: u32) -> Result<Self> {
         ChatId::create_for_contact_with_blocked(context, contact_id, Blocked::Not).await
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -24,7 +24,6 @@ use crate::login_param::LoginParam;
 use crate::message::{self, MessageState, MsgId};
 use crate::quota::QuotaInfo;
 use crate::scheduler::Scheduler;
-use crate::securejoin::Bob;
 use crate::sql::Sql;
 
 #[derive(Clone, Debug)]
@@ -45,7 +44,6 @@ pub struct InnerContext {
     /// Blob directory path
     pub(crate) blobdir: PathBuf,
     pub(crate) sql: Sql,
-    pub(crate) bob: Bob,
     pub(crate) last_smeared_timestamp: RwLock<i64>,
     pub(crate) running_state: RwLock<RunningState>,
     /// Mutex to avoid generating the key for the user more than once.
@@ -171,7 +169,6 @@ impl Context {
             blobdir,
             running_state: RwLock::new(Default::default()),
             sql: Sql::new(dbfile),
-            bob: Default::default(),
             last_smeared_timestamp: RwLock::new(0),
             generating_key_mutex: Mutex::new(()),
             oauth2_mutex: Mutex::new(()),

--- a/src/key.rs
+++ b/src/key.rs
@@ -318,7 +318,7 @@ pub async fn store_self_keypair(
 }
 
 /// A key fingerprint
-#[derive(Clone, Eq, PartialEq, Hash)]
+#[derive(Clone, Eq, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct Fingerprint(Vec<u8>);
 
 impl Fingerprint {

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -3,13 +3,12 @@
 use std::convert::TryFrom;
 
 use anyhow::{bail, Context as _, Error, Result};
-use async_std::sync::Mutex;
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 
 use crate::aheader::EncryptPreference;
-use crate::chat::{self, is_contact_in_chat, Chat, ChatId, ChatIdBlocked, ProtectionStatus};
+use crate::chat::{self, Chat, ChatId, ChatIdBlocked};
 use crate::config::Config;
-use crate::constants::{Blocked, Chattype, Viewtype, DC_CONTACT_ID_LAST_SPECIAL};
+use crate::constants::{Blocked, Viewtype, DC_CONTACT_ID_LAST_SPECIAL};
 use crate::contact::{Contact, Origin, VerifiedStatus};
 use crate::context::Context;
 use crate::dc_tools::time;
@@ -25,27 +24,15 @@ use crate::qr::check_qr;
 use crate::stock_str;
 use crate::token;
 
+mod bob;
 mod bobstate;
 mod qrinvite;
 
 use crate::token::Namespace;
-use bobstate::{BobHandshakeStage, BobState, BobStateHandle};
+use bobstate::BobState;
 use qrinvite::QrInvite;
 
 pub const NON_ALPHANUMERIC_WITHOUT_DOT: &AsciiSet = &NON_ALPHANUMERIC.remove(b'.');
-
-macro_rules! joiner_progress {
-    ($context:tt, $contact_id:expr, $progress:expr) => {
-        assert!(
-            $progress >= 0 && $progress <= 1000,
-            "value in range 0..1000 expected with: 0=error, 1..999=progress, 1000=success"
-        );
-        $context.emit_event($crate::events::EventType::SecurejoinJoinerProgress {
-            contact_id: $contact_id,
-            progress: $progress,
-        });
-    };
-}
 
 macro_rules! inviter_progress {
     ($context:tt, $contact_id:expr, $progress:expr) => {
@@ -58,100 +45,6 @@ macro_rules! inviter_progress {
             progress: $progress,
         });
     };
-}
-
-/// State for setup-contact/secure-join protocol joiner's side, aka Bob's side.
-///
-/// The setup-contact protocol needs to carry state for both the inviter (Alice) and the
-/// joiner/invitee (Bob).  For Alice this state is minimal and in the `tokens` table in the
-/// database.  For Bob this state is only carried live on the [`Context`] in this struct.
-#[derive(Debug, Default)]
-pub(crate) struct Bob {
-    inner: Mutex<Option<BobState>>,
-}
-
-/// Return value for [`Bob::start_protocol`].
-///
-/// This indicates which protocol variant was started and provides the required information
-/// about it.
-enum StartedProtocolVariant {
-    /// The setup-contact protocol, to verify a contact.
-    SetupContact,
-    /// The secure-join protocol, to join a group.
-    SecureJoin {
-        group_id: String,
-        group_name: String,
-    },
-}
-
-impl Bob {
-    /// Starts the securejoin protocol with the QR `invite`.
-    ///
-    /// This will try to start the securejoin protocol for the given QR `invite`.  If it
-    /// succeeded the protocol state will be tracked in `self`.
-    ///
-    /// This function takes care of starting the "ongoing" mechanism if required and
-    /// handling errors while starting the protocol.
-    ///
-    /// # Returns
-    ///
-    /// If the started protocol is joining a group the returned struct contains information
-    /// about the group and ongoing process.
-    async fn start_protocol(
-        &self,
-        context: &Context,
-        invite: QrInvite,
-    ) -> Result<StartedProtocolVariant, JoinError> {
-        let mut guard = self.inner.lock().await;
-        if guard.is_some() {
-            warn!(context, "The new securejoin will replace the ongoing one.");
-            *guard = None;
-        }
-        let variant = match invite {
-            QrInvite::Group {
-                ref grpid,
-                ref name,
-                ..
-            } => StartedProtocolVariant::SecureJoin {
-                group_id: grpid.clone(),
-                group_name: name.clone(),
-            },
-            _ => StartedProtocolVariant::SetupContact,
-        };
-        match BobState::start_protocol(context, invite).await {
-            Ok((state, stage)) => {
-                if matches!(stage, BobHandshakeStage::RequestWithAuthSent) {
-                    joiner_progress!(context, state.invite().contact_id(), 400);
-                }
-                *guard = Some(state);
-                Ok(variant)
-            }
-            Err(err) => {
-                if let StartedProtocolVariant::SecureJoin { .. } = variant {
-                    context.free_ongoing().await;
-                }
-                Err(err)
-            }
-        }
-    }
-
-    /// Returns a handle to the [`BobState`] of the handshake.
-    ///
-    /// If there currently isn't a handshake running this will return `None`.  Otherwise
-    /// this will return a handle to the current [`BobState`].  This handle allows
-    /// processing an incoming message and allows terminating the handshake.
-    ///
-    /// The handle contains an exclusive lock, which is held until the handle is dropped.
-    /// This guarantees all state and state changes are correct and allows safely
-    /// terminating the handshake without worrying about concurrency.
-    async fn state(&self, context: &Context) -> Option<BobStateHandle<'_>> {
-        let guard = self.inner.lock().await;
-        let ret = BobStateHandle::from_guard(guard);
-        if ret.is_none() {
-            info!(context, "No active BobState found for securejoin handshake");
-        }
-        ret
-    }
 }
 
 /// Generates a Secure Join QR code.
@@ -280,7 +173,7 @@ pub enum JoinError {
 pub async fn dc_join_securejoin(context: &Context, qr: &str) -> Result<ChatId, JoinError> {
     securejoin(context, qr).await.map_err(|err| {
         warn!(context, "Fatal joiner error: {:#}", err);
-        // This is a modal operation, the user has context on what failed.
+        // The user just scanned this QR code so has context on what failed.
         error!(context, "QR process failed");
         err
     })
@@ -297,47 +190,7 @@ async fn securejoin(context: &Context, qr: &str) -> Result<ChatId, JoinError> {
 
     let invite = QrInvite::try_from(qr_scan)?;
 
-    match context.bob.start_protocol(context, invite.clone()).await? {
-        StartedProtocolVariant::SetupContact => {
-            // for a one-to-one-chat, the chat is already known, return the chat-id,
-            // the verification runs in background
-            let chat_id = ChatId::create_for_contact(context, invite.contact_id())
-                .await
-                .map_err(JoinError::UnknownContact)?;
-            Ok(chat_id)
-        }
-        StartedProtocolVariant::SecureJoin {
-            group_id,
-            group_name,
-        } => {
-            // for a group-join, also create the chat soon and let the verification run in background.
-            // however, the group will become usable only when the protocol has finished.
-            let contact_id = invite.contact_id();
-            let chat_id = if let Some((chat_id, _protected, _blocked)) =
-                chat::get_chat_id_by_grpid(context, &group_id).await?
-            {
-                chat_id.unblock(context).await?;
-                chat_id
-            } else {
-                ChatId::create_multiuser_record(
-                    context,
-                    Chattype::Group,
-                    &group_id,
-                    &group_name,
-                    Blocked::Not,
-                    ProtectionStatus::Unprotected, // protection is added later as needed
-                    None,
-                )
-                .await?
-            };
-            if !is_contact_in_chat(context, chat_id, contact_id).await? {
-                chat::add_to_chat_contacts_table(context, chat_id, contact_id).await?;
-            }
-            let msg = stock_str::secure_join_started(context, contact_id).await;
-            chat::add_info_msg(context, chat_id, &msg, time()).await?;
-            Ok(chat_id)
-        }
-    }
+    bob::start_protocol(context, invite).await
 }
 
 /// Error when failing to send a protocol handshake message.
@@ -442,9 +295,8 @@ pub(crate) enum HandshakeMessage {
 
 /// Handle incoming secure-join handshake.
 ///
-/// This function will update the securejoin state in [`InnerContext::bob`] and also
-/// terminate the ongoing process using [`Context::stop_ongoing`] as required by the
-/// protocol.
+/// This function will update the securejoin state in the database as the protocol
+/// progresses.
 ///
 /// A message which results in [`Err`] will be hidden from the user but not deleted, it may
 /// be a valid message for something else we are not aware off.  E.g. it could be part of a
@@ -452,8 +304,6 @@ pub(crate) enum HandshakeMessage {
 ///
 /// When `handle_securejoin_handshake()` is called, the message is not yet filed in the
 /// database; this is done by `receive_imf()` later on as needed.
-///
-/// [`InnerContext::bob`]: crate::context::InnerContext::bob
 #[allow(clippy::indexing_slicing)]
 pub(crate) async fn handle_securejoin_handshake(
     context: &Context,
@@ -521,38 +371,7 @@ pub(crate) async fn handle_securejoin_handshake(
             ====             Bob - the joiner's side             =====
             ====   Step 4 in "Setup verified contact" protocol   =====
             ========================================================*/
-            match context.bob.state(context).await {
-                Some(mut bobstate) => match bobstate.handle_message(context, mime_message).await {
-                    Some(BobHandshakeStage::Terminated(why)) => {
-                        could_not_establish_secure_connection(
-                            context,
-                            contact_id,
-                            bobstate.chat_id(context).await?,
-                            why,
-                        )
-                        .await?;
-                        Ok(HandshakeMessage::Done)
-                    }
-                    Some(_stage) => {
-                        if join_vg {
-                            // the message reads "Alice replied, waiting for being added to the group…";
-                            // show it only on secure-join and not on setup-contact therefore.
-                            let msg = stock_str::secure_join_replies(context, contact_id).await;
-                            chat::add_info_msg(
-                                context,
-                                bobstate.chat_id(context).await?,
-                                &msg,
-                                time(),
-                            )
-                            .await?;
-                        }
-                        joiner_progress!(context, bobstate.invite().contact_id(), 400);
-                        Ok(HandshakeMessage::Done)
-                    }
-                    None => Ok(HandshakeMessage::Ignore),
-                },
-                None => Ok(HandshakeMessage::Ignore),
-            }
+            bob::handle_auth_required(context, mime_message).await
         }
         "vg-request-with-auth" | "vc-request-with-auth" => {
             /*==========================================================
@@ -683,44 +502,14 @@ pub(crate) async fn handle_securejoin_handshake(
             ====             Bob - the joiner's side             ====
             ====   Step 7 in "Setup verified contact" protocol   ====
             =======================================================*/
-            info!(context, "matched vc-contact-confirm step");
-            let retval = if join_vg {
-                HandshakeMessage::Propagate
-            } else {
-                HandshakeMessage::Ignore
-            };
-            match context.bob.state(context).await {
-                Some(mut bobstate) => match bobstate.handle_message(context, mime_message).await {
-                    Some(BobHandshakeStage::Terminated(why)) => {
-                        could_not_establish_secure_connection(
-                            context,
-                            contact_id,
-                            bobstate.chat_id(context).await?,
-                            why,
-                        )
-                        .await?;
-                        Ok(HandshakeMessage::Done)
-                    }
-                    Some(BobHandshakeStage::Completed) => {
-                        // Can only be BobHandshakeStage::Completed
-                        secure_connection_established(
-                            context,
-                            contact_id,
-                            bobstate.chat_id(context).await?,
-                        )
-                        .await?;
-                        Ok(retval)
-                    }
-                    Some(_) => {
-                        warn!(
-                            context,
-                            "Impossible state returned from handling handshake message"
-                        );
-                        Ok(retval)
-                    }
-                    None => Ok(retval),
+            match BobState::from_db(&context.sql).await? {
+                Some(bobstate) => {
+                    bob::handle_contact_confirm(context, bobstate, mime_message).await
+                }
+                None => match join_vg {
+                    true => Ok(HandshakeMessage::Propagate),
+                    false => Ok(HandshakeMessage::Ignore),
                 },
-                None => Ok(retval),
             }
         }
         "vg-member-added-received" | "vc-contact-confirm-received" => {
@@ -851,7 +640,7 @@ async fn secure_connection_established(
     chat_id: ChatId,
 ) -> Result<(), Error> {
     let contact = Contact::get_by_id(context, contact_id).await?;
-    let msg = stock_str::contact_verified(context, contact.get_name_n_addr()).await;
+    let msg = stock_str::contact_verified(context, &contact).await;
     chat::add_info_msg(context, chat_id, &msg, time()).await?;
     context.emit_event(EventType::ChatModified(chat_id));
     Ok(())
@@ -863,16 +652,8 @@ async fn could_not_establish_secure_connection(
     chat_id: ChatId,
     details: &str,
 ) -> Result<(), Error> {
-    let contact = Contact::get_by_id(context, contact_id).await;
-    let msg = stock_str::contact_not_verified(
-        context,
-        if let Ok(ref contact) = contact {
-            contact.get_addr()
-        } else {
-            "?"
-        },
-    )
-    .await;
+    let contact = Contact::get_by_id(context, contact_id).await?;
+    let msg = stock_str::contact_not_verified(context, &contact).await;
     chat::add_info_msg(context, chat_id, &msg, time()).await?;
     warn!(
         context,
@@ -945,19 +726,31 @@ mod tests {
     use crate::test_utils::{TestContext, TestContextManager};
 
     #[async_std::test]
-    async fn test_setup_contact() -> Result<()> {
+    async fn test_setup_contact() {
         let mut tcm = TestContextManager::new().await;
         let alice = tcm.alice().await;
         let bob = tcm.bob().await;
-        assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
-        assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 0);
+        assert_eq!(
+            Chatlist::try_load(&alice, 0, None, None)
+                .await
+                .unwrap()
+                .len(),
+            0
+        );
+        assert_eq!(
+            Chatlist::try_load(&bob, 0, None, None).await.unwrap().len(),
+            0
+        );
 
         // Step 1: Generate QR-code, ChatId(0) indicates setup-contact
-        let qr = dc_get_securejoin_qr(&alice.ctx, None).await?;
+        let qr = dc_get_securejoin_qr(&alice.ctx, None).await.unwrap();
 
         // Step 2: Bob scans QR-code, sends vc-request
-        dc_join_securejoin(&bob.ctx, &qr).await?;
-        assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 1);
+        dc_join_securejoin(&bob.ctx, &qr).await.unwrap();
+        assert_eq!(
+            Chatlist::try_load(&bob, 0, None, None).await.unwrap().len(),
+            1
+        );
 
         let sent = bob.pop_sent_msg().await;
         assert!(!bob.ctx.has_ongoing().await);
@@ -969,7 +762,13 @@ mod tests {
 
         // Step 3: Alice receives vc-request, sends vc-auth-required
         alice.recv_msg(&sent).await;
-        assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 1);
+        assert_eq!(
+            Chatlist::try_load(&alice, 0, None, None)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
 
         let sent = alice.pop_sent_msg().await;
         let msg = bob.parse_msg(&sent).await;
@@ -1031,21 +830,30 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            contact_bob.is_verified(&alice.ctx).await?,
+            contact_bob.is_verified(&alice.ctx).await.unwrap(),
             VerifiedStatus::Unverified
         );
 
         // Step 5+6: Alice receives vc-request-with-auth, sends vc-contact-confirm
         alice.recv_msg(&sent).await;
         assert_eq!(
-            contact_bob.is_verified(&alice.ctx).await?,
+            contact_bob.is_verified(&alice.ctx).await.unwrap(),
             VerifiedStatus::BidirectVerified
         );
 
         // exactly one one-to-one chat should be visible for both now
         // (check this before calling alice.create_chat() explicitly below)
-        assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 1);
-        assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 1);
+        assert_eq!(
+            Chatlist::try_load(&alice, 0, None, None)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            Chatlist::try_load(&bob, 0, None, None).await.unwrap().len(),
+            1
+        );
 
         // Check Alice got the verified message in her 1:1 chat.
         {
@@ -1085,14 +893,14 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            contact_bob.is_verified(&bob.ctx).await?,
+            contact_bob.is_verified(&bob.ctx).await.unwrap(),
             VerifiedStatus::Unverified
         );
 
         // Step 7: Bob receives vc-contact-confirm, sends vc-contact-confirm-received
         bob.recv_msg(&sent).await;
         assert_eq!(
-            contact_alice.is_verified(&bob.ctx).await?,
+            contact_alice.is_verified(&bob.ctx).await.unwrap(),
             VerifiedStatus::BidirectVerified
         );
 
@@ -1123,7 +931,6 @@ mod tests {
             msg.get_header(HeaderDef::SecureJoin).unwrap(),
             "vc-contact-confirm-received"
         );
-        Ok(())
     }
 
     #[async_std::test]
@@ -1295,14 +1102,15 @@ mod tests {
         let alice = tcm.alice().await;
         let bob = tcm.bob().await;
 
+        // We start with empty chatlists.
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
         assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 0);
 
-        let chatid =
+        let alice_chatid =
             chat::create_group_chat(&alice.ctx, ProtectionStatus::Protected, "the chat").await?;
 
         // Step 1: Generate QR-code, secure-join implied by chatid
-        let qr = dc_get_securejoin_qr(&alice.ctx, Some(chatid))
+        let qr = dc_get_securejoin_qr(&alice.ctx, Some(alice_chatid))
             .await
             .unwrap();
 
@@ -1393,6 +1201,35 @@ mod tests {
             "vg-member-added"
         );
 
+        {
+            // Now Alice's chat with Bob should still be hidden, the verified message should
+            // appear in the group chat.
+
+            let chat = alice
+                .get_chat(&bob)
+                .await
+                .expect("Alice has no 1:1 chat with bob");
+            assert_eq!(
+                chat.blocked,
+                Blocked::Yes,
+                "Alice's 1:1 chat with Bob is not hidden"
+            );
+            let msg_id = chat::get_chat_msgs(&alice.ctx, alice_chatid, 0x1, None)
+                .await
+                .unwrap()
+                .into_iter()
+                .filter_map(|item| match item {
+                    chat::ChatItem::Message { msg_id } => Some(msg_id),
+                    _ => None,
+                })
+                .min()
+                .expect("No messages in Alice's group chat");
+            let msg = Message::load_from_db(&alice.ctx, msg_id).await.unwrap();
+            assert!(msg.is_info());
+            let text = msg.get_text().unwrap();
+            assert!(text.contains("bob@example.net verified"));
+        }
+
         // Bob should not yet have Alice verified
         let contact_alice_id =
             Contact::lookup_id_by_addr(&bob.ctx, "alice@example.org", Origin::Unknown)
@@ -1407,10 +1244,53 @@ mod tests {
 
         // Step 7: Bob receives vg-member-added, sends vg-member-added-received
         bob.recv_msg(&sent).await;
-        assert_eq!(
-            contact_alice.is_verified(&bob.ctx).await?,
-            VerifiedStatus::BidirectVerified
-        );
+        {
+            // Bob has Alice verified, message shows up in the group chat.
+            assert_eq!(
+                contact_alice.is_verified(&bob.ctx).await?,
+                VerifiedStatus::BidirectVerified
+            );
+            let chat = bob
+                .get_chat(&alice)
+                .await
+                .expect("Bob has no 1:1 chat with Alice");
+            assert_eq!(
+                chat.blocked,
+                Blocked::Yes,
+                "Bob's 1:1 chat with Alice is not hidden"
+            );
+            for item in chat::get_chat_msgs(&bob.ctx, bob_chatid, 0x1, None)
+                .await
+                .unwrap()
+            {
+                if let chat::ChatItem::Message { msg_id } = item {
+                    let msg = Message::load_from_db(&bob.ctx, msg_id).await.unwrap();
+                    let text = msg.get_text().unwrap();
+                    println!("msg {} text: {}", msg_id, text);
+                }
+            }
+            let mut msg_iter = chat::get_chat_msgs(&bob.ctx, bob_chatid, 0x1, None)
+                .await
+                .unwrap()
+                .into_iter();
+            loop {
+                match msg_iter.next() {
+                    Some(chat::ChatItem::Message { msg_id }) => {
+                        let msg = Message::load_from_db(&bob.ctx, msg_id).await.unwrap();
+                        let text = msg.get_text().unwrap();
+                        match text.contains("alice@example.org verified") {
+                            true => {
+                                assert!(msg.is_info());
+                                break;
+                            }
+                            false => continue,
+                        }
+                    }
+                    Some(_) => continue,
+                    None => panic!("Verified message not found in Bob's group chat"),
+                }
+            }
+        }
 
         let sent = bob.pop_sent_msg().await;
         let msg = alice.parse_msg(&sent).await;

--- a/src/securejoin/bob.rs
+++ b/src/securejoin/bob.rs
@@ -1,0 +1,257 @@
+//! Bob's side of SecureJoin handling.
+//!
+//! This are some helper functions around [`BobState`] which augment the state changes with
+//! the required user interactions.
+
+use anyhow::Result;
+
+use crate::chat::{is_contact_in_chat, ChatId, ProtectionStatus};
+use crate::constants::{Blocked, Chattype};
+use crate::contact::Contact;
+use crate::context::Context;
+use crate::dc_tools::time;
+use crate::events::EventType;
+use crate::mimeparser::MimeMessage;
+use crate::{chat, stock_str};
+
+use super::bobstate::{BobHandshakeStage, BobState};
+use super::qrinvite::QrInvite;
+use super::{HandshakeMessage, JoinError};
+
+/// Starts the securejoin protocol with the QR `invite`.
+///
+/// This will try to start the securejoin protocol for the given QR `invite`.  If it
+/// succeeded the protocol state will be tracked in `self`.
+///
+/// This function takes care of handling multiple concurrent joins and handling errors while
+/// starting the protocol.
+///
+/// # Returns
+///
+/// The [`ChatId`] of the created chat is returned, for a SetupContact QR this is the 1:1
+/// chat with Alice, for a SecureJoin QR this is the group chat.
+pub(super) async fn start_protocol(
+    context: &Context,
+    invite: QrInvite,
+) -> Result<ChatId, JoinError> {
+    // A 1:1 chat is needed to send messages to Alice.  When joining a group this chat is
+    // hidden, if a user starts sending messages in it it will be unhidden in
+    // dc_receive_imf.
+    let hidden = match invite {
+        QrInvite::Contact { .. } => Blocked::Not,
+        QrInvite::Group { .. } => Blocked::Yes,
+    };
+    let chat_id = ChatId::create_for_contact_with_blocked(context, invite.contact_id(), hidden)
+        .await
+        .map_err(JoinError::UnknownContact)?;
+
+    // Now start the protocol and initialise the state
+    let (state, stage, aborted_states) =
+        BobState::start_protocol(context, invite.clone(), chat_id).await?;
+    for state in aborted_states {
+        error!(context, "Aborting previously unfinished QR Join process.");
+        state.notify_aborted(context, "new QR scanned").await?;
+        state.emit_progress(context, JoinerProgress::Error);
+    }
+    if matches!(stage, BobHandshakeStage::RequestWithAuthSent) {
+        state.emit_progress(context, JoinerProgress::RequestWithAuthSent);
+    }
+    match invite {
+        QrInvite::Group { .. } => {
+            // For a secure-join we need to create the group and add the contact.  The group will
+            // only become usable once the protocol is finished.
+            // TODO: how does this group become usable?
+            let group_chat_id = state.joining_chat_id(context).await?;
+            if !is_contact_in_chat(context, group_chat_id, invite.contact_id()).await? {
+                chat::add_to_chat_contacts_table(context, group_chat_id, invite.contact_id())
+                    .await?;
+            }
+            let msg = stock_str::secure_join_started(context, invite.contact_id()).await;
+            chat::add_info_msg(context, group_chat_id, &msg, time()).await?;
+            Ok(group_chat_id)
+        }
+        QrInvite::Contact { .. } => {
+            // For setup-contact the BobState already ensured the 1:1 chat exists because it
+            // uses it to send the handshake messages.
+            Ok(state.alice_chat())
+        }
+    }
+}
+
+/// Handles `vc-auth-required` and `vg-auth-required` handshake messages.
+///
+/// # Bob - the joiner's side
+/// ## Step 4 in the "Setup Contact protocol"
+pub(super) async fn handle_auth_required(
+    context: &Context,
+    message: &MimeMessage,
+) -> Result<HandshakeMessage> {
+    match BobState::from_db(&context.sql).await? {
+        Some(mut bobstate) => match bobstate.handle_message(context, message).await? {
+            Some(BobHandshakeStage::Terminated(why)) => {
+                bobstate.notify_aborted(context, why).await?;
+                Ok(HandshakeMessage::Done)
+            }
+            Some(_stage) => {
+                if bobstate.is_join_group() {
+                    // The message reads "Alice replied, waiting to be added to the group…",
+                    // so only show it on secure-join and not on setup-contact.
+                    let contact_id = bobstate.invite().contact_id();
+                    let msg = stock_str::secure_join_replies(context, contact_id).await;
+                    let chat_id = bobstate.joining_chat_id(context).await?;
+                    chat::add_info_msg(context, chat_id, &msg, time()).await?;
+                }
+                bobstate.emit_progress(context, JoinerProgress::RequestWithAuthSent);
+                Ok(HandshakeMessage::Done)
+            }
+            None => Ok(HandshakeMessage::Ignore),
+        },
+        None => Ok(HandshakeMessage::Ignore),
+    }
+}
+
+/// Handles `vc-contact-confirm` and `vg-member-added` handshake messages.
+///
+/// # Bob - the joiner's side
+/// ## Step 4 in the "Setup Contact protocol"
+pub(super) async fn handle_contact_confirm(
+    context: &Context,
+    mut bobstate: BobState,
+    message: &MimeMessage,
+) -> Result<HandshakeMessage> {
+    let retval = if bobstate.is_join_group() {
+        HandshakeMessage::Propagate
+    } else {
+        HandshakeMessage::Ignore
+    };
+    match bobstate.handle_message(context, message).await? {
+        Some(BobHandshakeStage::Terminated(why)) => {
+            bobstate.notify_aborted(context, why).await?;
+            Ok(HandshakeMessage::Done)
+        }
+        Some(BobHandshakeStage::Completed) => {
+            // Note this goes to the 1:1 chat, as when joining a group we implicitly also
+            // verify both contacts (this could be a bug/security issue, see
+            // e.g. https://github.com/deltachat/deltachat-core-rust/issues/1177).
+            bobstate.notify_peer_verified(context).await?;
+            Ok(retval)
+        }
+        Some(_) => {
+            warn!(
+                context,
+                "Impossible state returned from handling handshake message"
+            );
+            Ok(retval)
+        }
+        None => Ok(retval),
+    }
+}
+
+/// Private implementations for user interactions about this [`BobState`].
+impl BobState {
+    fn is_join_group(&self) -> bool {
+        match self.invite() {
+            QrInvite::Contact { .. } => false,
+            QrInvite::Group { .. } => true,
+        }
+    }
+
+    fn emit_progress(&self, context: &Context, progress: JoinerProgress) {
+        let contact_id = self.invite().contact_id();
+        context.emit_event(EventType::SecurejoinJoinerProgress {
+            contact_id,
+            progress: progress.into(),
+        });
+    }
+
+    /// Returns the [`ChatId`] of the chat being joined.
+    ///
+    /// This is the chat in which you want to notify the user as well.
+    ///
+    /// When joining a group this is the [`ChatId`] of the group chat, when verifying a
+    /// contact this is the [`ChatId`] of the 1:1 chat.  The 1:1 chat is assumed to exist
+    /// because a [`BobState`] can not exist without, the group chat will be created if it
+    /// does not yet exist.
+    async fn joining_chat_id(&self, context: &Context) -> Result<ChatId> {
+        match self.invite() {
+            QrInvite::Contact { .. } => Ok(self.alice_chat()),
+            QrInvite::Group {
+                ref grpid,
+                ref name,
+                ..
+            } => {
+                let group_chat_id = match chat::get_chat_id_by_grpid(context, grpid).await? {
+                    Some((chat_id, _protected, _blocked)) => {
+                        chat_id.unblock(context).await?;
+                        chat_id
+                    }
+                    None => {
+                        ChatId::create_multiuser_record(
+                            context,
+                            Chattype::Group,
+                            grpid,
+                            name,
+                            Blocked::Not,
+                            ProtectionStatus::Unprotected, // protection is added later as needed
+                            None,
+                        )
+                        .await?
+                    }
+                };
+                Ok(group_chat_id)
+            }
+        }
+    }
+
+    /// Notifies the user that the SecureJoin was aborted.
+    ///
+    /// This creates an info message in the chat being joined.
+    async fn notify_aborted(&self, context: &Context, why: &str) -> Result<()> {
+        let contact = Contact::get_by_id(context, self.invite().contact_id()).await?;
+        let msg = stock_str::contact_not_verified(context, &contact).await;
+        let chat_id = self.joining_chat_id(context).await?;
+        chat::add_info_msg(context, chat_id, &msg, time()).await?;
+        warn!(
+            context,
+            "StockMessage::ContactNotVerified posted to joining chat ({})", why
+        );
+        Ok(())
+    }
+
+    /// Notifies the user that the SecureJoin peer is verified.
+    ///
+    /// This creates an info message in the chat being joined.
+    async fn notify_peer_verified(&self, context: &Context) -> Result<()> {
+        let contact = Contact::get_by_id(context, self.invite().contact_id()).await?;
+        let msg = stock_str::contact_verified(context, &contact).await;
+        let chat_id = self.joining_chat_id(context).await?;
+        chat::add_info_msg(context, chat_id, &msg, time()).await?;
+        context.emit_event(EventType::ChatModified(chat_id));
+        Ok(())
+    }
+}
+
+/// Progress updates for [`EventType::SecurejoinJoinerProgress`].
+///
+/// This has an `From<JoinerProgress> for usize` impl yielding numbers between 0 and a 1000
+/// which can be shown as a progress bar.
+enum JoinerProgress {
+    /// An error occurred.
+    Error,
+    /// vg-vc-request-with-auth sent.
+    ///
+    /// Typically shows as "alice@addr verified, introducing myself."
+    RequestWithAuthSent,
+    // /// Completed securejoin.
+    // Succeeded,
+}
+
+impl From<JoinerProgress> for usize {
+    fn from(progress: JoinerProgress) -> Self {
+        match progress {
+            JoinerProgress::Error => 0,
+            JoinerProgress::RequestWithAuthSent => 400,
+            // JoinerProgress::Succeeded => 1000,
+        }
+    }
+}

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -579,6 +579,19 @@ CREATE INDEX smtp_messageid ON imap(rfc724_mid);
         )
         .await?;
     }
+    if dbversion < 86 {
+        info!(context, "[migration] v86");
+        sql.execute_migration(
+            r#"CREATE TABLE bobstate (
+                   id INTEGER PRIMARY KEY AUTOINCREMENT,
+                   invite TEXT NOT NULL,
+                   next_step INTEGER NOT NULL,
+                   chat_id INTEGER NOT NULL
+            );"#,
+            86,
+        )
+        .await?;
+    }
 
     Ok((
         recalc_fingerprints,

--- a/src/sql/tables.sql
+++ b/src/sql/tables.sql
@@ -168,6 +168,14 @@ CREATE TABLE tokens (
     timestamp INTEGER DEFAULT 0
 );
 
+-- The currently running securejoin protocols, joiner-side.
+-- CREATE TABLE bobstate (
+--     id INTEGER PRIMARY KEY AUTOINCREMENT,
+--     invite TEXT NOT NULL,
+--     next_step INTEGER NOT NULL,
+--     chat_id INTEGER NOT NULL
+-- );
+
 CREATE TABLE locations (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     latitude REAL DEFAULT 0.0,

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -636,20 +636,19 @@ pub(crate) async fn secure_join_group_qr_description(context: &Context, chat: &C
 }
 
 /// Stock string: `%1$s verified.`.
-pub(crate) async fn contact_verified(context: &Context, contact_addr: impl AsRef<str>) -> String {
+pub(crate) async fn contact_verified(context: &Context, contact: &Contact) -> String {
+    let addr = contact.get_name_n_addr();
     translated(context, StockMessage::ContactVerified)
         .await
-        .replace1(contact_addr)
+        .replace1(addr)
 }
 
 /// Stock string: `Cannot verify %1$s`.
-pub(crate) async fn contact_not_verified(
-    context: &Context,
-    contact_addr: impl AsRef<str>,
-) -> String {
+pub(crate) async fn contact_not_verified(context: &Context, contact: &Contact) -> String {
+    let addr = contact.get_name_n_addr();
     translated(context, StockMessage::ContactNotVerified)
         .await
-        .replace1(contact_addr)
+        .replace1(addr)
 }
 
 /// Stock string: `Changed setup for %1$s`.
@@ -1197,8 +1196,15 @@ mod tests {
     #[async_std::test]
     async fn test_stock_string_repl_str() {
         let t = TestContext::new().await;
+        let contact_id = Contact::create(&t.ctx, "Someone", "someone@example.org")
+            .await
+            .unwrap();
+        let contact = Contact::load_from_db(&t.ctx, contact_id).await.unwrap();
         // uses %1$s substitution
-        assert_eq!(contact_verified(&t, "Foo").await, "Foo verified.");
+        assert_eq!(
+            contact_verified(&t, &contact).await,
+            "Someone (someone@example.org) verified."
+        );
         // We have no string using %1$d to test...
     }
 


### PR DESCRIPTION
The state bob needs to maintain during a secure-join process when
exchanging messages used to be stored on the context.  This means if
the process was killed this state was lost and the securejoin process
would fail.  Moving this state into the database should help this.

This still only allows a single securejoin process at a time, this may
be relaxed in the future.  For now any previous securejoin process
that was running is killed if a new one is started (this was already
the case).

This can remove some of the complexity around BobState handling: since
the state is in the database we can already make state interactions
transactional and correct.  We no longer need the mutex around the
state handling.  This means the BobStateHandle construct that was
handling the interactions between always having a valid state and
handling the mutex is no longer needed, resulting in some nice
simplifications.

Part of #2777.

Note that the base of this PR is #2901 to make debugging nicer.