### PR TITLE
Remove `inbox_watch` option

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -293,9 +293,6 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    1=send a copy of outgoing messages to self.
  *                    Sending messages to self is needed for a proper multi-account setup,
  *                    however, on the other hand, may lead to unwanted notifications in non-delta clients.
- * - `inbox_watch`  = 1=watch `INBOX`-folder for changes (default),
- *                    0=do not watch the `INBOX`-folder,
- *                    changes require restarting IO by calling dc_stop_io() and then dc_start_io().
  * - `sentbox_watch`= 1=watch `Sent`-folder for changes (default),
  *                    0=do not watch the `Sent`-folder,
  *                    changes require restarting IO by calling dc_stop_io() and then dc_start_io().

--- a/src/config.rs
+++ b/src/config.rs
@@ -68,9 +68,6 @@ pub enum Config {
     MdnsEnabled,
 
     #[strum(props(default = "1"))]
-    InboxWatch,
-
-    #[strum(props(default = "1"))]
     SentboxWatch,
 
     #[strum(props(default = "1"))]

--- a/src/context.rs
+++ b/src/context.rs
@@ -322,7 +322,6 @@ impl Context {
             Err(err) => format!("<key failure: {}>", err),
         };
 
-        let inbox_watch = self.get_config_int(Config::InboxWatch).await?;
         let sentbox_watch = self.get_config_int(Config::SentboxWatch).await?;
         let mvbox_move = self.get_config_int(Config::MvboxMove).await?;
         let sentbox_move = self.get_config_int(Config::SentboxMove).await?;
@@ -380,7 +379,6 @@ impl Context {
                 .await?
                 .to_string(),
         );
-        res.insert("inbox_watch", inbox_watch.to_string());
         res.insert("sentbox_watch", sentbox_watch.to_string());
         res.insert("mvbox_move", mvbox_move.to_string());
         res.insert("sentbox_move", sentbox_move.to_string());

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -137,7 +137,7 @@ impl Context {
         }
 
         let quota = if imap.can_check_quota() {
-            let folders = get_watched_folders(self).await;
+            let folders = get_watched_folders(self).await?;
             get_unique_quota_roots_and_usage(folders, imap).await
         } else {
             Err(anyhow!(stock_str::not_supported_by_provider(self).await))

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -362,17 +362,17 @@ impl Context {
                 [
                     (
                         Config::ConfiguredInboxFolder,
-                        Config::InboxWatch,
+                        None,
                         inbox.state.connectivity.clone(),
                     ),
                     (
                         Config::ConfiguredMvboxFolder,
-                        Config::MvboxMove,
+                        Some(Config::MvboxMove),
                         mvbox.state.connectivity.clone(),
                     ),
                     (
                         Config::ConfiguredSentboxFolder,
-                        Config::SentboxWatch,
+                        Some(Config::SentboxWatch),
                         sentbox.state.connectivity.clone(),
                     ),
                 ],
@@ -393,10 +393,18 @@ impl Context {
 
         ret += &format!("<h3>{}</h3><ul>", stock_str::incoming_messages(self).await);
         for (folder, watch, state) in &folders_states {
-            let w = self.get_config(*watch).await.ok_or_log(self);
+            let w = if let Some(watch_config) = *watch {
+                self.get_config(watch_config)
+                    .await
+                    .ok_or_log(self)
+                    .flatten()
+                    == Some("1".to_string())
+            } else {
+                true
+            };
 
             let mut folder_added = false;
-            if w.flatten() == Some("1".to_string()) {
+            if w {
                 let f = self.get_config(*folder).await.ok_or_log(self).flatten();
 
                 if let Some(foldername) = f {


### PR DESCRIPTION
Also resultified `get_watched_folders`.

Python test `test_moved_markseen` is modified to test using incoming
message instead of BCC-self message, because BCC-self message is
detected immediately in the Inbox.

Closes #2921 