### PR TITLE
Fix: Also show the hop_info for encrypted messages

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -165,6 +165,7 @@ impl MimeMessage {
             .get_header_value(HeaderDef::Date)
             .and_then(|v| mailparse::dateparse(&v).ok())
             .unwrap_or_default();
+        let hop_info = parse_receive_headers(&mail.get_headers());
 
         let mut headers = Default::default();
         let mut recipients = Default::default();
@@ -296,7 +297,7 @@ impl MimeMessage {
             footer: None,
             is_mime_modified: false,
             decoded_data: Vec::new(),
-            hop_info: parse_receive_headers(&mail.get_headers()),
+            hop_info,
         };
 
         match partial {

--- a/test-data/message/encrypted_with_received_headers.eml
+++ b/test-data/message/encrypted_with_received_headers.eml
@@ -1,0 +1,77 @@
+Subject: ...
+MIME-Version: 1.0
+References: <Mr.TGEX8aAVEjU.2vk3EZTpuJV@example.org>
+        <Mr.TGEX8aAVEjU.2vk3EZTpuJV@example.org>
+In-Reply-To: <Mr.TGEX8aAVEjU.2vk3EZTpuJV@example.org>
+Date: Mon, 27 Dec 2021 13:12:03 +0000
+Chat-Version: 1.0
+Autocrypt: addr=bob@example.net; prefer-encrypt=mutual;
+        keydata=xsBNBF4wx1cBCADOwLS/xCd8iKDWUsyTfVzWby+ZGKPpamPTvdj0GFgnf0B1EBaA5//PjA
+        zbK5iKio6QNEmZagzJPkXPByJcAIRUm0T16tqDtCvxm+H93YEXpHi/XWOeJw9kohATSqUtsRO0pFJe
+        DvPiMTmQrEmHYoWDSQBfCrowZdvnMAlbJ9JjYOngcMeTxc0jxmPs5s17yFC+1OWu4fwWCyUM3wy1Jz
+        dKTcDWryrSkvmgFdUqJ7pJDk1HFTt+x9tvQlK3un9BXiRwv0u0zDSuI8eDH/dRLA4UL9Pq6vmJmBam
+        e1BPsE1PA7VzeTSJR2ooJXMT6o2AmH8PPUfRkv3OiWuh7LM5FSpHABEBAAHNETxib2JAZXhhbXBsZS
+        5uZXQ+wsCJBBABCAAzAhkBBQJeMMduAhsDBAsJCAcGFQgJCgsCAxYCARYhBMzLWqn24RQclDFl8dsY
+        sYy89wSHAAoJENsYsYy89wSH9oIIALbpmicuVghM3CloiCgJhPEFLFMaQZRDV/KCVVtBcHAhw6d42q
+        8T50mhs+W3Va5E37DN+wcenj8CgeGPQY3kPp2cnZruYtLhLkZ1+VEay5BQFUMb8kY21XrNTQQET8vc
+        0L8cCLQ7RCgm1tGiFVp1nqbjmGUdoru90ksoufWfoqVPjNrW+9eHFvY/Z7PqchCdMnbKOJiwwv4E3N
+        DTySZ1UVZnDztGy95Aa8OZ3cntvbq4JVi7S+N38rRPPPzpZKx+M4DUGfDAoaq7O/Xemyk1sP6C/NgQ
+        vS8rri54PgkMgKSS4TyyEzdM+fzeNYFPXFGTbgj4p0pSueQV7/JUfYHRfe3OwE0EXjDHVwEIAKIHgS
+        2yI2niSCN1tqcbLvkhLrEJCVcpGxmA7asl1flwWYrGOBhNJE2sCuZqkofqw6qrgsQ4GFgUU5xmcBCq
+        IZ49jRu+aY38lT4WDFHSbe/mGtaIhb2ZYK6zo9W7Y3r6ud8hbUKJTDfl9qEvJpX/Y0syMjwng8SZNT
+        dYMWgAE4NwcgMgdU3dMA3RT6ePJ4vKs38hmXmInLyZce+GJzmo2tpZyP8viPS7JpqojoCPB3G5h9aH
+        eakp1Y4XKQaExANeWCyBJEhNwtNEOVEpQ0txFYPyDrtxV5y5e79IUP418r/PHsnH6UnxXGzB6LfVbS
+        eEyDyKEl+w0PrlNklySomTZFUAEQEAAcLAdgQYAQgAIAUCXjDHbgIbDBYhBMzLWqn24RQclDFl8dsY
+        sYy89wSHAAoJENsYsYy89wSHVCIIAIH694HkQLXRAJlXmi8K/xMVP96ywJovL/B5l4S/vk/iR4P1lY
+        sF55A3Z2PK/iFtwAgVsppcBIPBlqSI0GPDMvEIxj7UFOQfQzVpDes29wG8grHJEJqI/4TlRjOacxTG
+        aJ5fIMsLXJD6nLBuoN5Z6zm3LjqIyOx4ZGrwradPO95OMGT2Xll3YNzUqSWe33RJLqNQ5ea9I7+qvK
+        nW5Z9Yt5nQwOo8yD+f5fql8904B3eAyLqxgkdLmngAWmYhc7KOaKdAsx7TXBAKsoeHk51OPk59u7Eb
+        X35HWD6snl/phJdUYDXiddyYN/n2ZY9g80ycle2JfgpfrQGlh7oJqgCjZuk=
+Message-ID: <Mr.adQpEwndXLH.LPDdlFVJ7wG@example.net>
+To: <alice@example.org>
+From: <bob@example.net>
+Content-Type: multipart/encrypted; protocol="application/pgp-encrypted";
+        boundary="M1Jorju4VotNmLKKE0sfOXoILeBrPT"
+
+
+--M1Jorju4VotNmLKKE0sfOXoILeBrPT
+Content-Type: application/pgp-encrypted
+Content-Description: PGP/MIME version identification
+
+Version: 1
+
+
+--M1Jorju4VotNmLKKE0sfOXoILeBrPT
+Content-Type: application/octet-stream; name="encrypted.asc"
+Content-Description: OpenPGP encrypted message
+Content-Disposition: inline; filename="encrypted.asc";
+
+-----BEGIN PGP MESSAGE-----
+
+wU4D5tq63hTeebASAQdAvnEfGvGoq5gqUvdfaQYTaYEpOGE/PwfwDmoP0dMoAHgg
+rjw3qVEAlAkvEjr6zZ55GTUFCPL+PTbePTCLXvNeFvjBwEwD49jcm8SO4yIBCACU
+Xxzv2wWPEXcHv3IC068E1maFYJgjbL4UUqEnepyQeRw6X4hqhivR1t+Sq5jtSB90
+ywDKf/z3gNytjUYwgWL0wC7hRc9HoctXf/j6pIGMui2FqyzOxmbD1E99lFvexDbo
+9qx47bFqC47HTc3pyOBHgnCqNsfLwRoBz+BMtpLOU8TeJeA1LanrXDPLxQoExitc
+CpdmrlpVXmLbgQ7h/tT7dwidQ8xMB5J4h/gXzaSrrPI8E5HVFUEp0nt1G0sRsMFZ
+HftxsyucK+GSppaU4mPQ5KgLjztY9Hd67f/XFLsJpU0Gxq8aRrMh43WzsM9kgAUB
+Gj6WW5KH/8gTsjNqMgPC0sHSATYf3TgPs9w2R7ZawiLDfYCRugzWuKwajpMBlt76
+Sa8XFOg53QPzgK2lIm4jzRCT7bmFXQ+jNn5i8/XsgNohsGCbTxfU37ieAX/RBPtj
+S4N2RwbMmNr+8PnZaEXz8MKAG1Ptpl3oceqJ8uUXtC2DK8SuGXkTumJYVM1qTNzx
+Y3T9xFuu56b6sEPQZPrbjdK9hP7KI91vsakbLa9KiNGDFxu/YtO9fM+CT2F+9geN
+Q4DPYuq/FMLvztjMm27cYT0jPU3sBCkxtb1nsxJViEo5DsFBZA5Xo4pg/waGbCc/
+u6C7tesb+hf/DgU76UsUKFQGMX6KDNqNiyiWp4nA6c8i5rIh0IXEk97JG6tGLhSc
+yMdsj59F9vTMFLuFFNCuLGyX9y/2JE2VKfPRbOwspmrbvg9yVLhdyFkxuv+M+cWv
+tj6E2oL3HhmJXSIbWbWH80c0Q5UUH9Z0tI2cxQZTvQxegnnnJ+VZmQAs2S5nZxds
+74/Wk0Gf4HHFn2jEDkaMEP4S1W6pvdowkzv7FnQ/3bFdEKGHNrNgZoPNXHh3eM+L
+HiY8Opx4vsRK5ia/1TbVkzyJtihL5y5LupS7PRXjjLlXjxbrZxQIpMztuC29lgMD
+Da5+F2hcrQEd2oDv/67s54+IkuBdTTM3YwXy6NJ0NtEVcEfiGILGoNpeBF5ppTgU
+N4ep54h0PYO/L8xLkzNrvIbJGfquYnKhgRicBNPyrPiDlB/1CmfTIE/K9jJosigV
+/jEQ2dSlDILFElmGCGRnb/t21PhWPhmiNcSaYdQKhjTf4LgYlBXP57YsEMdo+HAl
+koaQzcdV8os3PeBeFgQi11B2nOSoq0gHmto6lWZnZC7dIsJwI8cq6A/49WLKUFNR
+sO+twA==
+=Dvgk
+-----END PGP MESSAGE-----
+
+
+--M1Jorju4VotNmLKKE0sfOXoILeBrPT--

--- a/test-data/message/encrypted_with_received_headers.eml
+++ b/test-data/message/encrypted_with_received_headers.eml
@@ -1,8 +1,18 @@
+Return-Path: <bob@example.org>
+Delivered-To: alice@example.org
+Received: from hq5.example.org
+	by hq5.example.org with LMTP
+	id ODfyL7KhyWEANgAAPzvFDg
+	(envelope-from <bob@example.org>)
+	for <bob@example.org>; Mon, 27 Dec 2021 12:21:22 +0100
+Received: from mout.example.org (mout.example.org [212.227.17.22])
+	by hq5.example.org (Postfix) with ESMTPS id 45BAF27A0001
+	for <bob@example.org>; Mon, 27 Dec 2021 12:21:22 +0100 (CET)
+Received: from [127.0.0.1] ([217.80.24.163]) by mail.example.org (mrgmx105
+ [212.227.17.168]) with ESMTPSA (Nemesis) id 1MF3HU-1nCnTl33U0-00FXCF; Mon, 27
+ Dec 2021 12:21:21 +0100
 Subject: ...
 MIME-Version: 1.0
-References: <Mr.TGEX8aAVEjU.2vk3EZTpuJV@example.org>
-        <Mr.TGEX8aAVEjU.2vk3EZTpuJV@example.org>
-In-Reply-To: <Mr.TGEX8aAVEjU.2vk3EZTpuJV@example.org>
 Date: Mon, 27 Dec 2021 13:12:03 +0000
 Chat-Version: 1.0
 Autocrypt: addr=bob@example.net; prefer-encrypt=mutual;


### PR DESCRIPTION
Before, the hop_info was shown only for unencrypted messages.

Credits: The bug was noticed by @link2xt

Follow-up for #2751