### PR TITLE
Run CI with -Dwarnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       - staging
       - trying
 
+env:
+  RUSTFLAGS: -Dwarnings
+
 jobs:
 
   fmt:
@@ -114,8 +117,6 @@ jobs:
 
     - name: check
       uses: actions-rs/cargo@v1
-      env:
-        RUSTFLAGS: -D warnings
       with:
         command: check
         args: --all --bins --examples --tests --features repl --benches


### PR DESCRIPTION
This runs all CI jobs with -Dwarnings, turning warnings into errors
for CI.

This is useful since we run rustfmt and clippy on CI on stable rust,
while the builds and tests run with a specific older rustc.  The
latter is also used for local development usually since it is encoded
in the rust-toolchain file.  This warnings in clippy jobs of stable
rust would often go unnoticed, however stable rust usually finds more
genuine issues than the older compiler we use.