### PR TITLE
Improve log

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -183,7 +183,7 @@ pub unsafe extern "C" fn dc_get_config(
                     .unwrap_or_default()
                     .strdup(),
                 Err(_) => {
-                    warn!(ctx, "dc_get_config(): invalid key");
+                    warn!(ctx, "dc_get_config(): invalid key '{}'", &key);
                     "".strdup()
                 }
             }

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1228,7 +1228,7 @@ impl Imap {
                         last_uid = Some(server_uid)
                     }
                     Err(err) => {
-                        warn!(context, "dc_receive_imf error: {}", err);
+                        warn!(context, "dc_receive_imf error: {:#}", err);
                     }
                 };
             }


### PR DESCRIPTION
We had an unhelpful log in the Testing group:

- it repeatedly says "src/imap.rs:1010: dc_receive_imf error: add_parts error" but the actual error is not shown
- it says "deltachat-ffi/src/lib.rs:186: dc_get_config(): invalid key" but it doesn't say what key it's trying to get