### PR TITLE
Add `smtp` table

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -737,7 +737,6 @@ class TestOnlineAccount:
         # make sure we are not sending message to ourselves
         assert self_addr not in ev.data2
         assert other_addr in ev.data2
-        ev = ac1._evtracker.get_matching("DC_EVENT_DELETED_BLOB_FILE")
 
         lp.sec("ac1: setting bcc_self=1")
         ac1.set_config("bcc_self", "1")
@@ -753,7 +752,6 @@ class TestOnlineAccount:
         # now make sure we are sending message to ourselves too
         assert self_addr in ev.data2
         assert other_addr in ev.data2
-        ev = ac1._evtracker.get_matching("DC_EVENT_DELETED_BLOB_FILE")
         assert ac1.direct_imap.idle_wait_for_seen()
 
         # Second client receives only second message, but not the first

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -4866,7 +4866,7 @@ Second thread."#;
         let mdn_body = rendered_mdn.message;
 
         // Alice receives the read receipt.
-        dc_receive_imf(&alice, &mdn_body, "INBOX", false).await?;
+        dc_receive_imf(&alice, mdn_body.as_bytes(), "INBOX", false).await?;
 
         // Chat should not pop up in the chatlist.
         let chats = Chatlist::try_load(&alice, 0, None, None).await?;

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -81,7 +81,7 @@ pub struct MimeFactory<'a> {
 /// Result of rendering a message, ready to be submitted to a send job.
 #[derive(Debug, Clone)]
 pub struct RenderedEmail {
-    pub message: Vec<u8>,
+    pub message: String,
     // pub envelope: Envelope,
     pub is_encrypted: bool,
     pub is_gossiped: bool,
@@ -770,7 +770,7 @@ impl<'a> MimeFactory<'a> {
         } = self;
 
         Ok(RenderedEmail {
-            message: outer_message.build().as_string().into_bytes(),
+            message: outer_message.build().as_string(),
             // envelope: Envelope::new,
             is_encrypted,
             is_gossiped,
@@ -1931,7 +1931,7 @@ mod tests {
 
         let rendered_msg = mimefactory.render(context).await.unwrap();
 
-        let mail = mailparse::parse_mail(&rendered_msg.message).unwrap();
+        let mail = mailparse::parse_mail(rendered_msg.message.as_bytes()).unwrap();
         assert_eq!(
             mail.headers
                 .iter()
@@ -1941,7 +1941,7 @@ mod tests {
             "1.0"
         );
 
-        let _mime_msg = MimeMessage::from_bytes(context, &rendered_msg.message)
+        let _mime_msg = MimeMessage::from_bytes(context, rendered_msg.message.as_bytes())
             .await
             .unwrap();
     }
@@ -2015,8 +2015,9 @@ mod tests {
         let mut msg = Message::new(Viewtype::Text);
         msg.set_text(Some("this is the text!".to_string()));
 
-        let payload = t.send_msg(chat.id, &mut msg).await.payload();
-        let mut payload = payload.splitn(3, "\r\n\r\n");
+        let sent_msg = t.send_msg(chat.id, &mut msg).await;
+        let mut payload = sent_msg.payload().splitn(3, "\r\n\r\n");
+
         let outer = payload.next().unwrap();
         let inner = payload.next().unwrap();
         let body = payload.next().unwrap();
@@ -2034,8 +2035,8 @@ mod tests {
 
         // if another message is sent, that one must not contain the avatar
         // and no artificial multipart/mixed nesting
-        let payload = t.send_msg(chat.id, &mut msg).await.payload();
-        let mut payload = payload.splitn(2, "\r\n\r\n");
+        let sent_msg = t.send_msg(chat.id, &mut msg).await;
+        let mut payload = sent_msg.payload().splitn(2, "\r\n\r\n");
         let outer = payload.next().unwrap();
         let body = payload.next().unwrap();
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -110,9 +110,6 @@ pub enum Param {
     /// For Jobs
     AlsoMove = b'M',
 
-    /// For Jobs: space-separated list of message recipients
-    Recipients = b'R',
-
     /// For MDN-sending job
     MsgId = b'I',
 

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -4,14 +4,18 @@ pub mod send;
 
 use std::time::{Duration, SystemTime};
 
+use anyhow::{format_err, Context as _};
 use async_smtp::smtp::client::net::ClientTlsParameters;
+use async_smtp::smtp::response::{Category, Code, Detail};
 use async_smtp::{error, smtp, EmailAddress, ServerAddress};
 
 use crate::constants::DC_LP_AUTH_OAUTH2;
 use crate::events::EventType;
+use crate::job::Status;
 use crate::login_param::{
     dc_build_tls, CertificateChecks, LoginParam, ServerLoginParam, Socks5Config,
 };
+use crate::message::{self, MsgId};
 use crate::oauth2::dc_get_oauth2_access_token;
 use crate::provider::Socket;
 use crate::{context::Context, scheduler::connectivity::ConnectivityStore};
@@ -219,4 +223,235 @@ impl Smtp {
 
         Ok(())
     }
+}
+
+pub(crate) async fn smtp_send(
+    context: &Context,
+    recipients: Vec<async_smtp::EmailAddress>,
+    message: String,
+    smtp: &mut Smtp,
+    msg_id: MsgId,
+    rowid: i64,
+) -> Status {
+    if std::env::var(crate::DCC_MIME_DEBUG).is_ok() {
+        info!(context, "smtp-sending out mime message:");
+        println!("{}", message);
+    }
+
+    smtp.connectivity.set_working(context).await;
+
+    let send_result = smtp
+        .send(context, recipients, message.into_bytes(), rowid)
+        .await;
+    smtp.last_send_error = send_result.as_ref().err().map(|e| e.to_string());
+
+    let status = match send_result {
+        Err(crate::smtp::send::Error::SmtpSend(err)) => {
+            // Remote error, retry later.
+            warn!(context, "SMTP failed to send: {:?}", &err);
+
+            let res = match err {
+                async_smtp::smtp::error::Error::Permanent(ref response) => {
+                    // Workaround for incorrectly configured servers returning permanent errors
+                    // instead of temporary ones.
+                    let maybe_transient = match response.code {
+                        // Sometimes servers send a permanent error when actually it is a temporary error
+                        // For documentation see <https://tools.ietf.org/html/rfc3463>
+                        Code {
+                            category: Category::MailSystem,
+                            detail: Detail::Zero,
+                            ..
+                        } => {
+                            // Ignore status code 5.5.0, see <https://support.delta.chat/t/every-other-message-gets-stuck/877/2>
+                            // Maybe incorrectly configured Postfix milter with "reject" instead of "tempfail", which returns
+                            // "550 5.5.0 Service unavailable" instead of "451 4.7.1 Service unavailable - try again later".
+                            //
+                            // Other enhanced status codes, such as Postfix
+                            // "550 5.1.1 <foobar@example.org>: Recipient address rejected: User unknown in local recipient table"
+                            // are not ignored.
+                            response.first_word() == Some(&"5.5.0".to_string())
+                        }
+                        _ => false,
+                    };
+
+                    if maybe_transient {
+                        Status::RetryLater
+                    } else {
+                        // If we do not retry, add an info message to the chat.
+                        // Yandex error "554 5.7.1 [2] Message rejected under suspicion of SPAM; https://ya.cc/..."
+                        // should definitely go here, because user has to open the link to
+                        // resume message sending.
+                        Status::Finished(Err(format_err!("Permanent SMTP error: {}", err)))
+                    }
+                }
+                async_smtp::smtp::error::Error::Transient(ref response) => {
+                    // We got a transient 4xx response from SMTP server.
+                    // Give some time until the server-side error maybe goes away.
+
+                    if let Some(first_word) = response.first_word() {
+                        if first_word.ends_with(".1.1")
+                            || first_word.ends_with(".1.2")
+                            || first_word.ends_with(".1.3")
+                        {
+                            // Sometimes we receive transient errors that should be permanent.
+                            // Any extended smtp status codes like x.1.1, x.1.2 or x.1.3 that we
+                            // receive as a transient error are misconfigurations of the smtp server.
+                            // See <https://tools.ietf.org/html/rfc3463#section-3.2>
+                            info!(context, "Received extended status code {} for a transient error. This looks like a misconfigured smtp server, let's fail immediatly", first_word);
+                            Status::Finished(Err(format_err!("Permanent SMTP error: {}", err)))
+                        } else {
+                            Status::RetryLater
+                        }
+                    } else {
+                        Status::RetryLater
+                    }
+                }
+                _ => {
+                    if smtp.has_maybe_stale_connection().await {
+                        info!(context, "stale connection? immediately reconnecting");
+                        Status::RetryNow
+                    } else {
+                        Status::RetryLater
+                    }
+                }
+            };
+
+            // this clears last_success info
+            smtp.disconnect().await;
+
+            res
+        }
+        Err(crate::smtp::send::Error::Envelope(err)) => {
+            // Local error, job is invalid, do not retry.
+            smtp.disconnect().await;
+            warn!(context, "SMTP job is invalid: {}", err);
+            Status::Finished(Err(err.into()))
+        }
+        Err(crate::smtp::send::Error::NoTransport) => {
+            // Should never happen.
+            // It does not even make sense to disconnect here.
+            error!(context, "SMTP job failed because SMTP has no transport");
+            Status::Finished(Err(format_err!("SMTP has not transport")))
+        }
+        Err(crate::smtp::send::Error::Other(err)) => {
+            // Local error, job is invalid, do not retry.
+            smtp.disconnect().await;
+            warn!(context, "unable to load job: {}", err);
+            Status::Finished(Err(err))
+        }
+        Ok(()) => Status::Finished(Ok(())),
+    };
+
+    if let Status::Finished(Err(err)) = &status {
+        // We couldn't send the message, so mark it as failed
+        message::set_msg_failed(context, msg_id, Some(err.to_string())).await;
+    }
+    status
+}
+
+/// Sends message identified by `smtp` table rowid over SMTP connection.
+///
+/// Removes row if the message should not be retried, otherwise increments retry count.
+pub(crate) async fn send_msg_to_smtp(
+    context: &Context,
+    smtp: &mut Smtp,
+    rowid: i64,
+) -> anyhow::Result<()> {
+    if let Err(err) = smtp
+        .connect_configured(context)
+        .await
+        .context("SMTP connection failure")
+    {
+        smtp.last_send_error = Some(format!("SMTP connection failure: {:#}", err));
+        return Err(err);
+    }
+
+    let (body, recipients, msg_id) = context
+        .sql
+        .query_row(
+            "SELECT mime, recipients, msg_id FROM smtp WHERE id=?",
+            paramsv![rowid],
+            |row| {
+                let mime: String = row.get(0)?;
+                let recipients: String = row.get(1)?;
+                let msg_id: MsgId = row.get(2)?;
+                Ok((mime, recipients, msg_id))
+            },
+        )
+        .await?;
+    let recipients_list = recipients
+        .split(' ')
+        .filter_map(
+            |addr| match async_smtp::EmailAddress::new(addr.to_string()) {
+                Ok(addr) => Some(addr),
+                Err(err) => {
+                    warn!(context, "invalid recipient: {} {:?}", addr, err);
+                    None
+                }
+            },
+        )
+        .collect::<Vec<_>>();
+
+    let status = smtp_send(context, recipients_list, body, smtp, msg_id, rowid).await;
+    match status {
+        Status::Finished(res) => {
+            if res.is_ok() {
+                msg_id.set_delivered(context).await?;
+
+                context
+                    .sql
+                    .execute("DELETE FROM smtp WHERE id=?", paramsv![rowid])
+                    .await?;
+            }
+            res
+        }
+        Status::RetryNow | Status::RetryLater => {
+            context
+                .sql
+                .execute(
+                    "UPDATE smtp SET retries=retries+1 WHERE id=?",
+                    paramsv![rowid],
+                )
+                .await
+                .context("failed to update retries count")?;
+            Err(format_err!("Retry"))
+        }
+    }
+}
+
+/// Tries to send all messages currently in `smtp` table.
+///
+/// Logs and ignores SMTP errors to ensure that a single SMTP message constantly failing to be sent
+/// does not block other messages in the queue from being sent.
+pub(crate) async fn send_smtp_messages(
+    context: &Context,
+    connection: &mut Smtp,
+) -> anyhow::Result<()> {
+    context.send_sync_msg().await?; // Add sync message to the end of the queue if needed.
+    context
+        .sql
+        .execute("DELETE FROM smtp WHERE retries > 5", paramsv![])
+        .await?;
+    let rowids = context
+        .sql
+        .query_map(
+            "SELECT id FROM smtp ORDER BY id ASC",
+            paramsv![],
+            |row| {
+                let rowid: i64 = row.get(0)?;
+                Ok(rowid)
+            },
+            |rowids| {
+                rowids
+                    .collect::<std::result::Result<Vec<_>, _>>()
+                    .map_err(Into::into)
+            },
+        )
+        .await?;
+    for rowid in rowids {
+        if let Err(err) = send_msg_to_smtp(context, connection, rowid).await {
+            info!(context, "Failed to send message over SMTP: {:#}.", err);
+        }
+    }
+    Ok(())
 }

--- a/src/smtp/send.rs
+++ b/src/smtp/send.rs
@@ -30,7 +30,7 @@ impl Smtp {
         context: &Context,
         recipients: Vec<EmailAddress>,
         message: Vec<u8>,
-        job_id: u32,
+        rowid: i64,
     ) -> Result<()> {
         let message_len_bytes = message.len();
 
@@ -52,7 +52,7 @@ impl Smtp {
                 .map_err(Error::Envelope)?;
             let mail = SendableEmail::new(
                 envelope,
-                format!("{}", job_id), // only used for internal logging
+                rowid.to_string(), // only used for internal logging
                 &message,
             );
 

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -271,10 +271,10 @@ impl Sql {
         &self,
         query: impl AsRef<str>,
         params: impl rusqlite::Params,
-    ) -> anyhow::Result<usize> {
+    ) -> Result<i64> {
         let conn = self.get_conn().await?;
         conn.execute(query.as_ref(), params)?;
-        Ok(usize::try_from(conn.last_insert_rowid())?)
+        Ok(conn.last_insert_rowid())
     }
 
     /// Prepares and executes the statement and maps a function over the resulting rows.

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -562,6 +562,23 @@ CREATE INDEX msgs_status_updates_index1 ON msgs_status_updates (msg_id);"#,
         )
         .await?;
     }
+    if dbversion < 85 {
+        info!(context, "[migration] v85");
+        sql.execute_migration(
+            r#"CREATE TABLE smtp (
+id INTEGER PRIMARY KEY,
+rfc724_mid TEXT NOT NULL,          -- Message-ID
+mime TEXT NOT NULL,                -- SMTP payload
+msg_id INTEGER NOT NULL,           -- ID of the message in `msgs` table
+recipients TEXT NOT NULL,          -- List of recipients separated by space
+retries INTEGER NOT NULL DEFAULT 0 -- Number of failed attempts to send the messsage
+);
+CREATE INDEX smtp_messageid ON imap(rfc724_mid);
+"#,
+            85,
+        )
+        .await?;
+    }
 
     Ok((
         recalc_fingerprints,


### PR DESCRIPTION
It replaces SendMsgToSmtp job.

Prepared outgoing SMTP payloads are stored in the database now rather
than files in blobdir.