### PR TITLE
Error handling refactoring

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2443,7 +2443,14 @@ pub unsafe extern "C" fn dc_chatlist_get_chat_id(
         return 0;
     }
     let ffi_list = &*chatlist;
-    ffi_list.list.get_chat_id(index as usize).to_u32()
+    let ctx = &*ffi_list.context;
+    match ffi_list.list.get_chat_id(index as usize) {
+        Ok(chat_id) => chat_id.to_u32(),
+        Err(err) => {
+            warn!(ctx, "get_chat_id failed: {}", err);
+            0
+        }
+    }
 }
 
 #[no_mangle]

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -563,7 +563,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                 );
 
                 for i in (0..cnt).rev() {
-                    let chat = Chat::load_from_db(&context, chatlist.get_chat_id(i)).await?;
+                    let chat = Chat::load_from_db(&context, chatlist.get_chat_id(i)?).await?;
                     println!(
                         "{}#{}: {} [{} fresh] {}{}{}{}",
                         chat_prefix(&chat),
@@ -1142,7 +1142,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                     if 0 != i {
                         res += ", ";
                     }
-                    let chat = Chat::load_from_db(&context, chatlist.get_chat_id(i)).await?;
+                    let chat = Chat::load_from_db(&context, chatlist.get_chat_id(i)?).await?;
                     res += &format!("{}#{}", chat_prefix(&chat), chat.get_id());
                 }
             }

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -56,7 +56,9 @@ impl Accounts {
         let config_file = dir.join(CONFIG_NAME);
         ensure!(config_file.exists().await, "accounts.toml does not exist");
 
-        let config = Config::from_file(config_file).await?;
+        let config = Config::from_file(config_file)
+            .await
+            .context("failed to load accounts config")?;
         let accounts = config.load_accounts().await?;
 
         let emitter = EventEmitter::new();

--- a/src/aheader.rs
+++ b/src/aheader.rs
@@ -2,7 +2,7 @@
 //!
 //! Parse and create [Autocrypt-headers](https://autocrypt.org/en/latest/level1.html#the-autocrypt-header).
 
-use anyhow::{bail, format_err, Error, Result};
+use anyhow::{bail, Context as _, Error, Result};
 use std::collections::BTreeMap;
 use std::str::FromStr;
 use std::{fmt, str};
@@ -139,15 +139,14 @@ impl str::FromStr for Aheader {
         };
         let public_key: SignedPublicKey = attributes
             .remove("keydata")
-            .ok_or_else(|| format_err!("keydata attribute is not found"))
+            .context("keydata attribute is not found")
             .and_then(|raw| {
-                SignedPublicKey::from_base64(&raw)
-                    .map_err(|_| format_err!("Autocrypt key cannot be decoded"))
+                SignedPublicKey::from_base64(&raw).context("autocrypt key cannot be decoded")
             })
             .and_then(|key| {
                 key.verify()
                     .and(Ok(key))
-                    .map_err(|_| format_err!("Autocrypt key cannot be verified"))
+                    .context("autocrypt key cannot be verified")
             })?;
 
         let prefer_encrypt = attributes

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -620,7 +620,10 @@ impl ChatId {
     /// Returns `true`, if message was deleted, `false` otherwise.
     async fn maybe_delete_draft(self, context: &Context) -> Result<bool> {
         match self.get_draft_msg_id(context).await? {
-            Some(msg_id) => Ok(msg_id.delete_from_db(context).await.is_ok()),
+            Some(msg_id) => {
+                msg_id.delete_from_db(context).await?;
+                Ok(true)
+            }
             None => Ok(false),
         }
     }
@@ -640,7 +643,7 @@ impl ChatId {
                     .param
                     .get_blob(Param::File, context, !msg.is_increation())
                     .await?
-                    .ok_or_else(|| format_err!("No file stored in params"))?;
+                    .context("no file stored in params")?;
                 msg.param.set(Param::File, blob.as_name());
             }
         }
@@ -1804,9 +1807,7 @@ async fn prepare_msg_blob(context: &Context, msg: &mut Message) -> Result<()> {
             .param
             .get_blob(Param::File, context, !msg.is_increation())
             .await?
-            .ok_or_else(|| {
-                format_err!("Attachment missing for message of type #{}", msg.viewtype)
-            })?;
+            .with_context(|| format!("attachment missing for message of type #{}", msg.viewtype))?;
 
         if msg.viewtype == Viewtype::Image {
             if let Err(e) = blob.recode_to_image_size(context).await {
@@ -3914,7 +3915,7 @@ mod tests {
         assert_eq!(chats.len(), 1);
 
         // after the device-chat and all messages are deleted, a re-adding should do nothing
-        chats.get_chat_id(0).delete(&t).await.ok();
+        chats.get_chat_id(0).unwrap().delete(&t).await.ok();
         add_device_msg(&t, Some("some-label"), Some(&mut msg))
             .await
             .ok();
@@ -4079,7 +4080,7 @@ mod tests {
             .unwrap();
         let mut result = Vec::new();
         for chatlist_index in 0..chatlist.len() {
-            result.push(chatlist.get_chat_id(chatlist_index))
+            result.push(chatlist.get_chat_id(chatlist_index).unwrap())
         }
         result
     }
@@ -4502,7 +4503,7 @@ mod tests {
 
         let chats = Chatlist::try_load(&t, 0, None, None).await?;
         assert_eq!(chats.len(), 1);
-        assert_eq!(chats.get_chat_id(0), chat.id);
+        assert_eq!(chats.get_chat_id(0)?, chat.id);
         assert_eq!(chat.id.get_fresh_msg_cnt(&t).await?, 1);
         assert_eq!(t.get_fresh_msgs().await?.len(), 1);
 
@@ -4550,7 +4551,7 @@ mod tests {
 
         let chats = Chatlist::try_load(&t, 0, None, None).await?;
         assert_eq!(chats.len(), 1);
-        let chat_id = chats.get_chat_id(0);
+        let chat_id = chats.get_chat_id(0).unwrap();
         assert!(Chat::load_from_db(&t, chat_id)
             .await
             .unwrap()
@@ -4598,7 +4599,7 @@ mod tests {
 
         let chats = Chatlist::try_load(&t, 0, None, None).await?;
         assert_eq!(chats.len(), 1);
-        let chat_id = chats.get_chat_id(0);
+        let chat_id = chats.get_chat_id(0)?;
         assert!(Chat::load_from_db(&t, chat_id).await?.is_contact_request());
         assert_eq!(dc_get_archived_cnt(&t).await?, 0);
 
@@ -4607,13 +4608,13 @@ mod tests {
 
         let chats = Chatlist::try_load(&t, 0, None, None).await?;
         assert_eq!(chats.len(), 1);
-        let chat_id = chats.get_chat_id(0);
+        let chat_id = chats.get_chat_id(0)?;
         assert!(chat_id.is_archived_link());
         assert_eq!(dc_get_archived_cnt(&t).await?, 1);
 
         let chats = Chatlist::try_load(&t, DC_GCL_ARCHIVED_ONLY, None, None).await?;
         assert_eq!(chats.len(), 1);
-        let chat_id = chats.get_chat_id(0);
+        let chat_id = chats.get_chat_id(0)?;
         assert!(Chat::load_from_db(&t, chat_id).await?.is_contact_request());
 
         Ok(())

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,7 +5,7 @@ use std::ffi::OsString;
 use std::ops::Deref;
 use std::time::{Instant, SystemTime};
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{bail, ensure, Context as _, Result};
 use async_std::{
     channel::{self, Receiver, Sender},
     path::{Path, PathBuf},
@@ -155,7 +155,10 @@ impl Context {
         let ctx = Context {
             inner: Arc::new(inner),
         };
-        ctx.sql.open(&ctx, &ctx.dbfile, false).await?;
+        ctx.sql
+            .open(&ctx, &ctx.dbfile, false)
+            .await
+            .context("failed to open SQL database")?;
 
         Ok(ctx)
     }

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -1164,7 +1164,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
         maybe_warn_on_bad_time(&t, timestamp_past, get_provider_update_timestamp()).await;
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
-        let device_chat_id = chats.get_chat_id(0);
+        let device_chat_id = chats.get_chat_id(0).unwrap();
         let msgs = chat::get_chat_msgs(&t, device_chat_id, 0, None)
             .await
             .unwrap();
@@ -1202,7 +1202,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
         .await;
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
-        assert_eq!(device_chat_id, chats.get_chat_id(0));
+        assert_eq!(device_chat_id, chats.get_chat_id(0).unwrap());
         let msgs = chat::get_chat_msgs(&t, device_chat_id, 0, None)
             .await
             .unwrap();
@@ -1234,7 +1234,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
         .await;
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
-        let device_chat_id = chats.get_chat_id(0);
+        let device_chat_id = chats.get_chat_id(0).unwrap();
         let msgs = chat::get_chat_msgs(&t, device_chat_id, 0, None)
             .await
             .unwrap();
@@ -1256,7 +1256,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
         .await;
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
-        let device_chat_id = chats.get_chat_id(0);
+        let device_chat_id = chats.get_chat_id(0).unwrap();
         let msgs = chat::get_chat_msgs(&t, device_chat_id, 0, None)
             .await
             .unwrap();
@@ -1273,7 +1273,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
         .await;
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
-        let device_chat_id = chats.get_chat_id(0);
+        let device_chat_id = chats.get_chat_id(0).unwrap();
         let msgs = chat::get_chat_msgs(&t, device_chat_id, 0, None)
             .await
             .unwrap();

--- a/src/download.rs
+++ b/src/download.rs
@@ -196,9 +196,13 @@ impl Imap {
         // we are connected, and the folder is selected
         info!(context, "Downloading message {}/{} fully...", folder, uid);
 
-        let (last_uid, _received) = self
+        let (last_uid, _received) = match self
             .fetch_many_msgs(context, folder, vec![uid], false, false)
-            .await;
+            .await
+        {
+            Ok(res) => res,
+            Err(_) => return ImapActionResult::Failed,
+        };
         if last_uid.is_none() {
             ImapActionResult::Failed
         } else {

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use anyhow::{bail, format_err, Result};
+use anyhow::{bail, format_err, Context as _, Result};
 use mailparse::ParsedMail;
 use num_traits::FromPrimitive;
 
@@ -121,9 +121,9 @@ impl EncryptHelper {
             .into_iter()
             .filter_map(|(state, addr)| state.map(|s| (s, addr)))
         {
-            let key = peerstate.take_key(min_verified).ok_or_else(|| {
-                format_err!("proper enc-key for {} missing, cannot encrypt", addr)
-            })?;
+            let key = peerstate
+                .take_key(min_verified)
+                .with_context(|| format!("proper enc-key for {} missing, cannot encrypt", addr))?;
             keyring.add(key);
         }
         keyring.add(self.public_key.clone());
@@ -390,12 +390,10 @@ pub async fn ensure_secret_key_exists(context: &Context) -> Result<String> {
     let self_addr = context
         .get_config(Config::ConfiguredAddr)
         .await?
-        .ok_or_else(|| {
-            format_err!(concat!(
-                "Failed to get self address, ",
-                "cannot ensure secret key if not configured."
-            ))
-        })?;
+        .context(concat!(
+            "Failed to get self address, ",
+            "cannot ensure secret key if not configured."
+        ))?;
     SignedPublicKey::load_self(context).await?;
     Ok(self_addr)
 }

--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -1,6 +1,6 @@
 use super::Imap;
 
-use anyhow::{bail, format_err, Result};
+use anyhow::{bail, Context as _, Result};
 use async_imap::extensions::idle::IdleResponse;
 use async_std::prelude::*;
 use std::time::{Duration, SystemTime};
@@ -31,7 +31,7 @@ impl Imap {
         let timeout = Duration::from_secs(23 * 60);
         let mut info = Default::default();
 
-        if self.server_sent_unsolicited_exists(context) {
+        if self.server_sent_unsolicited_exists(context)? {
             return Ok(info);
         }
 
@@ -90,8 +90,8 @@ impl Imap {
             let session = handle
                 .done()
                 .timeout(Duration::from_secs(15))
-                .await
-                .map_err(|err| format_err!("IMAP IDLE protocol timed out: {}", err))??;
+                .await?
+                .context("IMAP IDLE protocol timed out")?;
             self.session = Some(Session { inner: session });
         } else {
             warn!(context, "Attempted to idle without a session");

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -71,7 +71,7 @@ impl Imap {
             // Don't scan folders that are watched anyway
             if !watched_folders.contains(&folder.name().to_string()) && !is_drafts {
                 // Drain leftover unsolicited EXISTS messages
-                self.server_sent_unsolicited_exists(context);
+                self.server_sent_unsolicited_exists(context)?;
 
                 loop {
                     self.fetch_move_delete(context, folder.name())
@@ -79,7 +79,7 @@ impl Imap {
                         .ok_or_log_msg(context, "Can't fetch new msgs in scanned folder");
 
                     // If the server sent an unsocicited EXISTS during the fetch, we need to fetch again
-                    if !self.server_sent_unsolicited_exists(context) {
+                    if !self.server_sent_unsolicited_exists(context)? {
                         break;
                     }
                 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -372,13 +372,13 @@ impl Job {
         let filename = job_try!(job_try!(self
             .param
             .get_path(Param::File, context)
-            .map_err(|_| format_err!("Can't get filename")))
-        .ok_or_else(|| format_err!("Can't get filename")));
+            .context("can't get filename"))
+        .context("Can't get filename"));
         let body = job_try!(dc_read_file(context, &filename).await);
-        let recipients = job_try!(self.param.get(Param::Recipients).ok_or_else(|| {
-            warn!(context, "Missing recipients for job {}", self.job_id);
-            format_err!("Missing recipients")
-        }));
+        let recipients = job_try!(self
+            .param
+            .get(Param::Recipients)
+            .context("missing recipients"));
 
         let recipients_list = recipients
             .split('\x1e')

--- a/src/message.rs
+++ b/src/message.rs
@@ -1534,9 +1534,7 @@ async fn ndn_maybe_add_info_msg(
                 let contact_id =
                     Contact::lookup_id_by_addr(context, failed_recipient, Origin::Unknown)
                         .await?
-                        .ok_or_else(|| {
-                            format_err!("ndn_maybe_add_info_msg: Contact ID not found")
-                        })?;
+                        .context("contact ID not found")?;
                 let contact = Contact::load_from_db(context, contact_id).await?;
                 // Tell the user which of the recipients failed if we know that (because in
                 // a group, this might otherwise be unclear)
@@ -1988,9 +1986,9 @@ mod tests {
         let msg2 = alice.get_last_msg().await;
         let chats = Chatlist::try_load(&alice, 0, None, None).await?;
         assert_eq!(chats.len(), 1);
-        assert_eq!(chats.get_chat_id(0), alice_chat.id);
-        assert_eq!(chats.get_chat_id(0), msg1.chat_id);
-        assert_eq!(chats.get_chat_id(0), msg2.chat_id);
+        assert_eq!(chats.get_chat_id(0)?, alice_chat.id);
+        assert_eq!(chats.get_chat_id(0)?, msg1.chat_id);
+        assert_eq!(chats.get_chat_id(0)?, msg2.chat_id);
         assert_eq!(alice_chat.id.get_fresh_msg_cnt(&alice).await?, 2);
         assert_eq!(alice.get_fresh_msgs().await?.len(), 2);
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -2,7 +2,7 @@
 
 use std::convert::TryInto;
 
-use anyhow::{bail, ensure, format_err, Context as _, Result};
+use anyhow::{bail, ensure, Context as _, Result};
 use chrono::TimeZone;
 use lettre_email::{mime, Address, Header, MimeMultipartType, PartBuilder};
 
@@ -281,7 +281,7 @@ impl<'a> MimeFactory<'a> {
         let self_addr = context
             .get_config(Config::ConfiguredAddr)
             .await?
-            .ok_or_else(|| format_err!("Not configured"))?;
+            .context("not configured")?;
 
         let mut res = Vec::new();
         for (_, addr) in self
@@ -1283,7 +1283,7 @@ async fn build_body_file(
         .param
         .get_blob(Param::File, context, true)
         .await?
-        .ok_or_else(|| format_err!("msg has no filename"))?;
+        .context("msg has no filename")?;
     let suffix = blob.suffix().unwrap_or("dat");
 
     // Get file name to use for sending.  For privacy purposes, we do
@@ -1875,7 +1875,7 @@ mod tests {
 
         let chats = Chatlist::try_load(context, 0, None, None).await.unwrap();
 
-        let chat_id = chats.get_chat_id(0);
+        let chat_id = chats.get_chat_id(0).unwrap();
         chat_id.accept(context).await.unwrap();
 
         let mut new_msg = Message::new(Viewtype::Text);
@@ -2058,11 +2058,11 @@ mod tests {
         let to = parsed
             .headers
             .get_first_header("To")
-            .ok_or_else(|| format_err!("No To: header parsed"))?;
+            .context("no To: header parsed")?;
         let to = addrparse_header(to)?;
         let mailbox = to
             .extract_single_info()
-            .ok_or_else(|| format_err!("To: field does not contain exactly one address"))?;
+            .context("to: field does not contain exactly one address")?;
         assert_eq!(mailbox.addr, "bob@example.net");
 
         Ok(())

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::io;
 use std::io::Cursor;
 
-use anyhow::{bail, ensure, format_err, Result};
+use anyhow::{bail, ensure, format_err, Context as _, Result};
 use pgp::armor::BlockType;
 use pgp::composed::{
     Deserializable, KeyType as PgpKeyType, Message, SecretKeyParamsBuilder, SignedPublicKey,
@@ -346,7 +346,7 @@ pub async fn pk_validate(
     // OpenPGP signature calculation.
     let content = content
         .get(..content.len().saturating_sub(2))
-        .ok_or_else(|| format_err!("index is out of range"))?;
+        .context("index is out of range")?;
 
     for pkey in pkeys {
         if standalone_signature.verify(pkey, content).is_ok() {
@@ -520,7 +520,6 @@ mod tests {
             &sig_check_keyring,
         )
         .await
-        .map_err(|err| println!("{:?}", err))
         .unwrap();
         assert_eq!(plain, CLEARTEXT);
         assert_eq!(valid_signatures.len(), 1);
@@ -536,7 +535,6 @@ mod tests {
             &sig_check_keyring,
         )
         .await
-        .map_err(|err| println!("{:?}", err))
         .unwrap();
         assert_eq!(plain, CLEARTEXT);
         assert_eq!(valid_signatures.len(), 1);

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -304,14 +304,14 @@ async fn decode_openpgp(context: &Context, qr: &str) -> Result<Qr> {
 fn decode_account(qr: &str) -> Result<Qr> {
     let payload = qr
         .get(DCACCOUNT_SCHEME.len()..)
-        .ok_or_else(|| format_err!("Invalid DCACCOUNT payload"))?;
+        .context("invalid DCACCOUNT payload")?;
     let url =
         url::Url::parse(payload).with_context(|| format!("Invalid account URL: {:?}", payload))?;
     if url.scheme() == "http" || url.scheme() == "https" {
         Ok(Qr::Account {
             domain: url
                 .host_str()
-                .ok_or_else(|| format_err!("Can't extract WebRTC instance domain"))?
+                .context("can't extract WebRTC instance domain")?
                 .to_string(),
         })
     } else {
@@ -323,7 +323,7 @@ fn decode_account(qr: &str) -> Result<Qr> {
 fn decode_webrtc_instance(_context: &Context, qr: &str) -> Result<Qr> {
     let payload = qr
         .get(DCWEBRTC_SCHEME.len()..)
-        .ok_or_else(|| format_err!("Invalid DCWEBRTC payload"))?;
+        .context("invalid DCWEBRTC payload")?;
 
     let (_type, url) = Message::parse_webrtc_instance(payload);
     let url =
@@ -333,7 +333,7 @@ fn decode_webrtc_instance(_context: &Context, qr: &str) -> Result<Qr> {
         Ok(Qr::WebrtcInstance {
             domain: url
                 .host_str()
-                .ok_or_else(|| format_err!("Can't extract WebRTC instance domain"))?
+                .context("can't extract WebRTC instance domain")?
                 .to_string(),
             instance_pattern: payload.to_string(),
         })

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -1,6 +1,6 @@
 //! # Support for IMAP QUOTA extension.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context as _, Result};
 use async_imap::types::{Quota, QuotaResource};
 use std::collections::BTreeMap;
 
@@ -64,7 +64,7 @@ async fn get_unique_quota_roots_and_usage(
                     .iter()
                     .find(|q| &q.root_name == quota_root_name)
                     .cloned()
-                    .ok_or_else(|| anyhow!("quota_root should have a quota"))?;
+                    .context("quota_root should have a quota")?;
                 // replace old quotas, because between fetching quotaroots for folders,
                 // messages could be recieved and so the usage could have been changed
                 *unique_quota_roots
@@ -96,7 +96,7 @@ fn get_highest_usage<'t>(
         }
     }
 
-    highest.ok_or_else(|| anyhow!("no quota_resource found, this is unexpected"))
+    highest.context("no quota_resource found, this is unexpected")
 }
 
 /// Checks if a quota warning is needed.

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -1280,11 +1280,13 @@ mod tests {
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 2);
 
-        let chat0 = Chat::load_from_db(&t, chats.get_chat_id(0)).await.unwrap();
+        let chat0 = Chat::load_from_db(&t, chats.get_chat_id(0).unwrap())
+            .await
+            .unwrap();
         let (self_talk_id, device_chat_id) = if chat0.is_self_talk() {
-            (chats.get_chat_id(0), chats.get_chat_id(1))
+            (chats.get_chat_id(0).unwrap(), chats.get_chat_id(1).unwrap())
         } else {
-            (chats.get_chat_id(1), chats.get_chat_id(0))
+            (chats.get_chat_id(1).unwrap(), chats.get_chat_id(0).unwrap())
         };
 
         // delete self-talk first; this adds a message to device-chat about how self-talk can be restored


### PR DESCRIPTION
- Replace .ok_or_else() and .map_err() with anyhow::Context where possible.
- Use .context() to check Option for None when it's an error
- Resultify Chatlist.get_chat_id()
- Add useful .context() to some errors
- IMAP error handling cleanup