### PR TITLE
allow removing quotes on existing drafts

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4165,7 +4165,8 @@ void            dc_msg_latefiling_mediasize   (dc_msg_t* msg, int width, int hei
  *
  * @memberof dc_msg_t
  * @param msg The message object to set the reply to.
- * @param quote The quote to set for msg.
+ * @param quote The quote to set for the message object given as `msg`.
+ *     NULL removes an previously set quote.
  */
 void             dc_msg_set_quote             (dc_msg_t* msg, const dc_msg_t* quote);
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -756,35 +756,40 @@ impl Message {
     ///
     /// The message itself is not required to exist in the database,
     /// it may even be deleted from the database by the time the message is prepared.
-    pub async fn set_quote(&mut self, context: &Context, quote: &Message) -> Result<()> {
-        ensure!(
-            !quote.rfc724_mid.is_empty(),
-            "Message without Message-Id cannot be quoted"
-        );
-        self.in_reply_to = Some(quote.rfc724_mid.clone());
+    pub async fn set_quote(&mut self, context: &Context, quote: Option<&Message>) -> Result<()> {
+        if let Some(quote) = quote {
+            ensure!(
+                !quote.rfc724_mid.is_empty(),
+                "Message without Message-Id cannot be quoted"
+            );
+            self.in_reply_to = Some(quote.rfc724_mid.clone());
 
-        if quote
-            .param
-            .get_bool(Param::GuaranteeE2ee)
-            .unwrap_or_default()
-        {
-            self.param.set(Param::GuaranteeE2ee, "1");
+            if quote
+                .param
+                .get_bool(Param::GuaranteeE2ee)
+                .unwrap_or_default()
+            {
+                self.param.set(Param::GuaranteeE2ee, "1");
+            }
+
+            let text = quote.get_text().unwrap_or_default();
+            self.param.set(
+                Param::Quote,
+                if text.is_empty() {
+                    // Use summary, similar to "Image" to avoid sending empty quote.
+                    quote
+                        .get_summary(context, None)
+                        .await?
+                        .truncated_text(500)
+                        .to_string()
+                } else {
+                    text
+                },
+            );
+        } else {
+            self.in_reply_to = None;
+            self.param.remove(Param::Quote);
         }
-
-        let text = quote.get_text().unwrap_or_default();
-        self.param.set(
-            Param::Quote,
-            if text.is_empty() {
-                // Use summary, similar to "Image" to avoid sending empty quote.
-                quote
-                    .get_summary(context, None)
-                    .await?
-                    .truncated_text(500)
-                    .to_string()
-            } else {
-                text
-            },
-        );
 
         Ok(())
     }
@@ -1850,7 +1855,9 @@ mod tests {
         assert!(!msg.rfc724_mid.is_empty());
 
         let mut msg2 = Message::new(Viewtype::Text);
-        msg2.set_quote(ctx, &msg).await.expect("can't set quote");
+        msg2.set_quote(ctx, Some(&msg))
+            .await
+            .expect("can't set quote");
         assert!(msg2.quoted_text() == msg.get_text());
 
         let quoted_msg = msg2

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1688,7 +1688,7 @@ mod tests {
             let mut new_msg = Message::new(Viewtype::Text);
             new_msg.set_text(Some("Hi".to_string()));
             if let Some(q) = quote {
-                new_msg.set_quote(t, q).await?;
+                new_msg.set_quote(t, Some(q)).await?;
             }
             let sent = t.send_msg(group_id, &mut new_msg).await;
             get_subject(t, sent).await
@@ -1857,7 +1857,7 @@ mod tests {
         }
 
         if reply {
-            new_msg.set_quote(&t, &incoming_msg).await.unwrap();
+            new_msg.set_quote(&t, Some(&incoming_msg)).await.unwrap();
         }
 
         let mf = MimeFactory::from_msg(&t, &new_msg, false).await.unwrap();


### PR DESCRIPTION
allow `dc_msg_set_quote(msg, NULL)` and `msg.set_quote(None)`
to simplify draft handling keeping message-ids (as needed for webxdc updates).

closes #2948