### PR TITLE
update changelog for 1.71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Added
 
-- added `dc_context_t*   dc_context_new_closed(const char* dbfile)`, `int  dc_context_open(dc_context_t *context, const char* passphrase)`, `int  dc_context_is_open(dc_context_t *context)` and `uint32_t  dc_accounts_add_closed_account(dc_accounts_t* accounts)` #2956
+- added `dc_context_new_closed()`, `dc_context_open()`, `dc_context_is_open()` and `dc_accounts_add_closed_account()` #2956
 
 - added `DC_MSG_WEBXDC`, `dc_send_webxdc_status_update()`,
   `dc_get_webxdc_status_updates()`, `dc_msg_get_webxdc_blob()`,
@@ -23,12 +23,12 @@
 - Removed `inbox_watch` option #2922
 
 #### Deprecated
-- deprecated `os_name` in `dc_context_new(const char* os_name, const char* dbfile, const char* blobdir)`, now you should pass `NULL` or an empty string.
+- deprecated `os_name` in `dc_context_new(const char* os_name, const char* dbfile, const char* blobdir)`, now you should pass `NULL` or an empty string. #2956
 
 ### Added
 - Add imap table to keep track of message UIDs #2909
-- add hop_info (#2751)
-- Start making it possible to write to mailing lists (#2736)
+- add hop_info #2751
+- Start making it possible to write to mailing lists #2736
 - sql: enable `auto_vacuum=INCREMENTAL` #2931
 - Synchronize Seen status across devices #2942
 - Add API to set the database password #2956
@@ -37,17 +37,16 @@
 ### Changed
 - selfstatus now defaults to empty
 - `dc_preconfigure_keypair` now takes ascii armored keys instead of base64. #2862
-- Put removed member in Bcc instead of To in the message about removal
-#2864
+- Put removed member in Bcc instead of To in the message about removal #2864
 - do not change the draft's message-id on updates and sending (#2887)
 - Improve group updates #2889
 - Merge `mvbox_move` and `mvbox_watch` options. #2903
 - allow removing quotes on existing drafts (#2950)
 - update provider database (11 Jan 2022) #2959
-- allow timeout for internal configure tracker API #2967 (python)
+- python: allow timeout for internal configure tracker API #2967
 
 ### Fixed
-- Fix: Make add_parts() not early-exit #2879
+- Fix: Make `add_parts()` not early-exit #2879
 - Fix: Encrypted and signed messages from Thunderbird don't show a padlock #2301
 - Fix: Recognize MS Exchange read receipts as read receipts #2890
 - Improve the log (#2928)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,58 @@
 
 ### API changes
 
+#### Added
+
+- added `dc_context_t*   dc_context_new_closed(const char* dbfile)`, `int  dc_context_open(dc_context_t *context, const char* passphrase)`, `int  dc_context_is_open(dc_context_t *context)` and `uint32_t  dc_accounts_add_closed_account(dc_accounts_t* accounts)` #2956
+
 - added `DC_MSG_WEBXDC`, `dc_send_webxdc_status_update()`,
   `dc_get_webxdc_status_updates()`, `dc_msg_get_webxdc_blob()`,
   `dc_msg_get_webxdc_info()`, and `DC_EVENT_WEBXDC_STATUS_UPDATE` #2826
+
+- Add `dc_msg_force_plaintext()` API for bots #2847
+
+- allow to remove quotes on drafts `dc_msg_set_quote(msg, NULL)` #2950
+
+#### Removed
+
 - Removed `mvbox_watch` option. #2906
   It is automatically enabled whenever `mvbox_move` is enabled.
+- Removed `inbox_watch` option #2922
 
+#### Deprecated
+- deprecated `os_name` in `dc_context_new(const char* os_name, const char* dbfile, const char* blobdir)`, now you should pass `NULL` or an empty string.
+
+### Added
+- Add imap table to keep track of message UIDs #2909
+- add hop_info (#2751)
+- Start making it possible to write to mailing lists (#2736)
+- sql: enable `auto_vacuum=INCREMENTAL` #2931
+- Synchronize Seen status across devices #2942
+- Add API to set the database password #2956
+- Add webXdc #2826
+
+### Changed
+- selfstatus now defaults to empty
+- `dc_preconfigure_keypair` now takes ascii armored keys instead of base64. #2862
+- Put removed member in Bcc instead of To in the message about removal
+#2864
+- do not change the draft's message-id on updates and sending (#2887)
+- Improve group updates #2889
+- Merge `mvbox_move` and `mvbox_watch` options. #2903
+- allow removing quotes on existing drafts (#2950)
+- update provider database (11 Jan 2022) #2959
+- allow timeout for internal configure tracker API #2967 (python)
+
+### Fixed
+- Fix: Make add_parts() not early-exit #2879
+- Fix: Encrypted and signed messages from Thunderbird don't show a padlock #2301
+- Fix: Recognize MS Exchange read receipts as read receipts #2890
+- Improve the log (#2928)
+- Fix: dc_receive_imf: don't fail on invalid address in the To field #2940
+
+## Removed
+- Remove `inbox_watch` option #2922
+- Remove default signature advertising Delta Chat #2951
 
 ## 1.70.0
 


### PR DESCRIPTION
I did not document the changes Changes to rust api and python api, just what changed generally for the lib users.
So some internal non-user-facing changes as error handling refactoring are not included now,
if you think they should be included, feel free to add them, same for other points I might have missed.