### PR TITLE
add mergable changelog check

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -3,7 +3,7 @@ mergeable:
   - when: pull_request.*
     name: "Changelog check"
     validate:
-        - do: or
+        - do: and
           validate:
             - do: dependent
               changed:

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -17,5 +17,5 @@ mergeable:
       - do: checks
         status: 'action_required' 
         payload:
-          title: Changelog needs to be updated
-          summary: "Please update the changelog"
+          title: Changlog might need an update
+          summary: "Changelog not updated, please check if an update is needed."

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,0 +1,21 @@
+version: 2
+mergeable:
+  - when: pull_request.*
+    name: "Changelog check"
+    validate:
+        - do: or
+          validate:
+            - do: dependent
+              changed:
+                file: 'src/**' 
+                required: ['CHANGELOG.md']
+            - do: dependent
+              changed:
+                file: 'deltachat-ffi/**'
+                required: ['CHANGELOG.md']
+    fail:
+      - do: checks
+        status: 'action_required' 
+        payload:
+          title: Changelog needs to be updated
+          summary: "Please update the changelog"

--- a/deltachat-ffi/README.md
+++ b/deltachat-ffi/README.md
@@ -1,5 +1,9 @@
 # Delta Chat C Interface
 
+## Installation
+
+see `Installing libdeltachat system wide` in [../README.md](../README.md)
+
 ## Documentation
 
 To generate the C Interface documentation,


### PR DESCRIPTION
Mergeable is very configurable so we can customise it to our needs, for example changing on changes tho which files the changeling needs to be updated.
Currently I set it up so that it requires changelog changes for changes in `src/` and `deltachat-ffi/`.
mergeable docs: https://mergeable.readthedocs.io/en/latest/

Also the check is not required so its goal is to be a **reminder**, sometimes we don't need a changelog change, for example for a bugfix for a bug that was introduced in a recent unreleased/untagged previous commit.