### PR TITLE
limit webxdc-sizes for a better ux

### DIFF
--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -34,7 +34,7 @@ pub(crate) const WEBXDC_SENDING_LIMIT: usize = 102400;
 
 /// Be more tolerant for .xdc sizes on receiving -
 /// might be, the senders version uses already a larger limit
-/// and not showing the .xpc on some devices would be even worse ux.
+/// and not showing the .xdc on some devices would be even worse ux.
 const WEBXDC_RECEIVING_LIMIT: usize = 1048576;
 
 /// Raw information read from manifest.toml

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -22,7 +22,7 @@ const WEBXDC_DEFAULT_ICON: &str = "__webxdc__/default-icon.png";
 
 /// Defines the maximal size in bytes of an .xdc file that can be sent.
 ///
-/// We introduce a limit to force developer to create small .xpc
+/// We introduce a limit to force developer to create small .xdc
 /// to save user's traffic and disk space for a better ux.
 ///
 /// The 100K limit should also let .xdc pass worse-quality auto-download filters


### PR DESCRIPTION
see code comment for reasoning.

@hpk42 i increased the limit to 100K as this fits nicely to the already existing limit for "worse quality" images.

if this pr is merged, we should also add a warning to the script at https://github.com/deltachat/webxdc-dev/blob/master/create-xdc.sh if the created .xdc gets too large.