### PR TITLE
Actually return a sensible error from create_new_file()

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -93,7 +93,7 @@ impl<'a> BlobObject<'a> {
     ) -> Result<(String, fs::File), BlobError> {
         let max_attempt = 15;
         let mut name = format!("{}{}", stem, ext);
-        for attempt in 0..max_attempt {
+        for attempt in 1..=max_attempt {
             let path = dir.join(&name);
             match fs::OpenOptions::new()
                 .create_new(true)


### PR DESCRIPTION
In https://github.com/deltachat/deltachat-android/pull/2186, configure sometimes fails because of `create_new_file()`, so let's start by letting it return a sensible error.

The thing is that below we are checking `if attempt == max_attempt {<return error>}` which is supposed to run in the last iteration of the loop.

BTW @link2xt the error I'm getting is `Failed to create blob icon-saved-messages-1803424689.png in /data/user/0/com.b44t.messenger.beta/files/accounts/0e402b37dcd14a9586aea46294c908f2/dc.db-blobs: No such file or directory (os error 2)` - do you have a quick idea why this could be? Otherwise I'll continue debugging and possibly ask you for help again (or just let `create_new_file()` create the parent dir on error)