### PR TITLE
Save "configured" flag later

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -454,11 +454,8 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
     drop(imap);
 
     progress!(ctx, 910);
-    // configuration success - write back the configured parameters with the
-    // "configured_" prefix; also write the "configured"-flag */
     // the trailing underscore is correct
     param.save_to_database(ctx, "configured_").await?;
-    ctx.sql.set_raw_config_bool("configured", true).await?;
     ctx.set_config(Config::ConfiguredTimestamp, Some(&time().to_string()))
         .await?;
 
@@ -475,6 +472,8 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
 
     progress!(ctx, 940);
     update_device_chats_handle.await?;
+
+    ctx.sql.set_raw_config_bool("configured", true).await?;
 
     Ok(())
 }


### PR DESCRIPTION
While experimenting with encrypted storage, once configuring failed between 920 and 940. But as the "configured" config had already been written after progress 910, some part of the code thought we are configured, some didn't.

Is there a reason we don't wait with

    ctx.sql.set_raw_config_bool("configured", true).await?;

until the very end of configure()?