### PR TITLE
make update messages work if a key is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 - sql: enable `auto_vacuum=INCREMENTAL` #2931
 - Synchronize Seen status across devices #2942
 - Add API to set the database password #2956
-- Add webXdc #2826
+- Add Webxdc #2826 #2998
 
 ### Changed
 - selfstatus now defaults to empty

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -251,6 +251,7 @@ impl Context {
                     .ok_or_else(|| format_err!("Status object expected."))?,
                 );
                 status_update.set_quote(self, Some(&instance)).await?;
+                status_update.param.remove(Param::GuaranteeE2ee); // may be set by set_quote(), if #2985 is done, this line can be removed
                 let status_update_msg_id =
                     chat::send_msg(self, instance.chat_id, &mut status_update).await?;
                 Ok(Some(status_update_msg_id))


### PR DESCRIPTION
see commit messages for details.

targets the webxdc part of https://github.com/deltachat/deltachat-core-rust/issues/2985, however, if #2985 gets implemented, we can remove the removal of GuaranteeE2ee here.