### PR TITLE
allow to #skip-changelog test

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -3,11 +3,16 @@ mergeable:
   - when: pull_request.*
     name: "Changelog check"
     validate:
+      - do: or
+        validate:
+        - do: description
+          must_include:
+            regex: '#skip-changelog'
         - do: and
           validate:
             - do: dependent
               changed:
-                file: 'src/**' 
+                file: 'src/**'
                 required: ['CHANGELOG.md']
             - do: dependent
               changed:


### PR DESCRIPTION
several pr do not need the changelog to be updated (as this one :), by adding #skip-changelog to the description, this test is skipped and ci is green again (before, the test was not required as well, however, ci was red which was a bit annoying)

used documentation:
https://mergeable.readthedocs.io/en/latest/configuration.html#validators
https://mergeable.readthedocs.io/en/latest/operators/or.html

nb: i can say i still hate this sort of yml configs ...

#skip-changelog