### PR TITLE
webxdc: synchronous state for read-only-chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Synchronize Seen status across devices #2942
 - Add API to set the database password #2956
 - Add information about whether the database is encrypted or not to `dc_get_info()` #3000
-- Add Webxdc #2826 #2971 #2975 #2977 #2979 #2993 #2998
+- Add Webxdc #2826 #2971 #2975 #2977 #2979 #2993 #2998 #3001
 
 ### Changed
 - selfstatus now defaults to empty

--- a/draft/webxdc-dev-reference.md
+++ b/draft/webxdc-dev-reference.md
@@ -44,6 +44,13 @@ To get a shared state, the peers use `sendUpdate()` to send updates to each othe
 All peers, including the sending one,
 will receive the update by the callback given to `setUpdateListener()`.
 
+There are situations where the user cannot send messages to a chat,
+eg. contact requests or if the user has left a group.
+In these cases, you can still call `sendUpdate()`,
+however, the update won't be sent to other peers
+and you won't get the update by `setUpdateListener()` nor by `getAllUpdates()`.
+
+
 ### setUpdateListener()
 
 ```js


### PR DESCRIPTION
already before,
we did _not_ sent updates to contact requests or other read-only-chats.
however, we _did_ modify the local database,
so that getAllUpdates() returns an update that was not sent out to other peers.

this is fixed by checking can_send() soon.

that way, all peers have the same state
also for contact requests or other read-only-chats
and webxdc in contact requests can be opened as usual.

further ui improvements may be needed for contact requests
(maybe allow the webxdc to know about that state or
let sendUpdate() return false,
maybe show a warning in the ui somewhere),
however, this is not part of this pr.

EDIT: a simple idea for a subsequent pr may be to just show a toast from the ui (not the app) in case sendUpdate() fails, or, at some later point maybe even an alert that allows to accept the contact request. that way, by default, there is not much need for the apps to think over contact requests.

closes #2997