### PR TITLE
raise webxdc sending limit to 640 kb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
 - Synchronize Seen status across devices #2942
 - Add API to set the database password #2956
 - Add information about whether the database is encrypted or not to `dc_get_info()` #3000
-- Add Webxdc #2826 #2971 #2975 #2977 #2979 #2993 #2998 #3001
+- Add Webxdc #2826 #2971 #2975 #2977 #2979 #2993 #2998 #3001 #3003 
 
 ### Changed
 - selfstatus now defaults to empty

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -32,12 +32,12 @@ const WEBXDC_DEFAULT_ICON: &str = "__webxdc__/default-icon.png";
 ///
 /// The limit is also an experiment to see how small we can go;
 /// it is planned to raise that limit as needed in subsequent versions.
-const WEBXDC_SENDING_LIMIT: usize = 102400;
+const WEBXDC_SENDING_LIMIT: usize = 655360;
 
 /// Be more tolerant for .xdc sizes on receiving -
 /// might be, the senders version uses already a larger limit
 /// and not showing the .xdc on some devices would be even worse ux.
-const WEBXDC_RECEIVING_LIMIT: usize = 1048576;
+const WEBXDC_RECEIVING_LIMIT: usize = 4194304;
 
 /// Raw information read from manifest.toml
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
as discussed in dev chat,
100 kb is too low if one wants to use any (game) framework.
also, many game that doesn't have poor graphics
or uses magic CSS-tricks to do fancy draws,
will have more than 100 kb probably just in tiles and sprites.

even for regions with low resources,
100 kb is low for a game -
esp. if we compare that with stickers that are send around as well,
are not deduplicated and also easily have several 100 kb in size -
for much less effect.

we should still encourage ppl to create tiny apps,
however, a too low limit also restricts possibilities wrt adaption.