### PR TITLE
Fix: Run migrations after importing backup again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+fix: run migrations on backup import #3006
+
 ## 1.71.0
 
 ### API Changes

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -423,7 +423,8 @@ async fn imex_inner(
             export_backup(context, path, passphrase.unwrap_or_default()).await
         }
         ImexMode::ImportBackup => {
-            import_backup(context, path, passphrase.unwrap_or_default()).await
+            import_backup(context, path, passphrase.unwrap_or_default()).await?;
+            context.sql.run_migrations(context).await
         }
     }
 }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -215,6 +215,12 @@ impl Sql {
             conn.pragma_update(None, "synchronous", &"NORMAL".to_string())?;
         }
 
+        self.run_migrations(context).await?;
+
+        Ok(())
+    }
+
+    pub async fn run_migrations(&self, context: &Context) -> Result<()> {
         // (1) update low-level database structure.
         // this should be done before updates that use high-level objects that
         // rely themselves on the low-level structure.


### PR DESCRIPTION
As of https://github.com/deltachat/deltachat-core-rust/pull/2980/, the migrations were not run after importing a backup. This lead to errors like "Failed to send message: no such table: smtp" if you imported a backup from a previous DC version.

#skip-update - hmmm, this doesn't seem to work, Mergable still fails. Edit: has to be #skip-changelog