### PR TITLE
prepare 1.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## Unreleased
+## 1.72.0
 
-fix: run migrations on backup import #3006
+### Fixes
+- run migrations on backup import #3006
+
 
 ## 1.71.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,7 +1063,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.71.0"
+version = "1.72.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1144,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.71.0"
+version = "1.72.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.71.0"
+version = "1.72.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.71.0"
+version = "1.72.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"


### PR DESCRIPTION
this fixes the missing migration after imports, esp. needed for testing :)

after commit, on master make sure to: 

   git tag -a 1.72.0
   git push origin 1.72.0
   git tag -a py-1.72.0
   git push origin py-1.72.0