### PR TITLE
Add OnlyFetchMvbox option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### API changes
+- added `only_fetch_mvbox` config #3014
+
 ## 1.72.0
 
 ### Fixes

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -343,6 +343,11 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    and watch the `DeltaChat` folder for updates (default),
  *                    0=do not move chat-messages
  *                    changes require restarting IO by calling dc_stop_io() and then dc_start_io().
+ * - `only_fetch_mvbox` = 1=ignore all folders except for the `DeltaChat` folder.
+ *                    Setting this will automatically set `mvbox_move` to 1 and `sentbox_watch` to 0.
+ *                    Setting `mvbox_move` to 0 or `sentbox_watch` to 1 will automatically disable this option.
+ *                    When this option is set, the UI should disable the `mvbox_move` and `sentbox_watch` options.
+ *                    0=watch all folders normally (default)
  * - `show_emails`  = DC_SHOW_EMAILS_OFF (0)=
  *                    show direct replies to chats only (default),
  *                    DC_SHOW_EMAILS_ACCEPTED_CONTACTS (1)=

--- a/src/config.rs
+++ b/src/config.rs
@@ -433,16 +433,40 @@ mod tests {
         Ok(())
     }
 
-    /// Regression test for https://github.com/deltachat/deltachat-core-rust/issues/3012
     #[async_std::test]
     async fn test_set_config_bool() -> Result<()> {
         let t = TestContext::new().await;
 
+        // Regression test for https://github.com/deltachat/deltachat-core-rust/issues/3012
         // We need some config that defaults to true
         let c = Config::E2eeEnabled;
         assert_eq!(t.get_config_bool(c).await?, true);
         t.set_config_bool(c, false).await?;
         assert_eq!(t.get_config_bool(c).await?, false);
+
+        // Test that OnlyFetchMvbox==true implies MvboxMove==true and SentboxWatch==false
+        t.set_config_bool(Config::SentboxWatch, true).await?;
+
+        t.set_config_bool(Config::OnlyFetchMvbox, true).await?;
+        assert_eq!(t.get_config_bool(Config::SentboxWatch).await?, false);
+        assert_eq!(t.get_config_bool(Config::OnlyFetchMvbox).await?, true);
+
+        t.set_config_bool(Config::MvboxMove, false).await?;
+        assert_eq!(t.get_config_bool(Config::MvboxMove).await?, false);
+        assert_eq!(t.get_config_bool(Config::OnlyFetchMvbox).await?, false);
+
+        t.set_config_bool(Config::SentboxWatch, true).await?;
+        assert_eq!(t.get_config_bool(Config::SentboxWatch).await?, true);
+
+        t.set_config_bool(Config::OnlyFetchMvbox, true).await?;
+        assert_eq!(t.get_config_bool(Config::SentboxWatch).await?, false);
+        assert_eq!(t.get_config_bool(Config::MvboxMove).await?, true);
+        assert_eq!(t.get_config_bool(Config::OnlyFetchMvbox).await?, true);
+
+        t.set_config_bool(Config::SentboxWatch, true).await?;
+        assert_eq!(t.get_config_bool(Config::SentboxWatch).await?, true);
+        assert_eq!(t.get_config_bool(Config::OnlyFetchMvbox).await?, false);
+
         Ok(())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,31 +281,25 @@ impl Context {
                     }
                 }
                 self.emit_event(EventType::SelfavatarChanged);
-                Ok(())
             }
             Config::DeleteDeviceAfter => {
-                let ret = self
-                    .sql
-                    .set_raw_config(key, value)
-                    .await
-                    .map_err(Into::into);
+                let ret = self.sql.set_raw_config(key, value).await;
                 // Force chatlist reload to delete old messages immediately.
                 self.emit_event(EventType::MsgsChanged {
                     msg_id: MsgId::new(0),
                     chat_id: ChatId::new(0),
                 });
-                ret
+                ret?
             }
             Config::Displayname => {
                 let value = value.map(improve_single_line_input);
                 self.sql.set_raw_config(key, value.as_deref()).await?;
-                Ok(())
             }
             _ => {
                 self.sql.set_raw_config(key, value).await?;
-                Ok(())
             }
         }
+        Ok(())
     }
 
     pub async fn set_config_bool(&self, key: Config, value: bool) -> Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,9 @@ pub enum Config {
     #[strum(props(default = "0"))]
     SentboxMove, // If `MvboxMove` is true, this config is ignored. Currently only used in tests.
 
+    #[strum(props(default = "0"))]
+    OnlyFetchMvbox,
+
     #[strum(props(default = "0"))] // also change ShowEmails.default() on changes
     ShowEmails,
 
@@ -295,6 +298,33 @@ impl Context {
                 let value = value.map(improve_single_line_input);
                 self.sql.set_raw_config(key, value.as_deref()).await?;
             }
+            Config::SentboxWatch => {
+                self.sql.set_raw_config(key, value).await?;
+                if config_to_bool(value) {
+                    self.sql
+                        .set_raw_config(Config::OnlyFetchMvbox, Some("0"))
+                        .await?;
+                }
+            }
+            Config::MvboxMove => {
+                self.sql.set_raw_config(key, value).await?;
+                if !config_to_bool(value) {
+                    self.sql
+                        .set_raw_config(Config::OnlyFetchMvbox, Some("0"))
+                        .await?;
+                }
+            }
+            Config::OnlyFetchMvbox => {
+                self.sql.set_raw_config(key, value).await?;
+                if config_to_bool(value) {
+                    self.sql
+                        .set_raw_config(Config::SentboxWatch, Some("0"))
+                        .await?;
+                    self.sql
+                        .set_raw_config(Config::MvboxMove, Some("1"))
+                        .await?;
+                }
+            }
             _ => {
                 self.sql.set_raw_config(key, value).await?;
             }
@@ -333,6 +363,13 @@ fn get_config_keys_string() -> String {
     });
 
     format!(" {} ", keys)
+}
+
+fn config_to_bool(value: Option<&str>) -> bool {
+    value
+        .and_then(|s| s.parse::<i32>().ok())
+        .unwrap_or_default()
+        != 0
 }
 
 #[cfg(test)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -358,6 +358,7 @@ impl Context {
         let sentbox_watch = self.get_config_int(Config::SentboxWatch).await?;
         let mvbox_move = self.get_config_int(Config::MvboxMove).await?;
         let sentbox_move = self.get_config_int(Config::SentboxMove).await?;
+        let only_fetch_mvbox = self.get_config_int(Config::OnlyFetchMvbox).await?;
         let folders_configured = self
             .sql
             .get_raw_config_int("folders_configured")
@@ -422,6 +423,7 @@ impl Context {
         res.insert("sentbox_watch", sentbox_watch.to_string());
         res.insert("mvbox_move", mvbox_move.to_string());
         res.insert("sentbox_move", sentbox_move.to_string());
+        res.insert("only_fetch_mvbox", only_fetch_mvbox.to_string());
         res.insert("folders_configured", folders_configured.to_string());
         res.insert("configured_sentbox_folder", configured_sentbox_folder);
         res.insert("configured_mvbox_folder", configured_mvbox_folder);

--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -157,7 +157,6 @@ impl Imap {
                     // in anything.  If so, we behave as if IDLE had data but
                     // will have already fetched the messages so perform_*_fetch
                     // will not find any new.
-
                     match self.fetch_new_messages(context, &watch_folder, false).await {
                         Ok(res) => {
                             info!(context, "fetch_new_messages returned {:?}", res);


### PR DESCRIPTION
Probably best to review commit-by-commit, but idk.

Adds an option to only fetch emails from the DeltaChat folder. This is needed for people who sort all the emails they want to show in DC into the DeltaChat folder, and want DC to ignore all other folders. This was requested here: https://support.delta.chat/t/schlechtes-handling-von-extentionsadressen/1990/6 (unfortunately in German)

With this PR, there are still some unnecessary IMAP operations done on the other folders, but if we want to optimize this, we should probably do it after the release.

I called it "OnlyFetchMvbox" instead of "OnlyWatchMvbox" because with "watch" we usually mean "do idle on it". But I could also change this again.