### PR TITLE
Improve error reporting in sync_seen_flags and make it more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### Fixes
 - fix splitting off text from webxdc messages #3032
 - call slow `delete_expired_imap_messages()` less often #3037
+- make synchronization of Seen status more robust in case unsolicited FETCH
+  result without UID is returned #3022
 
 
 ## 1.72.0

--- a/src/message.rs
+++ b/src/message.rs
@@ -180,7 +180,7 @@ impl rusqlite::types::ToSql for MsgId {
     fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput> {
         if self.0 <= DC_MSG_ID_LAST_SPECIAL {
             return Err(rusqlite::Error::ToSqlConversionFailure(
-                format_err!("Invalid MsgId").into(),
+                format_err!("Invalid MsgId {}", self.0).into(),
             ));
         }
         let val = rusqlite::types::Value::Integer(self.0 as i64);


### PR DESCRIPTION
If FETCH result has no UID (possibly an unsolicited response), ignore it
instead of trying to pass None into SQL query.

Update highest seen MODSEQ regardless of whether any message state has
changed or not.

Log special MsgIds on attempt to pass them into SQL query.

Closes #3005 