### PR TITLE
Reduce number of unsafe `as` conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changes
+- refactorings #3026
+
 ### Fixes
 - avoid archived, fresh chats #3053
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -960,7 +960,7 @@ impl std::fmt::Display for ChatId {
 /// well as query for a [ChatId].
 impl rusqlite::types::ToSql for ChatId {
     fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput> {
-        let val = rusqlite::types::Value::Integer(self.0 as i64);
+        let val = rusqlite::types::Value::Integer(i64::from(self.0));
         let out = rusqlite::types::ToSqlOutput::Owned(val);
         Ok(out)
     }
@@ -970,7 +970,7 @@ impl rusqlite::types::ToSql for ChatId {
 impl rusqlite::types::FromSql for ChatId {
     fn column_result(value: rusqlite::types::ValueRef) -> rusqlite::types::FromSqlResult<Self> {
         i64::column_result(value).and_then(|val| {
-            if 0 <= val && val <= std::u32::MAX as i64 {
+            if 0 <= val && val <= i64::from(std::u32::MAX) {
                 Ok(ChatId::new(val as u32))
             } else {
                 Err(rusqlite::types::FromSqlError::OutOfRange(val))

--- a/src/config.rs
+++ b/src/config.rs
@@ -245,7 +245,7 @@ impl Context {
         match self.get_config_int(Config::DeleteServerAfter).await? {
             0 => Ok(None),
             1 => Ok(Some(0)),
-            x => Ok(Some(x as i64)),
+            x => Ok(Some(i64::from(x))),
         }
     }
 
@@ -267,7 +267,7 @@ impl Context {
     pub async fn get_config_delete_device_after(&self) -> Result<Option<i64>> {
         match self.get_config_int(Config::DeleteDeviceAfter).await? {
             0 => Ok(None),
-            x => Ok(Some(x as i64)),
+            x => Ok(Some(i64::from(x))),
         }
     }
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1156,8 +1156,8 @@ INSERT INTO msgs
         stmt.execute(paramsv![
             rfc724_mid,
             chat_id,
-            if trash { 0 } else { from_id as i32 },
-            if trash { 0 } else { to_id as i32 },
+            if trash { 0 } else { i64::from(from_id) },
+            if trash { 0 } else { i64::from(to_id) },
             sort_timestamp,
             sent_timestamp,
             rcvd_timestamp,

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -71,7 +71,7 @@ pub(crate) fn dc_gm2local_offset() -> i64 {
     /* returns the offset that must be _added_ to an UTC/GMT-time to create the localtime.
     the function may return negative values. */
     let lt = Local::now();
-    lt.offset().local_minus_utc() as i64
+    i64::from(lt.offset().local_minus_utc())
 }
 
 // timesmearing

--- a/src/job.rs
+++ b/src/job.rs
@@ -197,7 +197,7 @@ impl Job {
                     "UPDATE jobs SET desired_timestamp=?, tries=?, param=? WHERE id=?;",
                     paramsv![
                         self.desired_timestamp,
-                        self.tries as i64,
+                        i64::from(self.tries),
                         self.param.to_string(),
                         self.job_id as i32,
                     ],
@@ -676,7 +676,7 @@ fn get_backoff_time_offset(tries: u32, action: Action) -> i64 {
             if seconds < 1 {
                 seconds = 1;
             }
-            seconds as i64
+            i64::from(seconds)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@
     clippy::all,
     clippy::indexing_slicing,
     clippy::wildcard_imports,
-    clippy::needless_borrow
+    clippy::needless_borrow,
+    clippy::cast_lossless
 )]
 #![allow(
     clippy::match_bool,

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -253,7 +253,8 @@ impl LoginParam {
         sql.set_raw_config(key, Some(&self.imap.server)).await?;
 
         let key = format!("{}mail_port", prefix);
-        sql.set_raw_config_int(key, self.imap.port as i32).await?;
+        sql.set_raw_config_int(key, i32::from(self.imap.port))
+            .await?;
 
         let key = format!("{}mail_user", prefix);
         sql.set_raw_config(key, Some(&self.imap.user)).await?;
@@ -273,7 +274,8 @@ impl LoginParam {
         sql.set_raw_config(key, Some(&self.smtp.server)).await?;
 
         let key = format!("{}send_port", prefix);
-        sql.set_raw_config_int(key, self.smtp.port as i32).await?;
+        sql.set_raw_config_int(key, i32::from(self.smtp.port))
+            .await?;
 
         let key = format!("{}send_user", prefix);
         sql.set_raw_config(key, Some(&self.smtp.user)).await?;

--- a/src/message.rs
+++ b/src/message.rs
@@ -183,7 +183,7 @@ impl rusqlite::types::ToSql for MsgId {
                 format_err!("Invalid MsgId {}", self.0).into(),
             ));
         }
-        let val = rusqlite::types::Value::Integer(self.0 as i64);
+        let val = rusqlite::types::Value::Integer(i64::from(self.0));
         let out = rusqlite::types::ToSqlOutput::Owned(val);
         Ok(out)
     }
@@ -194,7 +194,7 @@ impl rusqlite::types::FromSql for MsgId {
     fn column_result(value: rusqlite::types::ValueRef) -> rusqlite::types::FromSqlResult<Self> {
         // Would be nice if we could use match here, but alas.
         i64::column_result(value).and_then(|val| {
-            if 0 <= val && val <= std::u32::MAX as i64 {
+            if 0 <= val && val <= i64::from(std::u32::MAX) {
                 Ok(MsgId::new(val as u32))
             } else {
                 Err(rusqlite::types::FromSqlError::OutOfRange(val))

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -75,7 +75,7 @@ impl StatusUpdateId {
 
 impl rusqlite::types::ToSql for StatusUpdateId {
     fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput> {
-        let val = rusqlite::types::Value::Integer(self.0 as i64);
+        let val = rusqlite::types::Value::Integer(i64::from(self.0));
         let out = rusqlite::types::ToSqlOutput::Owned(val);
         Ok(out)
     }


### PR DESCRIPTION
Enable clippy::cast_lossless lint and get rid of
some conversions pointed out by  clippy::as_conversions.