### PR TITLE
use webxdc app name in chatlist/quotes/replies etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.72.0
 
+### Changes
+- use webxdc app name in chatlist/quotes/replies etc. #3027
+
 ### Fixes
 - run migrations on backup import #3006
 

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -139,7 +139,10 @@ impl Message {
             }
             Viewtype::Webxdc => {
                 append_text = true;
-                "Webxdc".to_string()
+                self.get_webxdc_info(context)
+                    .await
+                    .map(|info| info.name)
+                    .unwrap_or_else(|_| "ErrWebxdcName".to_string())
             }
             Viewtype::Text | Viewtype::Unknown => {
                 if self.param.get_cmd() != SystemMessage::LocationOnly {


### PR DESCRIPTION
this uses `get_webxdc_info().name` for chatlist etc.
the previuosly used static strings comes from a time
where we just did not had the correct name.

i was also thinking about adding `get_webxdc_info().summary`,
however, as this information is dynamic,
that may open several issues, eg. quoted text may change
so that the answer is out of context.