### PR TITLE
Flub/watch mvbox only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### API changes
-- added `only_fetch_mvbox` config #3014
+- added `watch_mvbox_only` config #3028
 
 ### Changes
 - don't watch Sent folder by default #3025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### API changes
-- added `watch_mvbox_only` config #3028
+- added `only_fetch_mvbox` config #3028
 
 ### Changes
 - don't watch Sent folder by default #3025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### API changes
+- added `only_fetch_mvbox` config #3014
+
 ### Changes
 - don't watch Sent folder by default #3025
 - use webxdc app name in chatlist/quotes/replies etc. #3027

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -344,7 +344,7 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    0=do not move chat-messages
  *                    changes require restarting IO by calling dc_stop_io() and then dc_start_io().
 
- * - `watch_mvbox_only`
+ * - `only_fetch_mvbox`
  *                  = 1=Do not fetch messages from folders other than the
  *                      `DeltaChat` folder.  Messages will still be fetched from the,
  *                       spam folder and `sendbox_watch` will also still be respected

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -343,10 +343,12 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    and watch the `DeltaChat` folder for updates (default),
  *                    0=do not move chat-messages
  *                    changes require restarting IO by calling dc_stop_io() and then dc_start_io().
- * - `only_fetch_mvbox` = 1=ignore all folders except for the `DeltaChat` folder.
- *                    Setting this will automatically set `mvbox_move` to 1 and `sentbox_watch` to 0.
- *                    Setting `mvbox_move` to 0 or `sentbox_watch` to 1 will automatically disable this option.
- *                    When this option is set, the UI should disable the `mvbox_move` and `sentbox_watch` options.
+
+ * - `watch_mvbox_only`
+ *                  = 1=Do not fetch messages from folders other than the
+ *                      `DeltaChat` folder.  Messages will still be fetched from the,
+ *                       spam folder and `sendbox_watch` will also still be respected
+ *                       if enabled.
  *                    0=watch all folders normally (default)
  * - `show_emails`  = DC_SHOW_EMAILS_OFF (0)=
  *                    show direct replies to chats only (default),

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -343,6 +343,11 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    and watch the `DeltaChat` folder for updates (default),
  *                    0=do not move chat-messages
  *                    changes require restarting IO by calling dc_stop_io() and then dc_start_io().
+ * - `only_fetch_mvbox` = 1=ignore all folders except for the `DeltaChat` folder.
+ *                    Setting this will automatically set `mvbox_move` to 1 and `sentbox_watch` to 0.
+ *                    Setting `mvbox_move` to 0 or `sentbox_watch` to 1 will automatically disable this option.
+ *                    When this option is set, the UI should disable the `mvbox_move` and `sentbox_watch` options.
+ *                    0=watch all folders normally (default)
  * - `show_emails`  = DC_SHOW_EMAILS_OFF (0)=
  *                    show direct replies to chats only (default),
  *                    DC_SHOW_EMAILS_ACCEPTED_CONTACTS (1)=

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -343,10 +343,9 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    and watch the `DeltaChat` folder for updates (default),
  *                    0=do not move chat-messages
  *                    changes require restarting IO by calling dc_stop_io() and then dc_start_io().
-
  * - `only_fetch_mvbox`
  *                  = 1=Do not fetch messages from folders other than the
- *                      `DeltaChat` folder.  Messages will still be fetched from the,
+ *                      `DeltaChat` folder. Messages will still be fetched from the
  *                       spam folder and `sendbox_watch` will also still be respected
  *                       if enabled.
  *                    0=watch all folders normally (default)

--- a/src/config.rs
+++ b/src/config.rs
@@ -232,6 +232,11 @@ impl Context {
         Ok(self.get_config_int(key).await? != 0)
     }
 
+    pub(crate) async fn should_watch_mvbox(&self) -> Result<bool> {
+        Ok(self.get_config_bool(Config::MvboxMove).await?
+            || self.get_config_bool(Config::WatchMvboxOnly).await?)
+    }
+
     /// Gets configured "delete_server_after" value.
     ///
     /// `None` means never delete the message, `Some(0)` means delete

--- a/src/config.rs
+++ b/src/config.rs
@@ -433,16 +433,40 @@ mod tests {
         Ok(())
     }
 
-    /// Regression test for https://github.com/deltachat/deltachat-core-rust/issues/3012
     #[async_std::test]
     async fn test_set_config_bool() -> Result<()> {
         let t = TestContext::new().await;
 
+        // Regression test for https://github.com/deltachat/deltachat-core-rust/issues/3012
         // We need some config that defaults to true
         let c = Config::E2eeEnabled;
         assert_eq!(t.get_config_bool(c).await?, true);
         t.set_config_bool(c, false).await?;
         assert_eq!(t.get_config_bool(c).await?, false);
+
+        // Test that OnlyFetchMvbox==true implies MvboxMove==true and SentboxWatch==false
+        t.set_config_bool(Config::SentboxWatch, true).await?;
+
+        t.set_config_bool(Config::OnlyFetchMvbox, true).await?;
+        assert_eq!(t.get_config_bool(Config::SentboxWatch).await?, false);
+        assert_eq!(t.get_config_bool(Config::OnlyFetchMvbox).await?, true);
+
+        t.set_config_bool(Config::MvboxMove, false).await?;
+        assert_eq!(t.get_config_bool(Config::MvboxMove).await?, false);
+        assert_eq!(t.get_config_bool(Config::OnlyFetchMvbox).await?, false);
+
+        t.set_config_bool(Config::SentboxWatch, true).await?;
+        assert_eq!(t.get_config_bool(Config::SentboxWatch).await?, true);
+
+        t.set_config_bool(Config::OnlyFetchMvbox, true).await?;
+        assert_eq!(t.get_config_bool(Config::SentboxWatch).await?, false);
+        assert_eq!(t.get_config_bool(Config::MvboxMove).await?, true);
+        assert_eq!(t.get_config_bool(Config::OnlyFetchMvbox).await?, true);
+
+        t.set_config_bool(Config::SentboxWatch, true).await?;
+        assert_eq!(t.get_config_bool(Config::SentboxWatch).await?, true);
+        assert_eq!(t.get_config_bool(Config::OnlyFetchMvbox).await?, false);
+
         Ok(())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -281,31 +281,25 @@ impl Context {
                     }
                 }
                 self.emit_event(EventType::SelfavatarChanged);
-                Ok(())
             }
             Config::DeleteDeviceAfter => {
-                let ret = self
-                    .sql
-                    .set_raw_config(key, value)
-                    .await
-                    .map_err(Into::into);
+                let ret = self.sql.set_raw_config(key, value).await;
                 // Force chatlist reload to delete old messages immediately.
                 self.emit_event(EventType::MsgsChanged {
                     msg_id: MsgId::new(0),
                     chat_id: ChatId::new(0),
                 });
-                ret
+                ret?
             }
             Config::Displayname => {
                 let value = value.map(improve_single_line_input);
                 self.sql.set_raw_config(key, value.as_deref()).await?;
-                Ok(())
             }
             _ => {
                 self.sql.set_raw_config(key, value).await?;
-                Ok(())
             }
         }
+        Ok(())
     }
 
     pub async fn set_config_bool(&self, key: Config, value: bool) -> Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,7 +79,7 @@ pub enum Config {
     /// This will not entirely disable other folders, e.g. the spam folder will also still
     /// be watched for new messages.
     #[strum(props(default = "0"))]
-    WatchMvboxOnly,
+    OnlyFetchMvbox,
 
     #[strum(props(default = "0"))] // also change ShowEmails.default() on changes
     ShowEmails,
@@ -234,7 +234,7 @@ impl Context {
 
     pub(crate) async fn should_watch_mvbox(&self) -> Result<bool> {
         Ok(self.get_config_bool(Config::MvboxMove).await?
-            || self.get_config_bool(Config::WatchMvboxOnly).await?)
+            || self.get_config_bool(Config::OnlyFetchMvbox).await?)
     }
 
     /// Gets configured "delete_server_after" value.

--- a/src/config.rs
+++ b/src/config.rs
@@ -403,17 +403,16 @@ mod tests {
         Ok(())
     }
 
+    /// Regression test for https://github.com/deltachat/deltachat-core-rust/issues/3012
     #[async_std::test]
     async fn test_set_config_bool() -> Result<()> {
         let t = TestContext::new().await;
 
-        // Regression test for https://github.com/deltachat/deltachat-core-rust/issues/3012
         // We need some config that defaults to true
         let c = Config::E2eeEnabled;
         assert_eq!(t.get_config_bool(c).await?, true);
         t.set_config_bool(c, false).await?;
         assert_eq!(t.get_config_bool(c).await?, false);
-
         Ok(())
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,6 +74,9 @@ pub enum Config {
     #[strum(props(default = "0"))]
     SentboxMove, // If `MvboxMove` is true, this config is ignored. Currently only used in tests.
 
+    #[strum(props(default = "0"))]
+    OnlyFetchMvbox,
+
     #[strum(props(default = "0"))] // also change ShowEmails.default() on changes
     ShowEmails,
 
@@ -295,6 +298,33 @@ impl Context {
                 let value = value.map(improve_single_line_input);
                 self.sql.set_raw_config(key, value.as_deref()).await?;
             }
+            Config::SentboxWatch => {
+                self.sql.set_raw_config(key, value).await?;
+                if config_to_bool(value) {
+                    self.sql
+                        .set_raw_config(Config::OnlyFetchMvbox, Some("0"))
+                        .await?;
+                }
+            }
+            Config::MvboxMove => {
+                self.sql.set_raw_config(key, value).await?;
+                if !config_to_bool(value) {
+                    self.sql
+                        .set_raw_config(Config::OnlyFetchMvbox, Some("0"))
+                        .await?;
+                }
+            }
+            Config::OnlyFetchMvbox => {
+                self.sql.set_raw_config(key, value).await?;
+                if config_to_bool(value) {
+                    self.sql
+                        .set_raw_config(Config::SentboxWatch, Some("0"))
+                        .await?;
+                    self.sql
+                        .set_raw_config(Config::MvboxMove, Some("1"))
+                        .await?;
+                }
+            }
             _ => {
                 self.sql.set_raw_config(key, value).await?;
             }
@@ -333,6 +363,13 @@ fn get_config_keys_string() -> String {
     });
 
     format!(" {} ", keys)
+}
+
+fn config_to_bool(value: Option<&str>) -> bool {
+    value
+        .and_then(|s| s.parse::<i32>().ok())
+        .unwrap_or_default()
+        != 0
 }
 
 #[cfg(test)]

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -443,7 +443,7 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
 
     progress!(ctx, 900);
 
-    let create_mvbox = ctx.get_config_bool(Config::MvboxMove).await?;
+    let create_mvbox = ctx.should_watch_mvbox().await?;
 
     imap.configure_folders(ctx, create_mvbox).await?;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -358,6 +358,7 @@ impl Context {
         let sentbox_watch = self.get_config_int(Config::SentboxWatch).await?;
         let mvbox_move = self.get_config_int(Config::MvboxMove).await?;
         let sentbox_move = self.get_config_int(Config::SentboxMove).await?;
+        let only_fetch_mvbox = self.get_config_int(Config::OnlyFetchMvbox).await?;
         let folders_configured = self
             .sql
             .get_raw_config_int("folders_configured")
@@ -422,6 +423,7 @@ impl Context {
         res.insert("sentbox_watch", sentbox_watch.to_string());
         res.insert("mvbox_move", mvbox_move.to_string());
         res.insert("sentbox_move", sentbox_move.to_string());
+        res.insert("only_fetch_mvbox", only_fetch_mvbox.to_string());
         res.insert("folders_configured", folders_configured.to_string());
         res.insert("configured_sentbox_folder", configured_sentbox_folder);
         res.insert("configured_mvbox_folder", configured_mvbox_folder);

--- a/src/context.rs
+++ b/src/context.rs
@@ -358,7 +358,7 @@ impl Context {
         let sentbox_watch = self.get_config_int(Config::SentboxWatch).await?;
         let mvbox_move = self.get_config_int(Config::MvboxMove).await?;
         let sentbox_move = self.get_config_int(Config::SentboxMove).await?;
-        let watch_mvbox_only = self.get_config_int(Config::WatchMvboxOnly).await?;
+        let only_fetch_mvbox = self.get_config_int(Config::OnlyFetchMvbox).await?;
         let folders_configured = self
             .sql
             .get_raw_config_int("folders_configured")
@@ -423,7 +423,7 @@ impl Context {
         res.insert("sentbox_watch", sentbox_watch.to_string());
         res.insert("mvbox_move", mvbox_move.to_string());
         res.insert("sentbox_move", sentbox_move.to_string());
-        res.insert("watch_mvbox_only", watch_mvbox_only.to_string());
+        res.insert("only_fetch_mvbox", only_fetch_mvbox.to_string());
         res.insert("folders_configured", folders_configured.to_string());
         res.insert("configured_sentbox_folder", configured_sentbox_folder);
         res.insert("configured_mvbox_folder", configured_mvbox_folder);

--- a/src/context.rs
+++ b/src/context.rs
@@ -358,7 +358,7 @@ impl Context {
         let sentbox_watch = self.get_config_int(Config::SentboxWatch).await?;
         let mvbox_move = self.get_config_int(Config::MvboxMove).await?;
         let sentbox_move = self.get_config_int(Config::SentboxMove).await?;
-        let only_fetch_mvbox = self.get_config_int(Config::OnlyFetchMvbox).await?;
+        let watch_mvbox_only = self.get_config_int(Config::WatchMvboxOnly).await?;
         let folders_configured = self
             .sql
             .get_raw_config_int("folders_configured")
@@ -423,7 +423,7 @@ impl Context {
         res.insert("sentbox_watch", sentbox_watch.to_string());
         res.insert("mvbox_move", mvbox_move.to_string());
         res.insert("sentbox_move", sentbox_move.to_string());
-        res.insert("only_fetch_mvbox", only_fetch_mvbox.to_string());
+        res.insert("watch_mvbox_not_inbox", watch_mvbox_only.to_string());
         res.insert("folders_configured", folders_configured.to_string());
         res.insert("configured_sentbox_folder", configured_sentbox_folder);
         res.insert("configured_mvbox_folder", configured_mvbox_folder);

--- a/src/context.rs
+++ b/src/context.rs
@@ -423,7 +423,7 @@ impl Context {
         res.insert("sentbox_watch", sentbox_watch.to_string());
         res.insert("mvbox_move", mvbox_move.to_string());
         res.insert("sentbox_move", sentbox_move.to_string());
-        res.insert("watch_mvbox_not_inbox", watch_mvbox_only.to_string());
+        res.insert("watch_mvbox_only", watch_mvbox_only.to_string());
         res.insert("folders_configured", folders_configured.to_string());
         res.insert("configured_sentbox_folder", configured_sentbox_folder);
         res.insert("configured_mvbox_folder", configured_mvbox_folder);

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -2085,7 +2085,7 @@ pub async fn get_config_last_seen_uid(context: &Context, folder: &str) -> Result
     }
 }
 
-/// Whether to ignore fetching messages form a folder.
+/// Whether to ignore fetching messages from a folder.
 ///
 /// This caters for the [`Config::OnlyFetchMvbox`] setting which means mails from folders
 /// not explicitly watched should not be fetched.

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -2082,11 +2082,12 @@ pub async fn get_config_last_seen_uid(context: &Context, folder: &str) -> Result
 }
 
 async fn should_ignore_folder(context: &Context, folder: &str) -> Result<bool> {
-    Ok(context.get_config_bool(Config::OnlyFetchMvbox).await?
-            && context.is_mvbox(folder).await?
-            // Even if OnlyFetchMvbox is set, we have a look at the spam folder
-            // in case an answer to a known message was put into spam:
-            && context.is_spam_folder(folder).await?)
+    let ignore = if context.get_config_bool(Config::WatchMvboxOnly).await? {
+        context.is_mvbox(folder).await? || context.is_spam_folder(folder).await?
+    } else {
+        false
+    };
+    Ok(ignore)
 }
 
 /// Builds a list of sequence/uid sets. The returned sets have each no more than around 1000

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1663,11 +1663,11 @@ async fn spam_target_folder(
         }
     }
 
-    if needs_move_to_mvbox(context, headers).await? {
-        Ok(Some(Config::ConfiguredMvboxFolder))
-    } else if context.get_config_bool(Config::OnlyFetchMvbox).await? {
+    if needs_move_to_mvbox(context, headers).await?
         // We don't want to move the message to the inbox or sentbox where we wouldn't
-        // see it again.
+        // fetch it again:
+        || context.get_config_bool(Config::OnlyFetchMvbox).await?
+    {
         Ok(Some(Config::ConfiguredMvboxFolder))
     } else if needs_move_to_sentbox(context, folder, headers).await? {
         Ok(Some(Config::ConfiguredSentboxFolder))

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1665,7 +1665,7 @@ async fn spam_target_folder(
 
     if needs_move_to_mvbox(context, headers).await? {
         Ok(Some(Config::ConfiguredMvboxFolder))
-    } else if context.get_config_bool(Config::WatchMvboxOnly).await? {
+    } else if context.get_config_bool(Config::OnlyFetchMvbox).await? {
         // We don't want to move the message to the inbox or sentbox where we wouldn't
         // see it again.
         Ok(Some(Config::ConfiguredMvboxFolder))
@@ -2087,10 +2087,10 @@ pub async fn get_config_last_seen_uid(context: &Context, folder: &str) -> Result
 
 /// Whether to ignore fetching messages form a folder.
 ///
-/// This caters for the [`Config::WatchMvboxOnly`] setting which means mails from folders
+/// This caters for the [`Config::OnlyFetchMvbox`] setting which means mails from folders
 /// not explicitly watched should not be fetched.
 async fn should_ignore_folder(context: &Context, folder: &str) -> Result<bool> {
-    if !context.get_config_bool(Config::WatchMvboxOnly).await? {
+    if !context.get_config_bool(Config::OnlyFetchMvbox).await? {
         return Ok(false);
     }
     if context.is_sentbox(folder).await? {

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1665,6 +1665,10 @@ async fn spam_target_folder(
 
     if needs_move_to_mvbox(context, headers).await? {
         Ok(Some(Config::ConfiguredMvboxFolder))
+    } else if context.get_config_bool(Config::WatchMvboxOnly).await? {
+        // We don't want to move the message to the inbox or sentbox where we wouldn't
+        // see it again.
+        Ok(Some(Config::ConfiguredMvboxFolder))
     } else if needs_move_to_sentbox(context, folder, headers).await? {
         Ok(Some(Config::ConfiguredSentboxFolder))
     } else {

--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -157,7 +157,6 @@ impl Imap {
                     // in anything.  If so, we behave as if IDLE had data but
                     // will have already fetched the messages so perform_*_fetch
                     // will not find any new.
-
                     match self.fetch_new_messages(context, &watch_folder, false).await {
                         Ok(res) => {
                             info!(context, "fetch_new_messages returned {:?}", res);

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -118,5 +118,12 @@ pub(crate) async fn get_watched_folders(context: &Context) -> Result<Vec<String>
             }
         }
     }
+    if context.get_config_bool(Config::WatchMvboxOnly).await? {
+        if let Some(folder) = context.get_config(Config::ConfiguredMvboxFolder).await? {
+            if !res.contains(&folder) {
+                res.push(folder);
+            }
+        }
+    }
     Ok(res)
 }

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -102,27 +102,23 @@ impl Imap {
     }
 }
 
+pub(crate) async fn get_watched_folder_configs(context: &Context) -> Result<Vec<Config>> {
+    let mut res = Vec::new();
+    res.push(Config::ConfiguredInboxFolder);
+    if context.get_config_bool(Config::SentboxWatch).await? {
+        res.push(Config::ConfiguredSentboxFolder);
+    }
+    if context.should_watch_mvbox().await? {
+        res.push(Config::ConfiguredMvboxFolder);
+    }
+    Ok(res)
+}
+
 pub(crate) async fn get_watched_folders(context: &Context) -> Result<Vec<String>> {
     let mut res = Vec::new();
-    if let Some(inbox_folder) = context.get_config(Config::ConfiguredInboxFolder).await? {
-        res.push(inbox_folder);
-    }
-    let folder_watched_configured = &[
-        (Config::SentboxWatch, Config::ConfiguredSentboxFolder),
-        (Config::MvboxMove, Config::ConfiguredMvboxFolder),
-    ];
-    for (watched, configured) in folder_watched_configured {
-        if context.get_config_bool(*watched).await? {
-            if let Some(folder) = context.get_config(*configured).await? {
-                res.push(folder);
-            }
-        }
-    }
-    if context.get_config_bool(Config::WatchMvboxOnly).await? {
-        if let Some(folder) = context.get_config(Config::ConfiguredMvboxFolder).await? {
-            if !res.contains(&folder) {
-                res.push(folder);
-            }
+    for folder_config in get_watched_folder_configs(context).await? {
+        if let Some(folder) = context.get_config(folder_config).await? {
+            res.push(folder);
         }
     }
     Ok(res)

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -103,8 +103,7 @@ impl Imap {
 }
 
 pub(crate) async fn get_watched_folder_configs(context: &Context) -> Result<Vec<Config>> {
-    let mut res = Vec::new();
-    res.push(Config::ConfiguredInboxFolder);
+    let mut res = vec![Config::ConfiguredInboxFolder];
     if context.get_config_bool(Config::SentboxWatch).await? {
         res.push(Config::ConfiguredSentboxFolder);
     }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -341,7 +341,7 @@ impl Scheduler {
             }))
         };
 
-        if ctx.get_config_bool(Config::MvboxMove).await? {
+        if ctx.should_watch_mvbox().await? {
             let ctx = ctx.clone();
             mvbox_handle = Some(task::spawn(async move {
                 simple_imap_loop(


### PR DESCRIPTION
This is an alternate attempt at what #3014 is trying to do, but without affecting other settings.  So a user can configure the `WatchMvboxOnly` option and regardless of whether they have `MvboxMove` enabled or not it will watch the mvbox only.

This means it effectively overrides the `SendboxWatch` option without giving user feedback about this.  I'm tempted to still allow the `SendboxWatch` even if `WatchMvboxOnly` is enabled, I think that would make more sense from the user's point of view.  The only problem is of course, wording it nicely. A longer tooltip would help.

Major caveat: I haven't tested this and this might not cover everything.

/cc @Hocuri @link2xt 