### PR TITLE
smtp: cancel message sending by removing the message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - use webxdc app name in chatlist/quotes/replies etc. #3027
 - refactorings #3023
 - remove direct dependency on `byteorder` crate #3031
+- make it possible to cancel message sending by removing the message #3034,
+  this was previosuly removed in 1.71.0 #2939
 
 ### Fixes
 - fix splitting off text from webxdc messages #3032


### PR DESCRIPTION
This restores the logic removed in
afd8c0d879fa0fdd625a3317fa334f975e3f9754