### PR TITLE
imap: skip sync flags update if highest modseq has not increased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - remove direct dependency on `byteorder` crate #3031
 - make it possible to cancel message sending by removing the message #3034,
   this was previosuly removed in 1.71.0 #2939
+- always skip Seen flag synchronization when there are no updates #3039
 
 ### Fixes
 - fix splitting off text from webxdc messages #3032

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,7 @@ dependencies = [
  "hex",
  "humansize",
  "image",
+ "imap-proto",
  "kamadak-exif",
  "lettre_email",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ escaper = "0.1"
 futures = "0.3"
 hex = "0.4.0"
 image = { version = "0.23.5", default-features=false, features = ["gif", "jpeg", "ico", "png", "pnm", "webp", "bmp"] }
+imap-proto = "0.14.3"
 kamadak-exif = "0.5"
 lettre_email = { git = "https://github.com/deltachat/lettre", branch = "master" }
 libc = "0.2"


### PR DESCRIPTION
This reduces `sync_seen_flags` time to less than one millisecond in most cases because there is nothing to update.