### PR TITLE
imap: do not synchronize Seen flags on unwatched folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - remove direct dependency on `byteorder` crate #3031
 - make it possible to cancel message sending by removing the message #3034,
   this was previosuly removed in 1.71.0 #2939
+- synchronize Seen flags only on watched folders to speed up
+  folder scanning #3041
 
 ### Fixes
 - fix splitting off text from webxdc messages #3032

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -464,9 +464,6 @@ impl Imap {
         self.delete_messages(context, watch_folder)
             .await
             .context("delete_messages")?;
-        self.sync_seen_flags(context, watch_folder)
-            .await
-            .context("sync_seen_flags")?;
 
         Ok(())
     }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -188,6 +188,17 @@ async fn fetch_idle(ctx: &Context, connection: &mut Imap, folder: Config) -> Int
                 return InterruptInfo::new(false);
             }
 
+            // Synchronize Seen flags.
+            if let Err(err) = connection
+                .sync_seen_flags(ctx, &watch_folder)
+                .await
+                .context("sync_seen_flags")
+            {
+                connection.trigger_reconnect(ctx).await;
+                warn!(ctx, "{:#}", err);
+                return InterruptInfo::new(false);
+            }
+
             connection.connectivity.set_connected(ctx).await;
 
             // idle


### PR DESCRIPTION
Synchronizing seen flags doubles the time required to scan all
folders. Delta Chat only marks messages as Seen on Inbox or DeltaChat,
so there is no need to check for Seen flag on other folders.

Addresses #3035 