### PR TITLE
imap: avoid reconnection loop when message without Message-ID is marked as seen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- avoid reconnection loop when message without Message-ID is marked as seen #3044
+
+
 ## 1.73.0
 
 ### API changes

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1980,7 +1980,7 @@ async fn mark_seen_by_uid(
         .sql
         .query_row_optional(
             "SELECT id, chat_id FROM msgs
-                 WHERE rfc724_mid IN (
+                 WHERE id > 9 AND rfc724_mid IN (
                    SELECT rfc724_mid FROM imap
                    WHERE folder=?1
                    AND uidvalidity=?2


### PR DESCRIPTION
- do not attempt to mark reserved meessages as seen when
  messages with empty Message-ID are marked as seen on IMAP
- do not reconnect on Seen flag synchronization failures This avoid
  reconnection loops in case of permanent errors in `sync_seen_flags`

Fixes #3005 