### PR TITLE
do set_visibility() in a transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- avoid archived, fresh chats #3053
+
+
 ## 1.75.0
 
 ### Changes


### PR DESCRIPTION
this avoids archived chats containing fresh messages:

before, it could happen that between the two SQL calls
a new fresh message arrives,
unarchives the chat that is immediately archived by the second SQL call -
resulting in an archive chat containing fresh messages.

as fresh messages counter are shown on app icon etc.
this is pretty weird for the user as they do not see what is "fresh".

the other way round,
there is no transaction in receive_imf(),
however, receive_imf() only unarchives chats,
so that is visible and no big issue for the user.

maybe the issue could also have been fixed by changing the order,
however, that may result in other rare cornercases i have currently not in mind :)

the issue is rare at all,
however, annoying if you get that as the badge counter may be stuck at "1"
nearly forever (until you open the archived chat in question).

closes https://github.com/deltachat/deltachat-core-rust/issues/3052
