### PR TITLE
Make working with encrypted storage RAII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 - refactorings #3026
 - move messages in batches #3058
+- working with encrypted storage drastically changed to be RAII #3063
 
 ### Fixes
 - avoid archived, fresh chats #3053

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2619,12 +2619,12 @@ void           dc_accounts_unref                (dc_accounts_t* accounts);
 uint32_t       dc_accounts_add_account          (dc_accounts_t* accounts);
 
 /**
- * Add a new account with a password to the account manager.
+ * Add a new account to the account manager, encrypted with a passphrase.
  *
- * The account's database will be encrypted with this password and will need
- * to be opened with the password to be usable.
+ * The account's database will be encrypted with a key derived from the
+ * passphrase and will need to be opened with the passphrase to be usable.
  *
- * Password-protected accounts are not automatically opened when the account
+ * Encrypted accounts are not automatically opened when the account
  * manager is created.  They need to be opened using dc_accounts_load_encrypted(),
  * to find unloaded encrypted accounts use dc_accounts_get_encrypted().
  *
@@ -2634,7 +2634,7 @@ uint32_t       dc_accounts_add_account          (dc_accounts_t* accounts);
  *     context object.
  *     On errors, 0 is returned.
  */
-uint32_t       dc_accounts_add_encrypted_account(dc_accounts_t* accounts, char* password);
+uint32_t       dc_accounts_add_encrypted_account(dc_accounts_t* accounts, char* passphrase);
 
 /**
  * Migrate independent accounts into accounts managed by the account manager.

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2734,7 +2734,7 @@ dc_context_t*  dc_accounts_load_encrypted (dc_accounts_t* accounts, uint32_t acc
 
 
 /**
- * Get the currently selected account.
+ * Get the currently selected account ID.
  *
  * If there is at least one account in the account-manager,
  * there is always a selected one.
@@ -2743,17 +2743,15 @@ dc_context_t*  dc_accounts_load_encrypted (dc_accounts_t* accounts, uint32_t acc
  *
  * @memberof dc_accounts_t
  * @param accounts Account manager as created by dc_accounts_new().
- * @return The account-context, this can be used most similar as a normal,
- *     unmanaged account-context as created by dc_context_new().
- *     Once you do no longer need the context-object, you have to call dc_context_unref() on it,
- *     which, however, will not close the account but only decrease a reference counter.
- *
- *     If there is no selected account, NULL is returned.
- *
- *     If the selected account is encrypted and not yet loaded using
- *     dc_accounts_load_encrypted(), NULL is returned.
+ * @return The account ID of the selected account.  The context of
+ *     the selected account can then be retrieved using dc_accounts_get_account().
+ *     Note that if the selected account is encrypted you may first have to
+ *     load it using dc_accounts_load_encrypted(), you can verify if this is needed
+ *     using dc_accounts_get_encrypted().
+ *     If no account is selected 0 is returned.  However this is only possible if
+ *     there is no single account in the account manager.
  */
-dc_context_t*  dc_accounts_get_selected_account (dc_accounts_t* accounts);
+uint32_t*  dc_accounts_get_selected_account_id (dc_accounts_t* accounts);
 
 
 /**

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -4068,18 +4068,17 @@ pub unsafe extern "C" fn dc_accounts_get_account(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_accounts_get_selected_account(
+pub unsafe extern "C" fn dc_accounts_get_selected_account_id(
     accounts: *mut dc_accounts_t,
-) -> *mut dc_context_t {
+) -> u32 {
     if accounts.is_null() {
         eprintln!("ignoring careless call to dc_accounts_get_selected_account()");
-        return ptr::null_mut();
+        return 0;
     }
 
     let accounts = &*accounts;
-    block_on(async move { accounts.read().await.get_selected_account().await })
-        .map(|ctx| Box::into_raw(Box::new(ctx)))
-        .unwrap_or_else(std::ptr::null_mut)
+    block_on(async move { accounts.read().await.get_selected_account_id().await })
+        .unwrap_or(0)
 }
 
 #[no_mangle]

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -857,7 +857,9 @@ mod tests {
         assert_eq!(vec![account_id], encrypted_ids);
 
         for id in encrypted_ids {
-            let res = accounts.load_encrypted_account(id, "secret".to_string()).await;
+            let res = accounts
+                .load_encrypted_account(id, "secret".to_string())
+                .await;
             assert!(res.is_ok());
         }
 

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -9,7 +9,7 @@ use async_std::prelude::*;
 use async_std::sync::{Arc, RwLock};
 use uuid::Uuid;
 
-use anyhow::{anyhow, ensure, Context as _, Result};
+use anyhow::{ensure, Context as _, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::context::{Context, ContextError};
@@ -150,7 +150,7 @@ impl Accounts {
             .config
             .get_account(id)
             .await
-            .ok_or_else(|| anyhow!("No such account with id {}", id))?;
+            .with_context(|| format!("No such account with id {}", id))?;
         let ctx = Context::new_encrypted(
             account_config.dbfile().into(),
             account_config.id,

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -93,7 +93,7 @@ impl Accounts {
     /// Get the currently selected account.
     ///
     /// If the selected account is encrypted and not yet loaded using
-    /// [`Accounts::load_encrypted`] `None` will be returned.
+    /// [`Accounts::load_encrypted_account`] `None` will be returned.
     pub async fn get_selected_account(&self) -> Option<Context> {
         let id = self.config.get_selected_account().await;
         self.accounts.get(&id).cloned()
@@ -259,7 +259,7 @@ impl Accounts {
     ///
     /// Note that we can't really distinguish between unreadable/corrupted accounts and
     /// encrypted accounts.  We consider all known accounts which failed to load encrypted,
-    /// they can be loaded using [`Accounts::load_encrypted`].
+    /// they can be loaded using [`Accounts::load_encrypted_account`].
     pub fn get_encrypted(&self) -> Vec<u32> {
         let configured_ids: BTreeSet<u32> = self
             .config

--- a/src/context.rs
+++ b/src/context.rs
@@ -1004,7 +1004,7 @@ mod tests {
     }
 
     #[async_std::test]
-    async fn test_reopen_unecrypted() {
+    async fn test_reopen_unencrypted() {
         let dir = tempfile::tempdir().unwrap();
         let dbfile = dir.path().join("db.sqlite");
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -120,7 +120,6 @@ impl From<SqlOpenError> for ContextError {
     }
 }
 
-
 impl Context {
     /// Creates new context and opens the database.
     pub async fn new(dbfile: PathBuf, id: u32) -> Result<Context, ContextError> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -135,11 +135,6 @@ impl Context {
         Context::new_common(dbfile, id, Some(passphrase)).await
     }
 
-    /// Returns true if database is open.
-    pub async fn is_open(&self) -> bool {
-        self.sql.is_open().await
-    }
-
     async fn new_common(
         dbfile: PathBuf,
         id: u32,


### PR DESCRIPTION
This refactors the APIs to work with encrypted storage to follow the Resource Acquisition Is Initialisation principle.  Having our structures behave like this is beneficial because it removes a lot of edge-cases that would need to be handled, in the end resulting in a more stable core.

This **will break current UIs**.  In particular it does not attempt to transition as doing so makes things even worse.  I think this tradeoff is desirable, and my apologies for not having the time to engage better at the time this was originally introduced.

# Using the new FFI

`dc_context_new_closed()`, `dc_context_is_open` and `dc_context_open` are gone, if a context exists it is always open and usable.

`dc_context_new_encrypted()` can be used to create a new standalone context with encrypted storage.

`dc_accounts_add_encrypted_account()` creates a new account with encrypted storage when using the account manager.

`dc_accounts_get_all()` will now only return "loaded" contexts, when creating `dc_accounts_t` all unencrypted databases are automatically loaded.

`dc_accounts_get_encrypted()` will return all accounts which need to be decrypted before they can be used, `dc_accounts_load_encrypted()` does this.  Once loaded the encrypted account will show up in `dc_accounts_get_all()` and no longer appear in `dc_accounts_get_encrypted()`.

`dc_accounts_get_selected()` has been renamed to `dc_accounts_get_selected_id()` and now only returns the ID of the account.  This lets you use `dc_accounts_get_encrypted()` and `dc_accounts_load_encrypted()` if it is an encrypted-not-yet-loaded account.  Use the existing `dc_accounts_get_account()` to get the pointer to the context.

# Design notes

Just like with the current implementation this can not distinguish between broken databases and encrypted ones.  So if a corrupted database appears it will show up in `dc_accounts_get_encrypted()` forever.

I have not tried to make the sql module RAII internally and tried to keep the changes there minimal to support the RAII interface.  This PR is more than large enough already and this can be done as a followup.