### PR TITLE
Fix CI

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -79,7 +79,7 @@ addopts = -v -ra --strict-markers
 norecursedirs = .tox 
 xfail_strict=true
 timeout = 90
-timeout_method = thread
+timeout_func_only = True
 markers = 
     ignored: ignore this test in default test runs, use --ignored to run.
 

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -8,6 +8,7 @@ use crate::{context::Context, imap::FolderMeaning};
 use async_std::prelude::*;
 
 use super::{get_folder_meaning, get_folder_meaning_by_name};
+// TODO unnecessary comment
 
 impl Imap {
     /// Returns true if folders were scanned, false if scanning was postponed.

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -8,7 +8,6 @@ use crate::{context::Context, imap::FolderMeaning};
 use async_std::prelude::*;
 
 use super::{get_folder_meaning, get_folder_meaning_by_name};
-// TODO unnecessary comment
 
 impl Imap {
     /// Returns true if folders were scanned, false if scanning was postponed.


### PR DESCRIPTION
#skip-changelog

The tests are flaky: (sometimes they just run through, though; I repeatetly hit re-run, the first two runs succeeded, in the third run six tests failed at once)

https://pipelines.actions.githubusercontent.com/0Cs9EsF2mwtr7icbiRvpCNrfoVF185ozSjOeo0Ale4nDoOrShu/_apis/pipelines/1/runs/8174/signedlogcontent/9?urlExpires=2022-02-07T20%3A40%3A06.1888390Z&urlSigningMethod=HMACV1&urlSignature=%2FO5JxNmTDQpKnBGVfL8wDKg7TVaN1ypDfmhQdepPyw4%3D

```
2022-02-07T18:52:10.6629468Z =================================== FAILURES ===================================
2022-02-07T18:52:10.6629891Z ____________________________ tests/test_account.py _____________________________
2022-02-07T18:52:10.6630709Z [gw3] linux -- Python 3.9.10 /home/runner/work/deltachat-core-rust/deltachat-core-rust/python/.tox/py3/bin/python
2022-02-07T18:52:10.6631453Z worker 'gw3' crashed while running 'tests/test_account.py::TestOnlineAccount::test_qr_join_chat'
2022-02-07T18:52:10.6632137Z ____________________________ tests/test_account.py _____________________________
2022-02-07T18:52:10.6632975Z [gw1] linux -- Python 3.9.10 /home/runner/work/deltachat-core-rust/deltachat-core-rust/python/.tox/py3/bin/python
2022-02-07T18:52:10.6633914Z worker 'gw1' crashed while running 'tests/test_account.py::TestOnlineAccount::test_immediate_autodelete'
2022-02-07T18:52:10.6634430Z ____________________________ tests/test_account.py _____________________________
2022-02-07T18:52:10.6635222Z [gw2] linux -- Python 3.9.10 /home/runner/work/deltachat-core-rust/deltachat-core-rust/python/.tox/py3/bin/python
2022-02-07T18:52:10.6635938Z worker 'gw2' crashed while running 'tests/test_account.py::TestOnlineAccount::test_set_get_contact_avatar'
2022-02-07T18:52:10.6636604Z ____________________________ tests/test_account.py _____________________________
2022-02-07T18:52:10.6637196Z [gw4] linux -- Python 3.9.10 /home/runner/work/deltachat-core-rust/deltachat-core-rust/python/.tox/py3/bin/python
2022-02-07T18:52:10.6638069Z worker 'gw4' crashed while running 'tests/test_account.py::TestOnlineAccount::test_group_quote'
2022-02-07T18:52:10.6638554Z ____________________________ tests/test_account.py _____________________________
2022-02-07T18:52:10.6639338Z [gw5] linux -- Python 3.9.10 /home/runner/work/deltachat-core-rust/deltachat-core-rust/python/.tox/py3/bin/python
2022-02-07T18:52:10.6640290Z worker 'gw5' crashed while running 'tests/test_account.py::TestOnlineAccount::test_name_changes'
2022-02-07T18:52:10.6640948Z ____________________________ tests/test_account.py _____________________________
2022-02-07T18:52:10.6641561Z [gw6] linux -- Python 3.9.10 /home/runner/work/deltachat-core-rust/deltachat-core-rust/python/.tox/py3/bin/python
2022-02-07T18:52:10.6642430Z worker 'gw6' crashed while running 'tests/test_account.py::TestOnlineAccount::test_fetch_existing[True]'
2022-02-07T18:52:10.6642919Z ____________________________ tests/test_account.py _____________________________
2022-02-07T18:52:10.6643704Z [gw0] linux -- Python 3.9.10 /home/runner/work/deltachat-core-rust/deltachat-core-rust/python/.tox/py3/bin/python
2022-02-07T18:52:10.6644454Z worker 'gw0' crashed while running 'tests/test_account.py::TestGroupStressTests::test_synchronize_member_list_on_group_rejoin'
```