### PR TITLE
Revert "python: remove arbitrary timeouts from tests"

### DIFF
--- a/python/src/deltachat/direct_imap.py
+++ b/python/src/deltachat/direct_imap.py
@@ -224,7 +224,9 @@ class DirectImap:
         """ (blocking) wait for next idle message from server. """
         assert self._idling
         self.account.log("imap-direct: calling idle_check")
-        res = self.conn.idle_check()
+        res = self.conn.idle_check(timeout=30)
+        if len(res) == 0:
+            raise TimeoutError
         if terminate:
             self.idle_done()
         self.account.log("imap-direct: idle_check returned {!r}".format(res))

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -241,6 +241,7 @@ def acfactory(pytestconfig, tmpdir, request, session_liveconfig, data):
         def make_account(self, path, logid, quiet=False):
             ac = Account(path, logging=self._logging)
             ac._evtracker = ac.add_account_plugin(FFIEventTracker(ac))
+            ac._evtracker.set_timeout(30)
             ac.addr = ac.get_self_contact().addr
             ac.set_config("displayname", logid)
             if not quiet:
@@ -482,7 +483,7 @@ class BotProcess:
     def kill(self) -> None:
         self.popen.kill()
 
-    def wait(self, timeout=None) -> None:
+    def wait(self, timeout=30) -> None:
         self.popen.wait(timeout=timeout)
 
     def fnmatch_lines(self, pattern_lines):
@@ -491,7 +492,7 @@ class BotProcess:
             print("+++FNMATCH:", next_pattern)
             ignored = []
             while 1:
-                line = self.stdout_queue.get()
+                line = self.stdout_queue.get(timeout=15)
                 if line is None:
                     if ignored:
                         print("BOT stdout terminated after these lines")


### PR DESCRIPTION
This reverts https://github.com/deltachat/deltachat-core-rust/pull/3059 and should fix the CI failures for now (hopefully).

See https://github.com/deltachat/deltachat-core-rust/pull/3064#issuecomment-1031939261 for reasoning.

Obviously, a better solution would be to rerun time-out-ed tests.

Let's see if the CI runs through on this PR, also, ping @link2xt already.

