### PR TITLE
Fix disappearing drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - avoid archived, fresh chats #3053
 - treat "NO" IMAP response to MOVE and COPY commands as an error #3058
 - Fix a bug where messages in the Spam folder created contact requests #3015
+- Fix a bug where drafts disappeared after some days #3067
 
 
 ## 1.75.0


### PR DESCRIPTION
Fix https://github.com/deltachat/deltachat-android/issues/2184

The problem is that housekeeping deletes all hidden messages that don't have a server UID, which was introduced two years ago in 9febc762dababa73ecdb45c9e5c17bacd528b27e - I don't even know if we even had drafts at this point, or if it affected them.

Hidden messages are (I hope the list is complete):
- drafts
- location updates
- multi-device sync messages (see src/sync.rs)
- webxdc status updates
- some securejoin messages

We can't just delete webxdc status updates, either; while we could delete the other types of hidden messages, this seems kind of risky to me for little gain. So, this PR just completely stops deleting hidden messages in housekeeping - even though I'm not 100% sure on this.