### PR TITLE
Add AcManager

### DIFF
--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -942,13 +942,13 @@ mod tests {
     use crate::chatlist::Chatlist;
     use crate::constants::Chattype;
     use crate::peerstate::Peerstate;
-    use crate::test_utils::{AcManager, TestContext};
+    use crate::test_utils::{TestContext, TestContextManager};
 
     #[async_std::test]
     async fn test_setup_contact() -> Result<()> {
-        let mut acm = AcManager::new().await;
-        let alice = acm.ac_alice().await;
-        let bob = acm.ac_bob().await;
+        let mut acm = TestContextManager::new().await;
+        let alice = acm.alice().await;
+        let bob = acm.bob().await;
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
         assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 0);
 
@@ -1135,9 +1135,9 @@ mod tests {
 
     #[async_std::test]
     async fn test_setup_contact_bob_knows_alice() -> Result<()> {
-        let mut acm = AcManager::new().await;
-        let alice = acm.ac_alice().await;
-        let bob = acm.ac_bob().await;
+        let mut acm = TestContextManager::new().await;
+        let alice = acm.alice().await;
+        let bob = acm.bob().await;
 
         // Ensure Bob knows Alice_FP
         let alice_pubkey = SignedPublicKey::load_self(&alice.ctx).await?;
@@ -1260,9 +1260,9 @@ mod tests {
 
     #[async_std::test]
     async fn test_setup_contact_concurrent_calls() -> Result<()> {
-        let mut acm = AcManager::new().await;
-        let alice = acm.ac_alice().await;
-        let bob = acm.ac_bob().await;
+        let mut acm = TestContextManager::new().await;
+        let alice = acm.alice().await;
+        let bob = acm.bob().await;
 
         // do a scan that is not working as claire is never responding
         let qr_stale = "OPENPGP4FPR:1234567890123456789012345678901234567890#a=claire%40foo.de&n=&i=12345678901&s=23456789012";
@@ -1291,9 +1291,9 @@ mod tests {
 
     #[async_std::test]
     async fn test_secure_join() -> Result<()> {
-        let mut acm = AcManager::new().await;
-        let alice = acm.ac_alice().await;
-        let bob = acm.ac_bob().await;
+        let mut acm = TestContextManager::new().await;
+        let alice = acm.alice().await;
+        let bob = acm.bob().await;
 
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
         assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 0);

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -942,21 +942,13 @@ mod tests {
     use crate::chatlist::Chatlist;
     use crate::constants::Chattype;
     use crate::peerstate::Peerstate;
-    use crate::test_utils::{LogSink, TestContext};
+    use crate::test_utils::{AcManager, TestContext};
 
     #[async_std::test]
     async fn test_setup_contact() -> Result<()> {
-        let (log_tx, _log_sink) = LogSink::create();
-        let alice = TestContext::builder()
-            .configure_alice()
-            .with_log_sink(log_tx.clone())
-            .build()
-            .await;
-        let bob = TestContext::builder()
-            .configure_bob()
-            .with_log_sink(log_tx)
-            .build()
-            .await;
+        let acm = AcManager::new().await;
+        let alice = acm.ac_alice().await;
+        let bob = acm.ac_bob().await;
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
         assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 0);
 
@@ -1143,17 +1135,9 @@ mod tests {
 
     #[async_std::test]
     async fn test_setup_contact_bob_knows_alice() -> Result<()> {
-        let (log_tx, _log_sink) = LogSink::create();
-        let alice = TestContext::builder()
-            .configure_alice()
-            .with_log_sink(log_tx.clone())
-            .build()
-            .await;
-        let bob = TestContext::builder()
-            .configure_bob()
-            .with_log_sink(log_tx)
-            .build()
-            .await;
+        let acm = AcManager::new().await;
+        let alice = acm.ac_alice().await;
+        let bob = acm.ac_bob().await;
 
         // Ensure Bob knows Alice_FP
         let alice_pubkey = SignedPublicKey::load_self(&alice.ctx).await?;
@@ -1276,17 +1260,9 @@ mod tests {
 
     #[async_std::test]
     async fn test_setup_contact_concurrent_calls() -> Result<()> {
-        let (log_tx, _log_sink) = LogSink::create();
-        let alice = TestContext::builder()
-            .configure_alice()
-            .with_log_sink(log_tx.clone())
-            .build()
-            .await;
-        let bob = TestContext::builder()
-            .configure_bob()
-            .with_log_sink(log_tx)
-            .build()
-            .await;
+        let acm = AcManager::new().await;
+        let alice = acm.ac_alice().await;
+        let bob = acm.ac_bob().await;
 
         // do a scan that is not working as claire is never responding
         let qr_stale = "OPENPGP4FPR:1234567890123456789012345678901234567890#a=claire%40foo.de&n=&i=12345678901&s=23456789012";
@@ -1315,17 +1291,10 @@ mod tests {
 
     #[async_std::test]
     async fn test_secure_join() -> Result<()> {
-        let (log_tx, _log_sink) = LogSink::create();
-        let alice = TestContext::builder()
-            .configure_alice()
-            .with_log_sink(log_tx.clone())
-            .build()
-            .await;
-        let bob = TestContext::builder()
-            .configure_bob()
-            .with_log_sink(log_tx)
-            .build()
-            .await;
+        let acm = AcManager::new().await;
+        let alice = acm.ac_alice().await;
+        let bob = acm.ac_bob().await;
+
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
         assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 0);
 

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -946,9 +946,9 @@ mod tests {
 
     #[async_std::test]
     async fn test_setup_contact() -> Result<()> {
-        let mut acm = TestContextManager::new().await;
-        let alice = acm.alice().await;
-        let bob = acm.bob().await;
+        let mut tcm = TestContextManager::new().await;
+        let alice = tcm.alice().await;
+        let bob = tcm.bob().await;
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
         assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 0);
 
@@ -1135,9 +1135,9 @@ mod tests {
 
     #[async_std::test]
     async fn test_setup_contact_bob_knows_alice() -> Result<()> {
-        let mut acm = TestContextManager::new().await;
-        let alice = acm.alice().await;
-        let bob = acm.bob().await;
+        let mut tcm = TestContextManager::new().await;
+        let alice = tcm.alice().await;
+        let bob = tcm.bob().await;
 
         // Ensure Bob knows Alice_FP
         let alice_pubkey = SignedPublicKey::load_self(&alice.ctx).await?;
@@ -1260,9 +1260,9 @@ mod tests {
 
     #[async_std::test]
     async fn test_setup_contact_concurrent_calls() -> Result<()> {
-        let mut acm = TestContextManager::new().await;
-        let alice = acm.alice().await;
-        let bob = acm.bob().await;
+        let mut tcm = TestContextManager::new().await;
+        let alice = tcm.alice().await;
+        let bob = tcm.bob().await;
 
         // do a scan that is not working as claire is never responding
         let qr_stale = "OPENPGP4FPR:1234567890123456789012345678901234567890#a=claire%40foo.de&n=&i=12345678901&s=23456789012";
@@ -1291,9 +1291,9 @@ mod tests {
 
     #[async_std::test]
     async fn test_secure_join() -> Result<()> {
-        let mut acm = TestContextManager::new().await;
-        let alice = acm.alice().await;
-        let bob = acm.bob().await;
+        let mut tcm = TestContextManager::new().await;
+        let alice = tcm.alice().await;
+        let bob = tcm.bob().await;
 
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
         assert_eq!(Chatlist::try_load(&bob, 0, None, None).await?.len(), 0);

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -946,7 +946,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_setup_contact() -> Result<()> {
-        let acm = AcManager::new().await;
+        let mut acm = AcManager::new().await;
         let alice = acm.ac_alice().await;
         let bob = acm.ac_bob().await;
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
@@ -1135,7 +1135,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_setup_contact_bob_knows_alice() -> Result<()> {
-        let acm = AcManager::new().await;
+        let mut acm = AcManager::new().await;
         let alice = acm.ac_alice().await;
         let bob = acm.ac_bob().await;
 
@@ -1260,7 +1260,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_setup_contact_concurrent_calls() -> Result<()> {
-        let acm = AcManager::new().await;
+        let mut acm = AcManager::new().await;
         let alice = acm.ac_alice().await;
         let bob = acm.ac_bob().await;
 
@@ -1291,7 +1291,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_secure_join() -> Result<()> {
-        let acm = AcManager::new().await;
+        let mut acm = AcManager::new().await;
         let alice = acm.ac_alice().await;
         let bob = acm.ac_bob().await;
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -2,7 +2,6 @@
 //!
 //! This private module is only compiled for test runs.
 
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::ops::Deref;
 use std::panic;
@@ -44,7 +43,7 @@ static CONTEXT_NAMES: Lazy<std::sync::RwLock<BTreeMap<u32, String>>> =
 pub struct AcManager {
     log_tx: Sender<Event>,
     _log_sink: LogSink,
-    accounts: RefCell<Vec<Rc<TestContext>>>,
+    accounts: Vec<Rc<TestContext>>,
 }
 
 impl AcManager {
@@ -53,11 +52,11 @@ impl AcManager {
         Self {
             log_tx,
             _log_sink,
-            accounts: RefCell::new(vec![]),
+            accounts: vec![],
         }
     }
 
-    pub async fn ac_alice(&self) -> Rc<TestContext> {
+    pub async fn ac_alice(&mut self) -> Rc<TestContext> {
         let ac = Rc::new(
             TestContext::builder()
                 .configure_alice()
@@ -65,12 +64,11 @@ impl AcManager {
                 .build()
                 .await,
         );
-        let mut accounts = self.accounts.borrow_mut();
-        accounts.push(ac);
-        accounts.last().unwrap().clone()
+        self.accounts.push(ac);
+        self.accounts.last().unwrap().clone()
     }
 
-    pub async fn ac_bob(&self) -> Rc<TestContext> {
+    pub async fn ac_bob(&mut self) -> Rc<TestContext> {
         let ac = Rc::new(
             TestContext::builder()
                 .configure_bob()
@@ -78,9 +76,8 @@ impl AcManager {
                 .build()
                 .await,
         );
-        let mut accounts = self.accounts.borrow_mut();
-        accounts.push(ac);
-        accounts.last().unwrap().clone()
+        self.accounts.push(ac);
+        self.accounts.last().unwrap().clone()
     }
 }
 
@@ -894,7 +891,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_with_both() {
-        let acm = AcManager::new().await;
+        let mut acm = AcManager::new().await;
         let alice = acm.ac_alice().await;
         let bob = acm.ac_bob().await;
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -5,7 +5,6 @@
 use std::collections::BTreeMap;
 use std::ops::Deref;
 use std::panic;
-use std::rc::Rc;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -43,41 +42,28 @@ static CONTEXT_NAMES: Lazy<std::sync::RwLock<BTreeMap<u32, String>>> =
 pub struct TestContextManager {
     log_tx: Sender<Event>,
     _log_sink: LogSink,
-    accounts: Vec<Rc<TestContext>>,
 }
 
 impl TestContextManager {
     pub async fn new() -> Self {
         let (log_tx, _log_sink) = LogSink::create();
-        Self {
-            log_tx,
-            _log_sink,
-            accounts: vec![],
-        }
+        Self { log_tx, _log_sink }
     }
 
-    pub async fn alice(&mut self) -> Rc<TestContext> {
-        let ac = Rc::new(
-            TestContext::builder()
-                .configure_alice()
-                .with_log_sink(self.log_tx.clone())
-                .build()
-                .await,
-        );
-        self.accounts.push(ac);
-        self.accounts.last().unwrap().clone()
+    pub async fn alice(&mut self) -> TestContext {
+        TestContext::builder()
+            .configure_alice()
+            .with_log_sink(self.log_tx.clone())
+            .build()
+            .await
     }
 
-    pub async fn bob(&mut self) -> Rc<TestContext> {
-        let ac = Rc::new(
-            TestContext::builder()
-                .configure_bob()
-                .with_log_sink(self.log_tx.clone())
-                .build()
-                .await,
-        );
-        self.accounts.push(ac);
-        self.accounts.last().unwrap().clone()
+    pub async fn bob(&mut self) -> TestContext {
+        TestContext::builder()
+            .configure_bob()
+            .with_log_sink(self.log_tx.clone())
+            .build()
+            .await
     }
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -40,13 +40,13 @@ pub const AVATAR_900x900_BYTES: &[u8] = include_bytes!("../test-data/image/avata
 static CONTEXT_NAMES: Lazy<std::sync::RwLock<BTreeMap<u32, String>>> =
     Lazy::new(|| std::sync::RwLock::new(BTreeMap::new()));
 
-pub struct AcManager {
+pub struct TestContextManager {
     log_tx: Sender<Event>,
     _log_sink: LogSink,
     accounts: Vec<Rc<TestContext>>,
 }
 
-impl AcManager {
+impl TestContextManager {
     pub async fn new() -> Self {
         let (log_tx, _log_sink) = LogSink::create();
         Self {
@@ -56,7 +56,7 @@ impl AcManager {
         }
     }
 
-    pub async fn ac_alice(&mut self) -> Rc<TestContext> {
+    pub async fn alice(&mut self) -> Rc<TestContext> {
         let ac = Rc::new(
             TestContext::builder()
                 .configure_alice()
@@ -68,7 +68,7 @@ impl AcManager {
         self.accounts.last().unwrap().clone()
     }
 
-    pub async fn ac_bob(&mut self) -> Rc<TestContext> {
+    pub async fn bob(&mut self) -> Rc<TestContext> {
         let ac = Rc::new(
             TestContext::builder()
                 .configure_bob()
@@ -891,9 +891,9 @@ mod tests {
 
     #[async_std::test]
     async fn test_with_both() {
-        let mut acm = AcManager::new().await;
-        let alice = acm.ac_alice().await;
-        let bob = acm.ac_bob().await;
+        let mut acm = TestContextManager::new().await;
+        let alice = acm.alice().await;
+        let bob = acm.bob().await;
 
         alice.ctx.emit_event(EventType::Info("hello".into()));
         bob.ctx.emit_event(EventType::Info("there".into()));

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -877,9 +877,9 @@ mod tests {
 
     #[async_std::test]
     async fn test_with_both() {
-        let mut acm = TestContextManager::new().await;
-        let alice = acm.alice().await;
-        let bob = acm.bob().await;
+        let mut tcm = TestContextManager::new().await;
+        let alice = tcm.alice().await;
+        let bob = tcm.bob().await;
 
         alice.ctx.emit_event(EventType::Info("hello".into()));
         bob.ctx.emit_event(EventType::Info("there".into()));


### PR DESCRIPTION
This reduces boilerplate code, improving the
signal-noise-ratio and reducing the mental barrier to start
writing a unit test.

Proposed by @flub at https://github.com/deltachat/deltachat-core-rust/pull/2901#issuecomment-998285039

Slightly off-topic:

I didn't add any advanced functions like `manager.get("alice");` because
they're not needed yet; however, once we have the AcManager we can
think about fancy things like:

```rust
acm.send_text(&alice, "Hi Bob, this is Alice!", &bob);
```
which automatically lets bob receive the message.

However, this may be less useful than it seems at first, since most of
the tests I looked at wouldn't benefit from it, so at I personally won't do
it until I have a test that would benefit from it.

#skip-changelog