### PR TITLE
Set X-Microsoft-Original-Message-ID on outgoing emails for amazonaws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   and remove update-id from `DC_EVENT_WEBXDC_STATUS_UPDATE` #3081
 
 ### Fixes
+- Hopefully fix a bug where outgoing messages appear twice with Amazon SES #3077
 - do not delete messages without Message-IDs as duplicates #3095
 - Assign replies from a different email address to the correct chat #3119
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -552,7 +552,7 @@ impl<'a> MimeFactory<'a> {
         // messages.
         // Amazon's servers do not add such a header, so we just add it ourselves.
         if let Some(server) = context.get_config(Config::ConfiguredSendServer).await? {
-            if server.ends_with("amazonaws.com") {
+            if server.ends_with(".amazonaws.com") {
                 headers.unprotected.push(Header::new(
                     "X-Microsoft-Original-Message-ID".into(),
                     rfc724_mid_headervalue.clone(),

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -546,11 +546,11 @@ impl<'a> MimeFactory<'a> {
         };
         let rfc724_mid_headervalue = render_rfc724_mid(&rfc724_mid);
 
-        // Amazon's SMTP server change the `Message-ID`, just as Outlook's SMTP server do.
-        // Outlook adds an `X-Microsoft-Original-Message-ID` header with the original `Message-ID`,
+        // Amazon's SMTP servers change the `Message-ID`, just as Outlook's SMTP servers do.
+        // Outlook's servers add an `X-Microsoft-Original-Message-ID` header with the original `Message-ID`,
         // and when downloading messages we look for this header in order to correctly identify
         // messages.
-        // Amazon does not add such a header, so we just add it ourselves.
+        // Amazon's servers do not add such a header, so we just add it ourselves.
         if let Some(server) = context.get_config(Config::ConfiguredSendServer).await? {
             if server.ends_with("amazonaws.com") {
                 headers.unprotected.push(Header::new(


### PR DESCRIPTION
Should fix #2885 by implementing the workaround I proposed in https://github.com/deltachat/deltachat-core-rust/issues/2885#issuecomment-991027388.

@link2xt you said this also happens with Mailgun - can we somehow find out whether Mailgun is being used?

