### PR TITLE
mimefactory: place important headers before Autocrypt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 - add more SMTP logging #3093
+- place common headers like `From:` before the large `Autocrypt:` header #3079
 
 
 ## 1.76.0


### PR DESCRIPTION
This moves most common headers like From, To, Subject etc. that spam filters may be interested in before the large Autocrypt header.

Was supposed to help with #3078 but the issue is actually different so now it's a standalone enhancement.