### PR TITLE
remove getAllUpdates() and add a typical replicatio API for the update call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### API changes
+- change semantics of `dc_get_webxdc_status_updates()` second parameter
+  and remove update-id from `DC_EVENT_WEBXDC_STATUS_UPDATE` #3081
+
 ### Changes
 - add more SMTP logging #3093
 - place common headers like `From:` before the large `Autocrypt:` header #3079

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1037,14 +1037,18 @@ int dc_send_webxdc_status_update (dc_context_t* context, uint32_t msg_id, const 
  * @memberof dc_context_t
  * @param context The context object
  * @param msg_id id of the message with the webxdc instance
- * @param status_update_id Can be used to filter out only a concrete status update.
- *     When set to 0, all known status updates are returned.
- * @return JSON-array containing the requested updates,
- *     each element was created by dc_send_webxdc_status_update()
- *     on this or other devices.
- *     If there are no updates, an empty JSON-array is returned.
+ * @param serial The last known serial. Pass 0 if there are no known serials to receive all updates.
+ * @return JSON-array containing the requested updates.
+ *     Each `update` comes with the following properties:
+ *     - `update.payload`: equals the payload given to dc_send_webxdc_status_update()
+ *     - `update.serial`: the serial number of this update. The first update will have the serial `1`.
+ *     - `update.max_serial`: the maximum serial currently known.
+ *        If `max_serial` equals `serial` this update is the last update (until new network messages arrive).
+ *     - `update.info`: optional, short, informational message.
+ *     - `update.summary`: optional, short text, shown beside app icon.
+ *        If there are no updates, an empty JSON-array is returned.
  */
-char* dc_get_webxdc_status_updates (dc_context_t* context, uint32_t msg_id, uint32_t status_update_id);
+char* dc_get_webxdc_status_updates (dc_context_t* context, uint32_t msg_id, uint32_t serial);
 
 /**
  * Save a draft for a chat in the database.
@@ -5603,15 +5607,12 @@ void dc_event_unref(dc_event_t* event);
 
 /**
  * webxdc status update received.
- * To get the received status update, use dc_get_webxdc_status_updates().
+ * To get the received status update, use dc_get_webxdc_status_updates() with
+ * `serial` set to the last known update.
  * To send status updates, use dc_send_webxdc_status_update().
  *
- * Note, that you do not get events that arrive when the app is not running;
- * instead, you can use dc_get_webxdc_status_updates() to get all status updates
- * and catch up that way.
- *
  * @param data1 (int) msg_id
- * @param data2 (int) status_update_id
+ * @param data2 (int) 0
  */
 #define DC_EVENT_WEBXDC_STATUS_UPDATE                2120
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1041,7 +1041,7 @@ int dc_send_webxdc_status_update (dc_context_t* context, uint32_t msg_id, const 
  * @return JSON-array containing the requested updates.
  *     Each `update` comes with the following properties:
  *     - `update.payload`: equals the payload given to dc_send_webxdc_status_update()
- *     - `update.serial`: the serial number of this update. The first update will have the serial `1`.
+ *     - `update.serial`: the serial number of this update. Serials are larger `0` and newer serials have higher numbers.
  *     - `update.max_serial`: the maximum serial currently known.
  *        If `max_serial` equals `serial` this update is the last update (until new network messages arrive).
  *     - `update.info`: optional, short, informational message.

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -903,7 +903,7 @@ pub unsafe extern "C" fn dc_send_webxdc_status_update(
 pub unsafe extern "C" fn dc_get_webxdc_status_updates(
     context: *mut dc_context_t,
     msg_id: u32,
-    status_update_id: u32,
+    last_known_serial: u32,
 ) -> *mut libc::c_char {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_webxdc_status_updates()");
@@ -911,14 +911,9 @@ pub unsafe extern "C" fn dc_get_webxdc_status_updates(
     }
     let ctx = &*context;
 
-    block_on(ctx.get_webxdc_status_updates(
-        MsgId::new(msg_id),
-        if status_update_id == 0 {
-            None
-        } else {
-            Some(StatusUpdateId::new(status_update_id))
-        },
-    ))
+    block_on(
+        ctx.get_webxdc_status_updates(MsgId::new(msg_id), StatusUpdateId::new(last_known_serial)),
+    )
     .unwrap_or_else(|_| "".to_string())
     .strdup()
 }

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -37,7 +37,7 @@ use deltachat::ephemeral::Timer as EphemeralTimer;
 use deltachat::key::DcKey;
 use deltachat::message::MsgId;
 use deltachat::stock_str::StockMessage;
-use deltachat::webxdc::StatusUpdateId;
+use deltachat::webxdc::StatusUpdateSerial;
 use deltachat::*;
 use deltachat::{accounts::Accounts, log::LogExt};
 
@@ -909,9 +909,10 @@ pub unsafe extern "C" fn dc_get_webxdc_status_updates(
     }
     let ctx = &*context;
 
-    block_on(
-        ctx.get_webxdc_status_updates(MsgId::new(msg_id), StatusUpdateId::new(last_known_serial)),
-    )
+    block_on(ctx.get_webxdc_status_updates(
+        MsgId::new(msg_id),
+        StatusUpdateSerial::new(last_known_serial),
+    ))
     .unwrap_or_else(|_| "".to_string())
     .strdup()
 }

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -501,7 +501,7 @@ pub unsafe extern "C" fn dc_event_get_data1_int(event: *mut dc_event_t) -> libc:
         EventType::ImexFileWritten(_) => 0,
         EventType::SecurejoinInviterProgress { contact_id, .. }
         | EventType::SecurejoinJoinerProgress { contact_id, .. } => *contact_id as libc::c_int,
-        EventType::WebxdcStatusUpdate { msg_id, .. } => msg_id.to_u32() as libc::c_int,
+        EventType::WebxdcStatusUpdate(msg_id) => msg_id.to_u32() as libc::c_int,
     }
 }
 
@@ -534,6 +534,7 @@ pub unsafe extern "C" fn dc_event_get_data2_int(event: *mut dc_event_t) -> libc:
         | EventType::MsgsNoticed(_)
         | EventType::ConnectivityChanged
         | EventType::SelfavatarChanged
+        | EventType::WebxdcStatusUpdate(_)
         | EventType::ChatModified(_) => 0,
         EventType::MsgsChanged { msg_id, .. }
         | EventType::IncomingMsg { msg_id, .. }
@@ -543,9 +544,6 @@ pub unsafe extern "C" fn dc_event_get_data2_int(event: *mut dc_event_t) -> libc:
         EventType::SecurejoinInviterProgress { progress, .. }
         | EventType::SecurejoinJoinerProgress { progress, .. } => *progress as libc::c_int,
         EventType::ChatEphemeralTimerModified { timer, .. } => timer.to_u32() as libc::c_int,
-        EventType::WebxdcStatusUpdate {
-            status_update_id, ..
-        } => status_update_id.to_u32() as libc::c_int,
     }
 }
 
@@ -587,7 +585,7 @@ pub unsafe extern "C" fn dc_event_get_data2_str(event: *mut dc_event_t) -> *mut 
         | EventType::SecurejoinJoinerProgress { .. }
         | EventType::ConnectivityChanged
         | EventType::SelfavatarChanged
-        | EventType::WebxdcStatusUpdate { .. }
+        | EventType::WebxdcStatusUpdate(_)
         | EventType::ChatEphemeralTimerModified { .. } => ptr::null_mut(),
         EventType::ConfigureProgress { comment, .. } => {
             if let Some(comment) = comment {

--- a/draft/webxdc-dev-reference.md
+++ b/draft/webxdc-dev-reference.md
@@ -65,8 +65,10 @@ Each `update` which is passed to the callback comes with the following propertie
 
 - `update.payload`: equals the payload given to `sendUpdate()`
 
-- `update.serial`: the serial number of this update. The first update
-  will have the serial `1`.
+- `update.serial`: the serial number of this update.
+  Serials are larger `0` and newer serials have higher numbers.
+  There may be gaps in the serials
+  and it is not guaranteed that the next serial is exactly incremented by one.
 
 - `update.max_serial`: the maximum serial currently known.
   If `max_serial` equals `serial` this update is the last update (until new network messages arrive).

--- a/draft/webxdc-dev-reference.md
+++ b/draft/webxdc-dev-reference.md
@@ -29,7 +29,7 @@ window.webxdc.sendUpdate(update, descr);
 Webxdc apps are usually shared in a chat and run independently on each peer.
 To get a shared state, the peers use `sendUpdate()` to send updates to each other.
 
-- `update`: an object with the following fields:  
+- `update`: an object with the following properties:  
     - `update.payload`: any javascript primitive, array or object.
     - `update.info`: optional, short, informational message that will be added to the chat,
        eg. "Alice voted" or "Bob scored 123 in MyGame";
@@ -45,48 +45,35 @@ All peers, including the sending one,
 will receive the update by the callback given to `setUpdateListener()`.
 
 There are situations where the user cannot send messages to a chat,
-eg. contact requests or if the user has left a group.
+eg. if the webxdc instance comes as a contact request or if the user has left a group.
 In these cases, you can still call `sendUpdate()`,
 however, the update won't be sent to other peers
-and you won't get the update by `setUpdateListener()` nor by `getAllUpdates()`.
+and you won't get the update by `setUpdateListener()`.
 
 
 ### setUpdateListener()
 
 ```js
-window.webxdc.setUpdateListener((update) => {});
+window.webxdc.setUpdateListener((update) => {}, serial);
 ```
 
 With `setUpdateListener()` you define a callback that receives the updates
-sent by `sendUpdate()`.
+sent by `sendUpdate()`. The callback is called for updates sent by you or other peers.
+The `serial` specifies the last serial that you know about (defaults to 0). 
 
-- `update`: passed to the callback on updates with the following fields:  
-  `update.payload`: equals the payload given to `sendUpdate()`
+Each `update` which is passed to the callback comes with the following properties: 
 
-The callback is called for updates sent by you or other peers.
+- `update.payload`: equals the payload given to `sendUpdate()`
 
+- `update.serial`: the serial number of this update. The first update
+  will have the serial `1`.
 
-### getAllUpdates()
+- `update.max_serial`: the maximum serial currently known.
+  If `max_serial` equals `serial` this update is the last update (until new network messages arrive).
 
-```js
-updates = await window.webxdc.getAllUpdates();
-```
+- `update.info`: optional, short, informational message (see `send_update`) 
 
-In case your Webxdc was just started,
-you may want to reconstruct the state from the last run -
-and also incorporate updates that may have arrived while the app was not running.
-
-- `updates`: All previous updates in an array, 
-  eg. `[{payload: "foo"},{payload: "bar"}]`
-  if `webxdc.sendUpdate({payload: "foo"}); webxdc.sendUpdate({payload: "bar"};` was called on the last run.
-
-The updates are wrapped into a Promise that you can `await` for.
-If you are not in an async function and cannot use `await` therefore,
-you can get the updates with `then()`:
-
-```js
-window.webxdc.getAllUpdates().then(updates => {});
-```
+- `update.summary`: optional, short text, shown beside app icon (see `send_update`)
 
 
 ### selfAddr
@@ -162,9 +149,7 @@ The following example shows an input field and  every input is show on all peers
         document.getElementById('output').innerHTML += update.payload + "<br>";
       }
     
-      window.webxdc.setUpdateListener(receiveUpdate);
-      window.webxdc.getAllUpdates().then(updates => updates.forEach(receiveUpdate));
-
+      window.webxdc.setUpdateListener(receiveUpdate, 0);
     </script>
   </body>
 </html>

--- a/src/events.rs
+++ b/src/events.rs
@@ -9,7 +9,6 @@ use strum::EnumProperty;
 use crate::chat::ChatId;
 use crate::ephemeral::Timer as EphemeralTimer;
 use crate::message::MsgId;
-use crate::webxdc::StatusUpdateId;
 
 #[derive(Debug)]
 pub struct Events {
@@ -329,8 +328,5 @@ pub enum EventType {
     SelfavatarChanged,
 
     #[strum(props(id = "2120"))]
-    WebxdcStatusUpdate {
-        msg_id: MsgId,
-        status_update_id: StatusUpdateId,
-    },
+    WebxdcStatusUpdate(MsgId),
 }

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -221,10 +221,7 @@ impl Context {
             .await?;
         let status_update_id = StatusUpdateId(u32::try_from(rowid)?);
 
-        self.emit_event(EventType::WebxdcStatusUpdate {
-            msg_id: instance.id,
-            status_update_id,
-        });
+        self.emit_event(EventType::WebxdcStatusUpdate(instance.id));
 
         Ok(status_update_id)
     }
@@ -954,10 +951,7 @@ mod tests {
             .get_matching(|evt| matches!(evt, EventType::WebxdcStatusUpdate { .. }))
             .await;
         match event {
-            EventType::WebxdcStatusUpdate {
-                msg_id,
-                status_update_id: _,
-            } => {
+            EventType::WebxdcStatusUpdate(msg_id) => {
                 assert_eq!(msg_id, instance_id);
             }
             _ => unreachable!(),

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -176,13 +176,7 @@ impl Context {
                     _ => item,
                 }
             } else {
-                // TODO: this fallback (legacy `PAYLOAD`) should be deleted soon, together with the test below
-                let payload: Value = serde_json::from_str(update_str)?; // checks if input data are valid json
-                StatusUpdateItem {
-                    payload,
-                    info: None,
-                    summary: None,
-                }
+                bail!("create_status_update_record: no valid update item.");
             }
         };
 
@@ -859,7 +853,7 @@ mod tests {
 {"payload":true}]"#
         );
 
-        let update_id3 = t
+        let _update_id3 = t
             .create_status_update_record(
                 &mut instance,
                 r#"{"payload" : 1, "sender": "that is not used"}"#,
@@ -870,15 +864,6 @@ mod tests {
             t.get_webxdc_status_updates(instance.id, update_id2).await?,
             r#"[{"payload":true},
 {"payload":1}]"#
-        );
-
-        // TODO: legacy `PAYLOAD` support should be deleted soon
-        let _update_id4 = t
-            .create_status_update_record(&mut instance, r#"{"foo" : 1}"#, 1640178619)
-            .await?;
-        assert_eq!(
-            t.get_webxdc_status_updates(instance.id, update_id3).await?,
-            r#"[{"payload":{"foo":1}}]"#
         );
 
         Ok(())


### PR DESCRIPTION
(r10s, adb, hpk) remove getAllUpdates() and add a typical replica-API. 

The change is meant to rather backwards compatible: 

- getAllUpdates() could return an empty array unconditionally 
- if you don't specify a "serial" with setUpdateListener it is 0 (give all updates) 


The `serial` and `max_serial` properties on the update item area meant to allow the webxdc instance to know how many updates are pending or if it's receiving the (for now) last one.  The webxdc can internally (in local storage) keep track of which update serials it successfully processed and on restart set the update listeneer to only start with receiving updates after the last successful one). 
