### PR TITLE
prepare 1.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## Unreleased
+## 1.76.0
 
 ### Changes
-- refactorings #3026
 - move messages in batches #3058
 - delete messages in batches #3060
+- python: remove arbitrary timeouts from tests #3059
+- refactorings #3026
 
 ### Fixes
 - avoid archived, fresh chats #3053

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.75.0"
+version = "1.76.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.75.0"
+version = "1.76.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.75.0"
+version = "1.76.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.75.0"
+version = "1.76.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"


### PR DESCRIPTION
bugfixes (and a bit more) for a 1.28.2

after commit, on master make sure to: 

   git tag -a 1.76.0
   git push origin 1.76.0
   git tag -a py-1.76.0
   git push origin py-1.76.0

#skip-changelog