### PR TITLE
[Help needed] Make dc_provider_info_from_email non blocking

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -333,4 +333,7 @@ pub enum EventType {
         msg_id: MsgId,
         status_update_id: StatusUpdateId,
     },
+
+    #[strum(props(id = "2201"))]
+    ProviderInfo(String),
 }


### PR DESCRIPTION
My idea to fix https://github.com/deltachat/deltachat-core-rust/issues/3086 is to make dc_provider_info_from_email return immediatly after calling, but it should spawn an async task that is executing the actual mx request etc and once it's done emit an event with the data.
My current problem is that I cannot send the *mut dc_context_t pointer to another thread, as the pointer doesn't impl Send. Any ideas?