### PR TITLE
Assign replies from different address to two-member-groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 - do not delete messages without Message-IDs as duplicates #3095
+- Assign replies from a different email address to the correct chat #3119
 
 ### Changes
 - add more SMTP logging #3093


### PR DESCRIPTION
@hpk42 had a case where he wrote with someone using a classing MUA.

He opened a two-member-group with this person (which also allowed him to
set the subject).

At some point the other person replied from a different email address.

What he expected: This reply should be sorted into the two-member-group.
What happened: This reply was sorted into the 1:1 chat.

---

I had added the line `&& chat_contacts.contains(&from_id)` months ago when I wrote
this code because it seemed vaguely sensible but without any real
reason. So, let's remove it and see if it creates other problems -
my gut feeling is no.