### PR TITLE
Benchmark dc_receive_imf()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,11 +833,13 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
 dependencies = [
+ "async-std",
  "atty",
  "cast",
  "clap",
  "criterion-plot",
  "csv",
+ "futures",
  "itertools",
  "lazy_static",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ zip = { version = "0.5.13", default-features = false, features = ["deflate"] }
 [dev-dependencies]
 ansi_term = "0.12.0"
 async-std = { version = "1", features = ["unstable", "attributes"] }
-criterion = "0.3"
+criterion = { version = "0.3.4", features = ["async_std"] }
 futures-lite = "1.12"
 log = "0.4"
 pretty_env_logger = "0.4"
@@ -114,6 +114,10 @@ harness = false
 
 [[bench]]
 name = "search_msgs"
+harness = false
+
+[[bench]]
+name = "receive_emails"
 harness = false
 
 [features]

--- a/benches/receive_emails.rs
+++ b/benches/receive_emails.rs
@@ -1,0 +1,84 @@
+use async_std::{path::PathBuf, task::block_on};
+use criterion::{
+    async_executor::AsyncStdExecutor, black_box, criterion_group, criterion_main, BatchSize,
+    Criterion,
+};
+use deltachat::{
+    config::Config,
+    context::Context,
+    dc_receive_imf::dc_receive_imf,
+    imex::{imex, ImexMode},
+};
+use tempfile::tempdir;
+
+async fn recv_all_emails(context: Context) -> Context {
+    for i in 0..100 {
+        let imf_raw = format!(
+            "Subject: Benchmark
+Message-ID: Mr.OssSYnOFkhR.{i}@testrun.org
+Date: Sat, 07 Dec 2019 19:00:27 +0000
+To: alice@example.com
+From: sender@testrun.org
+Chat-Version: 1.0
+Chat-Disposition-Notification-To: sender@testrun.org
+Chat-User-Avatar: 0
+In-Reply-To: Mr.OssSYnOFkhR.{i_dec}@testrun.org
+MIME-Version: 1.0
+
+Content-Type: text/plain; charset=utf-8; format=flowed; delsp=no
+
+Hello {i}",
+            i = i,
+            i_dec = i - 1,
+        );
+        dc_receive_imf(&context, black_box(imf_raw.as_bytes()), "INBOX", false)
+            .await
+            .unwrap();
+    }
+    context
+}
+
+async fn create_context() -> Context {
+    let dir = tempdir().unwrap();
+    let dbfile = dir.path().join("db.sqlite");
+    let id = 100;
+    let context = Context::new(dbfile.into(), id).await.unwrap();
+
+    let backup: PathBuf = std::env::current_dir()
+        .unwrap()
+        .join("delta-chat-backup.tar")
+        .into();
+    if backup.exists().await {
+        println!("Importing backup");
+        imex(&context, ImexMode::ImportBackup, &backup, None)
+            .await
+            .unwrap();
+    }
+
+    let addr = "alice@example.com";
+    context.set_config(Config::Addr, Some(addr)).await.unwrap();
+    context
+        .set_config(Config::ConfiguredAddr, Some(addr))
+        .await
+        .unwrap();
+    context
+        .set_config(Config::Configured, Some("1"))
+        .await
+        .unwrap();
+    context
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Receive messages");
+    group.bench_function("Receive 100 simple text msgs", |b| {
+        b.to_async(AsyncStdExecutor).iter_batched(
+            || block_on(create_context()),
+            |context| recv_all_emails(black_box(context)),
+            BatchSize::LargeInput,
+        );
+    });
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Follow-up for #2819

I had noticed that, when receiving tons of emails at once, and you turn off the wi-fi, e-mails keep coming in for a while.

So, apparently it's not the network that's the limiting factor, but `dc_receive_imf()`.

Soooo, I started by creating a benchmark.

Run it with:

`cargo +1.56.0 criterion --bench receive_emails`

View the report by opening `target/criterion/report/index.html`.

Create a lovely flamegraph by installing `perf` (or `linux-perf`, and possibly some other packages that were already present on my system - please tell me in this case) and running:

`CARGO_PROFILE_BENCH_DEBUG=true cargo flamegraph --bench receive_emails -o receive_emails_flamegraph.svg -- --bench` and opening `receive_emails_flamegraph.svg` in the browser (that's better than in an image viewer)

First findings:
- almost all the time is spent accessing the database
- But MimeParser also already takes some time, so it might help to use pipelining and run MimeParser on the next message already while dc_receive_imf is running on the previous message. However, MimeParser also verifies the email's signatures and needs the up-to-date key for this, so we have to be careful here.
- Flamegraphs are confusing when using async XD
- This approach here better than using emails from the test-data directory, maybe because the latter involves writing attachments to the disk.
- Profiling SQL statements using SQL's `profile()` method seems not to work 
- I wrote possible optimisations down in https://github.com/deltachat/deltachat-core-rust/pull/2819#issuecomment-1068933262

#skip-changelog