### PR TITLE
Customise Display impl of ContactId

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -15,8 +15,9 @@ use crate::chat::ChatId;
 use crate::color::str_to_color;
 use crate::config::Config;
 use crate::constants::{
-    Blocked, Chattype, DC_CONTACT_ID_DEVICE, DC_CONTACT_ID_DEVICE_ADDR, DC_CONTACT_ID_LAST_SPECIAL,
-    DC_CONTACT_ID_SELF, DC_GCL_ADD_SELF, DC_GCL_VERIFIED_ONLY,
+    Blocked, Chattype, DC_CONTACT_ID_DEVICE, DC_CONTACT_ID_DEVICE_ADDR, DC_CONTACT_ID_INFO,
+    DC_CONTACT_ID_LAST_SPECIAL, DC_CONTACT_ID_SELF, DC_CONTACT_ID_UNDEFINED, DC_GCL_ADD_SELF,
+    DC_GCL_VERIFIED_ONLY,
 };
 use crate::context::Context;
 use crate::dc_tools::{dc_get_abs_path, improve_single_line_input, EmailAddress};
@@ -52,21 +53,19 @@ impl ContactId {
 
 impl fmt::Display for ContactId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-        // TODO: Something like this
-        // if self == DC_CONTACT_ID_UNDEFINED {
-        //     write!(f, "Contact#Undefined")
-        // } else if self == DC_CONTACT_ID_SELF {
-        //     write!(f, "Contact#Self")
-        // } else if self == DC_CONTACT_ID_INFO {
-        //     write!(f, "Contact#Info")
-        // } else if self == DC_CONTACT_ID_DEVICE {
-        //     write!(f, "Contact#Device")
-        // } else if self <= DC_CONTACT_ID_LAST_SPECIAL {
-        //     write!(f, "Contact#Special{}", self.0)
-        // } else {
-        //     write!(f, "Contact#{}", self.0)
-        // }
+        if *self == DC_CONTACT_ID_UNDEFINED {
+            write!(f, "Contact#Undefined")
+        } else if *self == DC_CONTACT_ID_SELF {
+            write!(f, "Contact#Self")
+        } else if *self == DC_CONTACT_ID_INFO {
+            write!(f, "Contact#Info")
+        } else if *self == DC_CONTACT_ID_DEVICE {
+            write!(f, "Contact#Device")
+        } else if *self <= DC_CONTACT_ID_LAST_SPECIAL {
+            write!(f, "Contact#Special{}", self.0)
+        } else {
+            write!(f, "Contact#{}", self.0)
+        }
     }
 }
 

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -797,6 +797,19 @@ async fn prune_tombstones(sql: &Sql) -> Result<()> {
     Ok(())
 }
 
+/// Helper function to return comma-separated sequence of `?` chars.
+///
+/// Use this together with [`rusqlite::ParamsFromIter`] to use dynamically generated
+/// parameter lists.
+pub fn repeat_vars(count: usize) -> Result<String> {
+    if count == 0 {
+        bail!("Must have at least one repeat variable");
+    }
+    let mut s = "?,".repeat(count);
+    s.pop(); // Remove trailing comma
+    Ok(s)
+}
+
 #[cfg(test)]
 mod tests {
     use async_std::channel;


### PR DESCRIPTION
This brings the Display of ContactId in line with those of ChatId etc,
which is a bit clearer is logs and such places.

It also updates an SQL query to rely on the ToSql impl of ContactId
rather than it's Display when building the query.

#skip-changelog