### PR TITLE
imap: do not delete duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - do not delete messages without Message-IDs as duplicates #3095
 - Assign replies from a different email address to the correct chat #3119
 - start ephemeral timer when seen status is synchronized via IMAP #3122
+- do not delete duplicate messages on IMAP immediately to accidentally deleting
+  the last copy #3138
 
 ### Changes
 - add more SMTP logging #3093

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -713,19 +713,6 @@ impl Imap {
                 None => folder.to_string(),
             };
 
-            let duplicate = context
-                .sql
-                .count(
-                    "SELECT COUNT(*)
-                     FROM imap
-                     WHERE rfc724_mid=?
-                     AND folder=?
-                     AND uid<?",
-                    paramsv![message_id, &target, uid],
-                )
-                .await?
-                > 0;
-
             context
                 .sql
                 .execute(
@@ -734,13 +721,7 @@ impl Imap {
                        ON CONFLICT(folder, uid, uidvalidity)
                        DO UPDATE SET rfc724_mid=excluded.rfc724_mid,
                                      target=excluded.target",
-                    paramsv![
-                        message_id,
-                        folder,
-                        uid,
-                        uid_validity,
-                        if duplicate { "" } else { &target }
-                    ],
+                    paramsv![message_id, folder, uid, uid_validity, &target],
                 )
                 .await?;
 


### PR DESCRIPTION
Currently if user moves the message into some other folder and then
moves the message back, the message is considered duplicate even
though previous copy was already deleted. This is a common problem
reported by users at least twice.

Keeping duplicates does no harm except for additional storage usage.
If the message is later deleted by the user, all the copies on the
server will be deleted. anyway.

Fixes #3130 