### PR TITLE
log file size on backup import

### DIFF
--- a/src/imex.rs
+++ b/src/imex.rs
@@ -441,13 +441,6 @@ async fn import_backup(
     backup_to_import: &Path,
     passphrase: String,
 ) -> Result<()> {
-    info!(
-        context,
-        "Import \"{}\" to \"{}\".",
-        backup_to_import.display(),
-        context.get_dbfile().display()
-    );
-
     ensure!(
         !context.is_configured().await?,
         "Cannot import backups to accounts in use."
@@ -459,6 +452,14 @@ async fn import_backup(
 
     let backup_file = File::open(backup_to_import).await?;
     let file_size = backup_file.metadata().await?.len();
+    info!(
+        context,
+        "Import \"{}\" ({} bytes) to \"{}\".",
+        backup_to_import.display(),
+        file_size,
+        context.get_dbfile().display()
+    );
+
     let archive = Archive::new(backup_file);
 
     let mut entries = archive.entries()?;


### PR DESCRIPTION
due to an bug from Apple copying files from/to iPhones
(cmp. https://support.delta.chat/t/import-backup-to-ios/1628/7 )
it may easily happen that one gets corrupted/partly backups.

such imports usually fail with some error,
however, for debugging it is nice to have the concrete file size in the log.

replaces https://github.com/deltachat/deltachat-ios/pull/1501/commits/f15fb526e9412b97c3df74c88c0ce3bf35f7ca54

#skip-changelog