### PR TITLE
config_cache fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - place common headers like `From:` before the large `Autocrypt:` header #3079
 - keep track of securejoin joiner status in database to survive restarts #2920
 - remove never used `SentboxMove` option #3111
-- improve speed by caching config values
+- improve speed by caching config values #3131 #3145
 - optimize `markseen_msgs` #3141
 - automatically accept chats with outgoing messages #3143
 

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -460,6 +460,8 @@ async fn import_backup(
         context.get_dbfile().display()
     );
 
+    context.sql.config_cache.write().await.clear();
+
     let archive = Archive::new(backup_file);
 
     let mut entries = archive.entries()?;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -48,7 +48,7 @@ pub struct Sql {
     /// open without a passphrase.
     is_encrypted: RwLock<Option<bool>>,
 
-    config_cache: RwLock<HashMap<String, Option<String>>>,
+    pub(crate) config_cache: RwLock<HashMap<String, Option<String>>>,
 }
 
 impl Sql {

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -36,6 +36,13 @@ pub async fn run(context: &Context, sql: &Sql) -> Result<(bool, bool, bool, bool
             Ok(())
         })
         .await?;
+
+        let mut lock = context.sql.config_cache.write().await;
+        lock.insert(
+            VERSION_CFG.to_string(),
+            Some(format!("{}", dbversion_before_update)),
+        );
+        drop(lock);
     } else {
         exists_before_update = true;
         dbversion_before_update = sql


### PR DESCRIPTION
- this pr fixes the bug https://github.com/deltachat/deltachat-android/issues/2242 introduced by #3131 - reason was just a missing clear() after import, so nothing conceptually wrong or so :)

- moreover the pr targets a potential race when between SELECT and writing config_cache another thread updates the database. the race is avoided by doing db-update and config_cache-update together; see commits for details.

as we already got reports by some  noticeable  speed increase (in testing group and by measurements/remarks in #3131), i think, we could give config_cache another try - even if caches are considered harmful in general. if it turns out, more issues pop up, we can get rid of config_cache easily.

fixes https://github.com/deltachat/deltachat-android/issues/2242 - 
alternative fix would be to revert #3131, do another pr with only test_export_and_import_backup and close this pr.