### PR TITLE
Don't send messages in the self chat to self if bcc_self is off

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3899,6 +3899,7 @@ mod tests {
     #[async_std::test]
     async fn test_self_talk() -> Result<()> {
         let t = TestContext::new_alice().await;
+        t.set_config(Config::BccSelf, Some("1")).await?;
         let chat = &t.get_self_chat().await;
         assert_eq!(DC_CONTACT_ID_SELF, ContactId::new(1));
         assert!(!chat.id.is_special());

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -820,6 +820,7 @@ mod tests {
     #[async_std::test]
     async fn test_ephemeral_delete_msgs() -> Result<()> {
         let t = TestContext::new_alice().await;
+        t.set_config(Config::BccSelf, Some("1")).await?;
         let chat = t.get_self_chat().await;
 
         t.send_text(chat.id, "Saved message, which we delete manually")

--- a/src/html.rs
+++ b/src/html.rs
@@ -484,7 +484,11 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         // (`ShowEmails=1` lets Alice actually receive non-delta messages for known contacts,
         // the contact is marked as known by creating a chat using `chat_with_contact()`)
         let alice = TestContext::new_alice().await;
-        alice.set_config(Config::ShowEmails, Some("1")).await.ok();
+        alice
+            .set_config(Config::ShowEmails, Some("1"))
+            .await
+            .unwrap();
+        alice.set_config(Config::BccSelf, Some("1")).await.unwrap();
         let chat = alice
             .create_chat_with_contact("", "sender@testrun.org")
             .await;

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -153,7 +153,9 @@ impl<'a> MimeFactory<'a> {
         let mut req_mdn = false;
 
         if chat.is_self_talk() {
-            recipients.push((from_displayname.to_string(), from_addr.to_string()));
+            // Don't push any recipients; if bcc_self is turned on,
+            // the self-address will be added later; if it's turned off, we
+            // don't want to send the message to the self address
         } else if chat.is_mailing_list() {
             let list_post = chat
                 .param

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -467,6 +467,7 @@ mod tests {
     #[async_std::test]
     async fn test_send_sync_msg() -> Result<()> {
         let alice = TestContext::new_alice().await;
+        alice.set_config(Config::BccSelf, Some("1")).await?;
         alice.set_config_bool(Config::SendSyncMsgs, true).await?;
         alice
             .add_sync_item(SyncData::AddQrToken(QrTokenData {


### PR DESCRIPTION
**Some introduction, not thaaat important:**

When writing a UI regression test for
https://github.com/deltachat/deltachat-android/issues/1704, I had the
problem that all sent messages stay in state OutPending, and the UI
shows a rotating dotted circle in the lower right corner.

However, after clicking a button, the testing framework (Espresso)
always waits until the UI thread is IDLEing (which means that nothing on
the screen moves anymore) before continuing. The rotating circle means
that it waits forever.

This is fixed by this PR.

**The only really important part to this PR:**

We don't have to change this just because it would be useful for the UI
test, but I think that it makes sense anyway that messages in "Saved
Messages" aren't the only messages that are stored on the server when
`bcc_self` is off.