### PR TITLE
Add get_chat_msgs benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,10 @@ harness = false
 name = "receive_emails"
 harness = false
 
+[[bench]]
+name = "get_chat_msgs"
+harness = false
+
 [features]
 default = ["vendored"]
 internals = []

--- a/benches/get_chat_msgs.rs
+++ b/benches/get_chat_msgs.rs
@@ -1,0 +1,38 @@
+use async_std::path::Path;
+
+use criterion::async_executor::AsyncStdExecutor;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use deltachat::chat::{self, ChatId};
+use deltachat::chatlist::Chatlist;
+use deltachat::context::Context;
+
+async fn get_chat_msgs_benchmark(dbfile: &Path, chats: &[ChatId]) {
+    let id = 100;
+    let context = Context::new(dbfile.into(), id).await.unwrap();
+
+    for c in chats.iter().take(10) {
+        black_box(chat::get_chat_msgs(&context, *c, 0, None).await.ok());
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // To enable this benchmark, set `DELTACHAT_BENCHMARK_DATABASE` to some large database with many
+    // messages, such as your primary account.
+    if let Ok(path) = std::env::var("DELTACHAT_BENCHMARK_DATABASE") {
+        let chats: Vec<_> = async_std::task::block_on(async {
+            let context = Context::new((&path).into(), 100).await.unwrap();
+            let chatlist = Chatlist::try_load(&context, 0, None, None).await.unwrap();
+            let len = chatlist.len();
+            (0..len).map(|i| chatlist.get_chat_id(i).unwrap()).collect()
+        });
+
+        c.bench_function("Load all chats", |b| {
+            b.to_async(AsyncStdExecutor)
+                .iter(|| get_chat_msgs_benchmark(black_box(&path.as_ref()), black_box(&chats)))
+        });
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Using `CARGO_PROFILE_BENCH_DEBUG=true cargo +1.56.0 flamegraph --bench get_chat_msgs -o flamegraph.svg --image-width 5000 -- --bench --profile-time 7` confirms that `delete_expired_messages` takes most of the time (which @link2xt noticed first).

#skip-changelog