### PR TITLE
Add ephemeral_timestamp index for msgs table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - optimize `markseen_msgs` #3141
 - automatically accept chats with outgoing messages #3143
 - return result from `add_parts()` via structure #3154
+- add index to speedup deletion of expired ephemeral messages #3155
 
 
 ### Fixes

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -78,7 +78,7 @@ commands =
 addopts = -v -ra --strict-markers
 norecursedirs = .tox 
 xfail_strict=true
-timeout = 90
+timeout = 150
 timeout_func_only = True
 markers = 
     ignored: ignore this test in default test runs, use --ignored to run.

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -599,6 +599,15 @@ CREATE INDEX smtp_messageid ON imap(rfc724_mid);
         )
         .await?;
     }
+    if dbversion < 87 {
+        info!(context, "[migration] v87");
+        // the index is used to speed up delete_expired_messages()
+        sql.execute_migration(
+            "CREATE INDEX IF NOT EXISTS msgs_index8 ON msgs (ephemeral_timestamp);",
+            87,
+        )
+        .await?;
+    }
 
     Ok((
         recalc_fingerprints,


### PR DESCRIPTION
This reduced get_chat_msgs() benchmark time from 400ms to 170ms.