### PR TITLE
speedup get_chat_msgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - start ephemeral timer when seen status is synchronized via IMAP #3122
 - do not delete duplicate messages on IMAP immediately to accidentally deleting
   the last copy #3138
+- speed up loading of chat messages #3171
 
 ### Changes
 - add more SMTP logging #3093

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2270,12 +2270,11 @@ pub async fn get_chat_msgs(
         let mut ret = Vec::new();
         let mut last_day = 0;
         let cnv_to_local = dc_gm2local_offset();
-        let markerbefore.unwrap_or_else(MsgId::not_set()
+        let marker1 = marker1before.unwrap_or_else(MsgId::new_unset);
+
         for (ts, curr_id) in sorted_rows {
-            if let Some(marker_id) = marker1before {
-                if curr_id == marker_id {
-                    ret.push(ChatItem::Marker1);
-                }
+            if curr_id == marker1 {
+                ret.push(ChatItem::Marker1);
             }
             if (flags & DC_GCM_ADDDAYMARKER) != 0 {
                 let curr_local_timestamp = ts + cnv_to_local;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2258,17 +2258,20 @@ pub async fn get_chat_msgs(
     let process_rows = |rows: rusqlite::MappedRows<_>| {
         // It is faster to sort here rather than
         // let sqlite execute an ORDER BY clause.
-        let mut sorted_rows = Vec::<(i64, MsgId, bool)>::new();
+        let mut sorted_rows = Vec::new();
         for row in rows {
-            let (ts, curr_id, exclude_message) = row?;
-            sorted_rows.push((ts, curr_id, exclude_message));
+            let (ts, curr_id, exclude_message): (i64, MsgId, bool) = row?;
+            if !exclude_message {
+                sorted_rows.push((ts, curr_id));
+            }
         }
         sorted_rows.sort_unstable();
 
         let mut ret = Vec::new();
         let mut last_day = 0;
         let cnv_to_local = dc_gm2local_offset();
-        for (ts, curr_id, exclude_message) in sorted_rows {
+        let markerbefore.unwrap_or_else(MsgId::not_set()
+        for (ts, curr_id) in sorted_rows {
             if let Some(marker_id) = marker1before {
                 if curr_id == marker_id {
                     ret.push(ChatItem::Marker1);
@@ -2284,9 +2287,7 @@ pub async fn get_chat_msgs(
                     last_day = curr_day;
                 }
             }
-            if !exclude_message {
-                ret.push(ChatItem::Message { msg_id: curr_id });
-            }
+            ret.push(ChatItem::Message { msg_id: curr_id });
         }
         Ok(ret)
     };

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2258,9 +2258,9 @@ pub async fn get_chat_msgs(
     let process_rows = |rows: rusqlite::MappedRows<_>| {
         // It is faster to sort here rather than
         // let sqlite execute an ORDER BY clause.
-        let mut sorted_rows = Vec::new();
+        let mut sorted_rows = Vec::<(i64, MsgId, bool)>::new();
         for row in rows {
-            let (ts, curr_id, exclude_message): (i64, MsgId, bool) = row?;
+            let (ts, curr_id, exclude_message) = row?;
             sorted_rows.push((ts, curr_id, exclude_message));
         }
         sorted_rows.sort_unstable();
@@ -2314,7 +2314,7 @@ pub async fn get_chat_msgs(
         context
             .sql
             .query_map(
-                "SELECT m.id as id, m.timestamp as timestamp
+                "SELECT m.id AS id, m.timestamp AS timestamp
                FROM msgs m
               WHERE m.chat_id=?
                 AND m.hidden=0;",


### PR DESCRIPTION
this addresses and fixes https://github.com/deltachat/deltachat-core-rust/issues/3167 . This results in this speedup on the get_chat_msgs benchmark: 
```
Load all chats  time:   [260.44 ms 261.59 ms 262.74 ms]                           
                        change: [-11.101% -10.584% -10.070%] (p = 0.00 < 0.05)
                        Performance has improved.
```
Note that in another branch i tested [some tweaks to the SQL](https://github.com/deltachat/deltachat-core-rust/blob/fix_sql_order_by/src/chat.rs#L2310) but it did not result in an improvement.  
