### PR TITLE
[wip] Speed up get_chat_msgs (7 times) and get_chatlist (14% faster)

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -26,7 +26,7 @@ use crate::dc_tools::{
     dc_create_smeared_timestamps, dc_get_abs_path, dc_gm2local_offset, improve_single_line_input,
     time, IsNoneOrEmpty,
 };
-use crate::ephemeral::{delete_expired_messages, schedule_ephemeral_task, Timer as EphemeralTimer};
+use crate::ephemeral::{schedule_ephemeral_task, Timer as EphemeralTimer};
 use crate::events::EventType;
 use crate::html::new_html_mimepart;
 use crate::job::{self, Action};
@@ -2204,23 +2204,6 @@ pub async fn get_chat_msgs(
     flags: u32,
     marker1before: Option<MsgId>,
 ) -> Result<Vec<ChatItem>> {
-    match delete_expired_messages(context).await {
-        Err(err) => warn!(context, "Failed to delete expired messages: {}", err),
-        Ok(messages_deleted) => {
-            if messages_deleted {
-                // Trigger reload of chatlist.
-                //
-                // On desktop chatlist is always shown on the side,
-                // and it is important to update the last message shown
-                // there.
-                context.emit_event(EventType::MsgsChanged {
-                    msg_id: MsgId::new(0),
-                    chat_id: ChatId::new(0),
-                })
-            }
-        }
-    }
-
     let process_row = if (flags & DC_GCM_INFO_ONLY) != 0 {
         |row: &rusqlite::Row| {
             // is_info logic taken from Message.is_info()

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -9,7 +9,6 @@ use crate::constants::{
 };
 use crate::contact::{Contact, ContactId};
 use crate::context::Context;
-use crate::ephemeral::delete_expired_messages;
 use crate::message::{Message, MessageState, MsgId};
 use crate::stock_str;
 use crate::summary::Summary;
@@ -90,13 +89,6 @@ impl Chatlist {
         let flag_for_forwarding = 0 != listflags & DC_GCL_FOR_FORWARDING;
         let flag_no_specials = 0 != listflags & DC_GCL_NO_SPECIALS;
         let flag_add_alldone_hint = 0 != listflags & DC_GCL_ADD_ALLDONE_HINT;
-
-        // Note that we do not emit DC_EVENT_MSGS_MODIFIED here even if some
-        // messages get deleted to avoid reloading the same chatlist.
-        if let Err(err) = delete_expired_messages(context).await {
-            warn!(context, "Failed to hide expired messages: {}", err);
-        }
-
         let mut add_archived_link_item = false;
 
         let process_row = |row: &rusqlite::Row| {

--- a/src/config.rs
+++ b/src/config.rs
@@ -160,8 +160,11 @@ pub enum Config {
     /// address to webrtc instance to use for videochats
     WebrtcInstance,
 
-    /// Timestamp of the last time housekeeping was run
+    /// Timestamp of the last time fast housekeeping was run
     LastHousekeeping,
+
+    /// Timestamp of the last time full housekeeping was run
+    LastHousekeepingFull,
 
     /// To how many seconds to debounce scan_all_folders. Used mainly in tests, to disable debouncing completely.
     #[strum(props(default = "60"))]

--- a/src/config.rs
+++ b/src/config.rs
@@ -268,7 +268,15 @@ impl Context {
         }
     }
 
-    /// Set the given config key.
+    /// Set the given config key or emit a warning if it fails.
+    /// If `None` is passed as a value the value is cleared and set to the default if there is one.
+    pub async fn set_config_or_warn(&self, key: Config, value: Option<&str>) {
+        if let Err(err) = self.set_config(key, value).await {
+            warn!(self, "Can't set config: {}", err);
+        }
+    }
+
+    /// Set the given config key or emit a warning if it fails.
     /// If `None` is passed as a value the value is cleared and set to the default if there is one.
     pub async fn set_config(&self, key: Config, value: Option<&str>) -> Result<()> {
         match key {

--- a/src/context.rs
+++ b/src/context.rs
@@ -462,6 +462,12 @@ impl Context {
                 .to_string(),
         );
         res.insert(
+            "last_housekeeping_full",
+            self.get_config_int(Config::LastHousekeepingFull)
+                .await?
+                .to_string(),
+        );
+        res.insert(
             "scan_all_folders_debounce_secs",
             self.get_config_int(Config::ScanAllFoldersDebounceSecs)
                 .await?

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -851,7 +851,7 @@ mod tests {
     }
 
     async fn check_msg_was_deleted(t: &TestContext, chat: &Chat, msg_id: MsgId) {
-        sql::housekeeping(&t).await.unwrap();
+        sql::housekeeping(t).await.unwrap();
         let chat_items = chat::get_chat_msgs(t, chat.id, 0, None).await.unwrap();
         // Check that the chat is empty except for possibly info messages:
         for item in &chat_items {

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -362,9 +362,9 @@ impl Imap {
                     && err.to_string().to_lowercase().contains("authentication")
                     && context.get_config_bool(Config::NotifyAboutWrongPw).await?
                 {
-                    if let Err(e) = context.set_config(Config::NotifyAboutWrongPw, None).await {
-                        warn!(context, "{}", e);
-                    }
+                    context
+                        .set_config_or_warn(Config::NotifyAboutWrongPw, None)
+                        .await;
                     drop(lock);
 
                     let mut msg = Message::new(Viewtype::Text);
@@ -574,7 +574,7 @@ impl Imap {
                 if uid_next < old_uid_next {
                     warn!(
                         context,
-                        "The server illegally decreased the uid_next of folder {} from {} to {} without changing validity ({}), resyncing UIDs...", 
+                        "The server illegally decreased the uid_next of folder {} from {} to {} without changing validity ({}), resyncing UIDs...",
                         folder, old_uid_next, uid_next, new_uid_validity,
                     );
                     set_uid_next(context, folder, uid_next).await?;

--- a/src/job.rs
+++ b/src/job.rs
@@ -751,7 +751,7 @@ pub async fn add(context: &Context, job: Job) -> Result<()> {
 async fn load_housekeeping_job(context: &Context) -> Result<Option<Job>> {
     let last_time = context.get_config_i64(Config::LastHousekeeping).await?;
 
-    let next_time = last_time + 60;  // housekeeping every minute (for message expiry)
+    let next_time = last_time + 60;  // fast housekeeping every minute
     if next_time <= time() {
         kill_action(context, Action::Housekeeping).await?;
         Ok(Some(Job::new(Action::Housekeeping, 0, Params::new(), 0)))

--- a/src/job.rs
+++ b/src/job.rs
@@ -751,7 +751,7 @@ pub async fn add(context: &Context, job: Job) -> Result<()> {
 async fn load_housekeeping_job(context: &Context) -> Result<Option<Job>> {
     let last_time = context.get_config_i64(Config::LastHousekeeping).await?;
 
-    let next_time = last_time + 60;  // fast housekeeping every minute
+    let next_time = last_time + 60; // fast housekeeping happens every minute
     if next_time <= time() {
         kill_action(context, Action::Housekeeping).await?;
         Ok(Some(Job::new(Action::Housekeeping, 0, Params::new(), 0)))

--- a/src/job.rs
+++ b/src/job.rs
@@ -751,7 +751,7 @@ pub async fn add(context: &Context, job: Job) -> Result<()> {
 async fn load_housekeeping_job(context: &Context) -> Result<Option<Job>> {
     let last_time = context.get_config_i64(Config::LastHousekeeping).await?;
 
-    let next_time = last_time + (60 * 60 * 24);
+    let next_time = last_time + 60;  // housekeeping every minute (for message expiry)
     if next_time <= time() {
         kill_action(context, Action::Housekeeping).await?;
         Ok(Some(Job::new(Action::Housekeeping, 0, Params::new(), 0)))

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -603,17 +603,26 @@ pub async fn housekeeping(context: &Context) -> Result<()> {
         warn!(context, "Failed to delete expired messages: {}", err);
     }
 
-    if let Err(err) = remove_unused_files(context).await {
-        warn!(
-            context,
-            "Housekeeping: cannot remove unusued files: {}", err
-        );
-    }
-
     if let Err(err) = start_ephemeral_timers(context).await {
         warn!(
             context,
             "Housekeeping: cannot start ephemeral timers: {}", err
+        );
+    }
+
+    context.set_config_or_warn(Config::LastHousekeeping, Some(&time().to_string())).await;
+
+    let last_time = context.get_config_i64(Config::LastHousekeepingFull).await?;
+    let next_time = last_time + (60 * 60 * 24);
+    if next_time <= time() {
+        info!(context, "Quick Housekeeping done.");
+        return Ok(());
+    }
+
+    if let Err(err) = remove_unused_files(context).await {
+        warn!(
+            context,
+            "Housekeeping: cannot remove unusued files: {}", err
         );
     }
 
@@ -640,9 +649,9 @@ pub async fn housekeeping(context: &Context) -> Result<()> {
         warn!(context, "Failed to run incremental vacuum: {}", err);
     }
 
-    context.set_config_or_warn(Config::LastHousekeeping, Some(&time().to_string())).await;
+    context.set_config_or_warn(Config::LastHousekeepingFull, Some(&time().to_string())).await;
 
-    info!(context, "Housekeeping done.");
+    info!(context, "Full Housekeeping done.");
     Ok(())
 }
 

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -610,7 +610,9 @@ pub async fn housekeeping(context: &Context) -> Result<()> {
         );
     }
 
-    context.set_config_or_warn(Config::LastHousekeeping, Some(&time().to_string())).await;
+    context
+        .set_config_or_warn(Config::LastHousekeeping, Some(&time().to_string()))
+        .await;
 
     let last_time = context.get_config_i64(Config::LastHousekeepingFull).await?;
     let next_time = last_time + (60 * 60 * 24);
@@ -649,7 +651,9 @@ pub async fn housekeeping(context: &Context) -> Result<()> {
         warn!(context, "Failed to run incremental vacuum: {}", err);
     }
 
-    context.set_config_or_warn(Config::LastHousekeepingFull, Some(&time().to_string())).await;
+    context
+        .set_config_or_warn(Config::LastHousekeepingFull, Some(&time().to_string()))
+        .await;
 
     info!(context, "Full Housekeeping done.");
     Ok(())

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -640,12 +640,7 @@ pub async fn housekeeping(context: &Context) -> Result<()> {
         warn!(context, "Failed to run incremental vacuum: {}", err);
     }
 
-    if let Err(e) = context
-        .set_config(Config::LastHousekeeping, Some(&time().to_string()))
-        .await
-    {
-        warn!(context, "Can't set config: {}", e);
-    }
+    context.set_config_or_warn(Config::LastHousekeeping, Some(&time().to_string())).await;
 
     info!(context, "Housekeeping done.");
     Ok(())


### PR DESCRIPTION
This PR moves the calling of  delete_expired_messages into the housekeeping job which now runs every 60 seconds. A new timer for "full housekeeping" is added such that removing unused files continues to run only once a day.  This also means that delete_expired_messages() can now emit MsgsChanged events as needed as there is no recursion issues (get_chatlist() could trigger an event which would trigger an immediate recall of get_chatlist()). 

The speed improvements as measured by the benches: 
```
Benchmarking chatlist:try_load (Get Chatlist): Collecting 100 samples in estimated 16.155 s (100 ite                                                                                                    chatlist:try_load (Get Chatlist)                        
                        time:   [154.82 ms 155.72 ms 156.66 ms]
                        change: [-14.587% -14.000% -13.390%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking chat::get_chat_msgs (load messages from 10 chats): Collecting 100 samples in estimated                                                                                                     chat::get_chat_msgs (load messages from 10 chats)                        
                        time:   [43.638 ms 43.821 ms 44.025 ms]
                        change: [-85.553% -85.477% -85.396%] (p = 0.00 < 0.05)
                        Performance has improved.
```