### PR TITLE
smtp: do not try to use stale connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   the last copy #3138
 - speed up loading of chat messages #3171
 - clear more columns when message expires due to `delete_device_after` setting #3181
+- do not try to use stale SMTP connections #3180
 
 ### Changes
 - add more SMTP logging #3093


### PR DESCRIPTION
Previously first try used an old connection and. If using stale
connection, an immediate retry was performed using a new connection.

Now if connection is stale, it is closed immediately without trying to
use it.

This should reduce the delay in cases when old connection is unusable.

Fixes #3092 