### PR TITLE
ephemeral: clear more fields in delete_expired_messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - do not delete duplicate messages on IMAP immediately to accidentally deleting
   the last copy #3138
 - speed up loading of chat messages #3171
+- clear more columns when message expires due to `delete_device_after` setting #3181
 
 ### Changes
 - add more SMTP logging #3093

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -378,7 +378,8 @@ WHERE
             .sql
             .execute(
                 "UPDATE msgs \
-             SET txt = 'DELETED', chat_id = ? \
+             SET chat_id = ?, txt = '', subject='', txt_raw='', \
+                 mime_headers='', from_id=0, to_id=0, param='' \
              WHERE timestamp < ? \
              AND chat_id > ? \
              AND chat_id != ? \


### PR DESCRIPTION
These fields are cleared in other places,
but in the case of delete_device_after setting
only txt column was cleared previously.