### PR TITLE
muted chats stay archived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - automatically accept chats with outgoing messages #3143
 - `dc_receive_imf` refactorings #3154 #3156
 - add index to speedup deletion of expired ephemeral messages #3155
+- muted chats stay archived on new messages #3184
 
 
 ### Fixes

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1191,7 +1191,7 @@ INSERT INTO msgs
     }
     drop(conn);
 
-    chat_id.unarchive(context).await?;
+    chat_id.unarchive_if_not_muted(context).await?;
 
     info!(
         context,


### PR DESCRIPTION
this little change let archived chats stay archived on new messages if they are also muted.

this gives the user some more options to organize things, 
keeping unimportant chats in a separate section.
Telegram and WhatsApp (and maybe other messengers) have ~~the same~~ a similar behavior,
ui changes are not required.

(we have discussed that several times with different groups - and i needed something simple to do :)

