### PR TITLE
Consolidate ContactId constants

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1949,18 +1949,19 @@ pub unsafe extern "C" fn dc_block_contact(
     contact_id: u32,
     block: libc::c_int,
 ) {
-    if context.is_null() || contact_id <= ContactId::LAST_SPECIAL.to_u32() {
+    let contact_id = ContactId::new(contact_id);
+    if context.is_null() || contact_id.is_special() {
         eprintln!("ignoring careless call to dc_block_contact()");
         return;
     }
     let ctx = &*context;
     block_on(async move {
         if block == 0 {
-            Contact::unblock(ctx, ContactId::new(contact_id))
+            Contact::unblock(ctx, contact_id)
                 .await
                 .ok_or_log_msg(ctx, "Can't unblock contact");
         } else {
-            Contact::block(ctx, ContactId::new(contact_id))
+            Contact::block(ctx, contact_id)
                 .await
                 .ok_or_log_msg(ctx, "Can't block contact");
         }
@@ -1994,14 +1995,15 @@ pub unsafe extern "C" fn dc_delete_contact(
     context: *mut dc_context_t,
     contact_id: u32,
 ) -> libc::c_int {
-    if context.is_null() || contact_id <= ContactId::LAST_SPECIAL.to_u32() {
+    let contact_id = ContactId::new(contact_id);
+    if context.is_null() || contact_id.is_special() {
         eprintln!("ignoring careless call to dc_delete_contact()");
         return 0;
     }
     let ctx = &*context;
 
     block_on(async move {
-        match Contact::delete(ctx, ContactId::new(contact_id)).await {
+        match Contact::delete(ctx, contact_id).await {
             Ok(_) => 1,
             Err(_) => 0,
         }

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1949,7 +1949,7 @@ pub unsafe extern "C" fn dc_block_contact(
     contact_id: u32,
     block: libc::c_int,
 ) {
-    if context.is_null() || contact_id <= constants::DC_CONTACT_ID_LAST_SPECIAL.to_u32() {
+    if context.is_null() || contact_id <= ContactId::LAST_SPECIAL.to_u32() {
         eprintln!("ignoring careless call to dc_block_contact()");
         return;
     }
@@ -1994,7 +1994,7 @@ pub unsafe extern "C" fn dc_delete_contact(
     context: *mut dc_context_t,
     contact_id: u32,
 ) -> libc::c_int {
-    if context.is_null() || contact_id <= constants::DC_CONTACT_ID_LAST_SPECIAL.to_u32() {
+    if context.is_null() || contact_id <= ContactId::LAST_SPECIAL.to_u32() {
         eprintln!("ignoring careless call to dc_delete_contact()");
         return 0;
     }

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -210,7 +210,7 @@ async fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
         contact_id,
         msgtext.unwrap_or_default(),
         if msg.has_html() { "[HAS-HTML]️" } else { "" },
-        if msg.get_from_id() == DC_CONTACT_ID_SELF {
+        if msg.get_from_id() == ContactId::SELF {
             ""
         } else if msg.get_state() == MessageState::InSeen {
             "[SEEN]"
@@ -297,7 +297,7 @@ async fn log_contactlist(context: &Context, contacts: &[ContactId]) -> Result<()
         let peerstate = Peerstate::from_addr(context, addr)
             .await
             .expect("peerstate error");
-        if peerstate.is_some() && *contact_id != DC_CONTACT_ID_SELF {
+        if peerstate.is_some() && *contact_id != ContactId::SELF {
             line2 = format!(
                 ", prefer-encrypt={}",
                 peerstate.as_ref().unwrap().prefer_encrypt

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -860,7 +860,7 @@ impl ChatId {
         for contact_id in get_chat_contacts(context, self)
             .await?
             .iter()
-            .filter(|&contact_id| *contact_id > ContactId::LAST_SPECIAL)
+            .filter(|&contact_id| !contact_id.is_special())
         {
             let contact = Contact::load_from_db(context, *contact_id).await?;
             let addr = contact.get_addr();
@@ -1686,7 +1686,7 @@ impl ChatIdBlocked {
     ) -> Result<Option<Self>> {
         ensure!(context.sql.is_open().await, "Database not available");
         ensure!(
-            contact_id > ContactId::new(0),
+            contact_id != ContactId::UNDEFINED,
             "Invalid contact id requested"
         );
 
@@ -1722,7 +1722,7 @@ impl ChatIdBlocked {
     ) -> Result<Self> {
         ensure!(context.sql.is_open().await, "Database not available");
         ensure!(
-            contact_id > ContactId::new(0),
+            contact_id != ContactId::UNDEFINED,
             "Invalid contact id requested"
         );
 
@@ -2888,7 +2888,7 @@ pub async fn remove_contact_from_chat(
         chat_id
     );
     ensure!(
-        contact_id > ContactId::LAST_SPECIAL || contact_id == ContactId::SELF,
+        !contact_id.is_special() || contact_id == ContactId::SELF,
         "Cannot remove special contact"
     );
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -16,8 +16,7 @@ use crate::color::str_to_color;
 use crate::config::Config;
 use crate::constants::{
     Blocked, Chattype, DC_CHAT_ID_ALLDONE_HINT, DC_CHAT_ID_ARCHIVED_LINK, DC_CHAT_ID_LAST_SPECIAL,
-    DC_CHAT_ID_TRASH, DC_CONTACT_ID_DEVICE, DC_CONTACT_ID_INFO, DC_CONTACT_ID_LAST_SPECIAL,
-    DC_CONTACT_ID_SELF, DC_GCM_ADDDAYMARKER, DC_GCM_INFO_ONLY, DC_RESEND_USER_AVATAR_DAYS,
+    DC_CHAT_ID_TRASH, DC_GCM_ADDDAYMARKER, DC_GCM_INFO_ONLY, DC_RESEND_USER_AVATAR_DAYS,
 };
 use crate::contact::{addr_cmp, Contact, ContactId, Origin, VerifiedStatus};
 use crate::context::Context;
@@ -199,7 +198,7 @@ impl ChatId {
             }
             None => {
                 if Contact::real_exists_by_id(context, contact_id).await?
-                    || contact_id == DC_CONTACT_ID_SELF
+                    || contact_id == ContactId::SELF
                 {
                     let chat_id =
                         ChatIdBlocked::get_for_contact(context, contact_id, create_blocked)
@@ -297,7 +296,7 @@ impl ChatId {
             }
             Chattype::Single => {
                 for contact_id in get_chat_contacts(context, self).await? {
-                    if contact_id != DC_CONTACT_ID_SELF {
+                    if contact_id != ContactId::SELF {
                         info!(
                             context,
                             "Blocking the contact {} to block 1:1 chat", contact_id
@@ -340,7 +339,7 @@ impl ChatId {
                 // Previously accepting a chat literally created a chat because unaccepted chats
                 // went to "contact requests" list rather than normal chatlist.
                 for contact_id in get_chat_contacts(context, self).await? {
-                    if contact_id != DC_CONTACT_ID_SELF {
+                    if contact_id != ContactId::SELF {
                         Contact::scaleup_origin_by_id(context, contact_id, Origin::CreateChat)
                             .await?;
                     }
@@ -464,7 +463,7 @@ impl ChatId {
             return Err(e);
         }
 
-        self.add_protection_msg(context, protect, chat.is_promoted(), DC_CONTACT_ID_SELF)
+        self.add_protection_msg(context, protect, chat.is_promoted(), ContactId::SELF)
             .await
     }
 
@@ -714,7 +713,7 @@ impl ChatId {
          VALUES (?,?,?, ?,?,?,?,?,?);",
                 paramsv![
                     self,
-                    DC_CONTACT_ID_SELF,
+                    ContactId::SELF,
                     time(),
                     msg.viewtype,
                     MessageState::OutDraft,
@@ -861,7 +860,7 @@ impl ChatId {
         for contact_id in get_chat_contacts(context, self)
             .await?
             .iter()
-            .filter(|&contact_id| *contact_id > DC_CONTACT_ID_LAST_SPECIAL)
+            .filter(|&contact_id| *contact_id > ContactId::LAST_SPECIAL)
         {
             let contact = Contact::load_from_db(context, *contact_id).await?;
             let addr = contact.get_addr();
@@ -1087,7 +1086,7 @@ impl Chat {
     pub(crate) async fn is_self_in_chat(&self, context: &Context) -> Result<bool> {
         match self.typ {
             Chattype::Single | Chattype::Broadcast | Chattype::Mailinglist => Ok(true),
-            Chattype::Group => is_contact_in_chat(context, self.id, DC_CONTACT_ID_SELF).await,
+            Chattype::Group => is_contact_in_chat(context, self.id, ContactId::SELF).await,
             Chattype::Undefined => Ok(false),
         }
     }
@@ -1241,7 +1240,7 @@ impl Chat {
 
         if !self.can_send(context).await? {
             if self.typ == Chattype::Group
-                && !is_contact_in_chat(context, self.id, DC_CONTACT_ID_SELF).await?
+                && !is_contact_in_chat(context, self.id, ContactId::SELF).await?
             {
                 context.emit_event(EventType::ErrorSelfNotInGroup(
                     "Cannot send message; self not in group.".into(),
@@ -1355,7 +1354,7 @@ impl Chat {
                      VALUES (?,?,?, ?,?,1);",
                     paramsv![
                         timestamp,
-                        DC_CONTACT_ID_SELF,
+                        ContactId::SELF,
                         self.id,
                         msg.param.get_float(Param::SetLatitude).unwrap_or_default(),
                         msg.param.get_float(Param::SetLongitude).unwrap_or_default(),
@@ -1407,7 +1406,7 @@ impl Chat {
                     paramsv![
                         new_rfc724_mid,
                         self.id,
-                        DC_CONTACT_ID_SELF,
+                        ContactId::SELF,
                         to_id as i32,
                         timestamp,
                         msg.viewtype,
@@ -1456,7 +1455,7 @@ impl Chat {
                     paramsv![
                         new_rfc724_mid,
                         self.id,
-                        DC_CONTACT_ID_SELF,
+                        ContactId::SELF,
                         to_id as i32,
                         timestamp,
                         msg.viewtype,
@@ -1585,7 +1584,7 @@ pub struct ChatInfo {
 
 pub(crate) async fn update_saved_messages_icon(context: &Context) -> Result<()> {
     // if there is no saved-messages chat, there is nothing to update. this is no error.
-    if let Some(chat_id) = ChatId::lookup_by_contact(context, DC_CONTACT_ID_SELF).await? {
+    if let Some(chat_id) = ChatId::lookup_by_contact(context, ContactId::SELF).await? {
         let icon = include_bytes!("../assets/icon-saved-messages.png");
         let blob = BlobObject::create(context, "icon-saved-messages.png", icon).await?;
         let icon = blob.as_name().to_string();
@@ -1599,7 +1598,7 @@ pub(crate) async fn update_saved_messages_icon(context: &Context) -> Result<()> 
 
 pub(crate) async fn update_device_icon(context: &Context) -> Result<()> {
     // if there is no device-chat, there is nothing to update. this is no error.
-    if let Some(chat_id) = ChatId::lookup_by_contact(context, DC_CONTACT_ID_DEVICE).await? {
+    if let Some(chat_id) = ChatId::lookup_by_contact(context, ContactId::DEVICE).await? {
         let icon = include_bytes!("../assets/icon-device.png");
         let blob = BlobObject::create(context, "icon-device.png", icon).await?;
         let icon = blob.as_name().to_string();
@@ -1608,7 +1607,7 @@ pub(crate) async fn update_device_icon(context: &Context) -> Result<()> {
         chat.param.set(Param::ProfileImage, &icon);
         chat.update_param(context).await?;
 
-        let mut contact = Contact::load_from_db(context, DC_CONTACT_ID_DEVICE).await?;
+        let mut contact = Contact::load_from_db(context, ContactId::DEVICE).await?;
         contact.param.set(Param::ProfileImage, icon);
         contact.update_param(context).await?;
     }
@@ -1651,13 +1650,13 @@ async fn update_special_chat_name(
 pub(crate) async fn update_special_chat_names(context: &Context) -> Result<()> {
     update_special_chat_name(
         context,
-        DC_CONTACT_ID_DEVICE,
+        ContactId::DEVICE,
         stock_str::device_messages(context).await,
     )
     .await?;
     update_special_chat_name(
         context,
-        DC_CONTACT_ID_SELF,
+        ContactId::SELF,
         stock_str::saved_messages(context).await,
     )
     .await?;
@@ -1736,10 +1735,10 @@ impl ChatIdBlocked {
         let chat_name = contact.get_display_name().to_string();
         let mut params = Params::new();
         match contact_id {
-            DC_CONTACT_ID_SELF => {
+            ContactId::SELF => {
                 params.set_int(Param::Selftalk, 1);
             }
-            DC_CONTACT_ID_DEVICE => {
+            ContactId::DEVICE => {
                 params.set_int(Param::Devicetalk, 1);
             }
             _ => (),
@@ -1780,8 +1779,8 @@ impl ChatIdBlocked {
             .await?;
 
         match contact_id {
-            DC_CONTACT_ID_SELF => update_saved_messages_icon(context).await?,
-            DC_CONTACT_ID_DEVICE => update_device_icon(context).await?,
+            ContactId::SELF => update_saved_messages_icon(context).await?,
+            ContactId::DEVICE => update_device_icon(context).await?,
             _ => (),
         }
 
@@ -1917,8 +1916,8 @@ pub async fn is_contact_in_chat(
 ) -> Result<bool> {
     // this function works for group and for normal chats, however, it is more useful
     // for group chats.
-    // DC_CONTACT_ID_SELF may be used to check, if the user itself is in a group
-    // chat (DC_CONTACT_ID_SELF is not added to normal chats)
+    // ContactId::SELF may be used to check, if the user itself is in a group
+    // chat (ContactId::SELF is not added to normal chats)
 
     let exists = context
         .sql
@@ -1986,7 +1985,7 @@ async fn send_msg_inner(context: &Context, chat_id: ChatId, msg: &mut Message) -
         });
 
         if msg.param.exists(Param::SetLatitude) {
-            context.emit_event(EventType::LocationChanged(Some(DC_CONTACT_ID_SELF)));
+            context.emit_event(EventType::LocationChanged(Some(ContactId::SELF)));
         }
 
         context.interrupt_smtp(InterruptInfo::new(false)).await;
@@ -2230,8 +2229,8 @@ pub async fn get_chat_msgs(
                 row.get::<_, ContactId>("from_id")?,
                 row.get::<_, ContactId>("to_id")?,
             );
-            let is_info_msg: bool = from_id == DC_CONTACT_ID_INFO
-                || to_id == DC_CONTACT_ID_INFO
+            let is_info_msg: bool = from_id == ContactId::INFO
+                || to_id == ContactId::INFO
                 || match Params::from_str(&params) {
                     Ok(p) => {
                         let cmd = p.get_cmd();
@@ -2305,7 +2304,7 @@ pub async fn get_chat_msgs(
                     OR m.from_id == ?
                     OR m.to_id == ?
                 );",
-                paramsv![chat_id, DC_CONTACT_ID_INFO, DC_CONTACT_ID_INFO],
+                paramsv![chat_id, ContactId::INFO, ContactId::INFO],
                 process_row,
                 process_rows,
             )
@@ -2587,8 +2586,8 @@ pub async fn create_group_chat(
         .await?;
 
     let chat_id = ChatId::new(u32::try_from(row_id)?);
-    if !is_contact_in_chat(context, chat_id, DC_CONTACT_ID_SELF).await? {
-        add_to_chat_contacts_table(context, chat_id, DC_CONTACT_ID_SELF).await?;
+    if !is_contact_in_chat(context, chat_id, ContactId::SELF).await? {
+        add_to_chat_contacts_table(context, chat_id, ContactId::SELF).await?;
     }
 
     context.emit_event(EventType::MsgsChanged {
@@ -2717,13 +2716,13 @@ pub(crate) async fn add_contact_to_chat_ex(
         chat_id
     );
     ensure!(
-        Contact::real_exists_by_id(context, contact_id).await? || contact_id == DC_CONTACT_ID_SELF,
+        Contact::real_exists_by_id(context, contact_id).await? || contact_id == ContactId::SELF,
         "invalid contact_id {} for adding to group",
         contact_id
     );
     ensure!(!chat.is_mailing_list(), "Mailing lists can't be changed");
     ensure!(
-        chat.typ != Chattype::Broadcast || contact_id != DC_CONTACT_ID_SELF,
+        chat.typ != Chattype::Broadcast || contact_id != ContactId::SELF,
         "Cannot add SELF to broadcast."
     );
 
@@ -2745,7 +2744,7 @@ pub(crate) async fn add_contact_to_chat_ex(
         .await?
         .unwrap_or_default();
     if addr_cmp(contact.get_addr(), &self_addr) {
-        // ourself is added using DC_CONTACT_ID_SELF, do not add this address explicitly.
+        // ourself is added using ContactId::SELF, do not add this address explicitly.
         // if SELF is not in the group, members cannot be added at all.
         warn!(
             context,
@@ -2778,7 +2777,7 @@ pub(crate) async fn add_contact_to_chat_ex(
         msg.viewtype = Viewtype::Text;
 
         msg.text =
-            Some(stock_str::msg_add_member(context, contact.get_addr(), DC_CONTACT_ID_SELF).await);
+            Some(stock_str::msg_add_member(context, contact.get_addr(), ContactId::SELF).await);
         msg.param.set_cmd(SystemMessage::MemberAddedToGroup);
         msg.param.set(Param::Arg, contact.get_addr());
         msg.param.set_int(Param::Arg2, from_handshake.into());
@@ -2804,7 +2803,7 @@ pub(crate) async fn shall_attach_selfavatar(context: &Context, chat_id: ChatId) 
            FROM chats_contacts cc
            LEFT JOIN contacts c ON c.id=cc.contact_id
           WHERE cc.chat_id=? AND cc.contact_id!=?;",
-            paramsv![chat_id, DC_CONTACT_ID_SELF],
+            paramsv![chat_id, ContactId::SELF],
             |row| Ok(row.get::<_, i64>(0)),
             |rows| {
                 let mut needs_attach = false;
@@ -2889,7 +2888,7 @@ pub async fn remove_contact_from_chat(
         chat_id
     );
     ensure!(
-        contact_id > DC_CONTACT_ID_LAST_SPECIAL || contact_id == DC_CONTACT_ID_SELF,
+        contact_id > ContactId::LAST_SPECIAL || contact_id == ContactId::SELF,
         "Cannot remove special contact"
     );
 
@@ -2908,16 +2907,16 @@ pub async fn remove_contact_from_chat(
                 if let Ok(contact) = Contact::get_by_id(context, contact_id).await {
                     if chat.typ == Chattype::Group && chat.is_promoted() {
                         msg.viewtype = Viewtype::Text;
-                        if contact.id == DC_CONTACT_ID_SELF {
+                        if contact.id == ContactId::SELF {
                             set_group_explicitly_left(context, &chat.grpid).await?;
                             msg.text =
-                                Some(stock_str::msg_group_left(context, DC_CONTACT_ID_SELF).await);
+                                Some(stock_str::msg_group_left(context, ContactId::SELF).await);
                         } else {
                             msg.text = Some(
                                 stock_str::msg_del_member(
                                     context,
                                     contact.get_addr(),
-                                    DC_CONTACT_ID_SELF,
+                                    ContactId::SELF,
                                 )
                                 .await,
                             );
@@ -3010,8 +3009,7 @@ pub async fn set_chat_name(context: &Context, chat_id: ChatId, new_name: &str) -
             if chat.is_promoted() && !chat.is_mailing_list() && chat.typ != Chattype::Broadcast {
                 msg.viewtype = Viewtype::Text;
                 msg.text = Some(
-                    stock_str::msg_grp_name(context, &chat.name, &new_name, DC_CONTACT_ID_SELF)
-                        .await,
+                    stock_str::msg_grp_name(context, &chat.name, &new_name, ContactId::SELF).await,
                 );
                 msg.param.set_cmd(SystemMessage::GroupNameChanged);
                 if !chat.name.is_empty() {
@@ -3052,7 +3050,7 @@ pub async fn set_chat_profile_image(
         "Failed to set profile image; group does not exist"
     );
     /* we should respect this - whatever we send to the group, it gets discarded anyway! */
-    if !is_contact_in_chat(context, chat_id, DC_CONTACT_ID_SELF).await? {
+    if !is_contact_in_chat(context, chat_id, ContactId::SELF).await? {
         context.emit_event(EventType::ErrorSelfNotInGroup(
             "Cannot set chat profile image; self not in group.".into(),
         ));
@@ -3064,7 +3062,7 @@ pub async fn set_chat_profile_image(
     if new_image.as_ref().is_empty() {
         chat.param.remove(Param::ProfileImage);
         msg.param.remove(Param::Arg);
-        msg.text = Some(stock_str::msg_grp_img_deleted(context, DC_CONTACT_ID_SELF).await);
+        msg.text = Some(stock_str::msg_grp_img_deleted(context, ContactId::SELF).await);
     } else {
         let mut image_blob = match BlobObject::from_path(context, Path::new(new_image.as_ref())) {
             Ok(blob) => Ok(blob),
@@ -3078,7 +3076,7 @@ pub async fn set_chat_profile_image(
         image_blob.recode_to_avatar_size(context).await?;
         chat.param.set(Param::ProfileImage, image_blob.as_name());
         msg.param.set(Param::Arg, image_blob.as_name());
-        msg.text = Some(stock_str::msg_grp_img_changed(context, DC_CONTACT_ID_SELF).await);
+        msg.text = Some(stock_str::msg_grp_img_changed(context, ContactId::SELF).await);
     }
     chat.update_param(context).await?;
     if chat.is_promoted() && !chat.is_mailing_list() {
@@ -3253,7 +3251,7 @@ pub async fn add_device_msg_with_importance(
     }
 
     if let Some(msg) = msg {
-        chat_id = ChatId::get_for_contact(context, DC_CONTACT_ID_DEVICE).await?;
+        chat_id = ChatId::get_for_contact(context, ContactId::DEVICE).await?;
 
         let rfc724_mid = dc_create_outgoing_rfc724_mid(None, "@device");
         msg.try_calc_and_set_dimensions(context).await.ok();
@@ -3295,8 +3293,8 @@ pub async fn add_device_msg_with_importance(
             VALUES (?,?,?,?,?,?,?,?,?,?,?);",
                 paramsv![
                     chat_id,
-                    DC_CONTACT_ID_DEVICE,
-                    DC_CONTACT_ID_SELF,
+                    ContactId::DEVICE,
+                    ContactId::SELF,
                     timestamp_sort,
                     timestamp_sent,
                     timestamp_sent, // timestamp_sent equals timestamp_rcvd
@@ -3356,7 +3354,7 @@ pub async fn was_device_msg_ever_added(context: &Context, label: &str) -> Result
 }
 
 // needed on device-switches during export/import;
-// - deletion in `msgs` with `DC_CONTACT_ID_DEVICE` makes sure,
+// - deletion in `msgs` with `ContactId::DEVICE` makes sure,
 //   no wrong information are shown in the device chat
 // - deletion in `devmsglabels` makes sure,
 //   deleted messages are resetted and useful messages can be added again
@@ -3367,7 +3365,7 @@ pub(crate) async fn delete_and_reset_all_device_msgs(context: &Context) -> Resul
         .sql
         .execute(
             "DELETE FROM msgs WHERE from_id=?;",
-            paramsv![DC_CONTACT_ID_DEVICE],
+            paramsv![ContactId::DEVICE],
         )
         .await?;
     context
@@ -3402,8 +3400,8 @@ pub(crate) async fn add_info_msg_with_cmd(
         "INSERT INTO msgs (chat_id,from_id,to_id,timestamp,type,state,txt,rfc724_mid,ephemeral_timer, param,mime_in_reply_to) VALUES (?,?,?, ?,?,?, ?,?,?, ?,?);",
         paramsv![
             chat_id,
-            DC_CONTACT_ID_INFO,
-            DC_CONTACT_ID_INFO,
+            ContactId::INFO,
+            ContactId::INFO,
             timestamp,
             Viewtype::Text,
             MessageState::InNoticed,
@@ -3658,7 +3656,7 @@ mod tests {
         let chat_id = create_group_chat(&t, ProtectionStatus::Unprotected, "foo")
             .await
             .unwrap();
-        let added = add_contact_to_chat_ex(&t, chat_id, DC_CONTACT_ID_SELF, false)
+        let added = add_contact_to_chat_ex(&t, chat_id, ContactId::SELF, false)
             .await
             .unwrap();
         assert_eq!(added, false);
@@ -3868,7 +3866,7 @@ mod tests {
         let bob_msg = bob.get_last_msg().await;
         let bob_chat_id = bob_msg.chat_id;
         bob_chat_id.accept(&bob).await?;
-        remove_contact_from_chat(&bob, bob_chat_id, DC_CONTACT_ID_SELF).await?;
+        remove_contact_from_chat(&bob, bob_chat_id, ContactId::SELF).await?;
 
         let leave_msg = bob.pop_sent_msg().await;
         alice.recv_msg(&leave_msg).await;
@@ -3897,7 +3895,7 @@ mod tests {
         assert!(removed.is_err());
         assert_eq!(get_chat_contacts(&ctx, chat.id).await.unwrap().len(), 1);
 
-        let removed = remove_contact_from_chat(&ctx, chat.id, DC_CONTACT_ID_SELF).await;
+        let removed = remove_contact_from_chat(&ctx, chat.id, ContactId::SELF).await;
         assert!(removed.is_err());
         assert_eq!(get_chat_contacts(&ctx, chat.id).await.unwrap().len(), 1);
     }
@@ -3906,7 +3904,7 @@ mod tests {
     async fn test_self_talk() -> Result<()> {
         let t = TestContext::new_alice().await;
         let chat = &t.get_self_chat().await;
-        assert_eq!(DC_CONTACT_ID_SELF, ContactId::new(1));
+        assert_eq!(ContactId::SELF, ContactId::new(1));
         assert!(!chat.id.is_special());
         assert!(chat.is_self_talk());
         assert!(chat.visibility == ChatVisibility::Normal);
@@ -3917,8 +3915,8 @@ mod tests {
 
         let msg_id = send_text_msg(&t, chat.id, "foo self".to_string()).await?;
         let msg = Message::load_from_db(&t, msg_id).await?;
-        assert_eq!(msg.from_id, DC_CONTACT_ID_SELF);
-        assert_eq!(msg.to_id, DC_CONTACT_ID_SELF);
+        assert_eq!(msg.from_id, ContactId::SELF);
+        assert_eq!(msg.to_id, ContactId::SELF);
         assert!(msg.get_showpadlock());
 
         let sent_msg = t.pop_sent_msg().await;
@@ -3927,8 +3925,8 @@ mod tests {
         let chat = &t2.get_self_chat().await;
         let msg = t2.get_last_msg_in(chat.id).await;
         assert_eq!(msg.text, Some("foo self".to_string()));
-        assert_eq!(msg.from_id, DC_CONTACT_ID_SELF);
-        assert_eq!(msg.to_id, DC_CONTACT_ID_SELF);
+        assert_eq!(msg.from_id, ContactId::SELF);
+        assert_eq!(msg.to_id, ContactId::SELF);
         assert!(msg.get_showpadlock());
 
         Ok(())
@@ -3955,8 +3953,8 @@ mod tests {
         assert!(msg1.is_ok());
         let msg1 = msg1.unwrap();
         assert_eq!(msg1.text.as_ref().unwrap(), "first message");
-        assert_eq!(msg1.from_id, DC_CONTACT_ID_DEVICE);
-        assert_eq!(msg1.to_id, DC_CONTACT_ID_SELF);
+        assert_eq!(msg1.from_id, ContactId::DEVICE);
+        assert_eq!(msg1.to_id, ContactId::SELF);
         assert!(!msg1.is_info());
         assert!(!msg1.is_setupmessage());
 
@@ -3990,8 +3988,8 @@ mod tests {
         let msg1 = message::Message::load_from_db(&t, *msg1_id.as_ref().unwrap()).await?;
         assert_eq!(msg1_id.as_ref().unwrap(), &msg1.id);
         assert_eq!(msg1.text.as_ref().unwrap(), "first message");
-        assert_eq!(msg1.from_id, DC_CONTACT_ID_DEVICE);
-        assert_eq!(msg1.to_id, DC_CONTACT_ID_SELF);
+        assert_eq!(msg1.from_id, ContactId::DEVICE);
+        assert_eq!(msg1.to_id, ContactId::SELF);
         assert!(!msg1.is_info());
         assert!(!msg1.is_setupmessage());
 
@@ -4083,7 +4081,7 @@ mod tests {
     async fn test_device_chat_cannot_sent() {
         let t = TestContext::new().await;
         t.update_device_chats().await.unwrap();
-        let device_chat_id = ChatId::get_for_contact(&t, DC_CONTACT_ID_DEVICE)
+        let device_chat_id = ChatId::get_for_contact(&t, ContactId::DEVICE)
             .await
             .unwrap();
 
@@ -4569,13 +4567,13 @@ mod tests {
     async fn test_lookup_self_by_contact_id() {
         let ctx = TestContext::new_alice().await;
 
-        let chat = ChatId::lookup_by_contact(&ctx, DC_CONTACT_ID_SELF)
+        let chat = ChatId::lookup_by_contact(&ctx, ContactId::SELF)
             .await
             .unwrap();
         assert!(chat.is_none());
 
         ctx.update_device_chats().await.unwrap();
-        let chat = ChatIdBlocked::lookup_by_contact(&ctx, DC_CONTACT_ID_SELF)
+        let chat = ChatIdBlocked::lookup_by_contact(&ctx, ContactId::SELF)
             .await
             .unwrap()
             .unwrap();
@@ -5100,7 +5098,7 @@ mod tests {
                 .await?,
             true
         );
-        remove_contact_from_chat(&alice, chat_id, DC_CONTACT_ID_SELF).await?;
+        remove_contact_from_chat(&alice, chat_id, ContactId::SELF).await?;
         assert_eq!(
             Chat::load_from_db(&alice, chat_id)
                 .await?

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3904,7 +3904,6 @@ mod tests {
     async fn test_self_talk() -> Result<()> {
         let t = TestContext::new_alice().await;
         let chat = &t.get_self_chat().await;
-        assert_eq!(ContactId::SELF, ContactId::new(1));
         assert!(!chat.id.is_special());
         assert!(chat.is_self_talk());
         assert!(chat.visibility == ChatVisibility::Normal);
@@ -4321,7 +4320,7 @@ mod tests {
         let contact1 = Contact::create(&context.ctx, "bob", "bob@mail.de")
             .await
             .unwrap();
-        assert_ne!(contact1, ContactId::new(0));
+        assert_ne!(contact1, ContactId::UNDEFINED);
 
         let chat_id = ChatId::create_for_contact(&context.ctx, contact1)
             .await
@@ -4526,7 +4525,7 @@ mod tests {
 
         // create contact, then unblocked chat
         let contact_id = Contact::create(&ctx, "", "bob@foo.de").await.unwrap();
-        assert_ne!(contact_id, ContactId::new(0));
+        assert_ne!(contact_id, ContactId::UNDEFINED);
         let found = ChatId::lookup_by_contact(&ctx, contact_id).await.unwrap();
         assert!(found.is_none());
 

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -4,9 +4,8 @@ use anyhow::{ensure, Context as _, Result};
 
 use crate::chat::{update_special_chat_names, Chat, ChatId, ChatVisibility};
 use crate::constants::{
-    Blocked, Chattype, DC_CHAT_ID_ALLDONE_HINT, DC_CHAT_ID_ARCHIVED_LINK, DC_CONTACT_ID_DEVICE,
-    DC_CONTACT_ID_SELF, DC_CONTACT_ID_UNDEFINED, DC_GCL_ADD_ALLDONE_HINT, DC_GCL_ARCHIVED_ONLY,
-    DC_GCL_FOR_FORWARDING, DC_GCL_NO_SPECIALS,
+    Blocked, Chattype, DC_CHAT_ID_ALLDONE_HINT, DC_CHAT_ID_ARCHIVED_LINK, DC_GCL_ADD_ALLDONE_HINT,
+    DC_GCL_ARCHIVED_ONLY, DC_GCL_FOR_FORWARDING, DC_GCL_NO_SPECIALS,
 };
 use crate::contact::{Contact, ContactId};
 use crate::context::Context;
@@ -112,7 +111,7 @@ impl Chatlist {
         };
 
         let skip_id = if flag_for_forwarding {
-            ChatId::lookup_by_contact(context, DC_CONTACT_ID_DEVICE)
+            ChatId::lookup_by_contact(context, ContactId::DEVICE)
                 .await?
                 .unwrap_or_default()
         } else {
@@ -216,7 +215,7 @@ impl Chatlist {
         } else {
             //  show normal chatlist
             let sort_id_up = if flag_for_forwarding {
-                ChatId::lookup_by_contact(context, DC_CONTACT_ID_SELF)
+                ChatId::lookup_by_contact(context, ContactId::SELF)
                     .await?
                     .unwrap_or_default()
             } else {
@@ -326,7 +325,7 @@ impl Chatlist {
 
         let (lastmsg, lastcontact) = if let Some(lastmsg_id) = lastmsg_id {
             let lastmsg = Message::load_from_db(context, lastmsg_id).await?;
-            if lastmsg.from_id == DC_CONTACT_ID_SELF {
+            if lastmsg.from_id == ContactId::SELF {
                 (Some(lastmsg), None)
             } else {
                 match chat.typ {
@@ -343,7 +342,7 @@ impl Chatlist {
 
         if chat.id.is_archived_link() {
             Ok(Default::default())
-        } else if let Some(lastmsg) = lastmsg.filter(|msg| msg.from_id != DC_CONTACT_ID_UNDEFINED) {
+        } else if let Some(lastmsg) = lastmsg.filter(|msg| msg.from_id != ContactId::UNDEFINED) {
             Ok(Summary::new(context, &lastmsg, chat, lastcontact.as_ref()).await)
         } else {
             Ok(Summary {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,7 +4,6 @@ use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 
 use crate::chat::ChatId;
-use crate::contact::ContactId;
 
 pub static DC_VERSION_STR: Lazy<String> = Lazy::new(|| env!("CARGO_PKG_VERSION").to_string());
 
@@ -179,16 +178,6 @@ pub const DC_ELLIPSIS: &str = "[...]";
 /// Note that for simplicity maximum length is defined as the number of Unicode Scalar Values (Rust
 /// `char`s), not Unicode Grapheme Clusters.
 pub const DC_DESIRED_TEXT_LEN: usize = 5000;
-
-pub const DC_CONTACT_ID_UNDEFINED: ContactId = ContactId::new(0);
-pub const DC_CONTACT_ID_SELF: ContactId = ContactId::new(1);
-pub const DC_CONTACT_ID_INFO: ContactId = ContactId::new(2);
-pub const DC_CONTACT_ID_DEVICE: ContactId = ContactId::new(5);
-pub const DC_CONTACT_ID_LAST_SPECIAL: ContactId = ContactId::new(9);
-
-// decorative address that is used for DC_CONTACT_ID_DEVICE
-// when an api that returns an email is called.
-pub const DC_CONTACT_ID_DEVICE_ADDR: &str = "device@localhost";
 
 // Flags for empty server job
 

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1480,6 +1480,17 @@ mod tests {
     use crate::test_utils::{self, TestContext};
 
     #[test]
+    fn test_contact_id_values() {
+        // Some FFI users need to have the values of these fixed, how naughty.  But let's
+        // make sure we don't modify them anyway.
+        assert_eq!(ContactId::UNDEFINED.to_u32(), 0);
+        assert_eq!(ContactId::SELF.to_u32(), 1);
+        assert_eq!(ContactId::INFO.to_u32(), 2);
+        assert_eq!(ContactId::DEVICE.to_u32(), 5);
+        assert_eq!(ContactId::LAST_SPECIAL.to_u32(), 9);
+    }
+
+    #[test]
     fn test_may_be_valid_addr() {
         assert_eq!(may_be_valid_addr(""), false);
         assert_eq!(may_be_valid_addr("user@domain.tld"), true);

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -14,11 +14,7 @@ use crate::aheader::EncryptPreference;
 use crate::chat::ChatId;
 use crate::color::str_to_color;
 use crate::config::Config;
-use crate::constants::{
-    Blocked, Chattype, DC_CONTACT_ID_DEVICE, DC_CONTACT_ID_DEVICE_ADDR, DC_CONTACT_ID_INFO,
-    DC_CONTACT_ID_LAST_SPECIAL, DC_CONTACT_ID_SELF, DC_CONTACT_ID_UNDEFINED, DC_GCL_ADD_SELF,
-    DC_GCL_VERIFIED_ONLY,
-};
+use crate::constants::{Blocked, Chattype, DC_GCL_ADD_SELF, DC_GCL_VERIFIED_ONLY};
 use crate::context::Context;
 use crate::dc_tools::{dc_get_abs_path, improve_single_line_input, EmailAddress};
 use crate::events::EventType;
@@ -40,12 +36,30 @@ use crate::{chat, stock_str};
 pub struct ContactId(u32);
 
 impl ContactId {
+    pub const UNDEFINED: ContactId = ContactId::new(0);
+    /// The owner of the account.
+    ///
+    /// The email-address is set by `dc_set_config` using "addr".
+    pub const SELF: ContactId = ContactId::new(1);
+    pub const INFO: ContactId = ContactId::new(2);
+    pub const DEVICE: ContactId = ContactId::new(5);
+    pub const LAST_SPECIAL: ContactId = ContactId::new(9);
+
+    /// Address to go with [`ContactId::Device`].
+    ///
+    /// This is used by APIs which need to return an email address for this contact.
+    pub const DEVICE_ADDR: &'static str = "device@localhost";
+
     /// Creates a new [`ContactId`].
     pub const fn new(id: u32) -> ContactId {
         ContactId(id)
     }
 
-    /// Bad evil escape hatch, do not use.
+    /// Numerical representation of the [`ContactId`].
+    ///
+    /// Each contact ID has a unique numerical representation which is used in the database
+    /// (via [`rusqlite::ToSql`]) and also for FFI purposes.  In Rust code you should never
+    /// need to use this directly.
     pub const fn to_u32(&self) -> u32 {
         self.0
     }
@@ -53,15 +67,15 @@ impl ContactId {
 
 impl fmt::Display for ContactId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if *self == DC_CONTACT_ID_UNDEFINED {
+        if *self == ContactId::UNDEFINED {
             write!(f, "Contact#Undefined")
-        } else if *self == DC_CONTACT_ID_SELF {
+        } else if *self == ContactId::SELF {
             write!(f, "Contact#Self")
-        } else if *self == DC_CONTACT_ID_INFO {
+        } else if *self == ContactId::INFO {
             write!(f, "Contact#Info")
-        } else if *self == DC_CONTACT_ID_DEVICE {
+        } else if *self == ContactId::DEVICE {
             write!(f, "Contact#Device")
-        } else if *self <= DC_CONTACT_ID_LAST_SPECIAL {
+        } else if *self <= ContactId::LAST_SPECIAL {
             write!(f, "Contact#Special{}", self.0)
         } else {
             write!(f, "Contact#{}", self.0)
@@ -104,12 +118,6 @@ impl rusqlite::types::FromSql for ContactId {
 #[derive(Debug)]
 pub struct Contact {
     /// The contact ID.
-    ///
-    /// Special message IDs:
-    /// - DC_CONTACT_ID_SELF (1) - this is the owner of the account with the email-address set by
-    ///   `dc_set_config` using "addr".
-    ///
-    /// Normal contact IDs are larger than these special ones (larger than DC_CONTACT_ID_LAST_SPECIAL).
     pub id: ContactId,
 
     /// Contact name. It is recommended to use `Contact::get_name`,
@@ -278,7 +286,7 @@ impl Contact {
                 },
             )
             .await?;
-        if contact_id == DC_CONTACT_ID_SELF {
+        if contact_id == ContactId::SELF {
             contact.name = stock_str::self_msg(context).await;
             contact.addr = context
                 .get_config(Config::ConfiguredAddr)
@@ -288,9 +296,9 @@ impl Contact {
                 .get_config(Config::Selfstatus)
                 .await?
                 .unwrap_or_default();
-        } else if contact_id == DC_CONTACT_ID_DEVICE {
+        } else if contact_id == ContactId::DEVICE {
             contact.name = stock_str::device_messages(context).await;
-            contact.addr = DC_CONTACT_ID_DEVICE_ADDR.to_string();
+            contact.addr = ContactId::DEVICE_ADDR.to_string();
             contact.status = stock_str::device_messages_hint(context).await;
         }
         Ok(contact)
@@ -384,7 +392,7 @@ impl Contact {
 
         if let Some(addr_self) = context.get_config(Config::ConfiguredAddr).await? {
             if addr_cmp(addr_normalized, &addr_self) {
-                return Ok(Some(DC_CONTACT_ID_SELF));
+                return Ok(Some(ContactId::SELF));
             }
         }
         let id = context
@@ -393,11 +401,7 @@ impl Contact {
                 "SELECT id FROM contacts \
             WHERE addr=?1 COLLATE NOCASE \
             AND id>?2 AND origin>=?3 AND blocked=0;",
-                paramsv![
-                    addr_normalized,
-                    DC_CONTACT_ID_LAST_SPECIAL,
-                    min_origin as u32,
-                ],
+                paramsv![addr_normalized, ContactId::LAST_SPECIAL, min_origin as u32,],
             )
             .await?;
         Ok(id)
@@ -446,7 +450,7 @@ impl Contact {
             .unwrap_or_default();
 
         if addr_cmp(&addr, &addr_self) {
-            return Ok((DC_CONTACT_ID_SELF, sth_modified));
+            return Ok((ContactId::SELF, sth_modified));
         }
 
         if !may_be_valid_addr(&addr) {
@@ -706,7 +710,7 @@ impl Contact {
                  ORDER BY LOWER(iif(c.name='',c.authname,c.name)||c.addr),c.id;",
                     paramsv![
                         self_addr,
-                        DC_CONTACT_ID_LAST_SPECIAL,
+                        ContactId::LAST_SPECIAL,
                         Origin::IncomingReplyTo,
                         s3str_like_cmd,
                         s3str_like_cmd,
@@ -750,11 +754,7 @@ impl Contact {
                  AND origin>=?3
                  AND blocked=0
                  ORDER BY LOWER(iif(name='',authname,name)||addr),id;",
-                    paramsv![
-                        self_addr,
-                        DC_CONTACT_ID_LAST_SPECIAL,
-                        Origin::IncomingReplyTo
-                    ],
+                    paramsv![self_addr, ContactId::LAST_SPECIAL, Origin::IncomingReplyTo],
                     |row| row.get::<_, ContactId>(0),
                     |ids| {
                         for id in ids {
@@ -767,7 +767,7 @@ impl Contact {
         }
 
         if flag_add_self && add_self {
-            ret.push(DC_CONTACT_ID_SELF);
+            ret.push(ContactId::SELF);
         }
 
         Ok(ret)
@@ -822,7 +822,7 @@ impl Contact {
             .sql
             .count(
                 "SELECT COUNT(*) FROM contacts WHERE id>? AND blocked!=0",
-                paramsv![DC_CONTACT_ID_LAST_SPECIAL],
+                paramsv![ContactId::LAST_SPECIAL],
             )
             .await?;
         Ok(count as usize)
@@ -838,7 +838,7 @@ impl Contact {
             .sql
             .query_map(
                 "SELECT id FROM contacts WHERE id>? AND blocked!=0 ORDER BY LOWER(iif(name='',authname,name)||addr),id;",
-                paramsv![DC_CONTACT_ID_LAST_SPECIAL],
+                paramsv![ContactId::LAST_SPECIAL],
                 |row| row.get::<_, ContactId>(0),
                 |ids| {
                     ids.collect::<std::result::Result<Vec<_>, _>>()
@@ -856,7 +856,7 @@ impl Contact {
     /// fingerprints of the keys involved.
     pub async fn get_encrinfo(context: &Context, contact_id: ContactId) -> Result<String> {
         ensure!(
-            contact_id > DC_CONTACT_ID_LAST_SPECIAL,
+            contact_id > ContactId::LAST_SPECIAL,
             "Can not provide encryption info for special contact"
         );
 
@@ -925,7 +925,7 @@ impl Contact {
     /// May result in a `#DC_EVENT_CONTACTS_CHANGED` event.
     pub async fn delete(context: &Context, contact_id: ContactId) -> Result<()> {
         ensure!(
-            contact_id > DC_CONTACT_ID_LAST_SPECIAL,
+            contact_id > ContactId::LAST_SPECIAL,
             "Can not delete special contact"
         );
 
@@ -963,7 +963,7 @@ impl Contact {
 
     /// Get a single contact object.  For a list, see eg. dc_get_contacts().
     ///
-    /// For contact DC_CONTACT_ID_SELF (1), the function returns sth.
+    /// For contact ContactId::SELF (1), the function returns sth.
     /// like "Me" in the selected language and the email address
     /// defined by dc_set_config().
     pub async fn get_by_id(context: &Context, contact_id: ContactId) -> Result<Contact> {
@@ -1056,7 +1056,7 @@ impl Contact {
     /// This is the image set by each remote user on their own
     /// using dc_set_config(context, "selfavatar", image).
     pub async fn get_profile_image(&self, context: &Context) -> Result<Option<PathBuf>> {
-        if self.id == DC_CONTACT_ID_SELF {
+        if self.id == ContactId::SELF {
             if let Some(p) = context.get_config(Config::Selfavatar).await? {
                 return Ok(Some(PathBuf::from(p)));
             }
@@ -1102,7 +1102,7 @@ impl Contact {
     ) -> Result<VerifiedStatus> {
         // We're always sort of secured-verified as we could verify the key on this device any time with the key
         // on this device
-        if self.id == DC_CONTACT_ID_SELF {
+        if self.id == ContactId::SELF {
             return Ok(VerifiedStatus::BidirectVerified);
         }
 
@@ -1150,14 +1150,14 @@ impl Contact {
             .sql
             .count(
                 "SELECT COUNT(*) FROM contacts WHERE id>?;",
-                paramsv![DC_CONTACT_ID_LAST_SPECIAL],
+                paramsv![ContactId::LAST_SPECIAL],
             )
             .await?;
         Ok(count)
     }
 
     pub async fn real_exists_by_id(context: &Context, contact_id: ContactId) -> Result<bool> {
-        if contact_id <= DC_CONTACT_ID_LAST_SPECIAL {
+        if contact_id <= ContactId::LAST_SPECIAL {
             return Ok(false);
         }
 
@@ -1230,7 +1230,7 @@ async fn set_block_contact(
     new_blocking: bool,
 ) -> Result<()> {
     ensure!(
-        contact_id > DC_CONTACT_ID_LAST_SPECIAL,
+        contact_id > ContactId::LAST_SPECIAL,
         "Can't block special contact {}",
         contact_id
     );
@@ -1300,7 +1300,7 @@ pub(crate) async fn set_profile_image(
     let mut contact = Contact::load_from_db(context, contact_id).await?;
     let changed = match profile_image {
         AvatarAction::Change(profile_image) => {
-            if contact_id == DC_CONTACT_ID_SELF {
+            if contact_id == ContactId::SELF {
                 if was_encrypted {
                     context
                         .set_config(Config::Selfavatar, Some(profile_image))
@@ -1314,7 +1314,7 @@ pub(crate) async fn set_profile_image(
             true
         }
         AvatarAction::Delete => {
-            if contact_id == DC_CONTACT_ID_SELF {
+            if contact_id == ContactId::SELF {
                 if was_encrypted {
                     context.set_config(Config::Selfavatar, None).await?;
                 } else {
@@ -1345,7 +1345,7 @@ pub(crate) async fn set_status(
     encrypted: bool,
     has_chat_version: bool,
 ) -> Result<()> {
-    if contact_id == DC_CONTACT_ID_SELF {
+    if contact_id == ContactId::SELF {
         if encrypted && has_chat_version {
             context
                 .set_config(Config::Selfstatus, Some(&status))
@@ -1370,7 +1370,7 @@ pub(crate) async fn update_last_seen(
     timestamp: i64,
 ) -> Result<()> {
     ensure!(
-        contact_id > DC_CONTACT_ID_LAST_SPECIAL,
+        contact_id > ContactId::LAST_SPECIAL,
         "Can not update special contact last seen timestamp"
     );
 
@@ -1615,7 +1615,7 @@ mod tests {
             Contact::add_or_lookup(&t, "bla foo", "one@eins.org", Origin::IncomingUnknownTo)
                 .await
                 .unwrap();
-        assert!(contact_id > DC_CONTACT_ID_LAST_SPECIAL);
+        assert!(contact_id > ContactId::LAST_SPECIAL);
         assert_eq!(sth_modified, Modifier::Modified);
         let contact = Contact::load_from_db(&t, contact_id).await.unwrap();
         assert_eq!(contact.get_id(), contact_id);
@@ -1642,7 +1642,7 @@ mod tests {
             Contact::add_or_lookup(&t, "", "three@drei.sam", Origin::IncomingUnknownTo)
                 .await
                 .unwrap();
-        assert!(contact_id > DC_CONTACT_ID_LAST_SPECIAL);
+        assert!(contact_id > ContactId::LAST_SPECIAL);
         assert_eq!(sth_modified, Modifier::None);
         let contact = Contact::load_from_db(&t, contact_id).await.unwrap();
         assert_eq!(contact.get_name(), "");
@@ -1682,7 +1682,7 @@ mod tests {
             Contact::add_or_lookup(&t, "", "alice@w.de", Origin::IncomingUnknownTo)
                 .await
                 .unwrap();
-        assert!(contact_id > DC_CONTACT_ID_LAST_SPECIAL);
+        assert!(contact_id > ContactId::LAST_SPECIAL);
         assert_eq!(sth_modified, Modifier::None);
         let contact = Contact::load_from_db(&t, contact_id).await.unwrap();
         assert_eq!(contact.get_name(), "Wonderland, Alice");
@@ -1691,8 +1691,8 @@ mod tests {
         assert_eq!(contact.get_name_n_addr(), "Wonderland, Alice (alice@w.de)");
 
         // check SELF
-        let contact = Contact::load_from_db(&t, DC_CONTACT_ID_SELF).await.unwrap();
-        assert_eq!(DC_CONTACT_ID_SELF, ContactId::new(1));
+        let contact = Contact::load_from_db(&t, ContactId::SELF).await.unwrap();
+        assert_eq!(ContactId::SELF, ContactId::new(1));
         assert_eq!(contact.get_name(), stock_str::self_msg(&t).await);
         assert_eq!(contact.get_addr(), ""); // we're not configured
         assert!(!contact.is_blocked());
@@ -1702,7 +1702,7 @@ mod tests {
     async fn test_delete() -> Result<()> {
         let alice = TestContext::new_alice().await;
 
-        assert!(Contact::delete(&alice, DC_CONTACT_ID_SELF).await.is_err());
+        assert!(Contact::delete(&alice, ContactId::SELF).await.is_err());
 
         // Create Bob contact
         let (contact_id, _) =
@@ -1735,7 +1735,7 @@ mod tests {
             Contact::add_or_lookup(&t, "bob1", "bob@example.org", Origin::IncomingUnknownFrom)
                 .await
                 .unwrap();
-        assert!(contact_id > DC_CONTACT_ID_LAST_SPECIAL);
+        assert!(contact_id > ContactId::LAST_SPECIAL);
         assert_eq!(sth_modified, Modifier::Created);
         let contact = Contact::load_from_db(&t, contact_id).await.unwrap();
         assert_eq!(contact.get_authname(), "bob1");
@@ -1747,7 +1747,7 @@ mod tests {
             Contact::add_or_lookup(&t, "bob2", "bob@example.org", Origin::IncomingUnknownFrom)
                 .await
                 .unwrap();
-        assert!(contact_id > DC_CONTACT_ID_LAST_SPECIAL);
+        assert!(contact_id > ContactId::LAST_SPECIAL);
         assert_eq!(sth_modified, Modifier::Modified);
         let contact = Contact::load_from_db(&t, contact_id).await.unwrap();
         assert_eq!(contact.get_authname(), "bob2");
@@ -1758,7 +1758,7 @@ mod tests {
         let contact_id = Contact::create(&t, "bob3", "bob@example.org")
             .await
             .unwrap();
-        assert!(contact_id > DC_CONTACT_ID_LAST_SPECIAL);
+        assert!(contact_id > ContactId::LAST_SPECIAL);
         let contact = Contact::load_from_db(&t, contact_id).await.unwrap();
         assert_eq!(contact.get_authname(), "bob2");
         assert_eq!(contact.get_name(), "bob3");
@@ -1769,7 +1769,7 @@ mod tests {
             Contact::add_or_lookup(&t, "bob4", "bob@example.org", Origin::IncomingUnknownFrom)
                 .await
                 .unwrap();
-        assert!(contact_id > DC_CONTACT_ID_LAST_SPECIAL);
+        assert!(contact_id > ContactId::LAST_SPECIAL);
         assert_eq!(sth_modified, Modifier::Modified);
         let contact = Contact::load_from_db(&t, contact_id).await.unwrap();
         assert_eq!(contact.get_authname(), "bob4");
@@ -1783,7 +1783,7 @@ mod tests {
 
         // manually create "claire@example.org" without a given name
         let contact_id = Contact::create(&t, "", "claire@example.org").await.unwrap();
-        assert!(contact_id > DC_CONTACT_ID_LAST_SPECIAL);
+        assert!(contact_id > ContactId::LAST_SPECIAL);
         let contact = Contact::load_from_db(&t, contact_id).await.unwrap();
         assert_eq!(contact.get_authname(), "");
         assert_eq!(contact.get_name(), "");
@@ -1957,7 +1957,7 @@ mod tests {
         let id = Contact::lookup_id_by_addr(&alice.ctx, "alice@example.org", Origin::Unknown)
             .await
             .unwrap();
-        assert_eq!(id, Some(DC_CONTACT_ID_SELF));
+        assert_eq!(id, Some(ContactId::SELF));
     }
 
     #[async_std::test]
@@ -1965,9 +1965,9 @@ mod tests {
         let alice = TestContext::new_alice().await;
 
         // Return error for special IDs
-        let encrinfo = Contact::get_encrinfo(&alice, DC_CONTACT_ID_SELF).await;
+        let encrinfo = Contact::get_encrinfo(&alice, ContactId::SELF).await;
         assert!(encrinfo.is_err());
-        let encrinfo = Contact::get_encrinfo(&alice, DC_CONTACT_ID_DEVICE).await;
+        let encrinfo = Contact::get_encrinfo(&alice, ContactId::DEVICE).await;
         assert!(encrinfo.is_err());
 
         let (contact_bob_id, _modified) =

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1542,7 +1542,7 @@ mod tests {
             Origin::IncomingReplyTo,
         )
         .await?;
-        assert_ne!(id, ContactId::new(0));
+        assert_ne!(id, ContactId::UNDEFINED);
 
         let contact = Contact::load_from_db(&context.ctx, id).await.unwrap();
         assert_eq!(contact.get_name(), "");
@@ -1697,7 +1697,6 @@ mod tests {
 
         // check SELF
         let contact = Contact::load_from_db(&t, ContactId::SELF).await.unwrap();
-        assert_eq!(ContactId::SELF, ContactId::new(1));
         assert_eq!(contact.get_name(), stock_str::self_msg(&t).await);
         assert_eq!(contact.get_addr(), ""); // we're not configured
         assert!(!contact.is_blocked());

--- a/src/context.rs
+++ b/src/context.rs
@@ -670,7 +670,7 @@ mod tests {
     use crate::chat::{
         get_chat_contacts, get_chat_msgs, send_msg, set_muted, Chat, ChatId, MuteDuration,
     };
-    use crate::constants::DC_CONTACT_ID_SELF;
+    use crate::contact::ContactId;
     use crate::dc_receive_imf::dc_receive_imf;
     use crate::dc_tools::dc_create_outgoing_rfc724_mid;
     use crate::message::{Message, Viewtype};
@@ -956,7 +956,7 @@ mod tests {
     #[async_std::test]
     async fn test_search_msgs() -> Result<()> {
         let alice = TestContext::new_alice().await;
-        let self_talk = ChatId::create_for_contact(&alice, DC_CONTACT_ID_SELF).await?;
+        let self_talk = ChatId::create_for_contact(&alice, ContactId::SELF).await?;
         let chat = alice
             .create_chat_with_contact("Bob", "bob@example.org")
             .await;

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -277,7 +277,7 @@ pub(crate) async fn dc_receive_imf_inner(
     }
 
     if let Some(avatar_action) = &mime_parser.user_avatar {
-        if from_id != ContactId::new(0)
+        if from_id != ContactId::UNDEFINED
             && context
                 .update_contacts_timestamp(from_id, Param::AvatarTimestamp, sent_timestamp)
                 .await?
@@ -305,7 +305,7 @@ pub(crate) async fn dc_receive_imf_inner(
     // Ignore MDNs though, as they never contain the signature even if user has set it.
     if mime_parser.mdn_reports.is_empty()
         && is_partial_download.is_none()
-        && from_id != ContactId::new(0)
+        && from_id != ContactId::UNDEFINED
         && context
             .update_contacts_timestamp(from_id, Param::StatusTimestamp, sent_timestamp)
             .await?
@@ -417,7 +417,7 @@ pub async fn from_field_to_contact_id(
             "mail has an empty From header: {:?}", from_address_list
         );
 
-        Ok((ContactId::new(0), false, Origin::Unknown))
+        Ok((ContactId::UNDEFINED, false, Origin::Unknown))
     }
 }
 
@@ -524,7 +524,7 @@ async fn add_parts(
             securejoin_seen = false;
         }
 
-        let test_normal_chat = if from_id == ContactId::new(0) {
+        let test_normal_chat = if from_id == ContactId::UNDEFINED {
             Default::default()
         } else {
             ChatIdBlocked::lookup_by_contact(context, from_id).await?
@@ -1144,8 +1144,8 @@ INSERT INTO msgs
         stmt.execute(paramsv![
             rfc724_mid,
             chat_id,
-            if trash { ContactId::new(0) } else { from_id },
-            if trash { ContactId::new(0) } else { to_id },
+            if trash { ContactId::UNDEFINED } else { from_id },
+            if trash { ContactId::UNDEFINED } else { to_id },
             sort_timestamp,
             sent_timestamp,
             rcvd_timestamp,

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -13,9 +13,7 @@ use sha2::{Digest, Sha256};
 
 use crate::chat::{self, Chat, ChatId, ChatIdBlocked, ProtectionStatus};
 use crate::config::Config;
-use crate::constants::{
-    Blocked, Chattype, ShowEmails, DC_CHAT_ID_TRASH, DC_CONTACT_ID_LAST_SPECIAL, DC_CONTACT_ID_SELF,
-};
+use crate::constants::{Blocked, Chattype, ShowEmails, DC_CHAT_ID_TRASH};
 use crate::contact;
 use crate::contact::{
     addr_cmp, may_be_valid_addr, normalize_name, Contact, ContactId, Origin, VerifiedStatus,
@@ -180,7 +178,7 @@ pub(crate) async fn dc_receive_imf_inner(
     let (from_id, _from_id_blocked, incoming_origin) =
         from_field_to_contact_id(context, &mime_parser.from, prevent_rename).await?;
 
-    let incoming = from_id != DC_CONTACT_ID_SELF;
+    let incoming = from_id != ContactId::SELF;
 
     let to_ids = dc_add_or_lookup_contacts_by_address_list(
         context,
@@ -222,7 +220,7 @@ pub(crate) async fn dc_receive_imf_inner(
     .await
     .context("add_parts error")?;
 
-    if from_id > DC_CONTACT_ID_LAST_SPECIAL {
+    if from_id > ContactId::LAST_SPECIAL {
         contact::update_last_seen(context, from_id, sent_timestamp).await?;
     }
 
@@ -256,7 +254,7 @@ pub(crate) async fn dc_receive_imf_inner(
     save_locations(context, &mime_parser, chat_id, from_id, insert_msg_id).await?;
 
     if let Some(ref sync_items) = mime_parser.sync_items {
-        if from_id == DC_CONTACT_ID_SELF {
+        if from_id == ContactId::SELF {
             if mime_parser.was_encrypted() {
                 if let Err(err) = context.execute_sync_items(sync_items).await {
                     warn!(context, "receive_imf cannot execute sync items: {}", err);
@@ -395,8 +393,8 @@ pub async fn from_field_to_contact_id(
     )
     .await?;
 
-    if from_ids.contains(&DC_CONTACT_ID_SELF) {
-        Ok((DC_CONTACT_ID_SELF, false, Origin::OutgoingBcc))
+    if from_ids.contains(&ContactId::SELF) {
+        Ok((ContactId::SELF, false, Origin::OutgoingBcc))
     } else if !from_ids.is_empty() {
         if from_ids.len() > 1 {
             warn!(
@@ -494,7 +492,7 @@ async fn add_parts(
     let state: MessageState;
     let mut needs_delete_job = false;
     if incoming {
-        to_id = DC_CONTACT_ID_SELF;
+        to_id = ContactId::SELF;
 
         // Whether the message is a part of securejoin handshake that should be marked as seen
         // automatically.
@@ -668,7 +666,7 @@ async fn add_parts(
 
         if chat_id.is_none() {
             // try to create a normal chat
-            let create_blocked = if from_id == DC_CONTACT_ID_SELF {
+            let create_blocked = if from_id == ContactId::SELF {
                 Blocked::Not
             } else {
                 Blocked::Request
@@ -720,9 +718,8 @@ async fn add_parts(
         state = MessageState::OutDelivered;
         to_id = to_ids.get(0).cloned().unwrap_or_default();
 
-        let self_sent = from_id == DC_CONTACT_ID_SELF
-            && to_ids.len() == 1
-            && to_ids.contains(&DC_CONTACT_ID_SELF);
+        let self_sent =
+            from_id == ContactId::SELF && to_ids.len() == 1 && to_ids.contains(&ContactId::SELF);
 
         // handshake may mark contacts as verified and must be processed before chats are created
         if mime_parser.get_header(HeaderDef::SecureJoin).is_some() {
@@ -836,12 +833,11 @@ async fn add_parts(
         }
 
         if chat_id.is_none() && self_sent {
-            // from_id==to_id==DC_CONTACT_ID_SELF - this is a self-sent messages,
+            // from_id==to_id==ContactId::SELF - this is a self-sent messages,
             // maybe an Autocrypt Setup Message
-            if let Ok(chat) =
-                ChatIdBlocked::get_for_contact(context, DC_CONTACT_ID_SELF, Blocked::Not)
-                    .await
-                    .log_err(context, "Failed to get (new) chat for contact")
+            if let Ok(chat) = ChatIdBlocked::get_for_contact(context, ContactId::SELF, Blocked::Not)
+                .await
+                .log_err(context, "Failed to get (new) chat for contact")
             {
                 chat_id = Some(chat.id);
                 chat_id_blocked = chat.blocked;
@@ -1375,14 +1371,14 @@ async fn is_probably_private_reply(
     // contain a Chat-Group-Id header and can be sorted into the correct chat this way.
 
     let private_message =
-        (to_ids == [DC_CONTACT_ID_SELF]) || (from_id == DC_CONTACT_ID_SELF && to_ids.len() == 1);
+        (to_ids == [ContactId::SELF]) || (from_id == ContactId::SELF && to_ids.len() == 1);
     if !private_message {
         return Ok(false);
     }
 
     if !mime_parser.has_chat_version() {
         let chat_contacts = chat::get_chat_contacts(context, parent_chat_id).await?;
-        if chat_contacts.len() == 2 && chat_contacts.contains(&DC_CONTACT_ID_SELF) {
+        if chat_contacts.len() == 2 && chat_contacts.contains(&ContactId::SELF) {
             return Ok(false);
         }
     }
@@ -1410,8 +1406,8 @@ async fn create_or_lookup_group(
         if !member_ids.contains(&(from_id)) {
             member_ids.push(from_id);
         }
-        if !member_ids.contains(&(DC_CONTACT_ID_SELF)) {
-            member_ids.push(DC_CONTACT_ID_SELF);
+        if !member_ids.contains(&(ContactId::SELF)) {
+            member_ids.push(ContactId::SELF);
         }
 
         let res = create_adhoc_group(context, mime_parser, create_blocked, &member_ids)
@@ -1492,8 +1488,8 @@ async fn create_or_lookup_group(
         chat_id_blocked = create_blocked;
 
         // Create initial member list.
-        chat::add_to_chat_contacts_table(context, new_chat_id, DC_CONTACT_ID_SELF).await?;
-        if from_id > DC_CONTACT_ID_LAST_SPECIAL
+        chat::add_to_chat_contacts_table(context, new_chat_id, ContactId::SELF).await?;
+        if from_id > ContactId::LAST_SPECIAL
             && !chat::is_contact_in_chat(context, new_chat_id, from_id).await?
         {
             chat::add_to_chat_contacts_table(context, new_chat_id, from_id).await?;
@@ -1647,7 +1643,7 @@ async fn apply_group_changes(
 
     // add members to group/check members
     if recreate_member_list {
-        if chat::is_contact_in_chat(context, chat_id, DC_CONTACT_ID_SELF).await?
+        if chat::is_contact_in_chat(context, chat_id, ContactId::SELF).await?
             && !chat::is_contact_in_chat(context, chat_id, from_id).await?
         {
             warn!(
@@ -1661,7 +1657,7 @@ async fn apply_group_changes(
             .await?
         {
             if removed_id.is_some()
-                || !chat::is_contact_in_chat(context, chat_id, DC_CONTACT_ID_SELF).await?
+                || !chat::is_contact_in_chat(context, chat_id, ContactId::SELF).await?
             {
                 // Members could have been removed while we were
                 // absent. We can't use existing member list and need to
@@ -1674,11 +1670,11 @@ async fn apply_group_changes(
                     )
                     .await?;
 
-                if removed_id != Some(DC_CONTACT_ID_SELF) {
-                    chat::add_to_chat_contacts_table(context, chat_id, DC_CONTACT_ID_SELF).await?;
+                if removed_id != Some(ContactId::SELF) {
+                    chat::add_to_chat_contacts_table(context, chat_id, ContactId::SELF).await?;
                 }
             }
-            if from_id > DC_CONTACT_ID_LAST_SPECIAL
+            if from_id > ContactId::LAST_SPECIAL
                 && !Contact::addr_equals_contact(context, &self_addr, from_id).await?
                 && !chat::is_contact_in_chat(context, chat_id, from_id).await?
                 && removed_id != Some(from_id)
@@ -1699,7 +1695,7 @@ async fn apply_group_changes(
     }
 
     if let Some(avatar_action) = &mime_parser.group_avatar {
-        if !chat::is_contact_in_chat(context, chat_id, DC_CONTACT_ID_SELF).await? {
+        if !chat::is_contact_in_chat(context, chat_id, ContactId::SELF).await? {
             warn!(
                 context,
                 "Received group avatar update for group chat {} we are not a member of.", chat_id
@@ -1849,7 +1845,7 @@ async fn create_or_lookup_mailinglist(
             )
         })?;
 
-        chat::add_to_chat_contacts_table(context, chat_id, DC_CONTACT_ID_SELF).await?;
+        chat::add_to_chat_contacts_table(context, chat_id, ContactId::SELF).await?;
         Ok(Some((chat_id, Blocked::Request)))
     } else {
         info!(context, "creating list forbidden by caller");
@@ -2015,7 +2011,7 @@ async fn create_adhoc_grp_id(context: &Context, member_ids: &[ContactId]) -> Res
     );
     let mut params = Vec::new();
     params.extend_from_slice(member_ids);
-    params.push(DC_CONTACT_ID_SELF);
+    params.push(ContactId::SELF);
 
     let members = context
         .sql
@@ -2071,7 +2067,7 @@ async fn check_verified_properties(
     // and the message is signed with a verified key of the sender.
     // this check is skipped for SELF as there is no proper SELF-peerstate
     // and results in group-splits otherwise.
-    if from_id != DC_CONTACT_ID_SELF {
+    if from_id != ContactId::SELF {
         let peerstate = Peerstate::from_addr(context, contact.get_addr()).await?;
 
         if peerstate.is_none()
@@ -2096,7 +2092,7 @@ async fn check_verified_properties(
     let to_ids = to_ids
         .iter()
         .copied()
-        .filter(|id| *id != DC_CONTACT_ID_SELF)
+        .filter(|id| *id != ContactId::SELF)
         .collect::<Vec<ContactId>>();
 
     if to_ids.is_empty() {
@@ -2291,7 +2287,7 @@ async fn add_or_lookup_contact_by_addr(
     origin: Origin,
 ) -> Result<ContactId> {
     if context.is_self_addr(addr).await? {
-        return Ok(DC_CONTACT_ID_SELF);
+        return Ok(ContactId::SELF);
     }
     let display_name_normalized = display_name.map(normalize_name).unwrap_or_default();
 
@@ -2311,7 +2307,7 @@ mod tests {
     use crate::chat::get_chat_contacts;
     use crate::chat::{get_chat_msgs, ChatItem, ChatVisibility};
     use crate::chatlist::Chatlist;
-    use crate::constants::{DC_CONTACT_ID_INFO, DC_GCL_NO_SPECIALS};
+    use crate::constants::DC_GCL_NO_SPECIALS;
     use crate::message::Message;
     use crate::test_utils::{get_chat_msg, TestContext, TestContextManager};
 
@@ -2959,7 +2955,7 @@ mod tests {
             last_msg.text,
             Some(stock_str::failed_sending_to(&t, "assidhfaaspocwaeofi@gmail.com").await,)
         );
-        assert_eq!(last_msg.from_id, DC_CONTACT_ID_INFO);
+        assert_eq!(last_msg.from_id, ContactId::INFO);
         Ok(())
     }
 
@@ -4901,7 +4897,7 @@ Hi, I created a group"#,
         )
         .await?;
         let msg_out = t.get_last_msg().await;
-        assert_eq!(msg_out.from_id, DC_CONTACT_ID_SELF);
+        assert_eq!(msg_out.from_id, ContactId::SELF);
         assert_eq!(msg_out.text.unwrap(), "Hi, I created a group");
         assert_eq!(msg_out.in_reply_to, None);
 
@@ -4926,7 +4922,7 @@ Reply from different address
         )
         .await?;
         let msg_in = t.get_last_msg().await;
-        assert_eq!(msg_in.to_id, DC_CONTACT_ID_SELF);
+        assert_eq!(msg_in.to_id, ContactId::SELF);
         assert_eq!(msg_in.text.unwrap(), "Reply from different address");
         assert_eq!(
             msg_in.in_reply_to.unwrap(),
@@ -5077,7 +5073,7 @@ Reply from different address
         let received = alice1.get_last_msg().await;
         let alice1_bob_contact = alice1.add_or_lookup_contact(&bob).await;
         assert_eq!(received.from_id, alice1_bob_contact.id);
-        assert_eq!(received.to_id, DC_CONTACT_ID_SELF);
+        assert_eq!(received.to_id, ContactId::SELF);
         assert!(!received.hidden);
         assert_eq!(received.text, Some("Hello all!".to_string()));
         assert_eq!(received.in_reply_to, None);
@@ -5104,7 +5100,7 @@ Reply from different address
         assert_eq!(received.chat_id, alice2.get_chat(&bob).await.unwrap().id);
 
         let alice2_bob_contact = alice2.add_or_lookup_contact(&bob).await;
-        assert_eq!(received.from_id, DC_CONTACT_ID_SELF);
+        assert_eq!(received.from_id, ContactId::SELF);
         assert_eq!(received.to_id, alice2_bob_contact.id);
         assert!(!received.hidden);
         assert_eq!(received.text, Some("Private reply".to_string()));

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -66,9 +66,7 @@ use async_std::task;
 use serde::{Deserialize, Serialize};
 
 use crate::chat::{send_msg, ChatId};
-use crate::constants::{
-    DC_CHAT_ID_LAST_SPECIAL, DC_CHAT_ID_TRASH, DC_CONTACT_ID_DEVICE, DC_CONTACT_ID_SELF,
-};
+use crate::constants::{DC_CHAT_ID_LAST_SPECIAL, DC_CHAT_ID_TRASH};
 use crate::contact::ContactId;
 use crate::context::Context;
 use crate::dc_tools::time;
@@ -198,7 +196,7 @@ impl ChatId {
         }
         self.inner_set_ephemeral_timer(context, timer).await?;
         let mut msg = Message::new(Viewtype::Text);
-        msg.text = Some(stock_ephemeral_timer_changed(context, timer, DC_CONTACT_ID_SELF).await);
+        msg.text = Some(stock_ephemeral_timer_changed(context, timer, ContactId::SELF).await);
         msg.param.set_cmd(SystemMessage::EphemeralTimerChanged);
         if let Err(err) = send_msg(context, self, &mut msg).await {
             error!(
@@ -361,10 +359,10 @@ WHERE
         > 0;
 
     if let Some(delete_device_after) = context.get_config_delete_device_after().await? {
-        let self_chat_id = ChatId::lookup_by_contact(context, DC_CONTACT_ID_SELF)
+        let self_chat_id = ChatId::lookup_by_contact(context, ContactId::SELF)
             .await?
             .unwrap_or_default();
-        let device_chat_id = ChatId::lookup_by_contact(context, DC_CONTACT_ID_DEVICE)
+        let device_chat_id = ChatId::lookup_by_contact(context, ContactId::DEVICE)
             .await?
             .unwrap_or_default();
 
@@ -545,7 +543,7 @@ mod tests {
         let context = TestContext::new().await;
 
         assert_eq!(
-            stock_ephemeral_timer_changed(&context, Timer::Disabled, DC_CONTACT_ID_SELF).await,
+            stock_ephemeral_timer_changed(&context, Timer::Disabled, ContactId::SELF).await,
             "Message deletion timer is disabled by me."
         );
 
@@ -553,7 +551,7 @@ mod tests {
             stock_ephemeral_timer_changed(
                 &context,
                 Timer::Enabled { duration: 1 },
-                DC_CONTACT_ID_SELF
+                ContactId::SELF
             )
             .await,
             "Message deletion timer is set to 1 s by me."
@@ -562,7 +560,7 @@ mod tests {
             stock_ephemeral_timer_changed(
                 &context,
                 Timer::Enabled { duration: 30 },
-                DC_CONTACT_ID_SELF
+                ContactId::SELF
             )
             .await,
             "Message deletion timer is set to 30 s by me."
@@ -571,7 +569,7 @@ mod tests {
             stock_ephemeral_timer_changed(
                 &context,
                 Timer::Enabled { duration: 60 },
-                DC_CONTACT_ID_SELF
+                ContactId::SELF
             )
             .await,
             "Message deletion timer is set to 1 minute by me."
@@ -580,7 +578,7 @@ mod tests {
             stock_ephemeral_timer_changed(
                 &context,
                 Timer::Enabled { duration: 90 },
-                DC_CONTACT_ID_SELF
+                ContactId::SELF
             )
             .await,
             "Message deletion timer is set to 1.5 minutes by me."
@@ -589,7 +587,7 @@ mod tests {
             stock_ephemeral_timer_changed(
                 &context,
                 Timer::Enabled { duration: 30 * 60 },
-                DC_CONTACT_ID_SELF
+                ContactId::SELF
             )
             .await,
             "Message deletion timer is set to 30 minutes by me."
@@ -598,7 +596,7 @@ mod tests {
             stock_ephemeral_timer_changed(
                 &context,
                 Timer::Enabled { duration: 60 * 60 },
-                DC_CONTACT_ID_SELF
+                ContactId::SELF
             )
             .await,
             "Message deletion timer is set to 1 hour by me."
@@ -607,7 +605,7 @@ mod tests {
             stock_ephemeral_timer_changed(
                 &context,
                 Timer::Enabled { duration: 5400 },
-                DC_CONTACT_ID_SELF
+                ContactId::SELF
             )
             .await,
             "Message deletion timer is set to 1.5 hours by me."
@@ -618,7 +616,7 @@ mod tests {
                 Timer::Enabled {
                     duration: 2 * 60 * 60
                 },
-                DC_CONTACT_ID_SELF
+                ContactId::SELF
             )
             .await,
             "Message deletion timer is set to 2 hours by me."
@@ -629,7 +627,7 @@ mod tests {
                 Timer::Enabled {
                     duration: 24 * 60 * 60
                 },
-                DC_CONTACT_ID_SELF
+                ContactId::SELF
             )
             .await,
             "Message deletion timer is set to 1 day by me."
@@ -640,7 +638,7 @@ mod tests {
                 Timer::Enabled {
                     duration: 2 * 24 * 60 * 60
                 },
-                DC_CONTACT_ID_SELF
+                ContactId::SELF
             )
             .await,
             "Message deletion timer is set to 2 days by me."
@@ -651,7 +649,7 @@ mod tests {
                 Timer::Enabled {
                     duration: 7 * 24 * 60 * 60
                 },
-                DC_CONTACT_ID_SELF
+                ContactId::SELF
             )
             .await,
             "Message deletion timer is set to 1 week by me."
@@ -662,7 +660,7 @@ mod tests {
                 Timer::Enabled {
                     duration: 4 * 7 * 24 * 60 * 60
                 },
-                DC_CONTACT_ID_SELF
+                ContactId::SELF
             )
             .await,
             "Message deletion timer is set to 4 weeks by me."

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -855,8 +855,8 @@ mod tests {
 
         // Check that if there is a message left, the text and metadata are gone
         if let Ok(msg) = Message::load_from_db(t, msg_id).await {
-            assert_eq!(msg.from_id, ContactId::new(0));
-            assert_eq!(msg.to_id, ContactId::new(0));
+            assert_eq!(msg.from_id, ContactId::UNDEFINED);
+            assert_eq!(msg.to_id, ContactId::UNDEFINED);
             assert!(msg.text.is_none_or_empty(), "{:?}", msg.text);
             let rawtxt: Option<String> = t
                 .sql

--- a/src/html.rs
+++ b/src/html.rs
@@ -279,7 +279,7 @@ mod tests {
     use crate::chat;
     use crate::chat::forward_msgs;
     use crate::config::Config;
-    use crate::constants::DC_CONTACT_ID_SELF;
+    use crate::contact::ContactId;
     use crate::dc_receive_imf::dc_receive_imf;
     use crate::message::{MessengerMessage, Viewtype};
     use crate::test_utils::TestContext;
@@ -442,7 +442,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         let raw = include_bytes!("../test-data/message/text_alt_plain_html.eml");
         dc_receive_imf(&alice, raw, "INBOX", false).await.unwrap();
         let msg = alice.get_last_msg_in(chat.get_id()).await;
-        assert_ne!(msg.get_from_id(), DC_CONTACT_ID_SELF);
+        assert_ne!(msg.get_from_id(), ContactId::SELF);
         assert_eq!(msg.is_dc_message, MessengerMessage::No);
         assert!(!msg.is_forwarded());
         assert!(msg.get_text().unwrap().contains("this is plain"));
@@ -456,7 +456,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
             .await
             .unwrap();
         let msg = alice.get_last_msg_in(chat.get_id()).await;
-        assert_eq!(msg.get_from_id(), DC_CONTACT_ID_SELF);
+        assert_eq!(msg.get_from_id(), ContactId::SELF);
         assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
         assert!(msg.is_forwarded());
         assert!(msg.get_text().unwrap().contains("this is plain"));
@@ -469,7 +469,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         let chat = bob.create_chat_with_contact("", "alice@example.org").await;
         bob.recv_msg(&alice.pop_sent_msg().await).await;
         let msg = bob.get_last_msg_in(chat.get_id()).await;
-        assert_ne!(msg.get_from_id(), DC_CONTACT_ID_SELF);
+        assert_ne!(msg.get_from_id(), ContactId::SELF);
         assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
         assert!(msg.is_forwarded());
         assert!(msg.get_text().unwrap().contains("this is plain"));
@@ -506,7 +506,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         alice.recv_msg(&msg).await;
         let chat = alice.get_self_chat().await;
         let msg = alice.get_last_msg_in(chat.get_id()).await;
-        assert_eq!(msg.get_from_id(), DC_CONTACT_ID_SELF);
+        assert_eq!(msg.get_from_id(), ContactId::SELF);
         assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
         assert!(msg.get_showpadlock());
         assert!(msg.is_forwarded());

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -20,9 +20,10 @@ use num_traits::FromPrimitive;
 use crate::chat::{self, ChatId, ChatIdBlocked};
 use crate::config::Config;
 use crate::constants::{
-    Blocked, Chattype, ShowEmails, DC_CONTACT_ID_SELF, DC_FETCH_EXISTING_MSGS_COUNT,
-    DC_FOLDERS_CONFIGURED_VERSION, DC_LP_AUTH_OAUTH2,
+    Blocked, Chattype, ShowEmails, DC_FETCH_EXISTING_MSGS_COUNT, DC_FOLDERS_CONFIGURED_VERSION,
+    DC_LP_AUTH_OAUTH2,
 };
+use crate::contact::ContactId;
 use crate::context::Context;
 use crate::dc_receive_imf::{
     dc_receive_imf_inner, from_field_to_contact_id, get_prefetch_parent_message, ReceivedMsg,
@@ -1639,7 +1640,7 @@ async fn should_move_out_of_spam(
             if chat_id_blocked.blocked != Blocked::Not {
                 return Ok(false);
             }
-        } else if from_id != DC_CONTACT_ID_SELF {
+        } else if from_id != ContactId::SELF {
             // No chat with this contact found.
             return Ok(false);
         }

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -16,7 +16,7 @@ use rand::{thread_rng, Rng};
 use crate::blob::BlobObject;
 use crate::chat::{self, delete_and_reset_all_device_msgs, ChatId};
 use crate::config::Config;
-use crate::constants::DC_CONTACT_ID_SELF;
+use crate::contact::ContactId;
 use crate::context::Context;
 use crate::dc_tools::{
     dc_create_folder, dc_delete_file, dc_delete_files_in_dir, dc_get_filesuffix_lc,
@@ -176,7 +176,7 @@ async fn do_initiate_key_transfer(context: &Context) -> Result<String> {
     )
     .await?;
 
-    let chat_id = ChatId::create_for_contact(context, DC_CONTACT_ID_SELF).await?;
+    let chat_id = ChatId::create_for_contact(context, ContactId::SELF).await?;
     let mut msg = Message {
         viewtype: Viewtype::File,
         ..Default::default()

--- a/src/location.rs
+++ b/src/location.rs
@@ -7,7 +7,6 @@ use quick_xml::events::{BytesEnd, BytesStart, BytesText};
 
 use crate::chat::{self, ChatId};
 use crate::config::Config;
-use crate::constants::DC_CONTACT_ID_SELF;
 use crate::contact::ContactId;
 use crate::context::Context;
 use crate::dc_tools::time;
@@ -315,7 +314,7 @@ pub async fn set(context: &Context, latitude: f64, longitude: f64, accuracy: f64
                         accuracy,
                         time(),
                         chat_id,
-                        DC_CONTACT_ID_SELF,
+                        ContactId::SELF,
                     ]
             ).await {
                 warn!(context, "failed to store location {:?}", err);
@@ -324,7 +323,7 @@ pub async fn set(context: &Context, latitude: f64, longitude: f64, accuracy: f64
             }
         }
         if continue_streaming {
-            context.emit_event(EventType::LocationChanged(Some(DC_CONTACT_ID_SELF)));
+            context.emit_event(EventType::LocationChanged(Some(ContactId::SELF)));
         };
         schedule_maybe_send_locations(context, false).await.ok();
     }
@@ -463,10 +462,10 @@ pub async fn get_kml(context: &Context, chat_id: ChatId) -> Result<(String, u32)
              GROUP BY timestamp \
              ORDER BY timestamp;",
                 paramsv![
-                    DC_CONTACT_ID_SELF,
+                    ContactId::SELF,
                     locations_send_begin,
                     locations_last_sent,
-                    DC_CONTACT_ID_SELF
+                    ContactId::SELF
                 ],
                 |row| {
                     let location_id: i32 = row.get(0)?;
@@ -667,7 +666,7 @@ pub(crate) async fn job_maybe_send_locations(context: &Context, _job: &Job) -> j
             for (chat_id, locations_send_begin, locations_last_sent) in &rows {
                 if !stmt_locations
                     .exists(paramsv![
-                        DC_CONTACT_ID_SELF,
+                        ContactId::SELF,
                         *locations_send_begin,
                         *locations_last_sent,
                     ])

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -711,7 +711,7 @@ mod tests {
             ..
         } = qr
         {
-            assert_ne!(contact_id, ContactId::new(0));
+            assert_ne!(contact_id, ContactId::UNDEFINED);
             assert_eq!(grpname, "test ? test !");
         } else {
             bail!("Wrong QR code type");
@@ -729,7 +729,7 @@ mod tests {
             ..
         } = qr
         {
-            assert_ne!(contact_id, ContactId::new(0));
+            assert_ne!(contact_id, ContactId::UNDEFINED);
             assert_eq!(grpname, "test ? test !");
 
             let contact = Contact::get_by_id(&ctx.ctx, contact_id).await?;
@@ -751,7 +751,7 @@ mod tests {
         ).await?;
 
         if let Qr::AskVerifyContact { contact_id, .. } = qr {
-            assert_ne!(contact_id, ContactId::new(0));
+            assert_ne!(contact_id, ContactId::UNDEFINED);
         } else {
             bail!("Wrong QR code type");
         }

--- a/src/qr_code_generator.rs
+++ b/src/qr_code_generator.rs
@@ -6,8 +6,7 @@ use crate::{
     chat::{Chat, ChatId},
     color::color_int_to_hex_string,
     config::Config,
-    constants::DC_CONTACT_ID_SELF,
-    contact::Contact,
+    contact::{Contact, ContactId},
     context::Context,
     securejoin, stock_str,
 };
@@ -41,7 +40,7 @@ async fn generate_join_group_qr_code(context: &Context, chat_id: ChatId) -> Resu
 }
 
 async fn generate_verification_qr(context: &Context) -> Result<String> {
-    let contact = Contact::get_by_id(context, DC_CONTACT_ID_SELF).await?;
+    let contact = Contact::get_by_id(context, ContactId::SELF).await?;
 
     let avatar = match contact.get_profile_image(context).await? {
         Some(path) => {

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -8,7 +8,7 @@ use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use crate::aheader::EncryptPreference;
 use crate::chat::{self, Chat, ChatId, ChatIdBlocked};
 use crate::config::Config;
-use crate::constants::{Blocked, DC_CONTACT_ID_LAST_SPECIAL};
+use crate::constants::Blocked;
 use crate::contact::{Contact, ContactId, Origin, VerifiedStatus};
 use crate::context::Context;
 use crate::dc_tools::time;
@@ -310,7 +310,7 @@ pub(crate) async fn handle_securejoin_handshake(
     mime_message: &MimeMessage,
     contact_id: ContactId,
 ) -> Result<HandshakeMessage> {
-    if contact_id <= DC_CONTACT_ID_LAST_SPECIAL {
+    if contact_id <= ContactId::LAST_SPECIAL {
         return Err(Error::msg("Can not be called with special contact ID"));
     }
     let step = mime_message
@@ -573,7 +573,7 @@ pub(crate) async fn observe_securejoin_on_other_device(
     mime_message: &MimeMessage,
     contact_id: ContactId,
 ) -> Result<HandshakeMessage> {
-    if contact_id <= DC_CONTACT_ID_LAST_SPECIAL {
+    if contact_id <= ContactId::LAST_SPECIAL {
         return Err(Error::msg("Can not be called with special contact ID"));
     }
     let step = mime_message

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -310,7 +310,7 @@ pub(crate) async fn handle_securejoin_handshake(
     mime_message: &MimeMessage,
     contact_id: ContactId,
 ) -> Result<HandshakeMessage> {
-    if contact_id <= ContactId::LAST_SPECIAL {
+    if contact_id.is_special() {
         return Err(Error::msg("Can not be called with special contact ID"));
     }
     let step = mime_message
@@ -573,7 +573,7 @@ pub(crate) async fn observe_securejoin_on_other_device(
     mime_message: &MimeMessage,
     contact_id: ContactId,
 ) -> Result<HandshakeMessage> {
-    if contact_id <= ContactId::LAST_SPECIAL {
+    if contact_id.is_special() {
         return Err(Error::msg("Can not be called with special contact ID"));
     }
     let step = mime_message

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -10,7 +10,6 @@ use strum_macros::EnumProperty;
 use crate::blob::BlobObject;
 use crate::chat::{self, Chat, ChatId, ProtectionStatus};
 use crate::config::Config;
-use crate::constants::DC_CONTACT_ID_SELF;
 use crate::contact::{Contact, ContactId, Origin};
 use crate::context::Context;
 use crate::dc_tools::dc_timestamp_to_str;
@@ -397,7 +396,7 @@ trait StockStringMods: AsRef<str> + Sized {
         Box::pin(async move {
             let message = self.as_ref().trim_end_matches('.');
             match contact_id {
-                DC_CONTACT_ID_SELF => msg_action_by_me(context, message).await,
+                ContactId::SELF => msg_action_by_me(context, message).await,
                 _ => {
                     let displayname = Contact::get_by_id(context, contact_id)
                         .await
@@ -1129,7 +1128,7 @@ impl Context {
             self.sql
                 .set_raw_config_bool("self-chat-added", true)
                 .await?;
-            ChatId::create_for_contact(self, DC_CONTACT_ID_SELF).await?;
+            ChatId::create_for_contact(self, ContactId::SELF).await?;
         }
 
         // add welcome-messages. by the label, this is done only once,
@@ -1149,14 +1148,13 @@ impl Context {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test_utils::TestContext;
-
-    use crate::constants::DC_CONTACT_ID_SELF;
+    use num_traits::ToPrimitive;
 
     use crate::chat::Chat;
     use crate::chatlist::Chatlist;
-    use num_traits::ToPrimitive;
+    use crate::test_utils::TestContext;
+
+    use super::*;
 
     #[test]
     fn test_enum_mapping() {
@@ -1233,7 +1231,7 @@ mod tests {
     async fn test_stock_system_msg_add_member_by_me() {
         let t = TestContext::new().await;
         assert_eq!(
-            msg_add_member(&t, "alice@example.org", DC_CONTACT_ID_SELF).await,
+            msg_add_member(&t, "alice@example.org", ContactId::SELF).await,
             "Member alice@example.org added by me."
         )
     }
@@ -1245,7 +1243,7 @@ mod tests {
             .await
             .expect("failed to create contact");
         assert_eq!(
-            msg_add_member(&t, "alice@example.org", DC_CONTACT_ID_SELF).await,
+            msg_add_member(&t, "alice@example.org", ContactId::SELF).await,
             "Member Alice (alice@example.org) added by me."
         );
     }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -1,8 +1,8 @@
 //! # Message summary for chatlist.
 
 use crate::chat::Chat;
-use crate::constants::{Chattype, DC_CONTACT_ID_SELF};
-use crate::contact::Contact;
+use crate::constants::Chattype;
+use crate::contact::{Contact, ContactId};
 use crate::context::Context;
 use crate::dc_tools::dc_truncate;
 use crate::message::{Message, MessageState, Viewtype};
@@ -60,7 +60,7 @@ impl Summary {
     ) -> Self {
         let prefix = if msg.state == MessageState::OutDraft {
             Some(SummaryPrefix::Draft(stock_str::draft(context).await))
-        } else if msg.from_id == DC_CONTACT_ID_SELF {
+        } else if msg.from_id == ContactId::SELF {
             if msg.is_info() || chat.is_self_talk() {
                 None
             } else {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -2,7 +2,8 @@
 
 use crate::chat::{Chat, ChatId};
 use crate::config::Config;
-use crate::constants::{Blocked, DC_CONTACT_ID_SELF};
+use crate::constants::Blocked;
+use crate::contact::ContactId;
 use crate::context::Context;
 use crate::dc_tools::time;
 use crate::message::{Message, MsgId, Viewtype};
@@ -126,7 +127,7 @@ impl Context {
     pub async fn send_sync_msg(&self) -> Result<Option<MsgId>> {
         if let Some((json, ids)) = self.build_sync_json().await? {
             let chat_id =
-                ChatId::create_for_contact_with_blocked(self, DC_CONTACT_ID_SELF, Blocked::Yes)
+                ChatId::create_for_contact_with_blocked(self, ContactId::SELF, Blocked::Yes)
                     .await?;
             let mut msg = Message {
                 chat_id,
@@ -483,7 +484,7 @@ mod tests {
         // check that the used self-talk is not visible to the user
         // but that creation will still work (in this case, the chat is empty)
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 0);
-        let chat_id = ChatId::create_for_contact(&alice, DC_CONTACT_ID_SELF).await?;
+        let chat_id = ChatId::create_for_contact(&alice, ContactId::SELF).await?;
         let chat = Chat::load_from_db(&alice, chat_id).await?;
         assert!(chat.is_self_talk());
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 1);

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -22,8 +22,8 @@ use crate::chat::{self, Chat, ChatId};
 use crate::chatlist::Chatlist;
 use crate::config::Config;
 use crate::constants::Chattype;
-use crate::constants::{DC_CONTACT_ID_SELF, DC_MSG_ID_DAYMARKER, DC_MSG_ID_MARKER1};
-use crate::contact::{Contact, Modifier, Origin};
+use crate::constants::{DC_MSG_ID_DAYMARKER, DC_MSG_ID_MARKER1};
+use crate::contact::{Contact, ContactId, Modifier, Origin};
 use crate::context::Context;
 use crate::dc_receive_imf::dc_receive_imf;
 use crate::dc_tools::EmailAddress;
@@ -466,7 +466,7 @@ impl TestContext {
 
     /// Retrieves the "self" chat.
     pub async fn get_self_chat(&self) -> Chat {
-        let chat_id = ChatId::create_for_contact(self, DC_CONTACT_ID_SELF)
+        let chat_id = ChatId::create_for_contact(self, ContactId::SELF)
             .await
             .unwrap();
         Chat::load_from_db(self, chat_id).await.unwrap()
@@ -851,7 +851,7 @@ async fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
         &contact_name,
         contact_id,
         msgtext.unwrap_or_default(),
-        if msg.get_from_id() == DC_CONTACT_ID_SELF {
+        if msg.get_from_id() == ContactId::SELF {
             ""
         } else if msg.get_state() == MessageState::InSeen {
             "[SEEN]"


### PR DESCRIPTION
This tidies up the ContactId API a bit more:

- Move the constants to be associated with ContactId itself.

- Do not expose to the entire application that they are ordered and
  treat them as opaque.  Introduces the ContactId.is_special() method
  which also exists on most of our other IDs.
  Main downside here is the need to switch to HashSet from a BTreeSet
  in one location.
  
- Replace a few ContactId::new() calls directly with their constants.

#skip-changelog