### PR TITLE
Send setup-changed messages only in the chats we share with the peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Assign replies from a different email address to the correct chat #3119
 - Assing outgoing private replies to the correct chat #3177
 - start ephemeral timer when seen status is synchronized via IMAP #3122
+- Don't create empty contact requests with "setup changed" messages; instead, send a
+  "setup changed" message into all chats we share with the peer #3187
 - do not delete duplicate messages on IMAP immediately to accidentally deleting
   the last copy #3138
 - speed up loading of chat messages #3171

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -445,6 +445,7 @@ impl ChatId {
                 cmd,
                 dc_create_smeared_timestamp(context).await,
                 None,
+                None,
             )
             .await?;
         }
@@ -3384,7 +3385,9 @@ pub(crate) async fn add_info_msg_with_cmd(
     chat_id: ChatId,
     text: &str,
     cmd: SystemMessage,
-    timestamp: i64,
+    timestamp_sort: i64,
+    // Timestamp to show to the user (if this is None, `timestamp_sort` will be shown to the user)
+    timestamp_sent_rcvd: Option<i64>,
     parent: Option<&Message>,
 ) -> Result<MsgId> {
     let rfc724_mid = dc_create_outgoing_rfc724_mid(None, "@device");
@@ -3397,12 +3400,15 @@ pub(crate) async fn add_info_msg_with_cmd(
 
     let row_id =
     context.sql.insert(
-        "INSERT INTO msgs (chat_id,from_id,to_id,timestamp,type,state,txt,rfc724_mid,ephemeral_timer, param,mime_in_reply_to) VALUES (?,?,?, ?,?,?, ?,?,?, ?,?);",
+        "INSERT INTO msgs (chat_id,from_id,to_id,timestamp,timestamp_sent,timestamp_rcvd,type,state,txt,rfc724_mid,ephemeral_timer, param,mime_in_reply_to)
+        VALUES (?,?,?, ?,?,?,?,?, ?,?,?, ?,?);",
         paramsv![
             chat_id,
             ContactId::INFO,
             ContactId::INFO,
-            timestamp,
+            timestamp_sort,
+            timestamp_sent_rcvd.unwrap_or(0),
+            timestamp_sent_rcvd.unwrap_or(0),
             Viewtype::Text,
             MessageState::InNoticed,
             text,
@@ -3431,6 +3437,7 @@ pub(crate) async fn add_info_msg(
         text,
         SystemMessage::Unknown,
         timestamp,
+        None,
         None,
     )
     .await
@@ -4433,6 +4440,7 @@ mod tests {
             "foo bar info",
             SystemMessage::EphemeralTimerChanged,
             10000,
+            None,
             None,
         )
         .await?;

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -355,6 +355,10 @@ impl Chatlist {
     pub fn get_index_for_id(&self, id: ChatId) -> Option<usize> {
         self.ids.iter().position(|(chat_id, _)| chat_id == &id)
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = &(ChatId, Option<MsgId>)> {
+        self.ids.iter()
+    }
 }
 
 /// Returns the number of archived chats

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -273,8 +273,7 @@ impl Peerstate {
                 .query_get_value("SELECT id FROM contacts WHERE addr=?;", paramsv![self.addr])
                 .await?
             {
-                let chats = Chatlist::try_load(context, 0, None, contact_id)
-                    .await?;
+                let chats = Chatlist::try_load(context, 0, None, contact_id).await?;
                 let msg = stock_str::contact_setup_changed(context, self.addr.clone()).await;
                 for (chat_id, msg_id) in chats.iter() {
                     let timestamp_sort = if let Some(msg_id) = msg_id {

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -274,8 +274,7 @@ impl Peerstate {
                 .await?
             {
                 let chats = Chatlist::try_load(context, 0, None, contact_id)
-                    .await
-                    .unwrap();
+                    .await?;
                 let msg = stock_str::contact_setup_changed(context, self.addr.clone()).await;
                 for (chat_id, msg_id) in chats.iter() {
                     let timestamp_sort = if let Some(msg_id) = msg_id {

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -219,6 +219,7 @@ impl Context {
                 info.as_str(),
                 SystemMessage::Unknown,
                 timestamp,
+                None,
                 Some(instance),
             )
             .await?;


### PR DESCRIPTION
send setup-changed messages only in the chats we share with the peer, do not create contact request

closes #2557 

with this all shared chats with the peer will be sorted at the top with the "setup changed for X" so maybe some other dev can improve this PR so this system messages don't cause the chats to be sorted at the top, still this is better than getting annoying empty contact requests with "setup changed for X" which is confusing for users "this mean this person wants to talk with me?"

also the markers in the chats are much more useful than in the 1:1 chat with the contact since you can easily see what messages in chats are valid and what messages are compromised because they come after the "setup changed" marker in the chat