### PR TITLE
 Give setup-changed messages the same timestamp as the previous message 

### DIFF
--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -355,6 +355,10 @@ impl Chatlist {
     pub fn get_index_for_id(&self, id: ChatId) -> Option<usize> {
         self.ids.iter().position(|(chat_id, _)| chat_id == &id)
     }
+
+    pub fn iter(&self) -> impl Iterator<Item = &(ChatId, Option<MsgId>)> {
+        self.ids.iter()
+    }
 }
 
 /// Returns the number of archived chats

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -9,6 +9,8 @@ use crate::chatlist::Chatlist;
 use crate::context::Context;
 use crate::events::EventType;
 use crate::key::{DcKey, Fingerprint, SignedPublicKey};
+use crate::message::Message;
+use crate::mimeparser::SystemMessage;
 use crate::sql::Sql;
 use crate::stock_str;
 use anyhow::{bail, Result};
@@ -275,10 +277,21 @@ impl Peerstate {
                     .await
                     .unwrap();
                 let msg = stock_str::contact_setup_changed(context, self.addr.clone()).await;
-                for chat_index in 0..chats.len() {
-                    let chat_id = chats.get_chat_id(chat_index).unwrap();
-                    chat::add_info_msg(context, chat_id, &msg, timestamp).await?;
-                    context.emit_event(EventType::ChatModified(chat_id));
+                for (chat_id, msg_id) in chats.iter() {
+                    if let Some(msg_id) = msg_id {
+                        let lastmsg = Message::load_from_db(context, *msg_id).await?;
+                        chat::add_info_msg_with_cmd(
+                            context,
+                            *chat_id,
+                            &msg,
+                            SystemMessage::Unknown,
+                            lastmsg.timestamp_sort,
+                            Some(timestamp),
+                            None,
+                        )
+                        .await?;
+                        context.emit_event(EventType::ChatModified(*chat_id));
+                    }
                 }
             } else {
                 bail!("contact with peerstate.addr {:?} not found", &self.addr);

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -219,6 +219,7 @@ impl Context {
                 info.as_str(),
                 SystemMessage::Unknown,
                 timestamp,
+                None,
                 Some(instance),
             )
             .await?;


### PR DESCRIPTION
Addition for https://github.com/deltachat/deltachat-core-rust/pull/3187.

This PR simply gives the setup-changed messages the same timestamp_sort as the previous message. Disadvantage: Slightly hacky, advantage: rather few code changes, doesn't increase complexity by much.

![image_2022-04-04_12-32-51](https://user-images.githubusercontent.com/18012815/161551610-078f9a39-a6f7-4b25-ab91-0784d326e6e4.jpg)

As you can see in the following image, this means that the "setup changed" message is shown _before_ the daymarker ("Today") while it would be correcter to show it after the daymarker:
![image_2022-04-04_12-32-25](https://user-images.githubusercontent.com/18012815/161552980-f1e48990-99b7-47e2-b6e5-cc52a49b7065.jpg)


**TODO:**
- Currently, in empty chats (where there is no "previous message"), the info message is not shown at all. We should change this by setting the timestamp tot the creation time of the chat in this case (so that, again, the chatlist will be sorted as if the setup-changed message was not there). _I wanted to ask for feedback before doing this because I am not 100% sure about my approach._

**Alternatives:**
- Completely filter out system messages when showing the chatlist. Probably not wanted from a user perspective, but would be by very far the easiest solution. No system messages will be shown in the chatlist anymore at all (of course they will still be shown inside the chat).
- Filter out setup-changed messages when showing the chatlist. This means that we have to somehow mark setup-changed messages in the SQL table, possibly by adding a SQL column `ignore_in_chatlist` or similar.