### PR TITLE
Do ephemeral deletion in async task background loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - start ephemeral timer when seen status is synchronized via IMAP #3122
 - do not delete duplicate messages on IMAP immediately to accidentally deleting
   the last copy #3138
-- speed up loading of chat messages #3171
+- speed up loading of chat messages #3171 #3194
 - clear more columns when message expires due to `delete_device_after` setting #3181
 - do not try to use stale SMTP connections #3180
 - retry message sending automatically if loop is not interrupted #3183

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -9,7 +9,6 @@ use crate::constants::{
 };
 use crate::contact::{Contact, ContactId};
 use crate::context::Context;
-use crate::ephemeral::delete_expired_messages;
 use crate::message::{Message, MessageState, MsgId};
 use crate::stock_str;
 use crate::summary::Summary;
@@ -90,12 +89,6 @@ impl Chatlist {
         let flag_for_forwarding = 0 != listflags & DC_GCL_FOR_FORWARDING;
         let flag_no_specials = 0 != listflags & DC_GCL_NO_SPECIALS;
         let flag_add_alldone_hint = 0 != listflags & DC_GCL_ADD_ALLDONE_HINT;
-
-        // Note that we do not emit DC_EVENT_MSGS_MODIFIED here even if some
-        // messages get deleted to avoid reloading the same chatlist.
-        if let Err(err) = delete_expired_messages(context).await {
-            warn!(context, "Failed to hide expired messages: {}", err);
-        }
 
         let mut add_archived_link_item = false;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,7 +10,6 @@ use async_std::{
     channel::{self, Receiver, Sender},
     path::{Path, PathBuf},
     sync::{Arc, Mutex, RwLock},
-    task,
 };
 
 use crate::chat::{get_chat_cnt, ChatId};

--- a/src/context.rs
+++ b/src/context.rs
@@ -56,7 +56,6 @@ pub struct InnerContext {
     pub(crate) events: Events,
 
     pub(crate) scheduler: RwLock<Scheduler>,
-    pub(crate) ephemeral_task: RwLock<Option<task::JoinHandle<()>>>,
 
     /// Recently loaded quota information, if any.
     /// Set to `None` if quota was never tried to load.
@@ -176,7 +175,6 @@ impl Context {
             translated_stockstrings: RwLock::new(HashMap::new()),
             events: Events::default(),
             scheduler: RwLock::new(Scheduler::Stopped),
-            ephemeral_task: RwLock::new(None),
             quota: RwLock::new(None),
             creation_time: std::time::SystemTime::now(),
             last_full_folder_scan: Mutex::new(None),
@@ -641,10 +639,6 @@ impl InnerContext {
                 let lock = &mut *self.scheduler.write().await;
                 lock.stop(token).await;
             }
-        }
-
-        if let Some(ephemeral_task) = self.ephemeral_task.write().await.take() {
-            ephemeral_task.cancel().await;
         }
     }
 }

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -330,8 +330,8 @@ pub(crate) async fn start_ephemeral_timers_msgids(
     Ok(())
 }
 
-/// `delete_device_after` setting or `ephemeral_timestamp` column.
 /// Deletes messages which are expired according to
+/// `delete_device_after` setting or `ephemeral_timestamp` column.
 ///
 /// Returns true if any message is deleted, so caller can emit
 /// MsgsChanged event. If nothing has been deleted, returns

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -338,7 +338,7 @@ pub(crate) async fn start_ephemeral_timers_msgids(
 /// false. This function does not emit the MsgsChanged event itself,
 /// because it is also called when chatlist is reloaded, and emitting
 /// MsgsChanged there will cause infinite reload loop.
-pub(crate) async fn delete_expired_messages(context: &Context, now: i64) -> Result<bool> {
+pub(crate) async fn delete_expired_messages(context: &Context, now: i64) -> Result<()> {
     let mut updated = context
         .sql
         .execute(
@@ -405,7 +405,7 @@ WHERE
         });
     }
 
-    Ok(updated)
+    Ok(())
 }
 
 pub(crate) async fn ephemeral_loop(context: &Context, interrupt_receiver: Receiver<()>) {

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -414,12 +414,10 @@ pub(crate) async fn ephemeral_loop(context: &Context, interrupt_receiver: Receiv
             .sql
             .query_get_value(
                 r#"
-                SELECT ephemeral_timestamp
+                SELECT min(ephemeral_timestamp)
                 FROM msgs
                 WHERE ephemeral_timestamp != 0
-                  AND chat_id != ?
-                ORDER BY ephemeral_timestamp ASC
-                LIMIT 1;
+                  AND chat_id != ?;
                 "#,
                 paramsv![DC_CHAT_ID_TRASH], // Trash contains already deleted messages, skip them
             )
@@ -427,7 +425,7 @@ pub(crate) async fn ephemeral_loop(context: &Context, interrupt_receiver: Receiv
         {
             Err(err) => {
                 warn!(context, "Can't calculate next ephemeral timeout: {}", err);
-                return;
+                None
             }
             Ok(ephemeral_timestamp) => ephemeral_timestamp,
         };

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -70,7 +70,7 @@ use crate::chat::{send_msg, ChatId};
 use crate::constants::{DC_CHAT_ID_LAST_SPECIAL, DC_CHAT_ID_TRASH};
 use crate::contact::ContactId;
 use crate::context::Context;
-use crate::dc_tools::time;
+use crate::dc_tools::{duration_to_str, time};
 use crate::download::MIN_DELETE_SERVER_AFTER;
 use crate::events::EventType;
 use crate::log::LogExt;
@@ -441,6 +441,11 @@ pub(crate) async fn ephemeral_loop(context: &Context, interrupt_receiver: Receiv
         };
 
         if let Ok(duration) = until.duration_since(now) {
+            info!(
+                context,
+                "Ephemeral loop waiting for deletion in {} or interrupt",
+                duration_to_str(duration)
+            );
             if timeout(duration, interrupt_receiver.recv()).await.is_ok() {
                 // received an interruption signal, recompute waiting time (if any)
                 continue;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -599,10 +599,6 @@ impl Sql {
 }
 
 pub async fn housekeeping(context: &Context) -> Result<()> {
-    if let Err(err) = crate::ephemeral::delete_expired_messages(context).await {
-        warn!(context, "Failed to delete expired messages: {}", err);
-    }
-
     if let Err(err) = remove_unused_files(context).await {
         warn!(
             context,


### PR DESCRIPTION
1. in start_io start ephemeral async task, in stop_io cancel ephemeral async task

2. start ephemeral async task which loops like this:

- wait until next time a message deletion is needed or an interrupt occurs (see 3.)
- perform delete_expired_messages including sending MSGS_CHANGED events

3. on new messages (incoming or outgoing) with ephemeral timer:

- interrupt ephemeral async task

The question we (@hpk42 and I) had was if the shutdown works the way we implemented it.
- Starting and stopping imap and smtp tasks is done using lots of channels (shutdown_receiver, stop_sender, ...) - is this necessary also for our task?
- In `stop_io()` we are just calling `cancel()` on the task. Is it necessary to close the interrupt channel and react on the closed channel in the loop? Or is calling `cancel()` always sufficient?

Edit: By the way, the measurements of `get_chat_msgs()`: 
![relative_iteration_times_small](https://user-images.githubusercontent.com/18012815/162568211-1bf14544-f9a2-4daf-af4c-9e44265853dd.svg)
![relative_pdf_small](https://user-images.githubusercontent.com/18012815/162568259-de1a10d5-1e2e-49e2-940f-35cb14d9dfac.svg)
Improvement by a factor of 7 sounds good.