### PR TITLE
Drop unused table `backup_blobs` in migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   and remove update-id from `DC_EVENT_WEBXDC_STATUS_UPDATE` #3081
 
 ### Fixes
+- Fix an issue where the app crashes when trying to export a backup #3195
 - Hopefully fix a bug where outgoing messages appear twice with Amazon SES #3077
 - do not delete messages without Message-IDs as duplicates #3095
 - Assign replies from a different email address to the correct chat #3119

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -609,7 +609,7 @@ CREATE INDEX smtp_messageid ON imap(rfc724_mid);
         .await?;
     }
     if dbversion < 88 {
-        info!(context, "[migration] v87");
+        info!(context, "[migration] v88");
         sql.execute_migration("DROP TABLE IF EXISTS backup_blobs;", 88)
             .await?;
     }

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -608,6 +608,11 @@ CREATE INDEX smtp_messageid ON imap(rfc724_mid);
         )
         .await?;
     }
+    if dbversion < 88 {
+        info!(context, "[migration] v87");
+        sql.execute_migration("DROP TABLE IF EXISTS backup_blobs;", 88)
+            .await?;
+    }
 
     Ok((
         recalc_fingerprints,


### PR DESCRIPTION
Today, we solved an issue with holger's phone that he couldn't export
his account anymore because during the `VACUUM` the Android system
killed the app because of OOM. The solution was to drop the table
`backup_blobs`, so let's automatically do this in migration.

This table was used back in the olden days when we backuped by exporting
the dbfile and then putting all blobs into it. During import, the
`backup_blobs` table should have been dropped, seems like this didn't
work here.