### PR TITLE
only do monthly dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "cargo"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 50

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     commit-message:
       prefix: "cargo"
     open-pull-requests-limit: 10


### PR DESCRIPTION
it's probably better anyway to do dep updates synced with the release schedule. E.G. for the upcoming 1.30 we want to update now and then stick with the dependencies unless there is a good reason to upgrade a particular one.  