### PR TITLE
[wip] How to better/speedier do delete_expired_imap_messages?

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -162,14 +162,6 @@ async fn fetch_idle(ctx: &Context, connection: &mut Imap, folder: Config) -> Int
                 return connection.fake_idle(ctx, Some(watch_folder)).await;
             }
 
-            // Mark expired messages for deletion.
-            if let Err(err) = delete_expired_imap_messages(ctx)
-                .await
-                .context("delete_expired_imap_messages failed")
-            {
-                warn!(ctx, "{:#}", err);
-            }
-
             // Fetch the watched folder.
             if let Err(err) = connection.fetch_move_delete(ctx, &watch_folder).await {
                 connection.trigger_reconnect(ctx).await;


### PR DESCRIPTION
- `delete_expired_imap_messages` takes noticeable time (>100ms on my fast desktop and own db, even slower on android) because it does a full message table scan (i think) 
- is done for each watch folder, although it's not taking a folder as input and is a global scan
- delays receiving fresh incoming messages 

So i think there should be more efficient means to trigger imap-deletion.  This PR is for discussing that.  