### PR TITLE
Disable unused async-smtp transports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,9 +310,6 @@ dependencies = [
  "nom 5.1.2",
  "pin-project",
  "pin-utils",
- "serde",
- "serde_derive",
- "serde_json",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ansi_term = { version = "0.12.1", optional = true }
 anyhow = "1"
 async-imap = { git = "https://github.com/async-email/async-imap" }
 async-native-tls = { version = "0.3" }
-async-smtp = { git = "https://github.com/async-email/async-smtp", branch="master", features = ["socks5"] }
+async-smtp = { git = "https://github.com/async-email/async-smtp", branch="master", default-features=false, features = ["smtp-transport", "socks5"] }
 async-std-resolver = "0.21"
 async-std = { version = "1" }
 async-tar = { version = "0.4", default-features=false }


### PR DESCRIPTION
By default file and sendmail transports are enabled,
but deltachat does not use them.