### PR TITLE
Follow http redirects for autoconfigure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+- Further improve finding the correct server after logging in #3208
+
 ## 1.77.0
 
 ### API changes

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -699,11 +699,11 @@ pub enum Error {
         error: quick_xml::Error,
     },
 
-    #[error("Failed to get URL: {0}")]
-    ReadUrl(#[from] self::read_url::Error),
-
     #[error("Number of redirection is exceeded")]
     Redirection,
+
+    #[error("{0:#}")]
+    Other(#[from] anyhow::Error),
 }
 
 #[cfg(test)]

--- a/src/configure/read_url.rs
+++ b/src/configure/read_url.rs
@@ -1,20 +1,40 @@
 use crate::context::Context;
 
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("URL request error")]
-    GetError(surf::Error),
-}
+use anyhow::format_err;
+use anyhow::Context as _;
 
-pub async fn read_url(context: &Context, url: &str) -> Result<String, Error> {
-    info!(context, "Requesting URL {}", url);
-
-    match surf::get(url).recv_string().await {
-        Ok(res) => Ok(res),
-        Err(err) => {
-            info!(context, "Can\'t read URL {}: {}", url, err);
-
-            Err(Error::GetError(err))
+pub async fn read_url(context: &Context, url: &str) -> anyhow::Result<String> {
+    match read_url_inner(context, url).await {
+        Ok(s) => {
+            info!(context, "Successfully read url {}", url);
+            Ok(s)
+        }
+        Err(e) => {
+            info!(context, "Can't read URL {}: {:#}", url, e);
+            Err(format_err!("Can't read URL {}: {:#}", url, e))
         }
     }
+}
+
+pub async fn read_url_inner(context: &Context, mut url: &str) -> anyhow::Result<String> {
+    let mut _temp; // For the borrow checker
+
+    // Follow up to 10 http-redirects
+    for _i in 0..10 {
+        let mut response = surf::get(url).send().await.map_err(|e| e.into_inner())?;
+        if response.status().is_redirection() {
+            _temp = response
+                .header("location")
+                .context("Redirection doesn't have a target location")?
+                .last()
+                .to_string();
+            info!(context, "Following redirect to {}", _temp);
+            url = &_temp;
+            continue;
+        }
+
+        return Ok(response.body_string().await.map_err(|e| e.into_inner())?);
+    }
+
+    Err(format_err!("Followed 10 redirections"))
 }

--- a/src/configure/read_url.rs
+++ b/src/configure/read_url.rs
@@ -33,7 +33,7 @@ pub async fn read_url_inner(context: &Context, mut url: &str) -> anyhow::Result<
             continue;
         }
 
-        return Ok(response.body_string().await.map_err(|e| e.into_inner())?);
+        return response.body_string().await.map_err(|e| e.into_inner());
     }
 
     Err(format_err!("Followed 10 redirections"))


### PR DESCRIPTION
Fix #3158
closes #2963 

Turns out that the main problem in #3158 was only that we don't follow html redirects. The redirect is given in the header which is always ASCII, so there is no need to try and decode the body at all.

(For redirects (and obviously also 4xx errors), the body encoding is specified as `iso-8859-1`, which led to the error message in https://github.com/deltachat/deltachat-core-rust/issues/3158.)