### PR TITLE
make Connectivity-View-HTML not scalable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changes
 
 - Further improve finding the correct server after logging in #3208
+- `get_connectivity_html()` returns HTML as non-scalable #3213
+
 
 ## 1.77.0
 

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -304,7 +304,7 @@ impl Context {
             <html>
             <head>
                 <meta charset="UTF-8" />
-                <meta name="viewport" content="initial-scale=1.0" />
+                <meta name="viewport" content="initial-scale=1.0; user-scalable=no" />
                 <style>
                     ul {
                         list-style-type: none;


### PR DESCRIPTION
in practise, Android and Desktop already disallow scaling
by some other methods,
however, for iOS this is needed as we otherwise
have to do far more complicated things as drafted at
https://github.com/deltachat/deltachat-ios/pull/1531/files