### PR TITLE
Webxdc scaling/viewport is implementation specific

### DIFF
--- a/draft/webxdc-dev-reference.md
+++ b/draft/webxdc-dev-reference.md
@@ -176,6 +176,9 @@ just clone and start adapting things to your need.
 
 - older devices might not have the newest js features in their webview,
   you may want to transpile your code down to an older js version eg. with https://babeljs.io
+- viewport and scaling features are implementation specific,
+  if you want to have an explicit behavior, you can add eg.
+  `<meta name="viewport" content="initial-scale=1; user-scalable=no">` to your Webxdc
 - there are tons of ideas for enhancements of the API and the file format,
   eg. in the future, we will may define icon- and manifest-files,
   allow to aggregate the state or add metadata.


### PR DESCRIPTION
at least on iOS we would need to inject a script to force a behavior,
that is hard to merge with options set by the Webxdc, cmp. https://github.com/deltachat/deltachat-ios/pull/1472 - and also not really needed as it removes the option of the Webxdc to _allow_ scaling.

therefore, the easiest approach seems to be to leave that completely up to the Webxdc -
and, in practise, many Webxdc already set viewports, including scaling.

#skip-changelog