### PR TITLE
add status_update_serial to webxdc_status_update event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Further improve finding the correct server after logging in #3208
 - `get_connectivity_html()` returns HTML as non-scalable #3213
+- add update-serial to `DC_EVENT_WEBXDC_STATUS_UPDATE` #3215
 
 
 ## 1.77.0

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5606,11 +5606,16 @@ void dc_event_unref(dc_event_t* event);
 /**
  * webxdc status update received.
  * To get the received status update, use dc_get_webxdc_status_updates() with
- * `serial` set to the last known update.
+ * `serial` set to the last known update
+ * (in case of special bots, `status_update_serial` from `data2`
+ * may help to calculate the last known update for dc_get_webxdc_status_updates();
+ * UIs must not peek at this parameter to avoid races in the status replication
+ * eg. when events arrive while initial updates are played back).
+ *
  * To send status updates, use dc_send_webxdc_status_update().
  *
  * @param data1 (int) msg_id
- * @param data2 (int) 0
+ * @param data2 (int) status_update_serial - must not be used by UI implementations.
  */
 #define DC_EVENT_WEBXDC_STATUS_UPDATE                2120
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -503,7 +503,7 @@ pub unsafe extern "C" fn dc_event_get_data1_int(event: *mut dc_event_t) -> libc:
         | EventType::SecurejoinJoinerProgress { contact_id, .. } => {
             contact_id.to_u32() as libc::c_int
         }
-        EventType::WebxdcStatusUpdate(msg_id) => msg_id.to_u32() as libc::c_int,
+        EventType::WebxdcStatusUpdate { msg_id, .. } => msg_id.to_u32() as libc::c_int,
     }
 }
 
@@ -535,9 +535,8 @@ pub unsafe extern "C" fn dc_event_get_data2_int(event: *mut dc_event_t) -> libc:
         | EventType::ImexFileWritten(_)
         | EventType::MsgsNoticed(_)
         | EventType::ConnectivityChanged
-        | EventType::SelfavatarChanged
-        | EventType::WebxdcStatusUpdate(_)
-        | EventType::ChatModified(_) => 0,
+        | EventType::SelfavatarChanged => 0,
+        EventType::ChatModified(_) => 0,
         EventType::MsgsChanged { msg_id, .. }
         | EventType::IncomingMsg { msg_id, .. }
         | EventType::MsgDelivered { msg_id, .. }
@@ -546,6 +545,10 @@ pub unsafe extern "C" fn dc_event_get_data2_int(event: *mut dc_event_t) -> libc:
         EventType::SecurejoinInviterProgress { progress, .. }
         | EventType::SecurejoinJoinerProgress { progress, .. } => *progress as libc::c_int,
         EventType::ChatEphemeralTimerModified { timer, .. } => timer.to_u32() as libc::c_int,
+        EventType::WebxdcStatusUpdate {
+            status_update_serial,
+            ..
+        } => status_update_serial.to_u32() as libc::c_int,
     }
 }
 
@@ -587,7 +590,7 @@ pub unsafe extern "C" fn dc_event_get_data2_str(event: *mut dc_event_t) -> *mut 
         | EventType::SecurejoinJoinerProgress { .. }
         | EventType::ConnectivityChanged
         | EventType::SelfavatarChanged
-        | EventType::WebxdcStatusUpdate(_)
+        | EventType::WebxdcStatusUpdate { .. }
         | EventType::ChatEphemeralTimerModified { .. } => ptr::null_mut(),
         EventType::ConfigureProgress { comment, .. } => {
             if let Some(comment) = comment {

--- a/src/events.rs
+++ b/src/events.rs
@@ -10,6 +10,7 @@ use crate::chat::ChatId;
 use crate::contact::ContactId;
 use crate::ephemeral::Timer as EphemeralTimer;
 use crate::message::MsgId;
+use crate::webxdc::StatusUpdateSerial;
 
 #[derive(Debug)]
 pub struct Events {
@@ -335,5 +336,8 @@ pub enum EventType {
     SelfavatarChanged,
 
     #[strum(props(id = "2120"))]
-    WebxdcStatusUpdate(MsgId),
+    WebxdcStatusUpdate {
+        msg_id: MsgId,
+        status_update_serial: StatusUpdateSerial,
+    },
 }

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -254,9 +254,14 @@ impl Context {
             )
             .await?;
 
-        self.emit_event(EventType::WebxdcStatusUpdate(instance.id));
+        let status_update_serial = StatusUpdateSerial(u32::try_from(rowid)?);
 
-        Ok(StatusUpdateSerial(u32::try_from(rowid)?))
+        self.emit_event(EventType::WebxdcStatusUpdate {
+            msg_id: instance.id,
+            status_update_serial,
+        });
+
+        Ok(status_update_serial)
     }
 
     /// Sends a status update for an webxdc instance.
@@ -1016,7 +1021,10 @@ mod tests {
             .get_matching(|evt| matches!(evt, EventType::WebxdcStatusUpdate { .. }))
             .await;
         match event {
-            EventType::WebxdcStatusUpdate(msg_id) => {
+            EventType::WebxdcStatusUpdate {
+                msg_id,
+                status_update_serial: _,
+            } => {
                 assert_eq!(msg_id, instance_id);
             }
             _ => unreachable!(),


### PR DESCRIPTION
this bypasses the replication safety [introduced by letting the caller track the last serial](https://github.com/deltachat/deltachat-core-rust/pull/3081),
however, in case of bots that do not track much state and do not playback updates anyway,
it is still useful.

i am not too happy with adding that again, as i fear it gets misused and we get races again. otoh, @adbenitez reported that it helps in some cases (@adbenitez maybe you can comment in more detail about that), so this is also an strong argument :)