### PR TITLE
improve error message

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -54,7 +54,11 @@ impl Accounts {
         ensure!(dir.exists().await, "directory does not exist");
 
         let config_file = dir.join(CONFIG_NAME);
-        ensure!(config_file.exists().await, "{} does not exist", CONFIG_NAME);
+        ensure!(
+            config_file.exists().await,
+            "{:?} does not exist",
+            config_file
+        );
 
         let config = Config::from_file(config_file)
             .await

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -54,7 +54,7 @@ impl Accounts {
         ensure!(dir.exists().await, "directory does not exist");
 
         let config_file = dir.join(CONFIG_NAME);
-        ensure!(config_file.exists().await, "accounts.toml does not exist");
+        ensure!(config_file.exists().await, "{} does not exist", CONFIG_NAME);
 
         let config = Config::from_file(config_file)
             .await


### PR DESCRIPTION
This is just a minor fix I made while working on dreamer. Uses a variable instead of a hard-coded file-name.

#skip-changelog