### PR TITLE
Streamline access/working with configured params and configured addr

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2043,7 +2043,7 @@ async fn create_send_msg_job(context: &Context, msg_id: MsgId) -> Result<Option<
 
     let mut recipients = mimefactory.recipients();
 
-    let from = context.get_configured_addr().await.unwrap_or_default();
+    let from = context.get_configured_addr().await?;
     let lowercase_from = from.to_lowercase();
 
     // Send BCC to self if it is enabled and we are not going to

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1254,11 +1254,7 @@ impl Chat {
             }
         }
 
-        let from = context
-            .get_config(Config::ConfiguredAddr)
-            .await?
-            .context("Cannot prepare message for sending, address is not configured.")?;
-
+        let from = context.get_configured_addr().await?;
         let new_rfc724_mid = {
             let grpid = match self.typ {
                 Chattype::Group => Some(self.grpid.as_str()),
@@ -2047,10 +2043,7 @@ async fn create_send_msg_job(context: &Context, msg_id: MsgId) -> Result<Option<
 
     let mut recipients = mimefactory.recipients();
 
-    let from = context
-        .get_config(Config::ConfiguredAddr)
-        .await?
-        .unwrap_or_default();
+    let from = context.get_configured_addr().await.unwrap_or_default();
     let lowercase_from = from.to_lowercase();
 
     // Send BCC to self if it is enabled and we are not going to
@@ -2723,10 +2716,7 @@ pub(crate) async fn add_contact_to_chat_ex(
         context.sync_qr_code_tokens(Some(chat_id)).await?;
         context.send_sync_msg().await?;
     }
-    let self_addr = context
-        .get_config(Config::ConfiguredAddr)
-        .await?
-        .unwrap_or_default();
+    let self_addr = context.get_configured_addr().await.unwrap_or_default();
     if addr_cmp(contact.get_addr(), &self_addr) {
         // ourself is added using ContactId::SELF, do not add this address explicitly.
         // if SELF is not in the group, members cannot be added at all.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 //! # Key-value configuration management.
 
-use anyhow::{ensure, Result};
+use anyhow::{ensure, Context as _, Result};
 use strum::{EnumProperty, IntoEnumIterator};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumProperty, EnumString};
 
@@ -228,7 +228,6 @@ impl Context {
     }
 
     pub(crate) async fn get_configured_addr(&self) -> Result<String> {
-        use anyhow::Context;
         self.get_config(Config::ConfiguredAddr)
             .await?
             .context("no address configured")

--- a/src/config.rs
+++ b/src/config.rs
@@ -227,6 +227,13 @@ impl Context {
         Ok(self.get_config_int(key).await? != 0)
     }
 
+    pub(crate) async fn get_configured_addr(&self) -> Result<String> {
+        use anyhow::Context;
+        self.get_config(Config::ConfiguredAddr)
+            .await?
+            .context("no address configured")
+    }
+
     pub(crate) async fn should_watch_mvbox(&self) -> Result<bool> {
         Ok(self.get_config_bool(Config::MvboxMove).await?
             || self.get_config_bool(Config::OnlyFetchMvbox).await?)

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -85,7 +85,7 @@ impl Context {
     async fn inner_configure(&self) -> Result<()> {
         info!(self, "Configure ...");
 
-        let mut param = LoginParam::from_database(self, "").await?;
+        let mut param = LoginParam::load_candidate_params(self).await?;
         let success = configure(self, &mut param).await;
         self.set_config(Config::NotifyAboutWrongPw, None).await?;
 
@@ -454,7 +454,7 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
 
     progress!(ctx, 910);
     // the trailing underscore is correct
-    param.save_to_database(ctx, "configured_").await?;
+    param.save_as_configured_params(ctx).await?;
     ctx.set_config(Config::ConfiguredTimestamp, Some(&time().to_string()))
         .await?;
 

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -870,7 +870,7 @@ impl Contact {
 
         let mut ret = String::new();
         if let Ok(contact) = Contact::load_from_db(context, contact_id).await {
-            let loginparam = LoginParam::from_database(context, "configured_").await?;
+            let loginparam = LoginParam::load_configured_params(context).await?;
             let peerstate = Peerstate::from_addr(context, &contact.addr).await?;
 
             if let Some(peerstate) = peerstate.filter(|peerstate| {

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -296,10 +296,7 @@ impl Contact {
             .await?;
         if contact_id == ContactId::SELF {
             contact.name = stock_str::self_msg(context).await;
-            contact.addr = context
-                .get_config(Config::ConfiguredAddr)
-                .await?
-                .unwrap_or_default();
+            contact.addr = context.get_configured_addr().await.unwrap_or_default();
             contact.status = context
                 .get_config(Config::Selfstatus)
                 .await?
@@ -398,10 +395,8 @@ impl Contact {
 
         let addr_normalized = addr_normalize(addr);
 
-        if let Some(addr_self) = context.get_config(Config::ConfiguredAddr).await? {
-            if addr_cmp(addr_normalized, &addr_self) {
-                return Ok(Some(ContactId::SELF));
-            }
+        if context.is_self_addr(addr_normalized).await? {
+            return Ok(Some(ContactId::SELF));
         }
         let id = context
             .sql
@@ -452,11 +447,10 @@ impl Contact {
         ensure!(origin != Origin::Unknown, "Missing valid origin");
 
         let addr = addr_normalize(addr).to_string();
-        let addr_self = context
-            .get_config(Config::ConfiguredAddr)
-            .await?
-            .unwrap_or_default();
 
+        // during configuration process some chats are added and addr
+        // might not be configured yet
+        let addr_self = context.get_configured_addr().await.unwrap_or_default();
         if addr_cmp(&addr, &addr_self) {
             return Ok((ContactId::SELF, sth_modified));
         }
@@ -692,11 +686,7 @@ impl Contact {
         listflags: u32,
         query: Option<impl AsRef<str>>,
     ) -> Result<Vec<ContactId>> {
-        let self_addr = context
-            .get_config(Config::ConfiguredAddr)
-            .await?
-            .unwrap_or_default();
-
+        let self_addr = context.get_configured_addr().await.unwrap_or_default();
         let mut add_self = false;
         let mut ret = Vec::new();
         let flag_verified_only = (listflags & DC_GCL_VERIFIED_ONLY) != 0;

--- a/src/context.rs
+++ b/src/context.rs
@@ -311,8 +311,8 @@ impl Context {
 
     pub async fn get_info(&self) -> Result<BTreeMap<&'static str, String>> {
         let unset = "0";
-        let l = LoginParam::from_database(self, "").await?;
-        let l2 = LoginParam::from_database(self, "configured_").await?;
+        let l = LoginParam::load_candidate_params(self).await?;
+        let l2 = LoginParam::load_configured_params(self).await?;
         let displayname = self.get_config(Config::Displayname).await?;
         let chats = get_chat_cnt(self).await? as usize;
         let unblocked_msgs = message::get_unblocked_msg_cnt(self).await as usize;

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1451,10 +1451,7 @@ async fn create_or_lookup_group(
         ProtectionStatus::Unprotected
     };
 
-    let self_addr = context
-        .get_config(Config::ConfiguredAddr)
-        .await?
-        .context("no address configured")?;
+    let self_addr = context.get_configured_addr().await?;
     if chat_id.is_none()
             && !mime_parser.is_mailinglist_message()
             && !grpid.is_empty()
@@ -1550,11 +1547,7 @@ async fn apply_group_changes(
         return Ok(None);
     }
 
-    let self_addr = context
-        .get_config(Config::ConfiguredAddr)
-        .await?
-        .context("no address configured")?;
-
+    let self_addr = context.get_configured_addr().await?;
     let mut recreate_member_list = false;
     let mut send_event_chat_modified = false;
 
@@ -1998,12 +1991,7 @@ async fn create_adhoc_group(
 /// are hidden in BCC. This group ID is sent by DC in the messages sent to this chat,
 /// so having the same ID prevents group split.
 async fn create_adhoc_grp_id(context: &Context, member_ids: &[ContactId]) -> Result<String> {
-    let member_cs = context
-        .get_config(Config::ConfiguredAddr)
-        .await?
-        .unwrap_or_else(|| "no-self".to_string())
-        .to_lowercase();
-
+    let member_cs = context.get_configured_addr().await?.to_lowercase();
     let query = format!(
         "SELECT addr FROM contacts WHERE id IN({}) AND id!=?",
         sql::repeat_vars(member_ids.len())?

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashSet;
 
-use anyhow::{bail, format_err, Context as _, Result};
+use anyhow::{format_err, Context as _, Result};
 use mailparse::ParsedMail;
 use num_traits::FromPrimitive;
 
@@ -28,13 +28,7 @@ impl EncryptHelper {
         let prefer_encrypt =
             EncryptPreference::from_i32(context.get_config_int(Config::E2eeEnabled).await?)
                 .unwrap_or_default();
-        let addr = match context.get_config(Config::ConfiguredAddr).await? {
-            None => {
-                bail!("addr not configured!");
-            }
-            Some(addr) => addr,
-        };
-
+        let addr = context.get_configured_addr().await?;
         let public_key = SignedPublicKey::load_self(context).await?;
 
         Ok(EncryptHelper {
@@ -387,13 +381,7 @@ fn contains_report(mail: &ParsedMail<'_>) -> bool {
 /// [Config::ConfiguredAddr] is configured, this address is returned.
 // TODO, remove this once deltachat::key::Key no longer exists.
 pub async fn ensure_secret_key_exists(context: &Context) -> Result<String> {
-    let self_addr = context
-        .get_config(Config::ConfiguredAddr)
-        .await?
-        .context(concat!(
-            "Failed to get self address, ",
-            "cannot ensure secret key if not configured."
-        ))?;
+    let self_addr = context.get_configured_addr().await?;
     SignedPublicKey::load_self(context).await?;
     Ok(self_addr)
 }

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -224,7 +224,7 @@ impl Imap {
             bail!("IMAP Connect without configured params");
         }
 
-        let param = LoginParam::from_database(context, "configured_").await?;
+        let param = LoginParam::load_configured_params(context).await?;
         // the trailing underscore is correct
 
         let imap = Self::new(

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1117,11 +1117,7 @@ impl Imap {
             .session
             .as_mut()
             .context("IMAP No Connection established")?;
-        let self_addr = context
-            .get_config(Config::ConfiguredAddr)
-            .await?
-            .context("not configured")?;
-
+        let self_addr = context.get_configured_addr().await?;
         let search_command = format!("FROM \"{}\"", self_addr);
         let uids = session
             .uid_search(search_command)

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -351,9 +351,8 @@ async fn set_self_key(
         }
     };
 
-    let self_addr = context.get_config(Config::ConfiguredAddr).await?;
-    ensure!(self_addr.is_some(), "Missing self addr");
-    let addr = EmailAddress::new(&self_addr.unwrap_or_default())?;
+    let self_addr = context.get_configured_addr().await?;
+    let addr = EmailAddress::new(&self_addr)?;
     let keypair = pgp::KeyPair {
         addr,
         public: public_key,

--- a/src/key.rs
+++ b/src/key.rs
@@ -198,10 +198,7 @@ impl DcSecretKey for SignedSecretKey {
 }
 
 async fn generate_keypair(context: &Context) -> Result<KeyPair> {
-    let addr = context
-        .get_config(Config::ConfiguredAddr)
-        .await?
-        .context("no address configured")?;
+    let addr = context.get_configured_addr().await?;
     let addr = EmailAddress::new(&addr)?;
     let _guard = context.generating_key_mutex.lock().await;
 

--- a/src/location.rs
+++ b/src/location.rs
@@ -6,7 +6,6 @@ use bitflags::bitflags;
 use quick_xml::events::{BytesEnd, BytesStart, BytesText};
 
 use crate::chat::{self, ChatId};
-use crate::config::Config;
 use crate::contact::ContactId;
 use crate::context::Context;
 use crate::dc_tools::time;
@@ -424,10 +423,7 @@ pub async fn delete_all(context: &Context) -> Result<()> {
 pub async fn get_kml(context: &Context, chat_id: ChatId) -> Result<(String, u32)> {
     let mut last_added_location_id = 0;
 
-    let self_addr = context
-        .get_config(Config::ConfiguredAddr)
-        .await?
-        .unwrap_or_default();
+    let self_addr = context.get_configured_addr().await?;
 
     let (locations_send_begin, locations_send_until, locations_last_sent) = context.sql.query_row(
         "SELECT locations_send_begin, locations_send_until, locations_last_sent  FROM chats  WHERE id=?;",

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -139,12 +139,12 @@ pub struct LoginParam {
 }
 
 impl LoginParam {
-    /// Load entered (candidate) account settings 
+    /// Load entered (candidate) account settings
     pub async fn load_candidate_params(context: &Context) -> Result<Self> {
         LoginParam::from_database(context, "").await
     }
 
-    /// Load configured (working) account settings 
+    /// Load configured (working) account settings
     pub async fn load_configured_params(context: &Context) -> Result<Self> {
         LoginParam::from_database(context, "configured_").await
     }

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -139,8 +139,18 @@ pub struct LoginParam {
 }
 
 impl LoginParam {
+    /// Load entered (candidate) account settings 
+    pub async fn load_candidate_params(context: &Context) -> Result<Self> {
+        LoginParam::from_database(context, "").await
+    }
+
+    /// Load configured (working) account settings 
+    pub async fn load_configured_params(context: &Context) -> Result<Self> {
+        LoginParam::from_database(context, "configured_").await
+    }
+
     /// Read the login parameters from the database.
-    pub async fn from_database(context: &Context, prefix: impl AsRef<str>) -> Result<Self> {
+    async fn from_database(context: &Context, prefix: impl AsRef<str>) -> Result<Self> {
         let prefix = prefix.as_ref();
         let sql = &context.sql;
 
@@ -242,8 +252,8 @@ impl LoginParam {
     }
 
     /// Save this loginparam to the database.
-    pub async fn save_to_database(&self, context: &Context, prefix: impl AsRef<str>) -> Result<()> {
-        let prefix = prefix.as_ref();
+    pub async fn save_as_configured_params(&self, context: &Context) -> Result<()> {
+        let prefix = "configured_";
         let sql = &context.sql;
 
         let key = format!("{}addr", prefix);
@@ -438,8 +448,8 @@ mod tests {
             socks5_config: None,
         };
 
-        param.save_to_database(&t, "foobar_").await?;
-        let loaded = LoginParam::from_database(&t, "foobar_").await?;
+        param.save_as_configured_params(&t).await?;
+        let loaded = LoginParam::load_configured_params(&t).await?;
 
         assert_eq!(param, loaded);
         Ok(())

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -133,11 +133,7 @@ impl<'a> MimeFactory<'a> {
     ) -> Result<MimeFactory<'a>> {
         let chat = Chat::load_from_db(context, msg.chat_id).await?;
 
-        let from_addr = context
-            .get_config(Config::ConfiguredAddr)
-            .await?
-            .unwrap_or_default();
-
+        let from_addr = context.get_configured_addr().await.unwrap_or_default();
         let config_displayname = context
             .get_config(Config::Displayname)
             .await?
@@ -237,10 +233,7 @@ impl<'a> MimeFactory<'a> {
         ensure!(!msg.chat_id.is_special(), "Invalid chat id");
 
         let contact = Contact::load_from_db(context, msg.from_id).await?;
-        let from_addr = context
-            .get_config(Config::ConfiguredAddr)
-            .await?
-            .unwrap_or_default();
+        let from_addr = context.get_configured_addr().await?;
         let from_displayname = context
             .get_config(Config::Displayname)
             .await?
@@ -278,11 +271,7 @@ impl<'a> MimeFactory<'a> {
         &self,
         context: &Context,
     ) -> Result<Vec<(Option<Peerstate>, &str)>> {
-        let self_addr = context
-            .get_config(Config::ConfiguredAddr)
-            .await?
-            .context("not configured")?;
-
+        let self_addr = context.get_configured_addr().await?;
         let mut res = Vec::new();
         for (_, addr) in self
             .recipients

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -133,7 +133,7 @@ impl<'a> MimeFactory<'a> {
     ) -> Result<MimeFactory<'a>> {
         let chat = Chat::load_from_db(context, msg.chat_id).await?;
 
-        let from_addr = context.get_configured_addr().await.unwrap_or_default();
+        let from_addr = context.get_configured_addr().await?;
         let config_displayname = context
             .get_config(Config::Displayname)
             .await?

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -449,13 +449,7 @@ impl Context {
         //                                [======67%=====       ]
         // =============================================================================================
 
-        let domain = dc_tools::EmailAddress::new(
-            &self
-                .get_config(Config::ConfiguredAddr)
-                .await?
-                .unwrap_or_default(),
-        )?
-        .domain;
+        let domain = dc_tools::EmailAddress::new(&self.get_configured_addr().await?)?.domain;
         ret += &format!(
             "<h3>{}</h3><ul>",
             stock_str::storage_on_domain(self, domain).await

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -66,19 +66,7 @@ pub async fn dc_get_securejoin_qr(context: &Context, group: Option<ChatId>) -> R
         .is_none();
     let invitenumber = token::lookup_or_new(context, Namespace::InviteNumber, group).await;
     let auth = token::lookup_or_new(context, Namespace::Auth, group).await;
-    let self_addr = match context.get_config(Config::ConfiguredAddr).await {
-        Ok(Some(addr)) => addr,
-        Ok(None) => {
-            bail!("Not configured, cannot generate QR code.");
-        }
-        Err(err) => {
-            bail!(
-                "Unable to retrieve configuration, cannot generate QR code: {:?}",
-                err
-            );
-        }
-    };
-
+    let self_addr = context.get_configured_addr().await?;
     let self_name = context
         .get_config(Config::Displayname)
         .await?

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -87,7 +87,7 @@ impl Smtp {
         }
 
         self.connectivity.set_connecting(context).await;
-        let lp = LoginParam::from_database(context, "configured_").await?;
+        let lp = LoginParam::load_configured_params(context).await?;
         self.connect(
             context,
             &lp.smtp,

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -395,7 +395,7 @@ UPDATE chats SET protected=1, type=120 WHERE type=130;"#,
 
     if dbversion < 71 {
         info!(context, "[migration] v71");
-        if let Some(addr) = context.get_config(Config::ConfiguredAddr).await? {
+        if let Ok(addr) = context.get_configured_addr().await {
             if let Ok(domain) = addr.parse::<EmailAddress>().map(|email| email.domain) {
                 context
                     .set_config(

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -407,12 +407,7 @@ impl TestContext {
             .await
             .unwrap_or_default()
             .unwrap_or_default();
-        let addr = other
-            .ctx
-            .get_config(Config::ConfiguredAddr)
-            .await
-            .unwrap()
-            .unwrap();
+        let addr = other.ctx.get_configured_addr().await.unwrap();
         // MailinglistAddress is the lowest allowed origin, we'd prefer to not modify the
         // origin when creating this contact.
         let (contact_id, modified) =


### PR DESCRIPTION
- first commit gets rid of using "configured_" strings and rather provides two clean load_candidate_params and load_configured_params APIs 

- second commit gets rid of the many verbose places to access the configured addr. 

This small streamlining is meant to not change any semantics but just shorten source code and make it better readable. 
It came up during discussing with @hocuri on https://github.com/deltachat/deltachat-core-rust/pull/2896

#skip-changelog 