### PR TITLE
Mark messages as seen in IMAP loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `get_connectivity_html()` returns HTML as non-scalable #3213
 - add update-serial to `DC_EVENT_WEBXDC_STATUS_UPDATE` #3215
 - Speed up message receiving via IMAP a bit #3225
+- mark messages as seen on IMAP in batches #3223
 
 
 ## 1.77.0

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -24,7 +24,7 @@ use crate::download::DownloadState;
 use crate::ephemeral::{stock_ephemeral_timer_changed, Timer as EphemeralTimer};
 use crate::events::EventType;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
-use crate::imap::markseen_on_imap;
+use crate::imap::markseen_on_imap_table;
 use crate::location;
 use crate::log::LogExt;
 use crate::message::{
@@ -339,7 +339,7 @@ pub(crate) async fn dc_receive_imf_inner(
                 .await?;
         } else if !mime_parser.mdn_reports.is_empty() && mime_parser.has_chat_version() {
             // This is a Delta Chat MDN. Mark as read.
-            markseen_on_imap(context, rfc724_mid).await?;
+            markseen_on_imap_table(context, rfc724_mid).await?;
         }
     }
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -24,7 +24,7 @@ use crate::download::DownloadState;
 use crate::ephemeral::{stock_ephemeral_timer_changed, Timer as EphemeralTimer};
 use crate::events::EventType;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
-use crate::job::{self, Action};
+use crate::imap::markseen_on_imap;
 use crate::location;
 use crate::log::LogExt;
 use crate::message::{
@@ -339,16 +339,7 @@ pub(crate) async fn dc_receive_imf_inner(
                 .await?;
         } else if !mime_parser.mdn_reports.is_empty() && mime_parser.has_chat_version() {
             // This is a Delta Chat MDN. Mark as read.
-            job::add(
-                context,
-                job::Job::new(
-                    Action::MarkseenMsgOnImap,
-                    insert_msg_id.to_u32(),
-                    Params::new(),
-                    0,
-                ),
-            )
-            .await?;
+            markseen_on_imap(context, rfc724_mid).await?;
         }
     }
 
@@ -2300,6 +2291,7 @@ mod tests {
     use crate::chat::{get_chat_msgs, ChatItem, ChatVisibility};
     use crate::chatlist::Chatlist;
     use crate::constants::DC_GCL_NO_SPECIALS;
+    use crate::imap::prefetch_should_download;
     use crate::message::Message;
     use crate::test_utils::{get_chat_msg, TestContext, TestContextManager};
 
@@ -2883,7 +2875,7 @@ mod tests {
 
         // Check that the ndn would be downloaded:
         let headers = mailparse::parse_mail(raw_ndn).unwrap().headers;
-        assert!(crate::imap::prefetch_should_download(
+        assert!(prefetch_should_download(
             &t,
             &headers,
             "some-other-message-id",

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1054,7 +1054,7 @@ impl Imap {
     }
 
     /// Stores pending `\Seen` flags for messages in `imap_markseen` table.
-    pub(crate) async fn store_seen_flags(&mut self, context: &Context) -> Result<()> {
+    pub(crate) async fn store_seen_flags_on_imap(&mut self, context: &Context) -> Result<()> {
         self.prepare(context).await?;
 
         let rows = context

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1936,7 +1936,7 @@ pub(crate) async fn prefetch_should_download(
         .await?
         .is_some()
     {
-        markseen_on_imap(context, message_id).await?;
+        markseen_on_imap_table(context, message_id).await?;
         return Ok(false);
     }
 
@@ -2070,7 +2070,9 @@ async fn mark_seen_by_uid(
     }
 }
 
-pub(crate) async fn markseen_on_imap(context: &Context, message_id: &str) -> Result<()> {
+/// Schedule marking the message as Seen on IMAP by adding all known IMAP messages corresponding to
+/// the given Message-ID to `imap_markseen` table.
+pub(crate) async fn markseen_on_imap_table(context: &Context, message_id: &str) -> Result<()> {
     context
         .sql
         .execute(

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -7,6 +7,7 @@ use std::{
     cmp,
     cmp::max,
     collections::{BTreeMap, BTreeSet},
+    iter::Peekable,
 };
 
 use anyhow::{bail, format_err, Context as _, Result};
@@ -31,14 +32,13 @@ use crate::dc_receive_imf::{
 use crate::dc_tools::dc_create_id;
 use crate::events::EventType;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
-use crate::job::{self, Action};
+use crate::job;
 use crate::login_param::{
     CertificateChecks, LoginParam, ServerAddress, ServerLoginParam, Socks5Config,
 };
 use crate::message::{self, Message, MessageState, MessengerMessage, MsgId, Viewtype};
 use crate::mimeparser;
 use crate::oauth2::dc_get_oauth2_access_token;
-use crate::param::Params;
 use crate::provider::Socket;
 use crate::scheduler::connectivity::ConnectivityStore;
 use crate::scheduler::InterruptInfo;
@@ -163,6 +163,67 @@ struct ImapConfig {
     /// True if the server has CONDSTORE capability as defined in
     /// <https://tools.ietf.org/html/rfc7162>
     pub can_condstore: bool,
+}
+
+struct UidGrouper<T: Iterator<Item = (i64, u32, String)>> {
+    inner: Peekable<T>,
+}
+
+impl<T, I> From<I> for UidGrouper<T>
+where
+    T: Iterator<Item = (i64, u32, String)>,
+    I: IntoIterator<IntoIter = T>,
+{
+    fn from(inner: I) -> Self {
+        Self {
+            inner: inner.into_iter().peekable(),
+        }
+    }
+}
+
+impl<T: Iterator<Item = (i64, u32, String)>> Iterator for UidGrouper<T> {
+    // Tuple of folder, row IDs, and UID range as a string.
+    type Item = (String, Vec<i64>, String);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (_, _, folder) = self.inner.peek().cloned()?;
+
+        let mut uid_set = String::new();
+        let mut rowid_set = Vec::new();
+
+        while uid_set.len() < 1000 {
+            // Construct a new range.
+            if let Some((start_rowid, start_uid, _)) = self
+                .inner
+                .next_if(|(_, _, start_folder)| start_folder == &folder)
+            {
+                rowid_set.push(start_rowid);
+                let mut end_uid = start_uid;
+
+                while let Some((next_rowid, next_uid, _)) =
+                    self.inner.next_if(|(_, next_uid, next_folder)| {
+                        next_folder == &folder && *next_uid == end_uid + 1
+                    })
+                {
+                    end_uid = next_uid;
+                    rowid_set.push(next_rowid);
+                }
+
+                let uid_range = UidRange {
+                    start: start_uid,
+                    end: end_uid,
+                };
+                if !uid_set.is_empty() {
+                    uid_set.push(',');
+                }
+                uid_set.push_str(&uid_range.to_string());
+            } else {
+                break;
+            }
+        }
+
+        Some((folder, rowid_set, uid_set))
+    }
 }
 
 impl Imap {
@@ -944,7 +1005,7 @@ impl Imap {
     ///
     /// This is the only place where messages are moved or deleted on the IMAP server.
     async fn move_delete_messages(&mut self, context: &Context, folder: &str) -> Result<()> {
-        let mut rows = context
+        let rows = context
             .sql
             .query_map(
                 "SELECT id, uid, target FROM imap
@@ -960,48 +1021,12 @@ impl Imap {
                 },
                 |rows| rows.collect::<Result<Vec<_>, _>>().map_err(Into::into),
             )
-            .await?
-            .into_iter()
-            .peekable();
+            .await?;
 
         self.prepare(context).await?;
         self.select_folder(context, Some(folder)).await?;
 
-        while let Some((_, _, target)) = rows.peek().cloned() {
-            // Construct next request for the target folder.
-            let mut uid_set = String::new();
-            let mut rowid_set = Vec::new();
-
-            while uid_set.len() < 1000 {
-                // Construct a new range.
-                if let Some((start_rowid, start_uid, _)) =
-                    rows.next_if(|(_, _, start_target)| start_target == &target)
-                {
-                    rowid_set.push(start_rowid);
-                    let mut end_uid = start_uid;
-
-                    while let Some((next_rowid, next_uid, _)) =
-                        rows.next_if(|(_, next_uid, next_target)| {
-                            next_target == &target && *next_uid == end_uid + 1
-                        })
-                    {
-                        end_uid = next_uid;
-                        rowid_set.push(next_rowid);
-                    }
-
-                    let uid_range = UidRange {
-                        start: start_uid,
-                        end: end_uid,
-                    };
-                    if !uid_set.is_empty() {
-                        uid_set.push(',');
-                    }
-                    uid_set.push_str(&uid_range.to_string());
-                } else {
-                    break;
-                }
-            }
-
+        for (target, rowid_set, uid_set) in UidGrouper::from(rows) {
             // Empty target folder name means messages should be deleted.
             if target.is_empty() {
                 self.delete_message_batch(context, &uid_set, rowid_set)
@@ -1023,6 +1048,62 @@ impl Imap {
         // deleted messages on the server.
         if let Err(err) = self.maybe_close_folder(context).await {
             warn!(context, "failed to close folder: {:?}", err);
+        }
+
+        Ok(())
+    }
+
+    /// Stores pending `\Seen` flags for messages in `imap_markseen` table.
+    pub(crate) async fn store_seen_flags(&mut self, context: &Context) -> Result<()> {
+        self.prepare(context).await?;
+
+        let rows = context
+            .sql
+            .query_map(
+                "SELECT imap.id, uid, folder FROM imap, imap_markseen
+                 WHERE imap.id = imap_markseen.id AND target = folder
+                 ORDER BY folder, uid",
+                [],
+                |row| {
+                    let rowid: i64 = row.get(0)?;
+                    let uid: u32 = row.get(1)?;
+                    let folder: String = row.get(2)?;
+                    Ok((rowid, uid, folder))
+                },
+                |rows| rows.collect::<Result<Vec<_>, _>>().map_err(Into::into),
+            )
+            .await?;
+
+        for (folder, rowid_set, uid_set) in UidGrouper::from(rows) {
+            self.select_folder(context, Some(&folder))
+                .await
+                .context("failed to select folder")?;
+
+            if let Err(err) = self.add_flag_finalized_with_set(&uid_set, "\\Seen").await {
+                warn!(
+                    context,
+                    "Cannot mark messages {} in folder {} as seen, will retry later: {}.",
+                    uid_set,
+                    folder,
+                    err
+                );
+            } else {
+                info!(
+                    context,
+                    "Marked messages {} in folder {} as seen.", uid_set, folder
+                );
+                context
+                    .sql
+                    .execute(
+                        format!(
+                            "DELETE FROM imap_markseen WHERE id IN ({})",
+                            sql::repeat_vars(rowid_set.len())?
+                        ),
+                        rusqlite::params_from_iter(rowid_set),
+                    )
+                    .await
+                    .context("cannot remove messages marked as seen from imap_markseen table")?;
+            }
         }
 
         Ok(())
@@ -1364,11 +1445,6 @@ impl Imap {
     /// the flag, or other imap-errors, returns true as well.
     ///
     /// Returning error means that the operation can be retried.
-    async fn add_flag_finalized(&mut self, server_uid: u32, flag: &str) -> Result<()> {
-        let s = server_uid.to_string();
-        self.add_flag_finalized_with_set(&s, flag).await
-    }
-
     async fn add_flag_finalized_with_set(&mut self, uid_set: &str, flag: &str) -> Result<()> {
         if self.should_reconnect() {
             bail!("Can't set flag, should reconnect");
@@ -1386,7 +1462,7 @@ impl Imap {
         Ok(())
     }
 
-    pub async fn prepare_imap_operation_on_msg(
+    pub(crate) async fn prepare_imap_operation_on_msg(
         &mut self,
         context: &Context,
         folder: &str,
@@ -1423,32 +1499,6 @@ impl Imap {
                 warn!(context, "failed to select folder: {:?}: {:?}", folder, err);
                 Some(ImapActionResult::RetryLater)
             }
-        }
-    }
-
-    pub(crate) async fn set_seen(
-        &mut self,
-        context: &Context,
-        folder: &str,
-        uid: u32,
-    ) -> ImapActionResult {
-        if let Some(imapresult) = self
-            .prepare_imap_operation_on_msg(context, folder, uid)
-            .await
-        {
-            return imapresult;
-        }
-        // we are connected, and the folder is selected
-        info!(context, "Marking message {}/{} as seen...", folder, uid,);
-
-        if let Err(err) = self.add_flag_finalized(uid, "\\Seen").await {
-            warn!(
-                context,
-                "Cannot mark message {} in folder {} as seen, ignoring: {}.", uid, folder, err
-            );
-            ImapActionResult::Failed
-        } else {
-            ImapActionResult::Success
         }
     }
 
@@ -1882,13 +1932,11 @@ pub(crate) async fn prefetch_should_download(
     mut flags: impl Iterator<Item = Flag<'_>>,
     show_emails: ShowEmails,
 ) -> Result<bool> {
-    if let Some(msg_id) = message::rfc724_mid_exists(context, message_id).await? {
-        // We know the Message-ID already, it must be a Bcc: to self.
-        job::add(
-            context,
-            job::Job::new(Action::MarkseenMsgOnImap, msg_id.to_u32(), Params::new(), 0),
-        )
-        .await?;
+    if message::rfc724_mid_exists(context, message_id)
+        .await?
+        .is_some()
+    {
+        markseen_on_imap(context, message_id).await?;
         return Ok(false);
     }
 
@@ -2020,6 +2068,20 @@ async fn mark_seen_by_uid(
         // There is no message is `msgs` table matchng the given UID.
         Ok(None)
     }
+}
+
+pub(crate) async fn markseen_on_imap(context: &Context, message_id: &str) -> Result<()> {
+    context
+        .sql
+        .execute(
+            "INSERT OR IGNORE INTO imap_markseen (id)
+             SELECT id FROM imap WHERE rfc724_mid=?",
+            paramsv![message_id],
+        )
+        .await?;
+    context.interrupt_inbox(InterruptInfo::new(false)).await;
+
+    Ok(())
 }
 
 /// uid_next is the next unique identifier value from the last time we fetched a folder

--- a/src/message.rs
+++ b/src/message.rs
@@ -22,7 +22,7 @@ use crate::dc_tools::{
 use crate::download::DownloadState;
 use crate::ephemeral::{start_ephemeral_timers_msgids, Timer as EphemeralTimer};
 use crate::events::EventType;
-use crate::imap::markseen_on_imap;
+use crate::imap::markseen_on_imap_table;
 use crate::job::{self, Action};
 use crate::log::LogExt;
 use crate::mimeparser::{parse_message_id, FailureReport, SystemMessage};
@@ -1357,7 +1357,7 @@ pub async fn markseen_msgs(context: &Context, msg_ids: Vec<MsgId>) -> Result<()>
             update_msg_state(context, id, MessageState::InSeen).await?;
             info!(context, "Seen message {}.", id);
 
-            markseen_on_imap(context, &curr_rfc724_mid).await?;
+            markseen_on_imap_table(context, &curr_rfc724_mid).await?;
 
             // Read receipts for system messages are never sent. These messages have no place to
             // display received read receipt anyway.  And since their text is locally generated,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -168,6 +168,16 @@ async fn fetch_idle(ctx: &Context, connection: &mut Imap, folder: Config) -> Int
                 return connection.fake_idle(ctx, Some(watch_folder)).await;
             }
 
+            if folder == Config::ConfiguredInboxFolder {
+                if let Err(err) = connection
+                    .store_seen_flags(ctx)
+                    .await
+                    .context("store_seen_flags failed")
+                {
+                    warn!(ctx, "{:#}", err);
+                }
+            }
+
             // Fetch the watched folder.
             if let Err(err) = connection.fetch_move_delete(ctx, &watch_folder).await {
                 connection.trigger_reconnect(ctx).await;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -170,9 +170,9 @@ async fn fetch_idle(ctx: &Context, connection: &mut Imap, folder: Config) -> Int
 
             if folder == Config::ConfiguredInboxFolder {
                 if let Err(err) = connection
-                    .store_seen_flags(ctx)
+                    .store_seen_flags_on_imap(ctx)
                     .await
-                    .context("store_seen_flags failed")
+                    .context("store_seen_flags_on_imap failed")
                 {
                     warn!(ctx, "{:#}", err);
                 }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -181,6 +181,7 @@ impl Sql {
                      PRAGMA secure_delete=on;
                      PRAGMA busy_timeout = {};
                      PRAGMA temp_store=memory; -- Avoid SQLITE_IOERR_GETTEMPPATH errors on Android
+                     PRAGMA foreign_keys=on;
                      ",
                     Duration::from_secs(10).as_millis()
                 ))?;

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -613,6 +613,17 @@ CREATE INDEX smtp_messageid ON imap(rfc724_mid);
         sql.execute_migration("DROP TABLE IF EXISTS backup_blobs;", 88)
             .await?;
     }
+    if dbversion < 89 {
+        info!(context, "[migration] v89");
+        sql.execute_migration(
+            r#"CREATE TABLE imap_markseen (
+              id INTEGER,
+              FOREIGN KEY(id) REFERENCES imap(id) ON DELETE CASCADE
+            );"#,
+            89,
+        )
+        .await?;
+    }
 
     Ok((
         recalc_fingerprints,


### PR DESCRIPTION
MarkseenMsgOnImap job, that was responsible for marking messages as
seen on IMAP and sending MDNs, has been removed.

Messages waiting to be marked as seen are now stored in a
single-column imap_markseen table consisting of foreign keys pointing
to corresponding imap table records.

Messages are marked as seen in batches in the inbox loop. UIDs are
grouped by folders to reduce the number of requests, including folder
selection requests. UID grouping logic has been factored out of
move_delete_messages into UidGrouper iterator to avoid code duplication.

Messages are marked as seen right before fetching from the inbox
folder. This ensures that even if new messages arrive into inbox while
the connection has another folder selected to mark messages there, all
messages are fetched before going IDLE. Ideally marking messages as
seen should be done after fetching and moving, as it is a low-priority
task, but this requires skipping IDLE if UIDNEXT has advanced since
previous time inbox has been selected. This is outside of the scope of
this change.

MDNs are now queued independently of marking the messages as seen.
SendMdn job is created directly rather than after marking the message
as seen on IMAP. Previously sending MDNs was done in MarkseenMsgOnImap
avoid duplicate MDN sending by setting $MDNSent flag together with
\Seen flag and skipping MDN sending if the flag is already set. This
is not the case anymore as $MDNSent flag support has been removed in
9c077c98cde37714f1129a7f25c39eb081c96346 and duplicate MDN sending in
multi-device case is avoided by synchronizing Seen status since
833e5f46ccb0c47fd9b1e9452d3c069ec019dc23 as long as the server
supports CONDSTORE extension.

Closes #3190 