### PR TITLE
Remove unused stop-token dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
  "once_cell",
  "ouroboros",
  "pin-utils",
- "stop-token 0.2.0",
+ "stop-token",
  "thiserror",
 ]
 
@@ -1123,7 +1123,6 @@ dependencies = [
  "sha-1 0.10.0",
  "sha2 0.10.2",
  "smallvec",
- "stop-token 0.7.0",
  "strum",
  "strum_macros",
  "surf",
@@ -3606,18 +3605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d5e0f9b25bdd9bf18e33d1f4dd0194c77034b66b4a4842b0bf7f5cf53ca733a"
 dependencies = [
  "async-std",
- "pin-project-lite",
-]
-
-[[package]]
-name = "stop-token"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af91f480ee899ab2d9f8435bfdfc14d08a5754bd9d3fef1f1a1c23336aad6c8b"
-dependencies = [
- "async-channel",
- "cfg-if 1.0.0",
- "futures-core",
  "pin-project-lite",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ serde = { version = "1.0", features = ["derive"] }
 sha-1 = "0.10"
 sha2 = "0.10"
 smallvec = "1"
-stop-token = "0.7"
 strum = "0.24"
 strum_macros = "0.24"
 surf = { version = "2.3", default-features = false, features = ["h1-client"] }


### PR DESCRIPTION
stop-token 0.2.0 is required by async-imap. This Cargo.toml entry
additionally pulled in unused stop-token 0.7.0.