### PR TITLE
accounts: retry remove_account multiple times on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Take `delete_device_after` into account when calculating ephemeral loop timeout #3211
 - Fix a bug where a blocked contact could send a contact request #3218
 - Make sure, videochat-room-names are always URL-safe #3231
+- Try removing account folder multiple times in case of failure #3229
 
 ### Changes
 


### PR DESCRIPTION
When removing an account, try 60 times with 1 second sleep in between
in case removal of database files fails. This happens on Windows
platform sometimes due to a known bug in r2d2 which may result in 30
seconds delay until all connections are closed [1].

[1] https://github.com/sfackler/r2d2/issues/99