### PR TITLE
dc_receive_imf: remove Received: based draft detection heuristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - add update-serial to `DC_EVENT_WEBXDC_STATUS_UPDATE` #3215
 - Speed up message receiving via IMAP a bit #3225
 - mark messages as seen on IMAP in batches #3223
+- remove Received: based draft detection heuristic #3230
 
 
 ## 1.77.0

--- a/benches/receive_emails.rs
+++ b/benches/receive_emails.rs
@@ -31,7 +31,7 @@ Hello {i}",
             i = i,
             i_dec = i - 1,
         );
-        dc_receive_imf(&context, black_box(imf_raw.as_bytes()), "INBOX", false)
+        dc_receive_imf(&context, black_box(imf_raw.as_bytes()), false)
             .await
             .unwrap();
     }

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -102,7 +102,7 @@ async fn reset_tables(context: &Context, bits: i32) {
 async fn poke_eml_file(context: &Context, filename: impl AsRef<Path>) -> Result<()> {
     let data = dc_read_file(context, filename).await?;
 
-    if let Err(err) = dc_receive_imf(context, &data, "import", false).await {
+    if let Err(err) = dc_receive_imf(context, &data, false).await {
         println!("dc_receive_imf errored: {:?}", err);
     }
     Ok(())

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4226,7 +4226,6 @@ mod tests {
                     num
                 )
                 .as_bytes(),
-                "INBOX",
                 false,
             )
             .await?;
@@ -4676,9 +4675,7 @@ mod tests {
         assert_eq!(msg.match_indices("Gr.").count(), 1);
 
         // Bob receives this message, he may detect group by `References:`- or `Chat-Group:`-header
-        dc_receive_imf(&bob, msg.as_bytes(), "INBOX", false)
-            .await
-            .unwrap();
+        dc_receive_imf(&bob, msg.as_bytes(), false).await.unwrap();
         let msg = bob.get_last_msg().await;
 
         let bob_chat = Chat::load_from_db(&bob, msg.chat_id).await?;
@@ -4697,9 +4694,7 @@ mod tests {
         assert_eq!(msg.match_indices("Chat-").count(), 0);
 
         // Alice receives this message - she can still detect the group by the `References:`-header
-        dc_receive_imf(&alice, msg.as_bytes(), "INBOX", false)
-            .await
-            .unwrap();
+        dc_receive_imf(&alice, msg.as_bytes(), false).await.unwrap();
         let msg = alice.get_last_msg().await;
         assert_eq!(msg.chat_id, alice_chat_id);
         assert_eq!(msg.text, Some("ho!".to_string()));
@@ -4724,7 +4719,6 @@ mod tests {
                  Date: Fri, 23 Apr 2021 10:00:57 +0000\n\
                  \n\
                  hello\n",
-            "INBOX",
             false,
         )
         .await?;
@@ -4772,7 +4766,6 @@ mod tests {
                  Date: Sun, 22 Mar 2021 19:37:57 +0000\n\
                  \n\
                  hello\n",
-            "INBOX",
             false,
         )
         .await?;
@@ -4820,7 +4813,6 @@ mod tests {
                  Date: Sun, 22 Mar 2021 19:37:57 +0000\n\
                  \n\
                  hello\n",
-            "INBOX",
             false,
         )
         .await?;
@@ -4867,7 +4859,6 @@ mod tests {
                  Date: Sun, 22 Mar 2021 19:37:57 +0000\n\
                  \n\
                  hello\n",
-            "INBOX",
             false,
         )
         .await?;

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -503,7 +503,6 @@ mod tests {
                  Date: Sun, 22 Mar 2021 22:37:57 +0000\n\
                  \n\
                  hello foo\n",
-            "INBOX",
             false,
         )
         .await?;
@@ -564,7 +563,6 @@ mod tests {
                  Date: Sun, 22 Mar 2021 22:38:57 +0000\n\
                  \n\
                  hello foo\n",
-            "INBOX",
             false,
         )
         .await?;

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -2153,7 +2153,7 @@ Chat-Version: 1.0
 Date: Sun, 22 Mar 2020 22:37:55 +0000
 
 Hi."#;
-        dc_receive_imf(&alice, mime, "Inbox", false).await?;
+        dc_receive_imf(&alice, mime, false).await?;
         let msg = alice.get_last_msg().await;
 
         let timestamp = msg.get_timestamp();

--- a/src/context.rs
+++ b/src/context.rs
@@ -714,9 +714,7 @@ mod tests {
             dc_create_outgoing_rfc724_mid(None, contact.get_addr())
         );
         println!("{}", msg);
-        dc_receive_imf(t, msg.as_bytes(), "INBOX", false)
-            .await
-            .unwrap();
+        dc_receive_imf(t, msg.as_bytes(), false).await.unwrap();
     }
 
     #[async_std::test]

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -700,7 +700,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
     async fn check_parse_receive_headers_integration(raw: &[u8], expected: &str) {
         let t = TestContext::new_alice().await;
         t.set_config(Config::ShowEmails, Some("2")).await.unwrap();
-        dc_receive_imf(&t, raw, "INBOX", false).await.unwrap();
+        dc_receive_imf(&t, raw, false).await.unwrap();
         let msg = t.get_last_msg().await;
         let msg_info = get_msg_info(&t, msg.id).await.unwrap();
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -346,7 +346,6 @@ mod tests {
             &t,
             "Mr.12345678901@example.com",
             header.as_bytes(),
-            "INBOX",
             false,
             Some(100000),
             false,
@@ -364,7 +363,6 @@ mod tests {
             &t,
             "Mr.12345678901@example.com",
             format!("{}\n\n100k text...", header).as_bytes(),
-            "INBOX",
             false,
             None,
             false,
@@ -400,7 +398,6 @@ mod tests {
                     Message-ID: <first@example.org>\n\
                     Date: Sun, 14 Nov 2021 00:10:00 +0000\
                     Content-Type: text/plain",
-            "INBOX",
             false,
             Some(100000),
             false,

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -1118,7 +1118,6 @@ mod tests {
                     Date: Sun, 22 Mar 2020 00:10:00 +0000\n\
                     \n\
                     hello\n",
-            "INBOX",
             false,
         )
         .await?;
@@ -1139,7 +1138,6 @@ mod tests {
                     Ephemeral-Timer: 60\n\
                     \n\
                     second message\n",
-            "INBOX",
             false,
         )
         .await?;
@@ -1176,7 +1174,6 @@ mod tests {
                     In-Reply-To: <first@example.com>\n\
                     \n\
                     > hello\n",
-            "INBOX",
             false,
         )
         .await?;

--- a/src/html.rs
+++ b/src/html.rs
@@ -440,7 +440,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
             .create_chat_with_contact("", "sender@testrun.org")
             .await;
         let raw = include_bytes!("../test-data/message/text_alt_plain_html.eml");
-        dc_receive_imf(&alice, raw, "INBOX", false).await.unwrap();
+        dc_receive_imf(&alice, raw, false).await.unwrap();
         let msg = alice.get_last_msg_in(chat.get_id()).await;
         assert_ne!(msg.get_from_id(), ContactId::SELF);
         assert_eq!(msg.is_dc_message, MessengerMessage::No);
@@ -489,7 +489,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
             .create_chat_with_contact("", "sender@testrun.org")
             .await;
         let raw = include_bytes!("../test-data/message/text_alt_plain_html.eml");
-        dc_receive_imf(&alice, raw, "INBOX", false).await.unwrap();
+        dc_receive_imf(&alice, raw, false).await.unwrap();
         let msg = alice.get_last_msg_in(chat.get_id()).await;
 
         // forward the message to saved-messages,
@@ -555,7 +555,6 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         dc_receive_imf(
             &t,
             include_bytes!("../test-data/message/cp1252-html.eml"),
-            "INBOX",
             false,
         )
         .await?;

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1350,8 +1350,6 @@ impl Imap {
                 }
             };
 
-            let folder = folder.to_string();
-
             while let Some(Ok(msg)) = msgs.next().await {
                 let server_uid = msg.uid.unwrap_or_default();
 
@@ -1385,7 +1383,6 @@ impl Imap {
 
                 // XXX put flags into a set and pass them to dc_receive_imf
                 let context = context.clone();
-                let folder = folder.clone();
 
                 // safe, as we checked above that there is a body.
                 let body = body
@@ -1406,7 +1403,6 @@ impl Imap {
                     &context,
                     rfc724_mid,
                     body,
-                    &folder,
                     is_seen,
                     partial,
                     fetching_existing_messages,

--- a/src/message.rs
+++ b/src/message.rs
@@ -2050,7 +2050,6 @@ mod tests {
                     Date: Fri, 29 Jan 2021 21:37:55 +0000\n\
                     \n\
                     hello\n",
-            "INBOX",
             false,
         )
         .await
@@ -2259,7 +2258,6 @@ mod tests {
                     Date: Fri, 29 Jan 2021 21:37:55 +0000\n\
                     \n\
                     hello\n",
-            "INBOX",
             false,
         )
         .await?;
@@ -2277,7 +2275,6 @@ mod tests {
                     Date: Fri, 29 Jan 2021 21:37:55 +0000\n\
                     \n\
                     hello again\n",
-            "INBOX",
             false,
         )
         .await?;

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1661,7 +1661,6 @@ mod tests {
             Date: Sun, 22 Mar 2020 22:37:56 +0000\n\
             \n\
             hello\n",
-            "INBOX",
             false,
         )
         .await
@@ -1754,7 +1753,6 @@ mod tests {
                 t.get_last_msg().await.rfc724_mid
             )
             .as_bytes(),
-            "INBOX",
             false,
         )
         .await?;
@@ -1865,7 +1863,6 @@ mod tests {
                     Date: Sun, 22 Mar 2020 22:37:56 +0000\n\
                     \n\
                     Some other, completely unrelated content\n",
-                "INBOX",
                 false,
             )
             .await
@@ -1890,9 +1887,7 @@ mod tests {
             .await
             .unwrap();
 
-        dc_receive_imf(context, imf_raw, "INBOX", false)
-            .await
-            .unwrap();
+        dc_receive_imf(context, imf_raw, false).await.unwrap();
 
         let chats = Chatlist::try_load(context, 0, None, None).await.unwrap();
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -2915,7 +2915,6 @@ On 2020-10-25, Bob wrote:
         dc_receive_imf(
             &t.ctx,
             include_bytes!("../test-data/message/subj_with_multimedia_msg.eml"),
-            "INBOX",
             false,
         )
         .await
@@ -3064,7 +3063,7 @@ Subject: ...
 
 Some quote.
 "###;
-        dc_receive_imf(&t, raw, "INBOX", false).await?;
+        dc_receive_imf(&t, raw, false).await?;
 
         // Delta Chat generates In-Reply-To with a starting tab when Message-ID is too long.
         let raw = br###"In-Reply-To:
@@ -3081,7 +3080,7 @@ Subject: ...
 Some reply
 "###;
 
-        dc_receive_imf(&t, raw, "INBOX", false).await?;
+        dc_receive_imf(&t, raw, false).await?;
 
         let msg = t.get_last_msg().await;
         assert_eq!(msg.get_text().unwrap(), "Some reply");
@@ -3109,13 +3108,13 @@ Message.
 "###;
 
         // Bob receives message.
-        dc_receive_imf(&bob, raw, "INBOX", false).await?;
+        dc_receive_imf(&bob, raw, false).await?;
         let msg = bob.get_last_msg().await;
         // Message is incoming.
         assert!(msg.param.get_bool(Param::WantsMdn).unwrap());
 
         // Alice receives copy-to-self.
-        dc_receive_imf(&alice, raw, "INBOX", false).await?;
+        dc_receive_imf(&alice, raw, false).await?;
         let msg = alice.get_last_msg().await;
         // Message is outgoing, don't send read receipt to self.
         assert!(msg.param.get_bool(Param::WantsMdn).is_none());
@@ -3141,7 +3140,6 @@ Message.
                  \n\
                  hello\n"
                 .as_bytes(),
-            "INBOX",
             false,
         )
         .await?;
@@ -3179,7 +3177,6 @@ Message.
                  \n\
                  --SNIPP--"
             .as_bytes(),
-            "INBOX",
             false,
         )
         .await?;
@@ -3202,7 +3199,7 @@ Message.
 
         let original =
             include_bytes!("../test-data/message/ms_exchange_report_original_message.eml");
-        dc_receive_imf(&t, original, "INBOX", false).await?;
+        dc_receive_imf(&t, original, false).await?;
         let original_msg_id = t.get_last_msg().await.id;
 
         // 1. Test mimeparser directly
@@ -3217,7 +3214,7 @@ Message.
         assert!(mimeparser.mdn_reports[0].additional_message_ids.is_empty());
 
         // 2. Test that marking the original msg as read works
-        dc_receive_imf(&t, mdn, "INBOX", false).await?;
+        dc_receive_imf(&t, mdn, false).await?;
 
         assert_eq!(
             original_msg_id.get_state(&t).await?,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -364,7 +364,7 @@ impl TestContext {
             "Received: (Postfix, from userid 1000); Mon, 4 Dec 2006 14:51:39 +0100 (CET)\n"
                 .to_owned()
                 + msg.payload();
-        dc_receive_imf(&self.ctx, received_msg.as_bytes(), "INBOX", false)
+        dc_receive_imf(&self.ctx, received_msg.as_bytes(), false)
             .await
             .unwrap();
     }

--- a/src/update_helper.rs
+++ b/src/update_helper.rs
@@ -99,7 +99,6 @@ mod tests {
                  Date: Sun, 22 Mar 2021 23:37:57 +0000\n\
                  \n\
                  second message\n",
-            "INBOX",
             false,
         )
         .await?;
@@ -113,7 +112,6 @@ mod tests {
                  Date: Sun, 22 Mar 2021 22:37:57 +0000\n\
                  \n\
                  first message\n",
-            "INBOX",
             false,
         )
         .await?;
@@ -143,7 +141,6 @@ mod tests {
                  Date: Sun, 22 Mar 2021 01:00:00 +0000\n\
                  \n\
                  first message\n",
-            "INBOX",
             false,
         )
         .await?;
@@ -163,7 +160,6 @@ mod tests {
                  Date: Sun, 22 Mar 2021 03:00:00 +0000\n\
                  \n\
                  third message\n",
-            "INBOX",
             false,
         )
         .await?;
@@ -179,7 +175,6 @@ mod tests {
                  Date: Sun, 22 Mar 2021 02:00:00 +0000\n\
                  \n\
                  second message\n",
-            "INBOX",
             false,
         )
         .await?;

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -774,7 +774,6 @@ mod tests {
         dc_receive_imf(
             &t,
             include_bytes!("../test-data/message/webxdc_good_extension.eml"),
-            "INBOX",
             false,
         )
         .await?;
@@ -785,7 +784,6 @@ mod tests {
         dc_receive_imf(
             &t,
             include_bytes!("../test-data/message/webxdc_bad_extension.eml"),
-            "INBOX",
             false,
         )
         .await?;


### PR DESCRIPTION
Proper draft detection was implemented in
bf7f64d50ba30f63b1338c66aed780dab9461dfc

Removing this heuristic also removes the need to pass IMAP folder name
around.