### PR TITLE
url-safe id generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Take `delete_device_after` into account when calculating ephemeral loop timeout #3211
 - Fix a bug where a blocked contact could send a contact request #3218
+- Make sure, videochat-room-names are always URL-safe #3231
 
 ### Changes
 

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -214,7 +214,10 @@ pub(crate) fn dc_create_id() -> String {
     rng.fill(&mut arr[..]);
 
     // Take 11 base64 characters containing 66 random bits.
-    base64::encode(&arr).chars().take(11).collect()
+    base64::encode_config(&arr, base64::URL_SAFE)
+        .chars()
+        .take(11)
+        .collect()
 }
 
 /// Function generates a Message-ID that can be used for a new outgoing message.

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -763,6 +763,15 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
     }
 
     #[test]
+    fn test_dc_create_id_invalid_chars() {
+        for _ in 1..1000 {
+            let buf = dc_create_id();
+            assert!(!buf.contains('/')); // `/` must not be used to be URL-safe
+            assert!(!buf.contains('.')); // `.` is used as a delimiter when extracting grpid from Message-ID
+        }
+    }
+
+    #[test]
     fn test_dc_extract_grpid_from_rfc724_mid() {
         // Should return None if we pass invalid mid
         let mid = "foobar";


### PR DESCRIPTION
the ids created by `dc_create_id()` are used, among other things, for the random room name for video-chat-urls.

for this purpose, the IDs need to be URL-safe. this is even promised in the documentation, however, the used base64 encoding scheme "STANDARD"  uses the `/` character which results in _some_ IDs being not URL-safe.

this pr fixes that by switching to explicit  URL-safe base64 encoding scheme. moreover, a test is added that checks 1000 random IDs to not contain slashes.

thanks to the delta-testing-group to figure out this issue!