### PR TITLE
resend messages using the same Message-ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### API-Changes
 
 - replaced stock string `DC_STR_ONE_MOMENT` by `DC_STR_NOT_CONNECTED` #3222
+- add `dc_resend_msgs()` #3238
 
 ### Fixes
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1802,6 +1802,25 @@ void            dc_forward_msgs              (dc_context_t* context, const uint3
 
 
 /**
+ * Resend messages and make information available for newly added chat members.
+ * Resending sends out the original message, however, recipients and webxdc-status may differ.
+ * Clients that already have the original message can still ignore the resent message as
+ * they have tracked the state by dedicated updates.
+ *
+ * Some messages cannot be resent, eg. info-messages, drafts, already pending messages or messages that are not sent by SELF.
+ * In this case, the return value indicates an error and the error string from dc_get_last_error() should be shown to the user.
+ *
+ * @memberof dc_context_t
+ * @param context The context object.
+ * @param msg_ids An array of uint32_t containing all message IDs that should be resend.
+ *     All messages must belong to the same chat.
+ * @param msg_cnt The number of messages IDs in the msg_ids array.
+ * @return 1=all messages are queued for resending, 0=error
+ */
+int             dc_resend_msgs               (dc_context_t* context, const uint32_t* msg_ids, int msg_cnt);
+
+
+/**
  * Mark messages as presented to the user.
  * Typically, UIs call this function on scrolling through the message list,
  * when the messages are presented at least for a little moment.

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1752,6 +1752,27 @@ pub unsafe extern "C" fn dc_forward_msgs(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_resend_msgs(
+    context: *mut dc_context_t,
+    msg_ids: *const u32,
+    msg_cnt: libc::c_int,
+) -> libc::c_int {
+    if context.is_null() || msg_ids.is_null() || msg_cnt <= 0 {
+        eprintln!("ignoring careless call to dc_resend_msgs()");
+        return 0;
+    }
+    let ctx = &*context;
+    let msg_ids = convert_and_prune_message_ids(msg_ids, msg_cnt);
+
+    if let Err(err) = block_on(chat::resend_msgs(ctx, &msg_ids)) {
+        error!(ctx, "Resending failed: {}", err);
+        0
+    } else {
+        1
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_markseen_msgs(
     context: *mut dc_context_t,
     msg_ids: *const u32,

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -399,6 +399,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                  html <msg-id>\n\
                  listfresh\n\
                  forward <msg-id> <chat-id>\n\
+                 resend <msg-id>\n\
                  markseen <msg-id>\n\
                  delmsg <msg-id>\n\
                  ===========================Contact commands==\n\
@@ -1098,6 +1099,13 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             let chat_id = ChatId::new(arg2.parse()?);
             msg_ids[0] = MsgId::new(arg1.parse()?);
             chat::forward_msgs(&context, &msg_ids, chat_id).await?;
+        }
+        "resend" => {
+            ensure!(!arg1.is_empty(), "Arguments <msg-id> expected");
+
+            let mut msg_ids = [MsgId::new(0); 1];
+            msg_ids[0] = MsgId::new(arg1.parse()?);
+            chat::resend_msgs(&context, &msg_ids).await?;
         }
         "markseen" => {
             ensure!(!arg1.is_empty(), "Argument <msg-id> missing.");

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -207,11 +207,12 @@ const CHAT_COMMANDS: [&str; 36] = [
     "accept",
     "blockchat",
 ];
-const MESSAGE_COMMANDS: [&str; 7] = [
+const MESSAGE_COMMANDS: [&str; 8] = [
     "listmsgs",
     "msginfo",
     "listfresh",
     "forward",
+    "resend",
     "markseen",
     "delmsg",
     "download",

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3126,6 +3126,21 @@ pub async fn forward_msgs(context: &Context, msg_ids: &[MsgId], chat_id: ChatId)
     Ok(())
 }
 
+pub async fn resend_msgs(context: &Context, msg_ids: &[MsgId]) -> Result<()> {
+    ensure!(!msg_ids.is_empty(), "empty msgs_ids: nothing to resend");
+    for msg_id in msg_ids {
+        let msg = Message::load_from_db(context, *msg_id).await?;
+        ensure!(
+            msg.state != MessageState::OutPreparing && msg.state != MessageState::OutDraft,
+            "cannot resend unsent messages"
+        );
+        if create_send_msg_job(context, *msg_id).await?.is_some() {
+            context.interrupt_smtp(InterruptInfo::new(false)).await;
+        }
+    }
+    Ok(())
+}
+
 pub(crate) async fn get_chat_cnt(context: &Context) -> Result<usize> {
     if context.sql.is_open().await {
         // no database, no chats - this is no error (needed eg. for information)
@@ -5100,6 +5115,59 @@ mod tests {
             assert!(!sent_msg.payload().contains("secretname"));
             assert!(!sent_msg.payload().contains("alice"));
         }
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_resend_own_message() -> Result<()> {
+        // Alice creates group with Bob and sends an initial message
+        let alice = TestContext::new_alice().await;
+        let alice_grp = create_group_chat(&alice, ProtectionStatus::Unprotected, "grp").await?;
+        add_contact_to_chat(
+            &alice,
+            alice_grp,
+            Contact::create(&alice, "", "bob@example.net").await?,
+        )
+        .await?;
+        let sent1 = alice.send_text(alice_grp, "alice->bob").await;
+
+        // Alice adds Claire to group and resends her own initial message
+        add_contact_to_chat(
+            &alice,
+            alice_grp,
+            Contact::create(&alice, "", "claire@example.org").await?,
+        )
+        .await?;
+        let sent2 = alice.pop_sent_msg().await;
+        resend_msgs(&alice, &[sent1.sender_msg_id]).await?;
+        let sent3 = alice.pop_sent_msg().await;
+
+        // Bob receives all messages
+        let bob = TestContext::new_bob().await;
+        bob.recv_msg(&sent1).await;
+        let msg = bob.get_last_msg().await;
+        assert_eq!(msg.get_text().unwrap(), "alice->bob");
+        assert_eq!(get_chat_contacts(&bob, msg.chat_id).await?.len(), 2);
+        assert_eq!(get_chat_msgs(&bob, msg.chat_id, 0, None).await?.len(), 1);
+        bob.recv_msg(&sent2).await;
+        assert_eq!(get_chat_contacts(&bob, msg.chat_id).await?.len(), 3);
+        assert_eq!(get_chat_msgs(&bob, msg.chat_id, 0, None).await?.len(), 2);
+        bob.recv_msg(&sent3).await;
+        assert_eq!(get_chat_contacts(&bob, msg.chat_id).await?.len(), 3);
+        assert_eq!(get_chat_msgs(&bob, msg.chat_id, 0, None).await?.len(), 2);
+
+        // Claire does not receive the first message, however, due to resending, she has a similar view as Alice and Bob
+        let claire = TestContext::new().await;
+        claire.configure_addr("claire@example.org").await;
+        claire.recv_msg(&sent2).await;
+        claire.recv_msg(&sent3).await;
+        let msg = claire.get_last_msg().await;
+        assert_eq!(msg.get_text().unwrap(), "alice->bob");
+        assert_eq!(get_chat_contacts(&claire, msg.chat_id).await?.len(), 3);
+        assert_eq!(get_chat_msgs(&claire, msg.chat_id, 0, None).await?.len(), 2);
+        let msg_from = Contact::get_by_id(&claire, msg.get_from_id()).await?;
+        assert_eq!(msg_from.get_addr(), "alice@example.org");
 
         Ok(())
     }


### PR DESCRIPTION
this pr is currently mainly to check out the effort of resending messages using the same Message-ID as suggested and discussed skeptically at https://github.com/deltachat/deltachat-core-rust/issues/3236 

so ...

- the approach is quite simple - without the boilerplate, this is only few lines of new code, exiting code is not really touched, so no new states etc.
- i tested that with resending an webxdc to a new group member - works like a charme

notes:

- [x] resending is done in the name of the resender, **this is weird and needs to be fixed somehow**; there is the `Sender:` header that is already in use and could maybe also help on that EDIT: for now, we fixed that by allow resending own messages only
- [x] allow resending unencrypted if a peerstate is missing 
- [x] we should not allow resending info messages as member-added, webxdc updates etc. - these things will add many cornercases
- [x] for outgoing message, we could reset the state to `OutPending` before resending, so that some progress is visible again (this is not easily possible for incoming message that do not have pending-state not UI for that)
- if "delete on server" is enabled, resend messages, that are not downloaded as already known by a client, are probably not deleted. this is not targeted by this pr, also, not sure if this is a big issue at the end.

and, there are the general concerns about resending messages this way.

so, wondering how we can proceed here:
1. use the pr and get some experience:
    - (a) the resend function will probably not used widely in the first time  
    - only if it turns out, this pr messes up things, (b) we can enhance resending by eg. using a new Message-ID and putting the original somewhere eg. to `Original-Message-ID`. that would be a bit less smart, prefetch would need adaption etc. but probably still okay. the ffi would not be changed for that
2. skip directly to 1(b)
3. do something completely different

closes https://github.com/deltachat/deltachat-core-rust/issues/3236