### PR TITLE
Trash location.kml messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Make sure, videochat-room-names are always URL-safe #3231
 - Try removing account folder multiple times in case of failure #3229
 - Ignore messages from all spam folders if there are many #3246
+- Hide location-only messages instead of displaying empty bubbles #3248
 
 ### Changes
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1103,11 +1103,11 @@ INSERT INTO msgs
 
         // If you change which information is skipped if the message is trashed,
         // also change `MsgId::trash()` and `delete_expired_messages()`
-        let trash = chat_id.is_trash();
+        let trash = chat_id.is_trash() || (location_kml_is && msg.is_empty());
 
         stmt.execute(paramsv![
             rfc724_mid,
-            chat_id,
+            if trash { DC_CHAT_ID_TRASH } else { chat_id },
             if trash { ContactId::UNDEFINED } else { from_id },
             if trash { ContactId::UNDEFINED } else { to_id },
             sort_timestamp,


### PR DESCRIPTION
Assign location.kml message parts to the trash chat,
but return non-trash chat_id so locations are assigned
to the correct chat.

Due to a bug introduced in
7968f5519186a820ebe2f39211917fd51498058f
previously location.kml messages resulted in
empty message bubbles on the receiver.

Fixes #3249 