### PR TITLE
streamline emitting MsgsChanged and IncomingMsg event emission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ deltachat-ffi/xml
 
 coverage/
 .DS_Store
+.vscode/launch.json
+python/accounts.txt
+python/all-testaccounts.txt
+tmp/

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -21,7 +21,6 @@ use deltachat::message::{self, Message, MessageState, MsgId, Viewtype};
 use deltachat::peerstate::*;
 use deltachat::qr::*;
 use deltachat::sql;
-use deltachat::EventType;
 use deltachat::{config, provider};
 use std::fs;
 use std::time::{Duration, SystemTime};
@@ -93,10 +92,7 @@ async fn reset_tables(context: &Context, bits: i32) {
         println!("(8) Rest but server config reset.");
     }
 
-    context.emit_event(EventType::MsgsChanged {
-        chat_id: ChatId::new(0),
-        msg_id: MsgId::new(0),
-    });
+    context.emit_msgs_changed_without_ids();
 }
 
 async fn poke_eml_file(context: &Context, filename: impl AsRef<Path>) -> Result<()> {
@@ -164,10 +160,7 @@ async fn poke_spec(context: &Context, spec: Option<&str>) -> bool {
     }
     println!("Import: {} items read from \"{}\".", read_cnt, &real_spec);
     if read_cnt > 0 {
-        context.emit_event(EventType::MsgsChanged {
-            chat_id: ChatId::new(0),
-            msg_id: MsgId::new(0),
-        });
+        context.emit_msgs_changed_without_ids();
     }
     true
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -241,6 +241,24 @@ impl Context {
         });
     }
 
+    /// Emits a generic MsgsChanged event (without chat or message id)
+    pub fn emit_msgs_changed_without_ids(&self) {
+        self.emit_event(EventType::MsgsChanged {
+            chat_id: ChatId::new(0),
+            msg_id: MsgId::new(0),
+        });
+    }
+
+    /// Emits a MsgsChanged event with specified chat and message ids
+    pub fn emit_msgs_changed(&self, chat_id: ChatId, msg_id: MsgId) {
+        self.emit_event(EventType::MsgsChanged { chat_id, msg_id });
+    }
+
+    /// Emits an IncomingMsg event with specified chat and message ids
+    pub fn emit_incoming_msg(&self, chat_id: ChatId, msg_id: MsgId) {
+        self.emit_event(EventType::IncomingMsg { chat_id, msg_id });
+    }
+
     /// Returns a receiver for emitted events.
     ///
     /// Multiple emitters can be created, but note that in this case each emitted event will

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -329,18 +329,15 @@ pub(crate) async fn dc_receive_imf_inner(
     }
 
     if replace_partial_download {
-        context.emit_event(EventType::MsgsChanged {
-            msg_id: MsgId::new(0),
-            chat_id,
-        });
+        context.emit_msgs_changed(chat_id, MsgId::new(0));
     } else if !chat_id.is_trash() {
+        let fresh = added_parts.received_msg.state == MessageState::InFresh;
         for msg_id in added_parts.created_db_entries {
-            let event = if incoming && added_parts.received_msg.state == MessageState::InFresh {
-                EventType::IncomingMsg { msg_id, chat_id }
+            if incoming && fresh {
+                context.emit_incoming_msg(chat_id, msg_id);
             } else {
-                EventType::MsgsChanged { msg_id, chat_id }
+                context.emit_msgs_changed(chat_id, msg_id);
             };
-            context.emit_event(event);
         }
     }
 

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -399,10 +399,7 @@ WHERE
     }
 
     if updated {
-        context.emit_event(EventType::MsgsChanged {
-            chat_id: ChatId::new(0),
-            msg_id: MsgId::new(0),
-        });
+        context.emit_msgs_changed_without_ids();
     }
 
     Ok(())

--- a/src/message.rs
+++ b/src/message.rs
@@ -1254,10 +1254,7 @@ pub async fn delete_msgs(context: &Context, msg_ids: &[MsgId]) -> Result<()> {
     }
 
     if !msg_ids.is_empty() {
-        context.emit_event(EventType::MsgsChanged {
-            chat_id: ChatId::new(0),
-            msg_id: MsgId::new(0),
-        });
+        context.emit_msgs_changed_without_ids();
 
         // Run housekeeping to delete unused blobs.
         context.set_config(Config::LastHousekeeping, None).await?;

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -239,10 +239,7 @@ impl Context {
             {
                 instance.param.set(Param::WebxdcSummary, summary);
                 instance.update_param(self).await;
-                self.emit_event(EventType::MsgsChanged {
-                    chat_id: instance.chat_id,
-                    msg_id: instance.id,
-                });
+                self.emit_msgs_changed(instance.chat_id, instance.id);
             }
         }
 


### PR DESCRIPTION
All MsgsChanged and IncomingMsg events are now generated by three `context.emit_*` functions.  While reducing LOCs and improving readability this also is meant to help future experiments with caching of chat list loading (`ChatList::try_load`) where we would make the three emit functions invalidate the in-RAM cache of the chatlist.  This PR is not that, though, and meant to be an easy "approve" :)  
#skip-changelog 