### PR TITLE
Abort instead of unwinding on panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,11 @@ rust-version = "1.56"
 
 [profile.dev]
 debug = 0
+panic = 'abort'
 
 [profile.release]
 lto = true
+panic = 'abort'
 
 [dependencies]
 deltachat_derive = { path = "./deltachat_derive" }


### PR DESCRIPTION
@adbenitez just had a bug where the inbox loop seems to be gone. One possible reason for this is a panic in the inbox loop. So, instead of just stopping fetching messages altogether, we should rather abort so that the user or the system (as done on Android) can restart it.

I also noticed that it's undefined behavior to unwind over the FFI boundary.

With this change:
1. When a background task aborts, we get a nice stacktrace on the Android log. Before, there was no indication of the crash at all in the log:

<Details>
<Summary>Android stacktrace example</Summary>

```
04-28 13:27:50.295  9234  9275 F libc    : Fatal signal 6 (SIGABRT), code -1 (SI_QUEUE) in tid 9275 (async-std/runti), pid 9234 (.messenger.beta)
04-28 13:27:50.399  9330  9330 I crash_dump64: obtaining output fd from tombstoned, type: kDebuggerdTombstone
04-28 13:27:50.400   971   971 I /system/bin/tombstoned: received crash request for pid 9275
04-28 13:27:50.405  9330  9330 I crash_dump64: performing dump of process 9234 (target tid = 9275)
04-28 13:27:50.422  9330  9330 F DEBUG   : *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
04-28 13:27:50.423  9330  9330 F DEBUG   : Build fingerprint: 'Fairphone/FP3/FP3:10/8901.3.A.0066.20201119/11190844:user/release-keys'
04-28 13:27:50.423  9330  9330 F DEBUG   : Revision: '0'
04-28 13:27:50.423  9330  9330 F DEBUG   : ABI: 'arm64'
04-28 13:27:50.424  9330  9330 F DEBUG   : Timestamp: 2022-04-28 13:27:50+0200
04-28 13:27:50.424  9330  9330 F DEBUG   : pid: 9234, tid: 9275, name: async-std/runti  >>> com.b44t.messenger.beta <<<
04-28 13:27:50.424  9330  9330 F DEBUG   : uid: 10318
04-28 13:27:50.424  9330  9330 F DEBUG   : signal 6 (SIGABRT), code -1 (SI_QUEUE), fault addr --------
04-28 13:27:50.424  9330  9330 F DEBUG   : Abort message: 'explicit panic'
04-28 13:27:50.424  9330  9330 F DEBUG   :     x0  0000000000000000  x1  000000000000243b  x2  0000000000000006  x3  00000070d0b36a50
04-28 13:27:50.424  9330  9330 F DEBUG   :     x4  0000000000008080  x5  0000000000008080  x6  0000000000008080  x7  0000000000000038
04-28 13:27:50.424  9330  9330 F DEBUG   :     x8  00000000000000f0  x9  9ee3b2d5c8813b03  x10 0000000000000001  x11 0000000000000000
04-28 13:27:50.424  9330  9330 F DEBUG   :     x12 fffffff0fffffbdf  x13 0000000003eee1f4  x14 0000000000000006  x15 ffffffffffffffff
04-28 13:27:50.424  9330  9330 F DEBUG   :     x16 00000071c86fc8c0  x17 00000071c86d8910  x18 00000070cee0c000  x19 0000000000002412
04-28 13:27:50.424  9330  9330 F DEBUG   :     x20 000000000000243b  x21 00000000ffffffff  x22 00000070daee98d0  x23 00000070db029ec8
04-28 13:27:50.424  9330  9330 F DEBUG   :     x24 00000070da6624c0  x25 0000000000000001  x26 0000000000000000  x27 00000071cc2e2020
04-28 13:27:50.424  9330  9330 F DEBUG   :     x28 0000007fe542bfe0  x29 00000070d0b36af0
04-28 13:27:50.424  9330  9330 F DEBUG   :     sp  00000070d0b36a30  lr  00000071c868a0c4  pc  00000071c868a0f0
04-28 13:27:50.441  9234  9298 I DeltaChat: src/imap.rs:753: No new emails in folder Archives
04-28 13:27:50.469  9330  9330 F DEBUG   : 
04-28 13:27:50.469  9330  9330 F DEBUG   : backtrace:
04-28 13:27:50.469  9330  9330 F DEBUG   :       #00 pc 00000000000830f0  /apex/com.android.runtime/lib64/bionic/libc.so (abort+160) (BuildId: 21847aa9757f000b0461310a9f5e6e51)
04-28 13:27:50.469  9330  9330 F DEBUG   :       #01 pc 0000000002d410b0  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.469  9330  9330 F DEBUG   :       #02 pc 0000000002d410a0  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (__rust_start_panic+8) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.469  9330  9330 F DEBUG   :       #03 pc 0000000002d2cb3c  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (rust_panic+16) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.469  9330  9330 F DEBUG   :       #04 pc 0000000002d2c91c  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (std::panicking::rust_panic_with_hook::hcdc16bc1d6a90d9f+676) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.469  9330  9330 F DEBUG   :       #05 pc 0000000002d2c608  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.469  9330  9330 F DEBUG   :       #06 pc 0000000002d28dd8  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.469  9330  9330 F DEBUG   :       #07 pc 0000000002d2c37c  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (rust_begin_unwind+60) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.469  9330  9330 F DEBUG   :       #08 pc 000000000169f938  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (core::panicking::panic_fmt::h28a757e2227ef488+44) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.469  9330  9330 F DEBUG   :       #09 pc 000000000169f854  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (core::panicking::panic::h57be532174f5074a+48) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.469  9330  9330 F DEBUG   :       #10 pc 0000000002dfa1a8  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.469  9330  9330 F DEBUG   :       #11 pc 0000000001856ffc  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.469  9330  9330 F DEBUG   :       #12 pc 0000000002f6f4f8  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.469  9330  9330 F DEBUG   :       #13 pc 0000000001862a34  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.469  9330  9330 F DEBUG   :       #14 pc 0000000002f662e8  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.470  9330  9330 F DEBUG   :       #15 pc 0000000001859bc0  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.470  9330  9330 F DEBUG   :       #16 pc 0000000002f60118  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.470  9330  9330 F DEBUG   :       #17 pc 000000000184a110  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.470  9330  9330 F DEBUG   :       #18 pc 0000000002e68c8c  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.470  9330  9330 F DEBUG   :       #19 pc 000000000184311c  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.470  9330  9330 F DEBUG   :       #20 pc 0000000002e6b31c  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.470  9330  9330 F DEBUG   :       #21 pc 0000000001846c78  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.470  9330  9330 F DEBUG   :       #22 pc 000000000187ca98  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.470  9330  9330 F DEBUG   :       #23 pc 00000000017efa90  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.470  9330  9330 F DEBUG   :       #24 pc 00000000018f8b1c  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.470  9330  9330 F DEBUG   :       #25 pc 0000000002e6af38  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.470  9330  9330 F DEBUG   :       #26 pc 0000000001842470  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.470  9330  9330 F DEBUG   :       #27 pc 0000000002e6f85c  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #28 pc 000000000182b1b4  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #29 pc 00000000018c295c  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #30 pc 0000000002e3adb4  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #31 pc 0000000003151ec0  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #32 pc 0000000003117be8  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #33 pc 0000000002e353a4  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #34 pc 00000000018c0318  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #35 pc 00000000031c4260  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #36 pc 0000000001845118  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #37 pc 00000000017f0f4c  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #38 pc 0000000003056274  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #39 pc 0000000002a1c9b4  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (async_task::runnable::Runnable::run::h41b90548ef9ae302+48) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #40 pc 00000000034942a8  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (async_executor::Executor::run::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::hb43fc9b1bad7075d+484) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #41 pc 00000000029eba34  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (_$LT$core..future..from_generator..GenFuture$LT$T$GT$$u20$as$u20$core..future..future..Future$GT$::poll::hf7447014712de6a3+72) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #42 pc 00000000029e3ec4  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (_$LT$futures_lite..future..Or$LT$F1$C$F2$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h567478b27accba80+84) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #43 pc 0000000003493b8c  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (async_executor::Executor::run::_$u7b$$u7b$closure$u7d$$u7d$::h72b894649651f85f+368) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #44 pc 00000000029eb0f4  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (_$LT$core..future..from_generator..GenFuture$LT$T$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h1d508ec95e820b1a+72) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #45 pc 00000000029e3e28  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (_$LT$futures_lite..future..Or$LT$F1$C$F2$GT$$u20$as$u20$core..future..future..Future$GT$::poll::h29be65182c3cc2b3+84) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #46 pc 00000000029f7fe4  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (async_io::driver::block_on::h4fcd6713d9e44158+512) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #47 pc 00000000029f6460  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #48 pc 00000000029f6380  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (async_global_executor::reactor::block_on::h776e3e5c07b98719+60) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #49 pc 00000000029f2094  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #50 pc 00000000029feff0  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (std::thread::local::LocalKey$LT$T$GT$::try_with::ha44559a9bcee0c4f+120) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #51 pc 00000000029fe3cc  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (std::thread::local::LocalKey$LT$T$GT$::with::hd5685bd7ada3f557+8) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.471  9330  9330 F DEBUG   :       #52 pc 00000000029f1fe0  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #53 pc 00000000029e7374  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (std::panicking::try::do_call::h5177ae57688616a1+24) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #54 pc 00000000029e72ec  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (std::panicking::try::hca405fb3ca6a910b+36) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #55 pc 00000000029f3698  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (std::panic::catch_unwind::hb2098efc5c833c0d+8) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #56 pc 00000000029f1edc  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (async_global_executor::threading::thread_main_loop::h5fe2b8c8a2aa75c1+160) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #57 pc 00000000029f4608  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #58 pc 00000000029f6e50  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (std::sys_common::backtrace::__rust_begin_short_backtrace::h7de6d93c0f5be439+8) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #59 pc 0000000002a00cc4  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (std::thread::Builder::spawn_unchecked_::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::he7c6b34b137333c3+4) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #60 pc 00000000029f65e8  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (_$LT$core..panic..unwind_safe..AssertUnwindSafe$LT$F$GT$$u20$as$u20$core..ops..function..FnOnce$LT$$LP$$RP$$GT$$GT$::call_once::h7eef9b2db87a8b75+8) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #61 pc 00000000029e739c  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (std::panicking::try::do_call::h6c5ea0ea2b6b863f+16) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #62 pc 00000000029e7258  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (std::panicking::try::h385ef314fbe54e87+16) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #63 pc 00000000029f366c  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (std::panic::catch_unwind::h043938c7225a1c3b+8) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #64 pc 0000000002a00c28  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (std::thread::Builder::spawn_unchecked_::_$u7b$$u7b$closure$u7d$$u7d$::h4a07545b06e9bc78+180) (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #65 pc 00000000029f4568  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #66 pc 0000000002d366ac  /data/app/com.b44t.messenger.beta-nx5Xqln3AW5sZcQ6W0NuEg==/lib/arm64/libnative-utils.so (BuildId: 40f930d2b844be2376e29154745186e719946370)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #67 pc 00000000000e68a0  /apex/com.android.runtime/lib64/bionic/libc.so (__pthread_start(void*)+36) (BuildId: 21847aa9757f000b0461310a9f5e6e51)
04-28 13:27:50.472  9330  9330 F DEBUG   :       #68 pc 0000000000084b6c  /apex/com.android.runtime/lib64/bionic/libc.so (__start_thread+64) (BuildId: 21847aa9757f000b0461310a9f5e6e51)
```

</Details>

2.  Before, when a function called from the FFI API panicked, then this was undefined behavior and [strongly advised against](https://doc.rust-lang.org/nomicon/unwinding.html):
  > Rust's unwinding strategy is not specified to be fundamentally compatible with any other language's unwinding. As such, unwinding into Rust from another language, or unwinding into another language from Rust is Undefined Behavior. You must absolutely catch any panics at the FFI boundary! What you do at that point is up to you, but something must be done. If you fail to do this, at best, your application will crash and burn. At worst, your application won't crash and burn, and will proceed with completely clobbered state.

  With this change, there is no unwinding anymore and therefore no undefined behavior.

3. Tests are still compiled as panic=unwind (there is no way to compile tests with panic=abort)

4. In the REPL, the stack traces become worse:

<Details>
<Summary>REPL stacktraces</Summary>

```
   0: rust_begin_unwind
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/panicking.rs:143:14
   2: core::panicking::panic
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/panicking.rs:48:5
   3: deltachat::qr_code_generator::generate_verification_qr::{{closure}}
```
insetead of
```
   0: rust_begin_unwind
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/panicking.rs:143:14
   2: core::panicking::panic
             at /rustc/7737e0b5c4103216d6fd8cf941b7ab9bdbaace7c/library/core/src/panicking.rs:48:5
   3: deltachat::qr_code_generator::generate_verification_qr::{{closure}}
   4: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
   5: deltachat::qr_code_generator::get_securejoin_qr_svg::{{closure}}
   6: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
   7: repl::handle_cmd::{{closure}}
   8: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
   9: repl::start::{{closure}}
  10: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
  11: repl::main::{{closure}}
  12: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
  13: <async_std::task::builder::SupportTaskLocals<F> as core::future::future::Future>::poll::{{closure}}
  14: async_std::task::task_locals_wrapper::TaskLocalsWrapper::set_current::{{closure}}
  15: std::thread::local::LocalKey<T>::try_with
  16: std::thread::local::LocalKey<T>::with
  17: async_std::task::task_locals_wrapper::TaskLocalsWrapper::set_current
  18: <async_std::task::builder::SupportTaskLocals<F> as core::future::future::Future>::poll
  19: <futures_lite::future::Or<F1,F2> as core::future::future::Future>::poll
  20: async_executor::Executor::run::{{closure}}
  21: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
  22: async_executor::LocalExecutor::run::{{closure}}
  23: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
  24: async_io::driver::block_on
  25: async_global_executor::reactor::block_on::{{closure}}
  26: async_global_executor::reactor::block_on
  27: async_global_executor::executor::block_on::{{closure}}
  28: std::thread::local::LocalKey<T>::try_with
  29: std::thread::local::LocalKey<T>::with
  30: async_global_executor::executor::block_on
  31: async_std::task::builder::Builder::blocking::{{closure}}::{{closure}}
  32: async_std::task::task_locals_wrapper::TaskLocalsWrapper::set_current::{{closure}}
  33: std::thread::local::LocalKey<T>::try_with
  34: std::thread::local::LocalKey<T>::with
  35: async_std::task::task_locals_wrapper::TaskLocalsWrapper::set_current
  36: async_std::task::builder::Builder::blocking::{{closure}}
  37: std::thread::local::LocalKey<T>::try_with
  38: std::thread::local::LocalKey<T>::with
  39: async_std::task::builder::Builder::blocking
  40: async_std::task::block_on::block_on
  41: repl::main
  42: core::ops::function::FnOnce::call_once
```

(Note that as of https://github.com/deltachat/deltachat-core-rust/pull/2205 we don't have any line numbers anymore in the stack trace as a tradeoff for faster compile times)

</Details>

6. If we want, we can also make this configurable via command line options for `cargo run`/`cargo build` so that e.g. the REPL can use panic=unwind. Generally we could let some platforms use the old behavior in this way, but this doesn't seem advisable.

7. Nothing changes for other Rust projects using the dc core crate as a dependency since [profile settings defined in dependencies will be ignored](https://doc.rust-lang.org/cargo/reference/profiles.html).

### Alternatives

- `catch_unwind()` every function in the FFI (to get rid of the undefined behavior) and every loop (so that it can continue after panics, possibly fixing @adbenitez' bug).
- `catch_unwind()` every function in the FFI (to get rid of the undefined behavior) and add a supervisor loops that restarts other loops if they panicked.

(Edit: Put some stuff into "Details" to make everything easier to read)