### PR TITLE
replaced imapclient python library with imap-tools

### DIFF
--- a/python/mypy.ini
+++ b/python/mypy.ini
@@ -17,3 +17,7 @@ ignore_missing_imports = True
 
 [mypy-_pytest.*]
 ignore_missing_imports = True
+
+[mypy-imap_tools.*]
+ignore_missing_imports = True
+

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,6 +6,3 @@ build-backend = "setuptools.build_meta"
 root = ".."
 tag_regex = '^(?P<prefix>py-)?(?P<version>[^\+]+)(?P<suffix>.*)?$'
 git_describe_command = "git describe --dirty --tags --long --match py-*.*"
-
-[mypy-imap_tools]
-ignore_missing_imports = true

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,3 +6,6 @@ build-backend = "setuptools.build_meta"
 root = ".."
 tag_regex = '^(?P<prefix>py-)?(?P<version>[^\+]+)(?P<suffix>.*)?$'
 git_describe_command = "git describe --dirty --tags --long --match py-*.*"
+
+[mypy-imap_tools]
+ignore_missing_imports = true

--- a/python/setup.py
+++ b/python/setup.py
@@ -11,7 +11,7 @@ def main():
         description='Python bindings for the Delta Chat Core library using CFFI against the Rust-implemented libdeltachat',
         long_description=long_description,
         author='holger krekel, Floris Bruynooghe, Bjoern Petersen and contributors',
-        install_requires=['cffi>=1.0.0', 'pluggy', 'imapclient', 'requests'],
+        install_requires=['cffi>=1.0.0', 'pluggy', 'imap-tools', 'requests'],
         setup_requires=[
             'setuptools_scm', # required for compatibility with `python3 setup.py sdist`
             'pkgconfig',

--- a/python/src/deltachat/direct_imap.py
+++ b/python/src/deltachat/direct_imap.py
@@ -10,6 +10,7 @@ from imap_tools import MailBox, MailBoxTls, errors, AND, Header, MailMessageFlag
 import imaplib
 import deltachat
 from deltachat import const, Account
+from typing import List
 
 
 FLAGS = b'FLAGS'
@@ -118,7 +119,7 @@ class DirectImap:
         if foldername:
             return self.select_folder(foldername)
 
-    def list_folders(self) -> [str]:
+    def list_folders(self) -> List[str]:
         """ return list of all existing folder names"""
         assert not self._idling
         return [folder.name for folder in self.conn.folder.list()]
@@ -133,11 +134,11 @@ class DirectImap:
         if expunge:
             self.conn.expunge()
 
-    def get_all_messages(self) -> [MailMessage]:
+    def get_all_messages(self) -> List[MailMessage]:
         assert not self._idling
         return [mail for mail in self.conn.fetch()]
 
-    def get_unread_messages(self) -> [str]:
+    def get_unread_messages(self) -> List[str]:
         assert not self._idling
         return [msg.uid for msg in self.conn.fetch(AND(seen=False))]
 
@@ -196,7 +197,7 @@ class DirectImap:
         self._idling = True
         return res
 
-    def idle_check(self, terminate=False, timeout=60) -> [bytes]:
+    def idle_check(self, terminate=False, timeout=60) -> List[bytes]:
         """ (blocking) wait for next idle message from server. """
         assert self._idling
         self.account.log("imap-direct: calling idle_check")

--- a/python/src/deltachat/direct_imap.py
+++ b/python/src/deltachat/direct_imap.py
@@ -197,7 +197,7 @@ class DirectImap:
         self._idling = True
         return res
 
-    def idle_check(self, terminate=False, timeout=60) -> List[bytes]:
+    def idle_check(self, terminate=False, timeout=None) -> List[bytes]:
         """ (blocking) wait for next idle message from server. """
         assert self._idling
         self.account.log("imap-direct: calling idle_check")
@@ -207,7 +207,7 @@ class DirectImap:
         self.account.log("imap-direct: idle_check returned {!r}".format(res))
         return res
 
-    def idle_wait_for_new_message(self, terminate=False, timeout=60) -> bytes:
+    def idle_wait_for_new_message(self, terminate=False, timeout=None) -> bytes:
         while 1:
             for item in self.idle_check(timeout=timeout):
                 if b'EXISTS' in item or b'RECENT' in item:
@@ -215,7 +215,7 @@ class DirectImap:
                         self.idle_done()
                     return item
 
-    def idle_wait_for_seen(self, terminate=False, timeout=60) -> int:
+    def idle_wait_for_seen(self, terminate=False, timeout=None) -> int:
         """ Return first message with SEEN flag from a running idle-stream.
         """
         while 1:

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -2548,12 +2548,9 @@ class TestOnlineAccount:
 
         ac2._evtracker.get_info_contains("close/expunge succeeded")
 
-        lp.sec("imap2: test that only one message is left")
-        imap2 = ac2.direct_imap
-        imap2.idle_start()
-        imap2.idle_wait_for_new_message(timeout=600)
-        imap2.idle_done()
-        assert len(imap2.get_all_messages()) == 1
+        lp.sec("ac2: test that only one message is left")
+        ac2.direct_imap.select_config_folder("inbox")
+        assert len(ac2.direct_imap.get_all_messages()) == 1
 
     def test_configure_error_msgs(self, acfactory):
         ac1, configdict = acfactory.get_online_config()

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -2294,7 +2294,7 @@ class TestOnlineAccount:
         ac1.direct_imap.delete("1:*", expunge=False)
         ac1.start_io()
 
-        for ev in ac1._evtracker.iter_events(timeout=60):
+        for ev in ac1._evtracker.iter_events():
             if ev.name == "DC_EVENT_MSGS_CHANGED":
                 pytest.fail("A deleted message was shown to the user")
 


### PR DESCRIPTION
the python bindings have a direct_imap module responsible for direct IMAP calls. It's mostly used in the python tests. I replaced the old imapclient library with a different library which is much more up-to-date.
#skip-changelog 

With testrun.org as a mail server the tests pass so far.

What's still ugly: sometimes direct_imap uses strings, sometimes bytes, and this could be brought in a better order.