### PR TITLE
streamline python test machinery

### DIFF
--- a/python/examples/test_examples.py
+++ b/python/examples/test_examples.py
@@ -42,7 +42,7 @@ def test_group_tracking_plugin(acfactory, lp):
     lp.sec("creating one group-tracking bot and two temp accounts")
     botproc = acfactory.run_bot_process(group_tracking, ffi=False)
 
-    ac1, ac2 = acfactory.get_two_online_accounts(quiet=True)
+    ac1, ac2 = acfactory.get_two_online_accounts()
 
     botproc.fnmatch_lines("""
         *ac_configure_completed*

--- a/python/examples/test_examples.py
+++ b/python/examples/test_examples.py
@@ -22,7 +22,7 @@ def test_echo_quit_plugin(acfactory, lp):
     botproc = acfactory.run_bot_process(echo_and_quit)
 
     lp.sec("creating a temp account to contact the bot")
-    ac1 = acfactory.get_one_online_account()
+    ac1, = acfactory.get_online_accounts(1)
 
     lp.sec("sending a message to the bot")
     bot_contact = ac1.create_contact(botproc.addr)

--- a/python/examples/test_examples.py
+++ b/python/examples/test_examples.py
@@ -42,7 +42,7 @@ def test_group_tracking_plugin(acfactory, lp):
     lp.sec("creating one group-tracking bot and two temp accounts")
     botproc = acfactory.run_bot_process(group_tracking, ffi=False)
 
-    ac1, ac2 = acfactory.get_two_online_accounts()
+    ac1, ac2 = acfactory.get_online_accounts(2)
 
     botproc.fnmatch_lines("""
         *ac_configure_completed*

--- a/python/src/deltachat/__init__.py
+++ b/python/src/deltachat/__init__.py
@@ -2,7 +2,7 @@ import sys
 
 from . import capi, const, hookspec # noqa
 from .capi import ffi  # noqa
-from .account import Account  # noqa
+from .account import Account, get_core_info  # noqa
 from .message import Message  # noqa
 from .contact import Contact  # noqa
 from .chat import Chat        # noqa

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -129,6 +129,8 @@ class Account(object):
         namebytes = name.encode("utf8")
         if namebytes == b"addr" and self.is_configured():
             raise ValueError("can not change 'addr' after account is configured.")
+        if isinstance(value, (int, bool)):
+            value = str(int(value))
         if value is not None:
             valuebytes = value.encode("utf8")
         else:
@@ -169,7 +171,7 @@ class Account(object):
         :returns: None
         """
         for key, value in kwargs.items():
-            self.set_config(key, str(value))
+            self.set_config(key, value)
 
     def is_configured(self) -> bool:
         """ determine if the account is configured already; an initial connection

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -67,6 +67,9 @@ class Account(object):
         """ re-enable logging. """
         self._logging = True
 
+    def __repr__(self):
+        return "<Account path={}>".format(self.db_path)
+
     # def __del__(self):
     #    self.shutdown()
 
@@ -571,6 +574,8 @@ class Account(object):
         """ add an account plugin which implements one or more of
         the :class:`deltachat.hookspec.PerAccount` hooks.
         """
+        if name and self._pm.has_plugin(name=name):
+            self._pm.unregister(name=name)
         self._pm.register(plugin, name=name)
         self._pm.check_pending()
         return plugin

--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -221,6 +221,8 @@ class EventThread(threading.Thread):
             self._inner_run()
 
     def _inner_run(self):
+        if self._marked_for_shutdown or self.account._dc_context is None:
+            return
         event_emitter = ffi.gc(
             lib.dc_get_event_emitter(self.account._dc_context),
             lib.dc_event_emitter_unref,

--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -29,9 +29,9 @@ class FFIEventLogger:
     # to prevent garbled logging
     _loglock = threading.RLock()
 
-    def __init__(self, account, init_time=None) -> None:
+    def __init__(self, account, logid=None, init_time=None) -> None:
         self.account = account
-        self.logid = self.account.get_config("displayname")
+        self.logid = logid or self.account.get_config("displayname")
         if init_time is None:
             init_time = time.time()
         self.init_time = init_time

--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -156,14 +156,14 @@ class FFIEventTracker:
                 print("** SECUREJOINT-INVITER PROGRESS {}".format(target), self.account)
                 break
 
-    def wait_all_initial_fetches(self):
+    def wait_idle_inbox_ready(self):
         """Has to be called after start_io() to wait for fetch_existing_msgs to run
         so that new messages are not mistaken for old ones:
         - ac1 and ac2 are created
         - ac1 sends a message to ac2
         - ac2 is still running FetchExsistingMsgs job and thinks it's an existing, old message
         - therefore no DC_EVENT_INCOMING_MSG is sent"""
-        self.get_info_contains("Done fetching existing messages")
+        self.get_info_contains("INBOX: Idle entering")
 
     def wait_next_incoming_message(self):
         """ wait for and return next incoming message. """

--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -250,7 +250,7 @@ class EventThread(threading.Thread):
                     hook = getattr(self.account._pm.hook, name)
                     hook(**kwargs)
             except Exception:
-                if self.account._dc_context is not None:
+                if not self._marked_for_shutdown and self.account._dc_context is not None:
                     raise
 
     def _map_ffi_event(self, ffi_event: FFIEvent):

--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -29,10 +29,12 @@ class FFIEventLogger:
     # to prevent garbled logging
     _loglock = threading.RLock()
 
-    def __init__(self, account) -> None:
+    def __init__(self, account, init_time=None) -> None:
         self.account = account
         self.logid = self.account.get_config("displayname")
-        self.init_time = time.time()
+        if init_time is None:
+            init_time = time.time()
+        self.init_time = init_time
 
     @account_hookimpl
     def ac_process_ffi_event(self, ffi_event: FFIEvent) -> None:

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -273,10 +273,9 @@ class ACFactory:
             else:
                 print("WARN: could not use preconfigured keys for {!r}".format(addr))
 
-    def get_configured_offline_account(self):
-        ac = self.get_unconfigured_account()
-
+    def get_pseudo_configured_account(self):
         # do a pseudo-configured account
+        ac = self.get_unconfigured_account()
         acname = os.path.basename(ac.db_path)
         addr = "{}@offline.org".format(acname)
         ac.update_config(dict(

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -304,21 +304,9 @@ class ACFactory:
         self._preconfigure_key(ac, configdict["addr"])
         ac.update_config(configdict)
 
-    def get_one_online_account(self, mvbox_move=False):
-        ac1 = self.get_online_configuring_account(mvbox_move=mvbox_move)
-        self.wait_configure_and_start_io()
-        return ac1
-
-    def get_two_online_accounts(self, mvbox_move=False):
-        ac1 = self.get_online_configuring_account(mvbox_move=mvbox_move)
-        ac2 = self.get_online_configuring_account()
-        self.wait_configure_and_start_io()
-        return ac1, ac2
-
-    def get_many_online_accounts(self, num, **kwargs):
-        # to reduce number of log events for higher level tests
-        # logging only starts after initial successful configuration
-        accounts = [self.get_online_configuring_account(**kwargs) for i in range(num)]
+    def get_online_accounts(self, num):
+        # to reduce number of log events logging starts after accounts can receive
+        accounts = [self.get_online_configuring_account() for i in range(num)]
         self.wait_configure_and_start_io(logstart="after_inbox_idle_ready")
         return accounts
 

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -244,7 +244,7 @@ class ACFactory:
         assert "addr" in configdict and "mail_pw" in configdict
         return configdict
 
-    def make_account(self, quiet=False):
+    def get_unconfigured_account(self, quiet=False):
         logid = "ac{}".format(len(self._accounts) + 1)
         path = self.tmpdir.join(logid)
         ac = Account(path.strpath, logging=self._logging)
@@ -258,9 +258,6 @@ class ACFactory:
 
     def set_logging_default(self, logging):
         self._logging = bool(logging)
-
-    def get_unconfigured_account(self):
-        return self.make_account()
 
     def remove_preconfigured_keys(self):
         self._preconfigured_keys = []
@@ -297,7 +294,7 @@ class ACFactory:
     def get_online_configuring_account(self, sentbox=False, move=False,
                                        quiet=False, config={}):
         configdict = self.get_next_liveconfig()
-        ac = self.make_account(quiet=quiet)
+        ac = self.get_unconfigured_account(quiet=quiet)
         configdict.setdefault("displayname", os.path.basename(ac.db_path))
         self._preconfigure_key(ac, configdict["addr"])
         configdict.update(config)
@@ -333,7 +330,7 @@ class ACFactory:
         direct_imap object of an online account. This simulates the user setting
         up a new device without importing a backup.
         """
-        ac = self.make_account()
+        ac = self.get_unconfigured_account()
         # XXX we might want to transfer the key from the old account for some tests
         self._preconfigure_key(ac, account.get_config("addr"))
         ac.update_config(dict(
@@ -371,7 +368,7 @@ class ACFactory:
         fn = module.__file__
 
         bot_cfg = self.get_next_liveconfig()
-        bot_ac = self.make_account()
+        bot_ac = self.get_unconfigured_account()
         bot_ac.update_config(bot_cfg)
         self._preconfigure_key(bot_ac, bot_cfg["addr"])
 

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -327,19 +327,15 @@ class ACFactory:
         ac._configtracker = ac.configure()
         return ac
 
-    def wait_configure_and_start_io(self, logstart="after_inbox_idle_ready"):
-        assert logstart in ("after_inbox_idle_ready",), logstart
-
+    def bring_accounts_online(self):
         for acc in self._accounts:
-            logger = FFIEventLogger(acc, logid=acc._logid, init_time=self.init_time)
             self.wait_configure(acc)
             acc.start_io()
-            acc.log("waiting for inbox IDLE to become ready")
+            print("waiting for inbox IDLE to become ready")
             acc._evtracker.wait_idle_inbox_ready()
-            print("account IDLE: ready")
-            assert 0
-            if logstart == "after_inbox_idle_ready":
-                acc.add_account_plugin(logger)
+            logger = FFIEventLogger(acc, logid=acc._logid, init_time=self.init_time)
+            acc.add_account_plugin(logger)
+            acc.log("inbox IDLE ready!")
 
     def wait_configure(self, acc):
         if hasattr(acc, "_configtracker"):
@@ -353,7 +349,7 @@ class ACFactory:
     def get_online_accounts(self, num):
         # to reduce number of log events logging starts after accounts can receive
         accounts = [self.get_online_configuring_account() for i in range(num)]
-        self.wait_configure_and_start_io(logstart="after_inbox_idle_ready")
+        self.bring_accounts_online()
         return accounts
 
     def run_bot_process(self, module, ffi=True):

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -155,19 +155,21 @@ class TestProcess:
 
             yield from iter(configlist)
         else:
-            for index in range(10):
+            MAX_LIVE_CREATED_ACCOUNTS = 10
+            for index in range(MAX_LIVE_CREATED_ACCOUNTS):
                 try:
                     yield configlist[index]
                 except IndexError:
                     res = requests.post(liveconfig_opt)
                     if res.status_code != 200:
-                        pytest.fail("creat newtmpuser failed {}: '{}'".format(
-                                    res.status_code, res.text))
+                        pytest.fail("newtmpuser count={} code={}: '{}'".format(
+                                    index, res.status_code, res.text))
                     d = res.json()
                     config = dict(addr=d["email"], mail_pw=d["password"])
+                    print("newtmpuser {}: addr={}".format(index, config["addr"]))
                     configlist.append(config)
                     yield config
-            pytest.fail("more than 10 live accounts requested. Is a test running wild?")
+            pytest.fail("more than {} live accounts requested.".format(MAX_LIVE_CREATED_ACCOUNTS))
 
 
 @pytest.fixture

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -397,7 +397,7 @@ class ACFactory:
         logger = FFIEventLogger(acc, logid=acc._logid, init_time=self.init_time)
         acc.add_account_plugin(logger, name=acc._logid)
 
-    def wait_configure(self, acc):
+    def wait_configured(self, acc):
         self._pending_configure.wait_one(acc)
         self.init_direct_imap_and_logging(acc)
         acc._evtracker.consume_events()

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -293,7 +293,7 @@ class ACFactory:
         self._preconfigure_key(ac, addr)
         return ac
 
-    def get_online_configuring_account(self, **kwargs):
+    def new_online_configuring_account(self, **kwargs):
         configdict = self.get_next_liveconfig()
         configdict.update(kwargs)
         ac = self.prepare_account_from_liveconfig(configdict)
@@ -310,7 +310,7 @@ class ACFactory:
         self._preconfigure_key(ac, configdict["addr"])
         return ac
 
-    def get_cloned_configuring_account(self, account):
+    def new_cloned_configuring_account(self, account):
         """ Clones addr, mail_pw, mvbox_move, sentbox_watch and the
         direct_imap object of an online account. This simulates the user setting
         up a new device without importing a backup.
@@ -348,7 +348,7 @@ class ACFactory:
 
     def get_online_accounts(self, num):
         # to reduce number of log events logging starts after accounts can receive
-        accounts = [self.get_online_configuring_account() for i in range(num)]
+        accounts = [self.new_online_configuring_account() for i in range(num)]
         self.bring_accounts_online()
         return accounts
 

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -8,14 +8,13 @@ import threading
 import fnmatch
 import time
 import weakref
-import tempfile
 from queue import Queue
 from typing import List, Callable
 
 import pytest
 import requests
 
-from . import Account, const, account_hookimpl
+from . import Account, const, account_hookimpl, get_core_info
 from .events import FFIEventLogger, FFIEventTracker
 from _pytest._code import Source
 
@@ -108,20 +107,12 @@ def pytest_configure(config):
 
 
 def pytest_report_header(config, startdir):
-    summary = []
-
-    t = tempfile.mktemp()
-    try:
-        ac = Account(t)
-        info = ac.get_info()
-        ac.shutdown()
-    finally:
-        os.remove(t)
-    summary.extend(['Deltachat core={} sqlite={} journal_mode={}'.format(
-         info['deltachat_core_version'],
-         info['sqlite_version'],
-         info['journal_mode'],
-     )])
+    info = get_core_info()
+    summary = ['Deltachat core={} sqlite={} journal_mode={}'.format(
+        info['deltachat_core_version'],
+        info['sqlite_version'],
+        info['journal_mode'],
+    )]
 
     cfg = config.option.liveconfig
     if cfg:

--- a/python/tests/bench_test_setup.py
+++ b/python/tests/bench_test_setup.py
@@ -11,8 +11,8 @@ import pytest
 
 class TestEmpty:
     def test_prepare_setup_measurings(self, acfactory):
-        acfactory.get_many_online_accounts(5)
+        acfactory.get_online_accounts(5)
 
     @pytest.mark.parametrize("num", range(0, 5))
     def test_setup_online_accounts(self, acfactory, num):
-        acfactory.get_many_online_accounts(num)
+        acfactory.get_online_accounts(num)

--- a/python/tests/stress_test_db.py
+++ b/python/tests/stress_test_db.py
@@ -17,7 +17,7 @@ def test_db_busy_error(acfactory, tmpdir):
             print("%3.2f %s" % (time.time() - starttime, string))
 
     # make a number of accounts
-    accounts = acfactory.get_many_online_accounts(3, quiet=True)
+    accounts = acfactory.get_many_online_accounts(3)
     log("created %s accounts" % len(accounts))
 
     # put a bigfile into each account

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -699,7 +699,7 @@ class TestOnlineAccount:
         ac1 = acfactory.new_online_configuring_account()
         ac1.stop_ongoing()
         try:
-            acfactory._pending_configure.wait_one(ac1)
+            acfactory.wait_configured(ac1)
         except pytest.fail.Exception:
             pass
 
@@ -1454,7 +1454,7 @@ class TestOnlineAccount:
         ac1.set_config("show_emails", "2")
         ac1.create_contact("alice@example.org").create_chat()
 
-        acfactory.wait_configure(ac1)
+        acfactory.wait_configured(ac1)
         ac1.direct_imap.create_folder("Drafts")
         ac1.direct_imap.create_folder("Sent")
         ac1.direct_imap.create_folder("Spam")
@@ -2732,7 +2732,7 @@ class TestOnlineAccount:
         ac1 = acfactory.new_online_configuring_account(mvbox_move=move)
         ac2 = acfactory.new_online_configuring_account()
 
-        acfactory.wait_configure(ac1)
+        acfactory.wait_configured(ac1)
         ac1.direct_imap.create_folder(folder)
 
         # Wait until each folder was selected once and we are IDLEing:
@@ -2778,7 +2778,7 @@ class TestOnlineAccount:
 
         ac1 = acfactory.new_online_configuring_account(mvbox_move=mvbox_move)
         ac2 = acfactory.new_online_configuring_account()
-        acfactory.wait_configure(ac1)
+        acfactory.wait_configured(ac1)
         ac1.direct_imap.create_folder("Sent")
         ac1.set_config("sentbox_watch", "1")
 
@@ -2807,7 +2807,7 @@ class TestOnlineAccount:
         lp.sec("create a cloned ac1 and fetch contact history during configure")
         ac1_clone = acfactory.new_cloned_configuring_account(ac1)
         ac1_clone.set_config("fetch_existing_msgs", "1")
-        acfactory.wait_configure(ac1_clone)
+        acfactory.wait_configured(ac1_clone)
         ac1_clone.start_io()
         assert_folders_configured(ac1_clone)
 
@@ -2853,7 +2853,7 @@ class TestOnlineAccount:
         lp.sec("Clone online account and let it fetch the existing messages")
         ac1_clone = acfactory.new_cloned_configuring_account(ac1)
         ac1_clone.set_config("fetch_existing_msgs", "1")
-        acfactory.wait_configure(ac1_clone)
+        acfactory.wait_configured(ac1_clone)
 
         ac1_clone.start_io()
         ac1_clone._evtracker.wait_idle_inbox_ready()
@@ -2876,7 +2876,7 @@ class TestOnlineAccount:
         """Test that DeltaChat folder is recreated if user deletes it manually."""
         ac1 = acfactory.new_online_configuring_account(mvbox_move=True)
         ac2 = acfactory.new_online_configuring_account()
-        acfactory.wait_configure(ac1)
+        acfactory.wait_configured(ac1)
 
         ac1.direct_imap.conn.folder.delete("DeltaChat")
         assert "DeltaChat" not in ac1.direct_imap.list_folders()

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -2401,7 +2401,7 @@ class TestOnlineAccount:
         ac3.stop_io()
         acfactory.remove_preconfigured_keys()
         ac4 = acfactory.new_cloned_configuring_account(ac3)
-        acfactory._pending_configure.wait_one(ac4)
+        acfactory.wait_configured(ac4)
         # Create contacts to make sure incoming messages are not treated as contact requests
         chat41 = ac4.create_chat(ac1)
         chat42 = ac4.create_chat(ac2)

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -645,12 +645,11 @@ class TestOnlineAccount:
     @pytest.mark.ignored
     def test_configure_generate_key(self, acfactory, lp):
         # A slow test which will generate new keys.
+        acfactory.remove_preconfigured_keys()
         ac1 = acfactory.get_online_configuring_account(
-            pre_generated_key=False,
             config={"key_gen_type": str(const.DC_KEY_GEN_RSA2048)}
         )
         ac2 = acfactory.get_online_configuring_account(
-            pre_generated_key=False,
             config={"key_gen_type": str(const.DC_KEY_GEN_ED25519)}
         )
         acfactory.wait_configure_and_start_io()
@@ -2388,7 +2387,8 @@ class TestOnlineAccount:
 
         lp.sec("ac3 reinstalls DC and generates a new key")
         ac3.stop_io()
-        ac4 = acfactory.clone_online_account(ac3, pre_generated_key=False)
+        acfactory.remove_preconfigured_keys()
+        ac4 = acfactory.clone_online_account(ac3)
         ac4._configtracker.wait_finish()
         # Create contacts to make sure incoming messages are not treated as contact requests
         chat41 = ac4.create_chat(ac1)

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1724,7 +1724,7 @@ class TestOnlineAccount:
         assert mime.get_all("From")
         assert mime.get_all("Received")
 
-    def test_send_mark_seen_clean_incoming_events(self, acfactory, lp, data):
+    def test_send_mark_seen_clean_incoming_events(self, acfactory, lp):
         ac1, ac2 = acfactory.get_two_online_accounts()
         chat = acfactory.get_accepted_chat(ac1, ac2)
 

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -726,7 +726,7 @@ class TestOnlineAccount:
     def test_one_account_send_bcc_setting(self, acfactory, lp):
         ac1 = acfactory.new_online_configuring_account()
         ac2 = acfactory.new_online_configuring_account()
-        ac1_clone = acfactory.new_cloned_configuring_account(ac1)
+        ac1_clone = acfactory.new_online_configuring_account(cloned_from=ac1)
         acfactory.bring_accounts_online()
 
         # test if sent messages are copied to it via BCC.
@@ -1090,7 +1090,7 @@ class TestOnlineAccount:
         """Test that message marked as seen on one device is marked as seen on another."""
         ac1 = acfactory.new_online_configuring_account()
         ac2 = acfactory.new_online_configuring_account()
-        ac1_clone = acfactory.new_cloned_configuring_account(ac1)
+        ac1_clone = acfactory.new_online_configuring_account(cloned_from=ac1)
         acfactory.bring_accounts_online()
 
         ac1.set_config("bcc_self", "1")
@@ -1531,7 +1531,7 @@ class TestOnlineAccount:
     def test_no_old_msg_is_fresh(self, acfactory, lp):
         ac1 = acfactory.new_online_configuring_account()
         ac2 = acfactory.new_online_configuring_account()
-        ac1_clone = acfactory.new_cloned_configuring_account(ac1)
+        ac1_clone = acfactory.new_online_configuring_account(cloned_from=ac1)
         acfactory.bring_accounts_online()
 
         ac1.set_config("e2ee_enabled", "0")
@@ -1895,7 +1895,7 @@ class TestOnlineAccount:
         # before ther setup message is send. DC does not read old messages
         # as of Jul2019
         ac1 = acfactory.new_online_configuring_account()
-        ac2 = acfactory.new_cloned_configuring_account(ac1)
+        ac2 = acfactory.new_online_configuring_account(cloned_from=ac1)
         acfactory.bring_accounts_online()
 
         lp.sec("trigger ac setup message and return setupcode")
@@ -1916,7 +1916,7 @@ class TestOnlineAccount:
 
     def test_ac_setup_message_twice(self, acfactory, lp):
         ac1 = acfactory.new_online_configuring_account()
-        ac2 = acfactory.new_cloned_configuring_account(ac1)
+        ac2 = acfactory.new_online_configuring_account(cloned_from=ac1)
         acfactory.bring_accounts_online()
 
         lp.sec("trigger ac setup message but ignore")
@@ -2400,7 +2400,7 @@ class TestOnlineAccount:
         lp.sec("ac3 reinstalls DC and generates a new key")
         ac3.stop_io()
         acfactory.remove_preconfigured_keys()
-        ac4 = acfactory.new_cloned_configuring_account(ac3)
+        ac4 = acfactory.new_online_configuring_account(cloned_from=ac3)
         acfactory.wait_configured(ac4)
         # Create contacts to make sure incoming messages are not treated as contact requests
         chat41 = ac4.create_chat(ac1)
@@ -2787,7 +2787,7 @@ class TestOnlineAccount:
         # would also find the "Sent" folder, but it would be too late:
         # The sentbox thread, started by `start_io()`, would have seen that there is no
         # ConfiguredSentboxFolder and do nothing.
-        acfactory._pending_configure.add_account(ac1, reconfigure=True)
+        acfactory._acsetup.start_configure(ac1, reconfigure=True)
         acfactory.bring_accounts_online()
         assert_folders_configured(ac1)
 
@@ -2805,7 +2805,7 @@ class TestOnlineAccount:
         assert_folders_configured(ac1)
 
         lp.sec("create a cloned ac1 and fetch contact history during configure")
-        ac1_clone = acfactory.new_cloned_configuring_account(ac1)
+        ac1_clone = acfactory.new_online_configuring_account(cloned_from=ac1)
         ac1_clone.set_config("fetch_existing_msgs", "1")
         acfactory.wait_configured(ac1_clone)
         ac1_clone.start_io()
@@ -2851,7 +2851,7 @@ class TestOnlineAccount:
         assert ac1.direct_imap.idle_wait_for_seen()
 
         lp.sec("Clone online account and let it fetch the existing messages")
-        ac1_clone = acfactory.new_cloned_configuring_account(ac1)
+        ac1_clone = acfactory.new_online_configuring_account(cloned_from=ac1)
         ac1_clone.set_config("fetch_existing_msgs", "1")
         acfactory.wait_configured(ac1_clone)
 

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -110,7 +110,7 @@ class TestOfflineAccountBasic:
         assert not ac1.get_self_contact().addr
 
     def test_selfcontact_configured(self, acfactory):
-        ac1 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
         me = ac1.get_self_contact()
         assert me.display_name
         assert me.addr
@@ -121,14 +121,14 @@ class TestOfflineAccountBasic:
             ac1.get_config("123123")
 
     def test_empty_group_bcc_self_enabled(self, acfactory):
-        ac1 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
         ac1.set_config("bcc_self", "1")
         chat = ac1.create_group_chat(name="group1")
         msg = chat.send_text("msg1")
         assert msg in chat.get_messages()
 
     def test_empty_group_bcc_self_disabled(self, acfactory):
-        ac1 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
         ac1.set_config("bcc_self", "0")
         chat = ac1.create_group_chat(name="group1")
         msg = chat.send_text("msg1")
@@ -137,7 +137,7 @@ class TestOfflineAccountBasic:
 
 class TestOfflineContact:
     def test_contact_attr(self, acfactory):
-        ac1 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
         contact1 = ac1.create_contact("some1@example.org", name="some1")
         contact2 = ac1.create_contact("some1@example.org", name="some1")
         str(contact1)
@@ -150,7 +150,7 @@ class TestOfflineContact:
         assert not contact1.is_verified()
 
     def test_get_blocked(self, acfactory):
-        ac1 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
         contact1 = ac1.create_contact("some1@example.org", name="some1")
         contact2 = ac1.create_contact("some2@example.org", name="some2")
         ac1.create_contact("some3@example.org", name="some3")
@@ -164,12 +164,12 @@ class TestOfflineContact:
         assert ac1.get_blocked_contacts() == [contact1]
 
     def test_create_self_contact(self, acfactory):
-        ac1 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
         contact1 = ac1.create_contact(ac1.get_config("addr"))
         assert contact1.id == 1
 
     def test_get_contacts_and_delete(self, acfactory):
-        ac1 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
         contact1 = ac1.create_contact("some1@example.org", name="some1")
         contacts = ac1.get_contacts()
         assert len(contacts) == 1
@@ -184,15 +184,15 @@ class TestOfflineContact:
         assert contact1 not in ac1.get_contacts()
 
     def test_get_contacts_and_delete_fails(self, acfactory):
-        ac1 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
         contact1 = ac1.create_contact("some1@example.com", name="some1")
         msg = contact1.create_chat().send_text("one message")
         assert not ac1.delete_contact(contact1)
         assert not msg.filemime
 
     def test_create_chat_flexibility(self, acfactory):
-        ac1 = acfactory.get_configured_offline_account()
-        ac2 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
+        ac2 = acfactory.get_pseudo_configured_account()
         chat1 = ac1.create_chat(ac2)
         chat2 = ac1.create_chat(ac2.get_self_contact().addr)
         assert chat1 == chat2
@@ -201,7 +201,7 @@ class TestOfflineContact:
             ac1.create_chat(ac3)
 
     def test_contact_rename(self, acfactory):
-        ac1 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
         contact = ac1.create_contact("some1@example.com", name="some1")
         chat = ac1.create_chat(contact)
         assert chat.get_name() == "some1"
@@ -214,7 +214,7 @@ class TestOfflineContact:
 class TestOfflineChat:
     @pytest.fixture
     def ac1(self, acfactory):
-        return acfactory.get_configured_offline_account()
+        return acfactory.get_pseudo_configured_account()
 
     @pytest.fixture
     def chat1(self, ac1):
@@ -248,8 +248,8 @@ class TestOfflineChat:
             pytest.fail("could not find chat")
 
     def test_group_chat_add_second_account(self, acfactory):
-        ac1 = acfactory.get_configured_offline_account()
-        ac2 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
+        ac2 = acfactory.get_pseudo_configured_account()
         chat = ac1.create_group_chat(name="title1")
         with pytest.raises(ValueError):
             chat.add_contact(ac2.get_self_contact())
@@ -302,7 +302,7 @@ class TestOfflineChat:
 
     @pytest.mark.parametrize("verified", [True, False])
     def test_group_chat_qr(self, acfactory, ac1, verified):
-        ac2 = acfactory.get_configured_offline_account()
+        ac2 = acfactory.get_pseudo_configured_account()
         chat = ac1.create_group_chat(name="title1", verified=verified)
         assert chat.is_group()
         qr = chat.get_join_qr()
@@ -448,7 +448,7 @@ class TestOfflineChat:
         assert msg2.filename != msg.filename
 
     def test_create_contact(self, acfactory):
-        ac1 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
         email = "hello <hello@example.org>"
         contact1 = ac1.create_contact(email)
         assert contact1.addr == "hello@example.org"
@@ -459,7 +459,7 @@ class TestOfflineChat:
         assert contact2.name == "real"
 
     def test_create_chat_simple(self, acfactory):
-        ac1 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
         contact1 = ac1.create_contact("some1@example.org", name="some1")
         contact1.create_chat().send_text("hello")
 
@@ -481,7 +481,7 @@ class TestOfflineChat:
 
     def test_import_export_one_contact(self, acfactory, tmpdir):
         backupdir = tmpdir.mkdir("backup")
-        ac1 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
         chat = ac1.create_contact("some1 <some1@example.org>").create_chat()
         # send a text message
         msg = chat.send_text("msg1")
@@ -520,8 +520,8 @@ class TestOfflineChat:
         assert chat1.get_draft() is None
 
     def test_qr_setup_contact(self, acfactory, lp):
-        ac1 = acfactory.get_configured_offline_account()
-        ac2 = acfactory.get_configured_offline_account()
+        ac1 = acfactory.get_pseudo_configured_account()
+        ac2 = acfactory.get_pseudo_configured_account()
         qr = ac1.get_setup_contact_qr()
         assert qr.startswith("OPENPGP4FPR:")
         res = ac2.check_qr(qr)

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -639,7 +639,7 @@ class TestOfflineChat:
 
 
 def test_basic_imap_api(acfactory, tmpdir):
-    ac1, ac2 = acfactory.get_two_online_accounts()
+    ac1, ac2 = acfactory.get_online_accounts(2)
     chat12 = acfactory.get_accepted_chat(ac1, ac2)
 
     imap2 = ac2.direct_imap
@@ -705,7 +705,7 @@ class TestOnlineAccount:
             pass
 
     def test_export_import_self_keys(self, acfactory, tmpdir, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
 
         dir = tmpdir.mkdir("exportdir")
         export_files = ac1.export_self_keys(dir.strpath)
@@ -773,7 +773,7 @@ class TestOnlineAccount:
         assert ev_msg.text == msg_out.text
 
     def test_send_file_twice_unicode_filename_mangling(self, tmpdir, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         chat = acfactory.get_accepted_chat(ac1, ac2)
 
         basename = "somedäüta.html.zip"
@@ -805,7 +805,7 @@ class TestOnlineAccount:
         assert msg.filename != msg2.filename
 
     def test_send_file_html_attachment(self, tmpdir, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         chat = acfactory.get_accepted_chat(ac1, ac2)
 
         basename = "test.html"
@@ -829,7 +829,7 @@ class TestOnlineAccount:
         assert msg.filename.endswith(basename)
 
     def test_html_message(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         chat = acfactory.get_accepted_chat(ac1, ac2)
         html_text = "<p>hello HTML world</p>"
 
@@ -913,7 +913,7 @@ class TestOnlineAccount:
         ac1._evtracker.get_matching("DC_EVENT_IMAP_MESSAGE_MOVED")
 
     def test_forward_messages(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         chat = ac1.create_chat(ac2)
 
         lp.sec("ac1: send message to ac2")
@@ -945,7 +945,7 @@ class TestOnlineAccount:
         assert not chat3.get_messages()
 
     def test_forward_own_message(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         chat = acfactory.get_accepted_chat(ac1, ac2)
 
         lp.sec("sending message")
@@ -969,7 +969,8 @@ class TestOnlineAccount:
         assert msg_in.is_forwarded()
 
     def test_send_self_message(self, acfactory, lp):
-        ac1 = acfactory.get_one_online_account(mvbox_move=True)
+        ac1 = acfactory.get_online_configuring_account(mvbox_move=True)
+        acfactory.wait_configure_and_start_io()
         lp.sec("ac1: create self chat")
         chat = ac1.get_self_contact().create_chat()
         chat.send_text("hello")
@@ -977,7 +978,7 @@ class TestOnlineAccount:
 
     def test_send_dot(self, acfactory, lp):
         """Test that a single dot is properly escaped in SMTP protocol"""
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         chat = acfactory.get_accepted_chat(ac1, ac2)
 
         lp.sec("sending message")
@@ -988,7 +989,7 @@ class TestOnlineAccount:
         assert msg_in.text == msg_out.text
 
     def test_send_and_receive_message_markseen(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
 
         # make DC's life harder wrt to encodings
         ac1.set_config("displayname", "ä name")
@@ -1146,7 +1147,7 @@ class TestOnlineAccount:
         assert "Expires: " in ac1_clone_message.get_message_info()
 
     def test_message_override_sender_name(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         chat = acfactory.get_accepted_chat(ac1, ac2)
         overridden_name = "someone else"
 
@@ -1205,7 +1206,7 @@ class TestOnlineAccount:
         ac2.direct_imap.idle_done()
 
     def test_reply_privately(self, acfactory):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
 
         group1 = ac1.create_group_chat("group")
         group1.add_contact(ac2)
@@ -1229,7 +1230,9 @@ class TestOnlineAccount:
         assert msg_reply1.chat.id == private_chat1.id
 
     def test_mdn_asymmetric(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts(mvbox_move=True)
+        ac1 = acfactory.get_online_configuring_account(mvbox_move=True)
+        ac2 = acfactory.get_online_configuring_account()
+        acfactory.wait_configure_and_start_io()
 
         lp.sec("ac1: create chat with ac2")
         chat = ac1.create_chat(ac2)
@@ -1271,7 +1274,7 @@ class TestOnlineAccount:
         assert msg_out.is_out_mdn_received()
 
     def test_send_and_receive_will_encrypt_decrypt(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
 
         lp.sec("ac1: create chat with ac2")
         chat = ac1.create_chat(ac2)
@@ -1317,7 +1320,7 @@ class TestOnlineAccount:
         """Test that gossip timestamp is updated when someone else sends gossip,
         so we don't have to send gossip ourselves.
         """
-        ac1, ac2, ac3 = acfactory.get_many_online_accounts(3)
+        ac1, ac2, ac3 = acfactory.get_online_accounts(3)
 
         acfactory.introduce_each_other([ac1, ac2])
         acfactory.introduce_each_other([ac2, ac3])
@@ -1352,7 +1355,7 @@ class TestOnlineAccount:
         This is a Delta Chat extension to Autocrypt 1.1.0, which Autocrypt-Gossip headers
         SHOULD NOT contain encryption preference.
         """
-        ac1, ac2, ac3 = acfactory.get_many_online_accounts(3)
+        ac1, ac2, ac3 = acfactory.get_online_accounts(3)
 
         lp.sec("ac1 learns that ac2 prefers encryption")
         ac1.create_chat(ac2)
@@ -1406,7 +1409,7 @@ class TestOnlineAccount:
         assert msg.is_encrypted()
 
     def test_send_first_message_as_long_unicode_with_cr(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         ac2.set_config("save_mime_headers", "1")
 
         lp.sec("ac1: create chat with ac2")
@@ -1436,7 +1439,7 @@ class TestOnlineAccount:
 
     def test_no_draft_if_cant_send(self, acfactory):
         """Tests that no quote can be set if the user can't send to this chat"""
-        ac1 = acfactory.get_one_online_account()
+        ac1, = acfactory.get_online_accounts(1)
         device_chat = ac1.get_device_chat()
         msg = Message.new_empty(ac1, "text")
         device_chat.set_draft(msg)
@@ -1560,7 +1563,7 @@ class TestOnlineAccount:
 
     def test_prefer_encrypt(self, acfactory, lp):
         """Test quorum rule for encryption preference in 1:1 and group chat."""
-        ac1, ac2, ac3 = acfactory.get_many_online_accounts(3)
+        ac1, ac2, ac3 = acfactory.get_online_accounts(3)
         ac1.set_config("e2ee_enabled", "0")
         ac2.set_config("e2ee_enabled", "1")
         ac3.set_config("e2ee_enabled", "0")
@@ -1610,7 +1613,7 @@ class TestOnlineAccount:
 
     def test_bot(self, acfactory, lp):
         """Test that bot messages can be identified as such"""
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         ac1.set_config("bot", "0")
         ac2.set_config("bot", "1")
 
@@ -1637,7 +1640,7 @@ class TestOnlineAccount:
 
     def test_quote_encrypted(self, acfactory, lp):
         """Test that replies to encrypted messages with quotes are encrypted."""
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
 
         lp.sec("ac1: create chat with ac2")
         chat = ac1.create_chat(ac2)
@@ -1687,7 +1690,7 @@ class TestOnlineAccount:
 
     def test_quote_attachment(self, tmpdir, acfactory, lp):
         """Test that replies with an attachment and a quote are received correctly."""
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
 
         lp.sec("ac1 creates chat with ac2")
         chat1 = ac1.create_chat(ac2)
@@ -1719,7 +1722,7 @@ class TestOnlineAccount:
         assert open(received_reply.filename).read() == "data to send"
 
     def test_saved_mime_on_received_message(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
 
         lp.sec("configure ac2 to save mime headers, create ac1/ac2 chat")
         ac2.set_config("save_mime_headers", "1")
@@ -1738,7 +1741,7 @@ class TestOnlineAccount:
         assert mime.get_all("Received")
 
     def test_send_mark_seen_clean_incoming_events(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         chat = acfactory.get_accepted_chat(ac1, ac2)
 
         message_queue = queue.Queue()
@@ -1767,7 +1770,7 @@ class TestOnlineAccount:
                 break
 
     def test_send_and_receive_image(self, acfactory, lp, data):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         chat = ac1.create_chat(ac2)
 
         message_queue = queue.Queue()
@@ -1812,7 +1815,7 @@ class TestOnlineAccount:
         assert m == msg_in
 
     def test_import_export_online_all(self, acfactory, tmpdir, data, lp):
-        ac1 = acfactory.get_one_online_account()
+        ac1, = acfactory.get_online_accounts(1)
 
         lp.sec("create some chat content")
         chat1 = ac1.create_contact("some1@example.org", name="some1").create_chat()
@@ -1937,7 +1940,7 @@ class TestOnlineAccount:
         assert ac1.get_info()["fingerprint"] == ac2.get_info()["fingerprint"]
 
     def test_qr_setup_contact(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         lp.sec("ac1: create QR code and let ac2 scan it, starting the securejoin")
         qr = ac1.get_setup_contact_qr()
 
@@ -1947,7 +1950,7 @@ class TestOnlineAccount:
         ac1._evtracker.wait_securejoin_inviter_progress(1000)
 
     def test_qr_join_chat(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         lp.sec("ac1: create QR code and let ac2 scan it, starting the securejoin")
         chat = ac1.create_group_chat("hello")
         qr = chat.get_join_qr()
@@ -1961,7 +1964,7 @@ class TestOnlineAccount:
         ac1._evtracker.wait_securejoin_inviter_progress(1000)
 
     def test_qr_verified_group_and_chatting(self, acfactory, lp):
-        ac1, ac2, ac3 = acfactory.get_many_online_accounts(3)
+        ac1, ac2, ac3 = acfactory.get_online_accounts(3)
         lp.sec("ac1: create verified-group QR, ac2 scans and joins")
         chat1 = ac1.create_group_chat("hello", verified=True)
         assert chat1.is_protected()
@@ -2017,7 +2020,7 @@ class TestOnlineAccount:
 
     def test_set_get_contact_avatar(self, acfactory, data, lp):
         lp.sec("configuring ac1 and ac2")
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
 
         lp.sec("set ac1 and ac2 profile images")
         p = data.get_path("d.png")
@@ -2056,7 +2059,7 @@ class TestOnlineAccount:
         assert msg6.get_sender_contact().get_profile_image() is None
 
     def test_add_remove_member_remote_events(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         ac1_addr = ac1.get_config("addr")
         # activate local plugin for ac2
         in_list = queue.Queue()
@@ -2135,7 +2138,7 @@ class TestOnlineAccount:
         Also tests blocking in general.
         """
         lp.sec("Create a group chat with ac1 and ac2")
-        (ac1, ac2) = acfactory.get_two_online_accounts()
+        (ac1, ac2) = acfactory.get_online_accounts(2)
         acfactory.introduce_each_other((ac1, ac2))
         chat_on_ac1 = ac1.create_group_chat("title", contacts=[ac2])
         chat_on_ac1.send_text("First group message")
@@ -2170,7 +2173,7 @@ class TestOnlineAccount:
         assert not ac1.get_self_contact() in chat_on_ac1.get_contacts()
 
     def test_set_get_group_image(self, acfactory, data, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
 
         lp.sec("create unpromoted group chat")
         chat = ac1.create_group_chat("hello")
@@ -2221,7 +2224,7 @@ class TestOnlineAccount:
         assert chat.get_profile_image() is None
 
     def test_connectivity(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         ac1.set_config("scan_all_folders_debounce_secs", "0")
 
         ac1._evtracker.wait_for_connectivity(const.DC_CONNECTIVITY_CONNECTED)
@@ -2300,7 +2303,7 @@ class TestOnlineAccount:
 
         See https://github.com/deltachat/deltachat-core-rust/issues/2429.
         """
-        ac1 = acfactory.get_one_online_account()
+        ac1, = acfactory.get_online_accounts(1)
         ac1.stop_io()
 
         ac1.direct_imap.append("INBOX", """
@@ -2337,7 +2340,7 @@ class TestOnlineAccount:
 
     def test_send_receive_locations(self, acfactory, lp):
         now = datetime.now(timezone.utc)
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
 
         lp.sec("ac1: create chat with ac2")
         chat1 = ac1.create_chat(ac2)
@@ -2394,7 +2397,7 @@ class TestOnlineAccount:
         """
 
         lp.sec("creating and configuring three accounts")
-        ac1, ac2, ac3 = acfactory.get_many_online_accounts(3)
+        ac1, ac2, ac3 = acfactory.get_online_accounts(3)
 
         acfactory.introduce_each_other([ac1, ac2, ac3])
 
@@ -2490,7 +2493,7 @@ class TestOnlineAccount:
         assert ev.data2 == sent_msg.id
 
     def test_ephemeral_timer(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
 
         lp.sec("ac1: create chat with ac2")
         chat1 = ac1.create_chat(ac2)
@@ -2548,7 +2551,7 @@ class TestOnlineAccount:
         assert chat1.get_ephemeral_timer() == 0
 
     def test_delete_multiple_messages(self, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         chat12 = acfactory.get_accepted_chat(ac1, ac2)
 
         lp.sec("ac1: sending seven messages")
@@ -2609,7 +2612,7 @@ class TestOnlineAccount:
         assert "configuration" not in ev.data2.lower()
 
     def test_name_changes(self, acfactory):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         ac1.set_config("displayname", "Account 1")
 
         # Similar to acfactory.get_accepted_chat, but without setting the contact name.
@@ -2649,7 +2652,7 @@ class TestOnlineAccount:
 
     def test_status(self, acfactory):
         """Test that status is transferred over the network."""
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
 
         chat12 = acfactory.get_accepted_chat(ac1, ac2)
         ac1.set_config("selfstatus", "New status")
@@ -2682,7 +2685,7 @@ class TestOnlineAccount:
 
     def test_group_quote(self, acfactory, lp):
         """Test quoting in a group with a new member who have not seen the quoted message."""
-        ac1, ac2, ac3 = accounts = acfactory.get_many_online_accounts(3)
+        ac1, ac2, ac3 = accounts = acfactory.get_online_accounts(3)
         acfactory.introduce_each_other(accounts)
         chat = ac1.create_group_chat(name="quote group")
         chat.add_contact(ac2)
@@ -2891,7 +2894,7 @@ class TestOnlineAccount:
 
 class TestGroupStressTests:
     def test_group_many_members_add_leave_remove(self, acfactory, lp):
-        accounts = acfactory.get_many_online_accounts(5)
+        accounts = acfactory.get_online_accounts(5)
         acfactory.introduce_each_other(accounts)
         ac1, ac5 = accounts.pop(), accounts.pop()
 
@@ -2964,7 +2967,7 @@ class TestGroupStressTests:
         ac2 did not see that ac3 is removed, so it should rebuild member list from scratch.
         """
         lp.sec("setting up accounts, accepted with each other")
-        accounts = acfactory.get_many_online_accounts(3)
+        accounts = acfactory.get_online_accounts(3)
         acfactory.introduce_each_other(accounts)
         ac1, ac2, ac3 = accounts
 

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -1049,7 +1049,7 @@ class TestOnlineAccount:
         """Test that message already moved to DeltaChat folder is marked as seen."""
         ac1 = acfactory.get_online_configuring_account()
         ac2 = acfactory.get_online_configuring_account(move=True)
-        acfactory.wait_configure_and_start_io([ac1, ac2])
+        acfactory.wait_configure_and_start_io()
 
         ac2.stop_io()
         ac2.direct_imap.idle_start()
@@ -1447,8 +1447,6 @@ class TestOnlineAccount:
         ac1.direct_imap.create_folder("Junk")
 
         acfactory.wait_configure_and_start_io()
-        # Wait until each folder was selected once and we are IDLEing again:
-        ac1._evtracker.get_info_contains("INBOX: Idle entering wait-on-remote state")
         ac1.stop_io()
 
         ac1.direct_imap.append("Drafts", """
@@ -1495,7 +1493,7 @@ class TestOnlineAccount:
         msg = ac1._evtracker.wait_next_messages_changed()
 
         # Wait until each folder was scanned, this is necessary for this test to test what it should test:
-        ac1._evtracker.get_info_contains("INBOX: Idle entering wait-on-remote state")
+        ac1._evtracker.wait_idle_inbox_ready()
 
         assert msg.text == "subj – message in Sent"
         assert len(msg.chat.get_messages()) == 1
@@ -2394,7 +2392,7 @@ class TestOnlineAccount:
         chat41 = ac4.create_chat(ac1)
         chat42 = ac4.create_chat(ac2)
         ac4.start_io()
-        ac4._evtracker.wait_all_initial_fetches()
+        ac4._evtracker.wait_idle_inbox_ready()
 
         lp.sec("ac1: creating group chat with 2 other members")
         chat = ac1.create_group_chat("title", contacts=[ac2, ac3])
@@ -2723,7 +2721,6 @@ class TestOnlineAccount:
 
         acfactory.wait_configure_and_start_io()
         # Wait until each folder was selected once and we are IDLEing:
-        ac1._evtracker.get_info_contains("INBOX: Idle entering wait-on-remote state")
         ac1.stop_io()
 
         # Send a message to ac1 and move it to the mvbox:
@@ -2843,7 +2840,7 @@ class TestOnlineAccount:
         ac1_clone._configtracker.wait_finish()
 
         ac1_clone.start_io()
-        ac1_clone._evtracker.wait_all_initial_fetches()
+        ac1_clone._evtracker.wait_idle_inbox_ready()
         chats = ac1_clone.get_chats()
         assert len(chats) == 4  # two newly created chats + self-chat + device-chat
         group_chat = [c for c in chats if c.get_name() == "group name"][0]

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -2930,7 +2930,7 @@ class TestGroupStressTests:
 
         lp.sec("ac2: receiving system message about contact addition")
         sysmsg = ac2._evtracker.wait_next_incoming_message()
-        assert ac5.addr in sysmsg.text
+        assert ac5.get_config("configured_addr") in sysmsg.text
         assert sysmsg.chat.num_contacts() == 4
 
         lp.sec("ac5: waiting for message about addition to the chat")

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -668,7 +668,7 @@ class TestOnlineAccount:
         ac2 = acfactory.get_online_configuring_account(
             config={"key_gen_type": str(const.DC_KEY_GEN_ED25519)}
         )
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
         chat = acfactory.get_accepted_chat(ac1, ac2)
 
         lp.sec("ac1: send unencrypted message to ac2")
@@ -728,7 +728,7 @@ class TestOnlineAccount:
         ac1 = acfactory.get_online_configuring_account()
         ac2 = acfactory.get_online_configuring_account()
         ac1_clone = acfactory.get_cloned_configuring_account(ac1)
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
 
         # test if sent messages are copied to it via BCC.
 
@@ -875,7 +875,7 @@ class TestOnlineAccount:
         ac2 = acfactory.get_online_configuring_account(mvbox_move=False, sentbox_watch=False)
 
         lp.sec("ac2 and ac1: waiting for configuration")
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
 
         lp.sec("ac1: send message and wait for ac2 to receive it")
         acfactory.get_accepted_chat(ac1, ac2).send_text("message1")
@@ -884,7 +884,7 @@ class TestOnlineAccount:
     def test_move_works(self, acfactory):
         ac1 = acfactory.get_online_configuring_account()
         ac2 = acfactory.get_online_configuring_account(mvbox_move=True)
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
         chat = acfactory.get_accepted_chat(ac1, ac2)
         chat.send_text("message1")
 
@@ -898,7 +898,7 @@ class TestOnlineAccount:
     def test_move_works_on_self_sent(self, acfactory):
         ac1 = acfactory.get_online_configuring_account(mvbox_move=True)
         ac2 = acfactory.get_online_configuring_account()
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
         ac1.set_config("bcc_self", "1")
 
         chat = acfactory.get_accepted_chat(ac1, ac2)
@@ -967,7 +967,7 @@ class TestOnlineAccount:
 
     def test_send_self_message(self, acfactory, lp):
         ac1 = acfactory.get_online_configuring_account(mvbox_move=True)
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
         lp.sec("ac1: create self chat")
         chat = ac1.get_self_contact().create_chat()
         chat.send_text("hello")
@@ -1063,7 +1063,7 @@ class TestOnlineAccount:
         """Test that message already moved to DeltaChat folder is marked as seen."""
         ac1 = acfactory.get_online_configuring_account()
         ac2 = acfactory.get_online_configuring_account(mvbox_move=True)
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
 
         ac2.stop_io()
         ac2.direct_imap.idle_start()
@@ -1092,7 +1092,7 @@ class TestOnlineAccount:
         ac1 = acfactory.get_online_configuring_account()
         ac2 = acfactory.get_online_configuring_account()
         ac1_clone = acfactory.get_cloned_configuring_account(ac1)
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
 
         ac1.set_config("bcc_self", "1")
         ac1_clone.set_config("bcc_self", "1")
@@ -1182,8 +1182,7 @@ class TestOnlineAccount:
         # We had so many problems with markseen, if in doubt, rather create another test, it can't harm.
         ac1 = acfactory.get_online_configuring_account(mvbox_move=mvbox_move)
         ac2 = acfactory.get_online_configuring_account(mvbox_move=mvbox_move)
-
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
         # Do not send BCC to self, we only want to test MDN on ac1.
         ac1.set_config("bcc_self", "0")
 
@@ -1230,7 +1229,7 @@ class TestOnlineAccount:
     def test_mdn_asymmetric(self, acfactory, lp):
         ac1 = acfactory.get_online_configuring_account(mvbox_move=True)
         ac2 = acfactory.get_online_configuring_account()
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
 
         lp.sec("ac1: create chat with ac2")
         chat = ac1.create_chat(ac2)
@@ -1462,7 +1461,7 @@ class TestOnlineAccount:
         ac1.direct_imap.create_folder("Spam")
         ac1.direct_imap.create_folder("Junk")
 
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
         ac1.stop_io()
 
         ac1.direct_imap.append("Drafts", """
@@ -1534,7 +1533,7 @@ class TestOnlineAccount:
         ac1 = acfactory.get_online_configuring_account()
         ac2 = acfactory.get_online_configuring_account()
         ac1_clone = acfactory.get_cloned_configuring_account(ac1)
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
 
         ac1.set_config("e2ee_enabled", "0")
         ac1_clone.set_config("e2ee_enabled", "0")
@@ -1898,7 +1897,7 @@ class TestOnlineAccount:
         # as of Jul2019
         ac1 = acfactory.get_online_configuring_account()
         ac2 = acfactory.get_cloned_configuring_account(ac1)
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
 
         lp.sec("trigger ac setup message and return setupcode")
         assert ac1.get_info()["fingerprint"] != ac2.get_info()["fingerprint"]
@@ -1919,7 +1918,7 @@ class TestOnlineAccount:
     def test_ac_setup_message_twice(self, acfactory, lp):
         ac1 = acfactory.get_online_configuring_account()
         ac2 = acfactory.get_cloned_configuring_account(ac1)
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
 
         lp.sec("trigger ac setup message but ignore")
         assert ac1.get_info()["fingerprint"] != ac2.get_info()["fingerprint"]
@@ -2466,7 +2465,7 @@ class TestOnlineAccount:
         # "1" means delete immediately, while "0" means do not delete
         ac2.set_config("delete_server_after", "1")
 
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
 
         lp.sec("ac1: create chat with ac2")
         chat1 = ac1.create_chat(ac2)
@@ -2737,7 +2736,7 @@ class TestOnlineAccount:
         acfactory.wait_configure(ac1)
         ac1.direct_imap.create_folder(folder)
 
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
         # Wait until each folder was selected once and we are IDLEing:
         ac1.stop_io()
 
@@ -2791,7 +2790,7 @@ class TestOnlineAccount:
         # The sentbox thread, started by `start_io()`, would have seen that there is no
         # ConfiguredSentboxFolder and do nothing.
         ac1._configtracker = ac1.configure(reconfigure=True)
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
         assert_folders_configured(ac1)
 
         assert ac1.direct_imap.select_config_folder("mvbox" if mvbox_move else "inbox")
@@ -2838,7 +2837,7 @@ class TestOnlineAccount:
         ac1 = acfactory.get_online_configuring_account()
         ac2 = acfactory.get_online_configuring_account()
 
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
 
         lp.sec("receive a message")
         ac2.create_group_chat("group name", contacts=[ac1]).send_text("incoming, unencrypted group message")
@@ -2883,7 +2882,7 @@ class TestOnlineAccount:
 
         ac1.direct_imap.conn.folder.delete("DeltaChat")
         assert "DeltaChat" not in ac1.direct_imap.list_folders()
-        acfactory.wait_configure_and_start_io()
+        acfactory.bring_accounts_online()
 
         ac2.create_chat(ac1).send_text("hello")
         msg = ac1._evtracker.wait_next_incoming_message()

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -2562,7 +2562,7 @@ class TestOnlineAccount:
 
     def test_configure_error_msgs_wrong_pw(self, acfactory):
         configdict = acfactory.get_next_liveconfig()
-        ac1 = acfactory.make_account()
+        ac1 = acfactory.get_unconfigured_account()
         ac1.update_config(configdict)
         ac1.set_config("mail_pw", "abc")  # Wrong mail pw
         ac1.configure()
@@ -2574,7 +2574,7 @@ class TestOnlineAccount:
         assert "password" in ev.data2
 
     def test_configure_error_msgs_invalid_server(self, acfactory):
-        ac2 = acfactory.make_account()
+        ac2 = acfactory.get_unconfigured_account()
         ac2.set_config("addr", "abc@def.invalid")  # mail server can't be reached
         ac2.set_config("mail_pw", "123")
         ac2.configure()
@@ -2995,7 +2995,7 @@ class TestGroupStressTests:
 class TestOnlineConfigureFails:
     def test_invalid_password(self, acfactory):
         configdict = acfactory.get_next_liveconfig()
-        ac1 = acfactory.make_account()
+        ac1 = acfactory.get_unconfigured_account()
         ac1.update_config(dict(addr=configdict["addr"], mail_pw="123"))
         configtracker = ac1.configure()
         configtracker.wait_progress(500)
@@ -3003,7 +3003,7 @@ class TestOnlineConfigureFails:
 
     def test_invalid_user(self, acfactory):
         configdict = acfactory.get_next_liveconfig()
-        ac1 = acfactory.make_account()
+        ac1 = acfactory.get_unconfigured_account()
         configdict["addr"] = "x" + configdict["addr"]
         ac1.update_config(configdict)
         configtracker = ac1.configure()
@@ -3012,7 +3012,7 @@ class TestOnlineConfigureFails:
 
     def test_invalid_domain(self, acfactory):
         configdict = acfactory.get_next_liveconfig()
-        ac1 = acfactory.make_account()
+        ac1 = acfactory.get_unconfigured_account()
         configdict["addr"] += "x"
         ac1.update_config(configdict)
         configtracker = ac1.configure()

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -662,10 +662,10 @@ class TestOnlineAccount:
     def test_configure_generate_key(self, acfactory, lp):
         # A slow test which will generate new keys.
         acfactory.remove_preconfigured_keys()
-        ac1 = acfactory.get_online_configuring_account(
+        ac1 = acfactory.new_online_configuring_account(
             config={"key_gen_type": str(const.DC_KEY_GEN_RSA2048)}
         )
-        ac2 = acfactory.get_online_configuring_account(
+        ac2 = acfactory.new_online_configuring_account(
             config={"key_gen_type": str(const.DC_KEY_GEN_ED25519)}
         )
         acfactory.bring_accounts_online()
@@ -696,7 +696,7 @@ class TestOnlineAccount:
         assert msg3_in.is_encrypted()
 
     def test_configure_canceled(self, acfactory):
-        ac1 = acfactory.get_online_configuring_account()
+        ac1 = acfactory.new_online_configuring_account()
         ac1._configtracker.wait_progress()
         ac1.stop_ongoing()
         try:
@@ -725,9 +725,9 @@ class TestOnlineAccount:
         assert key_id2 == key_id
 
     def test_one_account_send_bcc_setting(self, acfactory, lp):
-        ac1 = acfactory.get_online_configuring_account()
-        ac2 = acfactory.get_online_configuring_account()
-        ac1_clone = acfactory.get_cloned_configuring_account(ac1)
+        ac1 = acfactory.new_online_configuring_account()
+        ac2 = acfactory.new_online_configuring_account()
+        ac1_clone = acfactory.new_cloned_configuring_account(ac1)
         acfactory.bring_accounts_online()
 
         # test if sent messages are copied to it via BCC.
@@ -869,10 +869,10 @@ class TestOnlineAccount:
 
     def test_mvbox_sentbox_threads(self, acfactory, lp):
         lp.sec("ac1: start with mvbox thread")
-        ac1 = acfactory.get_online_configuring_account(mvbox_move=True, sentbox_watch=True)
+        ac1 = acfactory.new_online_configuring_account(mvbox_move=True, sentbox_watch=True)
 
         lp.sec("ac2: start without mvbox/sentbox threads")
-        ac2 = acfactory.get_online_configuring_account(mvbox_move=False, sentbox_watch=False)
+        ac2 = acfactory.new_online_configuring_account(mvbox_move=False, sentbox_watch=False)
 
         lp.sec("ac2 and ac1: waiting for configuration")
         acfactory.bring_accounts_online()
@@ -882,8 +882,8 @@ class TestOnlineAccount:
         assert ac2._evtracker.wait_next_incoming_message().text == "message1"
 
     def test_move_works(self, acfactory):
-        ac1 = acfactory.get_online_configuring_account()
-        ac2 = acfactory.get_online_configuring_account(mvbox_move=True)
+        ac1 = acfactory.new_online_configuring_account()
+        ac2 = acfactory.new_online_configuring_account(mvbox_move=True)
         acfactory.bring_accounts_online()
         chat = acfactory.get_accepted_chat(ac1, ac2)
         chat.send_text("message1")
@@ -896,8 +896,8 @@ class TestOnlineAccount:
         assert ev.data2 > const.DC_CHAT_ID_LAST_SPECIAL
 
     def test_move_works_on_self_sent(self, acfactory):
-        ac1 = acfactory.get_online_configuring_account(mvbox_move=True)
-        ac2 = acfactory.get_online_configuring_account()
+        ac1 = acfactory.new_online_configuring_account(mvbox_move=True)
+        ac2 = acfactory.new_online_configuring_account()
         acfactory.bring_accounts_online()
         ac1.set_config("bcc_self", "1")
 
@@ -966,7 +966,7 @@ class TestOnlineAccount:
         assert msg_in.is_forwarded()
 
     def test_send_self_message(self, acfactory, lp):
-        ac1 = acfactory.get_online_configuring_account(mvbox_move=True)
+        ac1 = acfactory.new_online_configuring_account(mvbox_move=True)
         acfactory.bring_accounts_online()
         lp.sec("ac1: create self chat")
         chat = ac1.get_self_contact().create_chat()
@@ -1061,8 +1061,8 @@ class TestOnlineAccount:
 
     def test_moved_markseen(self, acfactory, lp):
         """Test that message already moved to DeltaChat folder is marked as seen."""
-        ac1 = acfactory.get_online_configuring_account()
-        ac2 = acfactory.get_online_configuring_account(mvbox_move=True)
+        ac1 = acfactory.new_online_configuring_account()
+        ac2 = acfactory.new_online_configuring_account(mvbox_move=True)
         acfactory.bring_accounts_online()
 
         ac2.stop_io()
@@ -1089,9 +1089,9 @@ class TestOnlineAccount:
 
     def test_multidevice_sync_seen(self, acfactory, lp):
         """Test that message marked as seen on one device is marked as seen on another."""
-        ac1 = acfactory.get_online_configuring_account()
-        ac2 = acfactory.get_online_configuring_account()
-        ac1_clone = acfactory.get_cloned_configuring_account(ac1)
+        ac1 = acfactory.new_online_configuring_account()
+        ac2 = acfactory.new_online_configuring_account()
+        ac1_clone = acfactory.new_cloned_configuring_account(ac1)
         acfactory.bring_accounts_online()
 
         ac1.set_config("bcc_self", "1")
@@ -1180,8 +1180,8 @@ class TestOnlineAccount:
     def test_markseen_message_and_mdn(self, acfactory, mvbox_move):
         # Please only change this test if you are very sure that it will still catch the issues it catches now.
         # We had so many problems with markseen, if in doubt, rather create another test, it can't harm.
-        ac1 = acfactory.get_online_configuring_account(mvbox_move=mvbox_move)
-        ac2 = acfactory.get_online_configuring_account(mvbox_move=mvbox_move)
+        ac1 = acfactory.new_online_configuring_account(mvbox_move=mvbox_move)
+        ac2 = acfactory.new_online_configuring_account(mvbox_move=mvbox_move)
         acfactory.bring_accounts_online()
         # Do not send BCC to self, we only want to test MDN on ac1.
         ac1.set_config("bcc_self", "0")
@@ -1227,8 +1227,8 @@ class TestOnlineAccount:
         assert msg_reply1.chat.id == private_chat1.id
 
     def test_mdn_asymmetric(self, acfactory, lp):
-        ac1 = acfactory.get_online_configuring_account(mvbox_move=True)
-        ac2 = acfactory.get_online_configuring_account()
+        ac1 = acfactory.new_online_configuring_account(mvbox_move=True)
+        ac2 = acfactory.new_online_configuring_account()
         acfactory.bring_accounts_online()
 
         lp.sec("ac1: create chat with ac2")
@@ -1451,7 +1451,7 @@ class TestOnlineAccount:
         If the draft email is sent out later (i.e. moved to "Sent"), it must be shown.
 
         Also, test that unknown emails in the Spam folder are not shown."""
-        ac1 = acfactory.get_online_configuring_account()
+        ac1 = acfactory.new_online_configuring_account()
         ac1.set_config("show_emails", "2")
         ac1.create_contact("alice@example.org").create_chat()
 
@@ -1530,9 +1530,9 @@ class TestOnlineAccount:
         assert len(msg.chat.get_messages()) == 2
 
     def test_no_old_msg_is_fresh(self, acfactory, lp):
-        ac1 = acfactory.get_online_configuring_account()
-        ac2 = acfactory.get_online_configuring_account()
-        ac1_clone = acfactory.get_cloned_configuring_account(ac1)
+        ac1 = acfactory.new_online_configuring_account()
+        ac2 = acfactory.new_online_configuring_account()
+        ac1_clone = acfactory.new_cloned_configuring_account(ac1)
         acfactory.bring_accounts_online()
 
         ac1.set_config("e2ee_enabled", "0")
@@ -1895,8 +1895,8 @@ class TestOnlineAccount:
         # note that the receiving account needs to be configured and running
         # before ther setup message is send. DC does not read old messages
         # as of Jul2019
-        ac1 = acfactory.get_online_configuring_account()
-        ac2 = acfactory.get_cloned_configuring_account(ac1)
+        ac1 = acfactory.new_online_configuring_account()
+        ac2 = acfactory.new_cloned_configuring_account(ac1)
         acfactory.bring_accounts_online()
 
         lp.sec("trigger ac setup message and return setupcode")
@@ -1916,8 +1916,8 @@ class TestOnlineAccount:
         assert ac1.get_info()["fingerprint"] == ac2.get_info()["fingerprint"]
 
     def test_ac_setup_message_twice(self, acfactory, lp):
-        ac1 = acfactory.get_online_configuring_account()
-        ac2 = acfactory.get_cloned_configuring_account(ac1)
+        ac1 = acfactory.new_online_configuring_account()
+        ac2 = acfactory.new_cloned_configuring_account(ac1)
         acfactory.bring_accounts_online()
 
         lp.sec("trigger ac setup message but ignore")
@@ -2401,7 +2401,7 @@ class TestOnlineAccount:
         lp.sec("ac3 reinstalls DC and generates a new key")
         ac3.stop_io()
         acfactory.remove_preconfigured_keys()
-        ac4 = acfactory.get_cloned_configuring_account(ac3)
+        ac4 = acfactory.new_cloned_configuring_account(ac3)
         ac4._configtracker.wait_finish()
         # Create contacts to make sure incoming messages are not treated as contact requests
         chat41 = ac4.create_chat(ac1)
@@ -2459,8 +2459,8 @@ class TestOnlineAccount:
         assert msg.chat == ac2.create_chat(ac4)
 
     def test_immediate_autodelete(self, acfactory, lp):
-        ac1 = acfactory.get_online_configuring_account()
-        ac2 = acfactory.get_online_configuring_account()
+        ac1 = acfactory.new_online_configuring_account()
+        ac2 = acfactory.new_online_configuring_account()
 
         # "1" means delete immediately, while "0" means do not delete
         ac2.set_config("delete_server_after", "1")
@@ -2730,8 +2730,8 @@ class TestOnlineAccount:
         """Delta Chat periodically scans all folders for new messages to make sure we don't miss any."""
         variant = folder + "-" + str(move) + "-" + expected_destination
         lp.sec("Testing variant " + variant)
-        ac1 = acfactory.get_online_configuring_account(mvbox_move=move)
-        ac2 = acfactory.get_online_configuring_account()
+        ac1 = acfactory.new_online_configuring_account(mvbox_move=move)
+        ac2 = acfactory.new_online_configuring_account()
 
         acfactory.wait_configure(ac1)
         ac1.direct_imap.create_folder(folder)
@@ -2776,8 +2776,8 @@ class TestOnlineAccount:
             if mvbox_move:
                 assert ac.get_config("configured_mvbox_folder")
 
-        ac1 = acfactory.get_online_configuring_account(mvbox_move=mvbox_move)
-        ac2 = acfactory.get_online_configuring_account()
+        ac1 = acfactory.new_online_configuring_account(mvbox_move=mvbox_move)
+        ac2 = acfactory.new_online_configuring_account()
 
         acfactory.wait_configure(ac1)
 
@@ -2807,7 +2807,7 @@ class TestOnlineAccount:
         assert_folders_configured(ac1)
 
         lp.sec("create a cloned ac1 and fetch contact history during configure")
-        ac1_clone = acfactory.get_cloned_configuring_account(ac1)
+        ac1_clone = acfactory.new_cloned_configuring_account(ac1)
         ac1_clone.set_config("fetch_existing_msgs", "1")
         ac1_clone._configtracker.wait_finish()
         ac1_clone.start_io()
@@ -2834,8 +2834,8 @@ class TestOnlineAccount:
         So, after fetch-existing-msgs you have one contact request and one chat with the same person.
 
         See https://github.com/deltachat/deltachat-core-rust/issues/2097"""
-        ac1 = acfactory.get_online_configuring_account()
-        ac2 = acfactory.get_online_configuring_account()
+        ac1 = acfactory.new_online_configuring_account()
+        ac2 = acfactory.new_online_configuring_account()
 
         acfactory.bring_accounts_online()
 
@@ -2853,7 +2853,7 @@ class TestOnlineAccount:
         assert ac1.direct_imap.idle_wait_for_seen()
 
         lp.sec("Clone online account and let it fetch the existing messages")
-        ac1_clone = acfactory.get_cloned_configuring_account(ac1)
+        ac1_clone = acfactory.new_cloned_configuring_account(ac1)
         ac1_clone.set_config("fetch_existing_msgs", "1")
         ac1_clone._configtracker.wait_finish()
 
@@ -2876,8 +2876,8 @@ class TestOnlineAccount:
 
     def test_delete_deltachat_folder(self, acfactory):
         """Test that DeltaChat folder is recreated if user deletes it manually."""
-        ac1 = acfactory.get_online_configuring_account(mvbox_move=True)
-        ac2 = acfactory.get_online_configuring_account()
+        ac1 = acfactory.new_online_configuring_account(mvbox_move=True)
+        ac2 = acfactory.new_online_configuring_account()
         acfactory.wait_configure(ac1)
 
         ac1.direct_imap.conn.folder.delete("DeltaChat")

--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -727,15 +727,12 @@ class TestOnlineAccount:
     def test_one_account_send_bcc_setting(self, acfactory, lp):
         ac1 = acfactory.get_online_configuring_account()
         ac2 = acfactory.get_online_configuring_account()
-
-        # Clone the first account: we will test if sent messages
-        # are copied to it via BCC.
-        ac1_clone = acfactory.clone_online_account(ac1)
-
+        ac1_clone = acfactory.get_cloned_configuring_account(ac1)
         acfactory.wait_configure_and_start_io()
 
-        chat = acfactory.get_accepted_chat(ac1, ac2)
+        # test if sent messages are copied to it via BCC.
 
+        chat = acfactory.get_accepted_chat(ac1, ac2)
         self_addr = ac1.get_config("addr")
         other_addr = ac2.get_config("addr")
 
@@ -1094,7 +1091,7 @@ class TestOnlineAccount:
         """Test that message marked as seen on one device is marked as seen on another."""
         ac1 = acfactory.get_online_configuring_account()
         ac2 = acfactory.get_online_configuring_account()
-        ac1_clone = acfactory.clone_online_account(ac1)
+        ac1_clone = acfactory.get_cloned_configuring_account(ac1)
         acfactory.wait_configure_and_start_io()
 
         ac1.set_config("bcc_self", "1")
@@ -1535,7 +1532,7 @@ class TestOnlineAccount:
     def test_no_old_msg_is_fresh(self, acfactory, lp):
         ac1 = acfactory.get_online_configuring_account()
         ac2 = acfactory.get_online_configuring_account()
-        ac1_clone = acfactory.clone_online_account(ac1)
+        ac1_clone = acfactory.get_cloned_configuring_account(ac1)
         acfactory.wait_configure_and_start_io()
 
         ac1.set_config("e2ee_enabled", "0")
@@ -1899,7 +1896,7 @@ class TestOnlineAccount:
         # before ther setup message is send. DC does not read old messages
         # as of Jul2019
         ac1 = acfactory.get_online_configuring_account()
-        ac2 = acfactory.clone_online_account(ac1)
+        ac2 = acfactory.get_cloned_configuring_account(ac1)
         acfactory.wait_configure_and_start_io()
 
         lp.sec("trigger ac setup message and return setupcode")
@@ -1920,7 +1917,7 @@ class TestOnlineAccount:
 
     def test_ac_setup_message_twice(self, acfactory, lp):
         ac1 = acfactory.get_online_configuring_account()
-        ac2 = acfactory.clone_online_account(ac1)
+        ac2 = acfactory.get_cloned_configuring_account(ac1)
         acfactory.wait_configure_and_start_io()
 
         lp.sec("trigger ac setup message but ignore")
@@ -2404,7 +2401,7 @@ class TestOnlineAccount:
         lp.sec("ac3 reinstalls DC and generates a new key")
         ac3.stop_io()
         acfactory.remove_preconfigured_keys()
-        ac4 = acfactory.clone_online_account(ac3)
+        ac4 = acfactory.get_cloned_configuring_account(ac3)
         ac4._configtracker.wait_finish()
         # Create contacts to make sure incoming messages are not treated as contact requests
         chat41 = ac4.create_chat(ac1)
@@ -2810,7 +2807,7 @@ class TestOnlineAccount:
         assert_folders_configured(ac1)
 
         lp.sec("create a cloned ac1 and fetch contact history during configure")
-        ac1_clone = acfactory.clone_online_account(ac1)
+        ac1_clone = acfactory.get_cloned_configuring_account(ac1)
         ac1_clone.set_config("fetch_existing_msgs", "1")
         ac1_clone._configtracker.wait_finish()
         ac1_clone.start_io()
@@ -2855,7 +2852,7 @@ class TestOnlineAccount:
         assert ac1.direct_imap.idle_wait_for_seen()
 
         lp.sec("Clone online account and let it fetch the existing messages")
-        ac1_clone = acfactory.clone_online_account(ac1)
+        ac1_clone = acfactory.get_cloned_configuring_account(ac1)
         ac1_clone.set_config("fetch_existing_msgs", "1")
         ac1_clone._configtracker.wait_finish()
 

--- a/python/tests/test_increation.py
+++ b/python/tests/test_increation.py
@@ -33,7 +33,7 @@ def wait_msgs_changed(account, msgs_list):
 
 class TestOnlineInCreation:
     def test_increation_not_blobdir(self, tmpdir, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         chat = ac1.create_chat(ac2)
 
         lp.sec("Creating in-creation file outside of blobdir")
@@ -43,7 +43,7 @@ class TestOnlineInCreation:
             chat.prepare_message_file(src.strpath)
 
     def test_no_increation_copies_to_blobdir(self, tmpdir, acfactory, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
         chat = ac1.create_chat(ac2)
 
         lp.sec("Creating file outside of blobdir")
@@ -56,7 +56,7 @@ class TestOnlineInCreation:
         assert os.path.exists(blob_src), "file.txt not copied to blobdir"
 
     def test_forward_increation(self, acfactory, data, lp):
-        ac1, ac2 = acfactory.get_two_online_accounts()
+        ac1, ac2 = acfactory.get_online_accounts(2)
 
         chat = ac1.create_chat(ac2)
         wait_msgs_changed(ac1, [(0, 0)])  # why no chat id?

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -6,16 +6,16 @@ from deltachat import register_global_plugin
 from deltachat.hookspec import global_hookimpl
 from deltachat.capi import ffi
 from deltachat.capi import lib
-from deltachat.testplugin import PendingConfigure
+from deltachat.testplugin import ACSetup
 # from deltachat.account import EventLogger
 
 
-class TestPendingConfigure:
+class TestACSetup:
     def test_basic_states(self, acfactory, monkeypatch):
-        pc = PendingConfigure(init_time=0.0)
+        pc = ACSetup(init_time=0.0)
         acc = acfactory.get_unconfigured_account()
         monkeypatch.setattr(acc, "configure", lambda **kwargs: None)
-        pc.add_account(acc)
+        pc.start_configure(acc)
         assert pc._account2state[acc] == pc.CONFIGURING
         pc._configured_events.put((acc, True))
         monkeypatch.setattr(pc, "init_direct_imap", lambda *args, **kwargs: None)
@@ -26,15 +26,15 @@ class TestPendingConfigure:
         assert pc._account2state[acc] == pc.IDLEREADY
 
     def test_two_accounts_one_waited_all_started(self, monkeypatch, acfactory):
-        pc = PendingConfigure(init_time=0.0)
+        pc = ACSetup(init_time=0.0)
         monkeypatch.setattr(pc, "init_direct_imap", lambda *args, **kwargs: None)
         monkeypatch.setattr(pc, "_onconfigure_start_io", lambda *args, **kwargs: None)
         ac1 = acfactory.get_unconfigured_account()
         monkeypatch.setattr(ac1, "configure", lambda **kwargs: None)
-        pc.add_account(ac1)
+        pc.start_configure(ac1)
         ac2 = acfactory.get_unconfigured_account()
         monkeypatch.setattr(ac2, "configure", lambda **kwargs: None)
-        pc.add_account(ac2)
+        pc.start_configure(ac2)
         assert pc._account2state[ac1] == pc.CONFIGURING
         assert pc._account2state[ac2] == pc.CONFIGURING
         pc._configured_events.put((ac1, True))

--- a/python/tests/test_lowlevel.py
+++ b/python/tests/test_lowlevel.py
@@ -68,8 +68,7 @@ def test_sig():
 
 
 def test_markseen_invalid_message_ids(acfactory):
-    ac1 = acfactory.get_configured_offline_account()
-
+    ac1 = acfactory.get_pseudo_configured_account()
     contact1 = ac1.create_contact("some1@example.com", name="some1")
     chat = contact1.create_chat()
     chat.send_text("one messae")
@@ -80,7 +79,7 @@ def test_markseen_invalid_message_ids(acfactory):
 
 
 def test_get_special_message_id_returns_empty_message(acfactory):
-    ac1 = acfactory.get_configured_offline_account()
+    ac1 = acfactory.get_pseudo_configured_account()
     for i in range(1, 10):
         msg = ac1.get_message_by_id(i)
         assert msg.id == 0

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -8,7 +8,7 @@ envlist =
 
 [testenv]
 commands = 
-    pytest -n1 --reruns 2 --reruns-delay 5 -v -rsXx --ignored --strict-tls {posargs: tests examples}
+    pytest -n6 --extra-info --reruns 2 --reruns-delay 5 -v -rsXx --ignored --strict-tls {posargs: tests examples}
     python tests/package_wheels.py {toxworkdir}/wheelhouse
 passenv = 
     TRAVIS 


### PR DESCRIPTION
make account setup more deterministic, safer and simpler for use from tests:
- introduces a tested ACSetup class to manage the transition between configuring/started/ready-to-receive states of multiple accounts 
- removes global deltachat plugin to perform test initialization 
- adds more doc strings and reduces number of API methods and intricate dependencies between test initialization code and tests 
- introduces "--extra-info" pytest option which enables showing of imap state on test failures and stdout during teardown. By default output is less verbose now, so one is closer to the logs and the actual python test failure. tox runs use --extra-info so CI runs should show this extra info as before. 
- prepares a subsequent optimization step that would cache "configured live accounts" -- live configuration (and reconfiguration) adds between 2-4 seconds overhead for each test 

this PR is probably best reviewed by reading "testplugin.py" in full (it's largely refactored) and otherwise the individual changes to files (rather few, and mostly naming related) 
#skip-changelog 