### PR TITLE
Hopefully make test_connectivity() unflaky

### DIFF
--- a/python/tests/test_account.py
+++ b/python/tests/test_account.py
@@ -2217,7 +2217,7 @@ class TestOnlineAccount:
         ac1.direct_imap.idle_start()
         ac2.create_chat(ac1).send_text("Hi")
 
-        ac1.direct_imap.idle_wait_for_new_message(terminate=False)
+        ac1.direct_imap.idle_wait_for_new_message(terminate=True)
         ac1.maybe_network()
 
         ac1._evtracker.wait_for_all_work_done()
@@ -2229,8 +2229,6 @@ class TestOnlineAccount:
 
         ac2.create_chat(ac1).send_text("Hi 2")
 
-        ac1.direct_imap.idle_wait_for_new_message(terminate=True)
-        ac1.maybe_network()
         ac1._evtracker.wait_for_connectivity_change(const.DC_CONNECTIVITY_CONNECTED, const.DC_CONNECTIVITY_WORKING)
         ac1._evtracker.wait_for_connectivity_change(const.DC_CONNECTIVITY_WORKING, const.DC_CONNECTIVITY_CONNECTED)
 


### PR DESCRIPTION
Fix #3269. I couldn't reproduce the flakiness, but I think that this should fix it.

I don't understand why I added these lines back when I wrote this test; there is no need to call `maybe_network()` since DC core will see that there is a new email all by itself, and doing `idle_wait_for_new_message()` just delays the call to `wait_for_connectivity_change()` so that we possibly miss it.

Technically, this is still a race condition since we have to assume that the python test realizes that the connectivity is WORKING before the core is done receiving the message. But Python only has to execute a single-digit number of lines while the core has to receive a whole email involving lots of I/O (and takes long enough that a human will see it), so that should be fine.