### PR TITLE
Remove panics from the scheduler and simplify stop_io() 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- simplify `dc_stop_io()` and remove potential panics and race conditions #3273
+
 ## 1.78.0
 
 ### API-Changes


### PR DESCRIPTION
Hold scheduler lock during the whole procedure of
scheduler stopping. This ensures that two
processes can't get two read locks in parallel
and send the stop signal twice.

Also remove shutdown channels: it is enough to wait
for the loop handle without receiving a shutdown signal
from the end of the loop.