### PR TITLE
Deprecate marker1before argument of dc_get_chat_msgs()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - send normal messages with higher priority than MDNs #3243
 - make Scheduler stateless #3302
 
+### API-Changes
+- deprecate unused `marker1before` argument of `dc_get_chat_msgs`
+  and remove `DC_MSG_ID_MARKER1` constant #3274
+
 
 ## 1.80.0
 

--- a/benches/get_chat_msgs.rs
+++ b/benches/get_chat_msgs.rs
@@ -12,7 +12,7 @@ async fn get_chat_msgs_benchmark(dbfile: &Path, chats: &[ChatId]) {
     let context = Context::new(dbfile.into(), id).await.unwrap();
 
     for c in chats.iter().take(10) {
-        black_box(chat::get_chat_msgs(&context, *c, 0, None).await.ok());
+        black_box(chat::get_chat_msgs(&context, *c, 0).await.ok());
     }
 }
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1174,8 +1174,7 @@ dc_msg_t*       dc_get_draft                 (dc_context_t* context, uint32_t ch
  *     be added before each day (regarding the local timezone). Set this to 0 if you do not want this behaviour.
  *     To get the concrete time of the marker, use dc_array_get_timestamp().
  *     If set to DC_GCM_INFO_ONLY, only system messages will be returned, can be combined with DC_GCM_ADDDAYMARKER.
- * @param marker1before An optional message ID. If set, the ID DC_MSG_ID_MARKER1 will be added just
- *   before the given ID in the returned array. Set this to 0 if you do not want this behaviour.
+ * @param marker1before Deprecated, set this to 0.
  * @return Array of message IDs, must be dc_array_unref()'d when no longer used.
  */
 dc_array_t*     dc_get_chat_msgs             (dc_context_t* context, uint32_t chat_id, uint32_t flags, uint32_t marker1before);
@@ -3447,7 +3446,6 @@ int64_t          dc_chat_get_remaining_mute_duration (const dc_chat_t* chat);
  */
 
 
-#define         DC_MSG_ID_MARKER1            1
 #define         DC_MSG_ID_DAYMARKER          9
 #define         DC_MSG_ID_LAST_SPECIAL       9
 

--- a/deltachat-ffi/src/dc_array.rs
+++ b/deltachat-ffi/src/dc_array.rs
@@ -1,5 +1,5 @@
 use crate::chat::ChatItem;
-use crate::constants::{DC_MSG_ID_DAYMARKER, DC_MSG_ID_MARKER1};
+use crate::constants::DC_MSG_ID_DAYMARKER;
 use crate::location::Location;
 use crate::message::MsgId;
 
@@ -18,7 +18,6 @@ impl dc_array_t {
             Self::MsgIds(array) => array[index].to_u32(),
             Self::Chat(array) => match array[index] {
                 ChatItem::Message { msg_id } => msg_id.to_u32(),
-                ChatItem::Marker1 => DC_MSG_ID_MARKER1,
                 ChatItem::DayMarker { .. } => DC_MSG_ID_DAYMARKER,
             },
             Self::Locations(array) => array[index].location_id,
@@ -31,7 +30,6 @@ impl dc_array_t {
             Self::MsgIds(_) => None,
             Self::Chat(array) => array.get(index).and_then(|item| match item {
                 ChatItem::Message { .. } => None,
-                ChatItem::Marker1 { .. } => None,
                 ChatItem::DayMarker { timestamp } => Some(*timestamp),
             }),
             Self::Locations(array) => array.get(index).map(|location| location.timestamp),

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1027,22 +1027,17 @@ pub unsafe extern "C" fn dc_get_chat_msgs(
     context: *mut dc_context_t,
     chat_id: u32,
     flags: u32,
-    marker1before: u32,
+    _marker1before: u32,
 ) -> *mut dc_array::dc_array_t {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_chat_msgs()");
         return ptr::null_mut();
     }
     let ctx = &*context;
-    let marker_flag = if marker1before <= DC_MSG_ID_LAST_SPECIAL {
-        None
-    } else {
-        Some(MsgId::new(marker1before))
-    };
 
     block_on(async move {
         Box::into_raw(Box::new(
-            chat::get_chat_msgs(ctx, ChatId::new(chat_id), flags, marker_flag)
+            chat::get_chat_msgs(ctx, ChatId::new(chat_id), flags)
                 .await
                 .unwrap_or_log_default(ctx, "failed to get chat msgs")
                 .into(),

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -639,14 +639,13 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
 
             let time_start = std::time::SystemTime::now();
             let msglist =
-                chat::get_chat_msgs(&context, sel_chat.get_id(), DC_GCM_ADDDAYMARKER, None).await?;
+                chat::get_chat_msgs(&context, sel_chat.get_id(), DC_GCM_ADDDAYMARKER).await?;
             let time_needed = time_start.elapsed().unwrap_or_default();
 
             let msglist: Vec<MsgId> = msglist
                 .into_iter()
                 .map(|x| match x {
                     ChatItem::Message { msg_id } => msg_id,
-                    ChatItem::Marker1 => MsgId::new(DC_MSG_ID_MARKER1),
                     ChatItem::DayMarker { .. } => MsgId::new(DC_MSG_ID_DAYMARKER),
                 })
                 .collect();

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -47,10 +47,6 @@ pub enum ChatItem {
         msg_id: MsgId,
     },
 
-    /// A marker without inherent meaning. It is inserted before user
-    /// supplied MsgId.
-    Marker1,
-
     /// Day marker, separating messages that correspond to different
     /// days according to local time.
     DayMarker {
@@ -2176,7 +2172,6 @@ pub async fn get_chat_msgs(
     context: &Context,
     chat_id: ChatId,
     flags: u32,
-    marker1before: Option<MsgId>,
 ) -> Result<Vec<ChatItem>> {
     let process_row = if (flags & DC_GCM_INFO_ONLY) != 0 {
         |row: &rusqlite::Row| {
@@ -2226,12 +2221,8 @@ pub async fn get_chat_msgs(
         let mut ret = Vec::new();
         let mut last_day = 0;
         let cnv_to_local = dc_gm2local_offset();
-        let marker1 = marker1before.unwrap_or_else(MsgId::new_unset);
 
         for (ts, curr_id) in sorted_rows {
-            if curr_id == marker1 {
-                ret.push(ChatItem::Marker1);
-            }
             if (flags & DC_GCM_ADDDAYMARKER) != 0 {
                 let curr_local_timestamp = ts + cnv_to_local;
                 let curr_day = curr_local_timestamp / 86400;
@@ -4547,7 +4538,7 @@ mod tests {
         assert!(chat.is_protected());
         assert!(chat.is_unpromoted());
 
-        let msgs = get_chat_msgs(&t, chat_id, 0, None).await.unwrap();
+        let msgs = get_chat_msgs(&t, chat_id, 0).await.unwrap();
         assert_eq!(msgs.len(), 1);
 
         let msg = t.get_last_msg_in(chat_id).await;
@@ -4577,7 +4568,7 @@ mod tests {
         assert!(!chat.is_protected());
         assert!(!chat.is_unpromoted());
 
-        let msgs = get_chat_msgs(&t, chat_id, 0, None).await.unwrap();
+        let msgs = get_chat_msgs(&t, chat_id, 0).await.unwrap();
         assert_eq!(msgs.len(), 3);
 
         // enable protection on promoted chat, the info-message is sent via send_msg() this time
@@ -4674,10 +4665,7 @@ mod tests {
         add_contact_to_chat(&alice, alice_chat_id, contact_id).await?;
         assert_eq!(get_chat_contacts(&alice, alice_chat_id).await?.len(), 2);
         send_text_msg(&alice, alice_chat_id, "hi!".to_string()).await?;
-        assert_eq!(
-            get_chat_msgs(&alice, alice_chat_id, 0, None).await?.len(),
-            1
-        );
+        assert_eq!(get_chat_msgs(&alice, alice_chat_id, 0).await?.len(), 1);
 
         // Alice has an SMTP-server replacing the `Message-ID:`-header (as done eg. by outlook.com).
         let sent_msg = alice.pop_sent_msg().await;
@@ -4710,10 +4698,7 @@ mod tests {
         let msg = alice.get_last_msg().await;
         assert_eq!(msg.chat_id, alice_chat_id);
         assert_eq!(msg.text, Some("ho!".to_string()));
-        assert_eq!(
-            get_chat_msgs(&alice, alice_chat_id, 0, None).await?.len(),
-            2
-        );
+        assert_eq!(get_chat_msgs(&alice, alice_chat_id, 0).await?.len(), 2);
         Ok(())
     }
 
@@ -4741,7 +4726,7 @@ mod tests {
         assert_eq!(chat.id.get_fresh_msg_cnt(&t).await?, 1);
         assert_eq!(t.get_fresh_msgs().await?.len(), 1);
 
-        let msgs = get_chat_msgs(&t, chat.id, 0, None).await?;
+        let msgs = get_chat_msgs(&t, chat.id, 0).await?;
         assert_eq!(msgs.len(), 1);
         let msg_id = match msgs.first().unwrap() {
             ChatItem::Message { msg_id } => *msg_id,
@@ -4791,7 +4776,7 @@ mod tests {
             .is_contact_request());
         assert_eq!(chat_id.get_msg_cnt(&t).await?, 1);
         assert_eq!(chat_id.get_fresh_msg_cnt(&t).await?, 1);
-        let msgs = get_chat_msgs(&t, chat_id, 0, None).await?;
+        let msgs = get_chat_msgs(&t, chat_id, 0).await?;
         assert_eq!(msgs.len(), 1);
         let msg_id = match msgs.first().unwrap() {
             ChatItem::Message { msg_id } => *msg_id,
@@ -4879,7 +4864,7 @@ mod tests {
         let chat_id = msg.chat_id;
         assert_eq!(chat_id.get_fresh_msg_cnt(&alice).await?, 1);
 
-        let msgs = get_chat_msgs(&alice, chat_id, 0, None).await?;
+        let msgs = get_chat_msgs(&alice, chat_id, 0).await?;
         assert_eq!(msgs.len(), 1);
 
         // Alice disables receiving classic emails.
@@ -4891,7 +4876,7 @@ mod tests {
         // Already received classic email should still be in the chat.
         assert_eq!(chat_id.get_fresh_msg_cnt(&alice).await?, 1);
 
-        let msgs = get_chat_msgs(&alice, chat_id, 0, None).await?;
+        let msgs = get_chat_msgs(&alice, chat_id, 0).await?;
         assert_eq!(msgs.len(), 1);
 
         Ok(())
@@ -5180,13 +5165,13 @@ mod tests {
         let msg = bob.get_last_msg().await;
         assert_eq!(msg.get_text().unwrap(), "alice->bob");
         assert_eq!(get_chat_contacts(&bob, msg.chat_id).await?.len(), 2);
-        assert_eq!(get_chat_msgs(&bob, msg.chat_id, 0, None).await?.len(), 1);
+        assert_eq!(get_chat_msgs(&bob, msg.chat_id, 0).await?.len(), 1);
         bob.recv_msg(&sent2).await;
         assert_eq!(get_chat_contacts(&bob, msg.chat_id).await?.len(), 3);
-        assert_eq!(get_chat_msgs(&bob, msg.chat_id, 0, None).await?.len(), 2);
+        assert_eq!(get_chat_msgs(&bob, msg.chat_id, 0).await?.len(), 2);
         bob.recv_msg(&sent3).await;
         assert_eq!(get_chat_contacts(&bob, msg.chat_id).await?.len(), 3);
-        assert_eq!(get_chat_msgs(&bob, msg.chat_id, 0, None).await?.len(), 2);
+        assert_eq!(get_chat_msgs(&bob, msg.chat_id, 0).await?.len(), 2);
 
         // Claire does not receive the first message, however, due to resending, she has a similar view as Alice and Bob
         let claire = TestContext::new().await;
@@ -5196,7 +5181,7 @@ mod tests {
         let msg = claire.get_last_msg().await;
         assert_eq!(msg.get_text().unwrap(), "alice->bob");
         assert_eq!(get_chat_contacts(&claire, msg.chat_id).await?.len(), 3);
-        assert_eq!(get_chat_msgs(&claire, msg.chat_id, 0, None).await?.len(), 2);
+        assert_eq!(get_chat_msgs(&claire, msg.chat_id, 0).await?.len(), 2);
         let msg_from = Contact::get_by_id(&claire, msg.get_from_id()).await?;
         assert_eq!(msg_from.get_addr(), "alice@example.org");
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -162,7 +162,6 @@ impl Default for Chattype {
     }
 }
 
-pub const DC_MSG_ID_MARKER1: u32 = 1;
 pub const DC_MSG_ID_DAYMARKER: u32 = 9;
 pub const DC_MSG_ID_LAST_SPECIAL: u32 = 9;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -726,23 +726,20 @@ mod tests {
         assert_eq!(t.get_fresh_msgs().await.unwrap().len(), 0);
 
         receive_msg(&t, &bob).await;
-        assert_eq!(get_chat_msgs(&t, bob.id, 0, None).await.unwrap().len(), 1);
+        assert_eq!(get_chat_msgs(&t, bob.id, 0).await.unwrap().len(), 1);
         assert_eq!(bob.id.get_fresh_msg_cnt(&t).await.unwrap(), 1);
         assert_eq!(t.get_fresh_msgs().await.unwrap().len(), 1);
 
         receive_msg(&t, &claire).await;
         receive_msg(&t, &claire).await;
-        assert_eq!(
-            get_chat_msgs(&t, claire.id, 0, None).await.unwrap().len(),
-            2
-        );
+        assert_eq!(get_chat_msgs(&t, claire.id, 0).await.unwrap().len(), 2);
         assert_eq!(claire.id.get_fresh_msg_cnt(&t).await.unwrap(), 2);
         assert_eq!(t.get_fresh_msgs().await.unwrap().len(), 3);
 
         receive_msg(&t, &dave).await;
         receive_msg(&t, &dave).await;
         receive_msg(&t, &dave).await;
-        assert_eq!(get_chat_msgs(&t, dave.id, 0, None).await.unwrap().len(), 3);
+        assert_eq!(get_chat_msgs(&t, dave.id, 0).await.unwrap().len(), 3);
         assert_eq!(dave.id.get_fresh_msg_cnt(&t).await.unwrap(), 3);
         assert_eq!(t.get_fresh_msgs().await.unwrap().len(), 6);
 
@@ -757,10 +754,7 @@ mod tests {
         receive_msg(&t, &bob).await;
         receive_msg(&t, &claire).await;
         receive_msg(&t, &dave).await;
-        assert_eq!(
-            get_chat_msgs(&t, claire.id, 0, None).await.unwrap().len(),
-            3
-        );
+        assert_eq!(get_chat_msgs(&t, claire.id, 0).await.unwrap().len(), 3);
         assert_eq!(claire.id.get_fresh_msg_cnt(&t).await.unwrap(), 3);
         assert_eq!(t.get_fresh_msgs().await.unwrap().len(), 6); // muted claire is not counted
 
@@ -777,7 +771,7 @@ mod tests {
         let t = TestContext::new_alice().await;
         let bob = t.create_chat_with_contact("", "bob@g.it").await;
         receive_msg(&t, &bob).await;
-        assert_eq!(get_chat_msgs(&t, bob.id, 0, None).await.unwrap().len(), 1);
+        assert_eq!(get_chat_msgs(&t, bob.id, 0).await.unwrap().len(), 1);
 
         // chat is unmuted by default, here and in the following assert(),
         // we check mainly that the SQL-statements in is_muted() and get_fresh_msgs()

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2350,26 +2350,14 @@ mod tests {
         assert_eq!(chat.typ, Chattype::Single);
         assert_eq!(chat.name, "Bob");
         assert_eq!(chat::get_chat_contacts(&t, chat_id).await.unwrap().len(), 1);
-        assert_eq!(
-            chat::get_chat_msgs(&t, chat_id, 0, None)
-                .await
-                .unwrap()
-                .len(),
-            1
-        );
+        assert_eq!(chat::get_chat_msgs(&t, chat_id, 0).await.unwrap().len(), 1);
 
         // receive a non-delta-message from Bob, shows up because of the show_emails setting
         dc_receive_imf(&t, ONETOONE_NOREPLY_MAIL, false)
             .await
             .unwrap();
 
-        assert_eq!(
-            chat::get_chat_msgs(&t, chat_id, 0, None)
-                .await
-                .unwrap()
-                .len(),
-            2
-        );
+        assert_eq!(chat::get_chat_msgs(&t, chat_id, 0).await.unwrap().len(), 2);
 
         // let Bob create an adhoc-group by a non-delta-message, shows up because of the show_emails setting
         dc_receive_imf(&t, GRP_MAIL, false).await.unwrap();
@@ -2418,13 +2406,7 @@ mod tests {
         // create a group with bob, archive group
         let group_id = chat::create_group_chat(&t, ProtectionStatus::Unprotected, "foo").await?;
         chat::add_contact_to_chat(&t, group_id, bob_id).await?;
-        assert_eq!(
-            chat::get_chat_msgs(&t, group_id, 0, None)
-                .await
-                .unwrap()
-                .len(),
-            0
-        );
+        assert_eq!(chat::get_chat_msgs(&t, group_id, 0).await.unwrap().len(), 0);
         group_id
             .set_visibility(&t, ChatVisibility::Archived)
             .await?;
@@ -2505,7 +2487,7 @@ mod tests {
             false,
         )
         .await?;
-        assert_eq!(chat::get_chat_msgs(&t, group_id, 0, None).await?.len(), 1);
+        assert_eq!(chat::get_chat_msgs(&t, group_id, 0).await?.len(), 1);
         let msg = message::Message::load_from_db(&t, msg.id).await?;
         assert_eq!(msg.state, MessageState::OutMdnRcvd);
 
@@ -2834,7 +2816,7 @@ mod tests {
 
         assert_eq!(msg.state, MessageState::OutFailed);
 
-        let msgs = chat::get_chat_msgs(&t, msg.chat_id, 0, None).await?;
+        let msgs = chat::get_chat_msgs(&t, msg.chat_id, 0).await?;
         let msg_id = if let ChatItem::Message { msg_id } = msgs.last().unwrap() {
             msg_id
         } else {
@@ -3087,7 +3069,7 @@ Hello mailinglist!\r\n"
         assert_eq!(chats.len(), 0); // Test that the message is not shown
 
         // Both messages are in the same blocked chat.
-        let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0, None).await.unwrap();
+        let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0).await.unwrap();
         assert_eq!(msgs.len(), 2);
     }
 
@@ -3120,7 +3102,7 @@ Hello mailinglist!\r\n"
             .await
             .unwrap();
         let msg = t.get_last_msg().await;
-        let msgs = chat::get_chat_msgs(&t, msg.chat_id, 0, None).await.unwrap();
+        let msgs = chat::get_chat_msgs(&t, msg.chat_id, 0).await.unwrap();
         assert_eq!(msgs.len(), 2);
     }
 
@@ -3142,7 +3124,7 @@ Hello mailinglist!\r\n"
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1); // Test that chat is still in the chatlist
-        let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0, None).await.unwrap();
+        let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0).await.unwrap();
         assert_eq!(msgs.len(), 1); // ...and contains 1 message
 
         dc_receive_imf(&t.ctx, DC_MAILINGLIST2, false)
@@ -3151,7 +3133,7 @@ Hello mailinglist!\r\n"
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1); // Test that the new mailing list message got into the same chat
-        let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0, None).await.unwrap();
+        let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0).await.unwrap();
         assert_eq!(msgs.len(), 2);
         let chat = Chat::load_from_db(&t.ctx, chat_id).await.unwrap();
         assert!(chat.is_contact_request());
@@ -3179,7 +3161,7 @@ Hello mailinglist!\r\n"
             .await
             .unwrap();
 
-        let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0, None).await.unwrap();
+        let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0).await.unwrap();
         assert_eq!(msgs.len(), 2);
         let chat = chat::Chat::load_from_db(&t.ctx, chat_id).await.unwrap();
         assert!(chat.can_send(&t.ctx).await.unwrap());
@@ -3212,13 +3194,7 @@ Hello mailinglist!\r\n"
         assert_eq!(chat.typ, Chattype::Mailinglist);
         assert_eq!(chat.grpid, "mylist@bar.org");
         assert_eq!(chat.name, "ola");
-        assert_eq!(
-            chat::get_chat_msgs(&t, chat.id, 0, None)
-                .await
-                .unwrap()
-                .len(),
-            1
-        );
+        assert_eq!(chat::get_chat_msgs(&t, chat.id, 0).await.unwrap().len(), 1);
 
         // receive another message with no sender name but the same address,
         // make sure this lands in the same chat
@@ -3237,13 +3213,7 @@ Hello mailinglist!\r\n"
         )
         .await
         .unwrap();
-        assert_eq!(
-            chat::get_chat_msgs(&t, chat.id, 0, None)
-                .await
-                .unwrap()
-                .len(),
-            2
-        );
+        assert_eq!(chat::get_chat_msgs(&t, chat.id, 0).await.unwrap().len(), 2);
     }
 
     #[async_std::test]
@@ -3422,10 +3392,7 @@ Hello mailinglist!\r\n"
         );
         assert!(msg.has_html());
         let chat = Chat::load_from_db(&t, msg.chat_id).await.unwrap();
-        assert_eq!(
-            get_chat_msgs(&t, msg.chat_id, 0, None).await.unwrap().len(),
-            1
-        );
+        assert_eq!(get_chat_msgs(&t, msg.chat_id, 0).await.unwrap().len(), 1);
         assert_eq!(chat.typ, Chattype::Mailinglist);
         assert_eq!(chat.blocked, Blocked::Request);
         assert_eq!(chat.grpid, "intern.lists.abc.de");
@@ -3445,10 +3412,7 @@ Hello mailinglist!\r\n"
         .await
         .unwrap();
         let msg = t.get_last_msg().await;
-        assert_eq!(
-            get_chat_msgs(&t, msg.chat_id, 0, None).await.unwrap().len(),
-            1
-        );
+        assert_eq!(get_chat_msgs(&t, msg.chat_id, 0).await.unwrap().len(), 1);
         let text = msg.text.clone().unwrap();
         assert!(text.contains("content text"));
         assert!(!text.contains("footer text"));
@@ -3604,7 +3568,7 @@ YEAAAAAA!.
         assert_eq!(msg.viewtype, Viewtype::Image);
         assert!(msg.has_html());
         let chat = Chat::load_from_db(&t, msg.chat_id).await.unwrap();
-        assert_eq!(get_chat_msgs(&t, chat.id, 0, None).await.unwrap().len(), 1);
+        assert_eq!(get_chat_msgs(&t, chat.id, 0).await.unwrap().len(), 1);
     }
 
     /// Test that classical MUA messages are assigned to group chats based on the `In-Reply-To`
@@ -3654,7 +3618,7 @@ YEAAAAAA!.
         assert_eq!(msg.get_text().unwrap(), "reply foo");
 
         // Load the first message from the same chat.
-        let msgs = chat::get_chat_msgs(&t, msg.chat_id, 0, None).await.unwrap();
+        let msgs = chat::get_chat_msgs(&t, msg.chat_id, 0).await.unwrap();
         let msg_id = if let ChatItem::Message { msg_id } = msgs.first().unwrap() {
             msg_id
         } else {
@@ -3887,10 +3851,7 @@ YEAAAAAA!.
         assert!(msg.get_text().unwrap().contains("hi support!"));
         let chat = Chat::load_from_db(&alice, msg.chat_id).await.unwrap();
         assert_eq!(chat.typ, Chattype::Group);
-        assert_eq!(
-            get_chat_msgs(&alice, chat.id, 0, None).await.unwrap().len(),
-            1
-        );
+        assert_eq!(get_chat_msgs(&alice, chat.id, 0).await.unwrap().len(), 1);
         if group_request {
             assert_eq!(get_chat_contacts(&alice, chat.id).await.unwrap().len(), 4);
         } else {
@@ -3923,13 +3884,7 @@ YEAAAAAA!.
         } else {
             assert_eq!(chat.typ, Chattype::Single);
         }
-        assert_eq!(
-            get_chat_msgs(&claire, chat.id, 0, None)
-                .await
-                .unwrap()
-                .len(),
-            1
-        );
+        assert_eq!(get_chat_msgs(&claire, chat.id, 0).await.unwrap().len(), 1);
         assert_eq!(msg.get_override_sender_name(), None);
 
         (claire, alice)
@@ -4044,7 +3999,7 @@ YEAAAAAA!.
         println!("\n========= Delete the message ==========");
         msg.id.trash(&t).await.unwrap();
 
-        let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0, None).await.unwrap();
+        let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0).await.unwrap();
         assert_eq!(msgs.len(), 0);
 
         println!("\n========= Receive a message that is a reply to the deleted message ==========");

--- a/src/dc_tools.rs
+++ b/src/dc_tools.rs
@@ -1042,9 +1042,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         let device_chat_id = chats.get_chat_id(0).unwrap();
-        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0, None)
-            .await
-            .unwrap();
+        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
         assert_eq!(msgs.len(), 1);
 
         // the message should be added only once a day - test that an hour later and nearly a day later
@@ -1054,9 +1052,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
             get_provider_update_timestamp(),
         )
         .await;
-        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0, None)
-            .await
-            .unwrap();
+        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
         assert_eq!(msgs.len(), 1);
 
         maybe_warn_on_bad_time(
@@ -1065,9 +1061,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
             get_provider_update_timestamp(),
         )
         .await;
-        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0, None)
-            .await
-            .unwrap();
+        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
         assert_eq!(msgs.len(), 1);
 
         // next day, there should be another device message
@@ -1080,9 +1074,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         assert_eq!(device_chat_id, chats.get_chat_id(0).unwrap());
-        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0, None)
-            .await
-            .unwrap();
+        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
         assert_eq!(msgs.len(), 2);
     }
 
@@ -1112,9 +1104,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         let device_chat_id = chats.get_chat_id(0).unwrap();
-        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0, None)
-            .await
-            .unwrap();
+        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
         assert_eq!(msgs.len(), 1);
 
         // do not repeat the warning every day ...
@@ -1134,9 +1124,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         let device_chat_id = chats.get_chat_id(0).unwrap();
-        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0, None)
-            .await
-            .unwrap();
+        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
         let test_len = msgs.len();
         assert!(test_len == 1 || test_len == 2);
 
@@ -1151,9 +1139,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         let device_chat_id = chats.get_chat_id(0).unwrap();
-        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0, None)
-            .await
-            .unwrap();
+        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
         assert_eq!(msgs.len(), test_len + 1);
     }
 }

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -966,7 +966,7 @@ mod tests {
     }
 
     async fn check_msg_is_deleted(t: &TestContext, chat: &Chat, msg_id: MsgId) {
-        let chat_items = chat::get_chat_msgs(t, chat.id, 0, None).await.unwrap();
+        let chat_items = chat::get_chat_msgs(t, chat.id, 0).await.unwrap();
         // Check that the chat is empty except for possibly info messages:
         for item in &chat_items {
             if let ChatItem::Message { msg_id } = item {

--- a/src/message.rs
+++ b/src/message.rs
@@ -1980,9 +1980,7 @@ mod tests {
             .unwrap();
 
         let mut has_image = false;
-        let chatitems = chat::get_chat_msgs(&t, device_chat_id, 0, None)
-            .await
-            .unwrap();
+        let chatitems = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
         for chatitem in chatitems {
             if let ChatItem::Message { msg_id } = chatitem {
                 if let Ok(msg) = Message::load_from_db(&t, msg_id).await {
@@ -2128,7 +2126,7 @@ mod tests {
         assert_eq!(msg1.chat_id, msg2.chat_id);
         let chats = Chatlist::try_load(&bob, 0, None, None).await?;
         assert_eq!(chats.len(), 1);
-        let msgs = chat::get_chat_msgs(&bob, bob_chat_id, 0, None).await?;
+        let msgs = chat::get_chat_msgs(&bob, bob_chat_id, 0).await?;
         assert_eq!(msgs.len(), 2);
         assert_eq!(bob.get_fresh_msgs().await?.len(), 0);
 
@@ -2139,7 +2137,7 @@ mod tests {
         let bob_chat = Chat::load_from_db(&bob, bob_chat_id).await?;
         assert_eq!(bob_chat.blocked, Blocked::Request);
 
-        let msgs = chat::get_chat_msgs(&bob, bob_chat_id, 0, None).await?;
+        let msgs = chat::get_chat_msgs(&bob, bob_chat_id, 0).await?;
         assert_eq!(msgs.len(), 2);
         bob_chat_id.accept(&bob).await.unwrap();
 

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -715,7 +715,7 @@ mod tests {
     use crate::chat;
     use crate::chat::ProtectionStatus;
     use crate::chatlist::Chatlist;
-    use crate::constants::Chattype;
+    use crate::constants::{Chattype, DC_GCM_ADDDAYMARKER};
     use crate::dc_receive_imf::dc_receive_imf;
     use crate::peerstate::Peerstate;
     use crate::test_utils::{TestContext, TestContextManager};
@@ -853,7 +853,7 @@ mod tests {
         // Check Alice got the verified message in her 1:1 chat.
         {
             let chat = alice.create_chat(&bob).await;
-            let msg_id = chat::get_chat_msgs(&alice.ctx, chat.get_id(), 0x1, None)
+            let msg_id = chat::get_chat_msgs(&alice.ctx, chat.get_id(), DC_GCM_ADDDAYMARKER)
                 .await
                 .unwrap()
                 .into_iter()
@@ -902,7 +902,7 @@ mod tests {
         // Check Bob got the verified message in his 1:1 chat.
         {
             let chat = bob.create_chat(&alice).await;
-            let msg_id = chat::get_chat_msgs(&bob.ctx, chat.get_id(), 0x1, None)
+            let msg_id = chat::get_chat_msgs(&bob.ctx, chat.get_id(), DC_GCM_ADDDAYMARKER)
                 .await
                 .unwrap()
                 .into_iter()
@@ -1209,7 +1209,7 @@ mod tests {
                 Blocked::Yes,
                 "Alice's 1:1 chat with Bob is not hidden"
             );
-            let msg_id = chat::get_chat_msgs(&alice.ctx, alice_chatid, 0x1, None)
+            let msg_id = chat::get_chat_msgs(&alice.ctx, alice_chatid, DC_GCM_ADDDAYMARKER)
                 .await
                 .unwrap()
                 .into_iter()
@@ -1254,7 +1254,7 @@ mod tests {
                 Blocked::Yes,
                 "Bob's 1:1 chat with Alice is not hidden"
             );
-            for item in chat::get_chat_msgs(&bob.ctx, bob_chatid, 0x1, None)
+            for item in chat::get_chat_msgs(&bob.ctx, bob_chatid, DC_GCM_ADDDAYMARKER)
                 .await
                 .unwrap()
             {
@@ -1264,7 +1264,7 @@ mod tests {
                     println!("msg {} text: {}", msg_id, text);
                 }
             }
-            let mut msg_iter = chat::get_chat_msgs(&bob.ctx, bob_chatid, 0x1, None)
+            let mut msg_iter = chat::get_chat_msgs(&bob.ctx, bob_chatid, DC_GCM_ADDDAYMARKER)
                 .await
                 .unwrap()
                 .into_iter();

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -1300,13 +1300,13 @@ mod tests {
         };
 
         // delete self-talk first; this adds a message to device-chat about how self-talk can be restored
-        let device_chat_msgs_before = chat::get_chat_msgs(&t, device_chat_id, 0, None)
+        let device_chat_msgs_before = chat::get_chat_msgs(&t, device_chat_id, 0)
             .await
             .unwrap()
             .len();
         self_talk_id.delete(&t).await.ok();
         assert_eq!(
-            chat::get_chat_msgs(&t, device_chat_id, 0, None)
+            chat::get_chat_msgs(&t, device_chat_id, 0)
                 .await
                 .unwrap()
                 .len(),

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -488,7 +488,7 @@ mod tests {
         let chat = Chat::load_from_db(&alice, chat_id).await?;
         assert!(chat.is_self_talk());
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 1);
-        let msgs = chat::get_chat_msgs(&alice, chat_id, 0, None).await?;
+        let msgs = chat::get_chat_msgs(&alice, chat_id, 0).await?;
         assert_eq!(msgs.len(), 0);
 
         // let alice's other device receive and execute the sync message,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -22,7 +22,7 @@ use crate::chat::{self, Chat, ChatId};
 use crate::chatlist::Chatlist;
 use crate::config::Config;
 use crate::constants::Chattype;
-use crate::constants::{DC_MSG_ID_DAYMARKER, DC_MSG_ID_MARKER1};
+use crate::constants::{DC_GCM_ADDDAYMARKER, DC_MSG_ID_DAYMARKER};
 use crate::contact::{Contact, ContactId, Modifier, Origin};
 use crate::context::Context;
 use crate::dc_receive_imf::dc_receive_imf;
@@ -387,9 +387,7 @@ impl TestContext {
     ///
     /// Panics on errors or if the most recent message is a marker.
     pub async fn get_last_msg_in(&self, chat_id: ChatId) -> Message {
-        let msgs = chat::get_chat_msgs(&self.ctx, chat_id, 0, None)
-            .await
-            .unwrap();
+        let msgs = chat::get_chat_msgs(&self.ctx, chat_id, 0).await.unwrap();
         let msg_id = if let ChatItem::Message { msg_id } = msgs.last().unwrap() {
             msg_id
         } else {
@@ -511,12 +509,13 @@ impl TestContext {
     #[allow(dead_code)]
     #[allow(clippy::indexing_slicing)]
     pub async fn print_chat(&self, chat_id: ChatId) {
-        let msglist = chat::get_chat_msgs(self, chat_id, 0x1, None).await.unwrap();
+        let msglist = chat::get_chat_msgs(self, chat_id, DC_GCM_ADDDAYMARKER)
+            .await
+            .unwrap();
         let msglist: Vec<MsgId> = msglist
             .into_iter()
             .map(|x| match x {
                 ChatItem::Message { msg_id } => msg_id,
-                ChatItem::Marker1 => MsgId::new(DC_MSG_ID_MARKER1),
                 ChatItem::DayMarker { .. } => MsgId::new(DC_MSG_ID_DAYMARKER),
             })
             .collect();
@@ -773,7 +772,7 @@ pub(crate) async fn get_chat_msg(
     index: usize,
     asserted_msgs_count: usize,
 ) -> Message {
-    let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0, None).await.unwrap();
+    let msgs = chat::get_chat_msgs(&t.ctx, chat_id, 0).await.unwrap();
     assert_eq!(msgs.len(), asserted_msgs_count);
     let msg_id = if let ChatItem::Message { msg_id } = msgs[index] {
         msg_id


### PR DESCRIPTION
It is not used by iOS/Android/Desktop.