### PR TITLE
prepare 1.79

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # Changelog
 
-## Unreleased
+## 1.79.0
 
 ### Changes
 - Send locations in the background regardless of SMTP loop activity #3247
+- refactorings #3268
+- improve tests and ci #3266 #3271
 
 ### Fixes
-
 - simplify `dc_stop_io()` and remove potential panics and race conditions #3273
+- fix correct message escaping consisting of a dot in SMTP protocol #3265
+
 
 ## 1.78.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.78.0"
+version = "1.79.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.78.0"
+version = "1.79.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.78.0"
+version = "1.79.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.78.0"
+version = "1.79.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"


### PR DESCRIPTION
i think, this should go in before dong 1.30 at https://github.com/deltachat/deltachat-android/pull/2286 resp. https://github.com/deltachat/deltachat-ios/pull/1562

after commit, on master make sure to: 

   git tag -a 1.79.0
   git push origin 1.79.0
   git tag -a py-1.79.0
   git push origin py-1.79.0