### PR TITLE
Add dc_event_emitter_close() API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 1.79.0
 
+### API-Changes
+- add `dc_event_emitter_close()` to termitate event loops in a thread-safe way
+
 ### Changes
 - Send locations in the background regardless of SMTP loop activity #3247
 - refactorings #3268

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5202,6 +5202,15 @@ void  dc_event_emitter_unref(dc_event_emitter_t* emitter);
 
 
 /**
+ * Closes event emitter object.
+ *
+ * @memberof dc_event_emitter_t
+ * @param emitter Event emitter object as returned from dc_get_event_emitter().
+ */
+void  dc_event_emitter_close(dc_event_emitter_t* emitter);
+
+
+/**
  * @class dc_accounts_event_emitter_t
  *
  * Opaque object that is used to get events from the dc_accounts_t account manager.

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -641,6 +641,18 @@ pub unsafe extern "C" fn dc_event_emitter_unref(emitter: *mut dc_event_emitter_t
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_event_emitter_close(emitter: *mut dc_event_emitter_t) {
+    if emitter.is_null() {
+        eprintln!("ignoring careless call to dc_event_emitter_close()");
+        return;
+    }
+
+    let emitter = &mut *emitter;
+
+    block_on(emitter.close())
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_get_next_event(events: *mut dc_event_emitter_t) -> *mut dc_event_t {
     if events.is_null() {
         eprintln!("ignoring careless call to dc_get_next_event()");

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -699,20 +699,15 @@ class Account(object):
 
         self.log("remove dc_context references")
 
-        # if _dc_context is unref'ed the event thread should quickly
-        # receive the termination signal. However, some python code might
-        # still hold a reference and so we use a secondary signal
-        # to make sure the even thread terminates if it receives any new
-        # event, indepedently from waiting for the core to send NULL to
-        # get_next_event().
         self._event_thread.mark_shutdown()
-        self._dc_context = None
 
         self.log("wait for event thread to finish")
         try:
             self._event_thread.wait(timeout=2)
         except RuntimeError as e:
             self.log("Waiting for event thread failed: {}".format(e))
+
+        self._dc_context = None
 
         if self._event_thread.is_alive():
             self.log("WARN: event thread did not terminate yet, ignoring.")

--- a/src/events.rs
+++ b/src/events.rs
@@ -64,14 +64,19 @@ impl Events {
 pub struct EventEmitter(Receiver<Event>);
 
 impl EventEmitter {
-    /// Blocking recv of an event. Return `None` if the `Sender` has been droped.
+    /// Blocking recv of an event. Return `None` if the `Sender` has been dropped.
     pub fn recv_sync(&self) -> Option<Event> {
         async_std::task::block_on(self.recv())
     }
 
-    /// Async recv of an event. Return `None` if the `Sender` has been droped.
+    /// Async recv of an event. Return `None` if the `Sender` has been dropped.
     pub async fn recv(&self) -> Option<Event> {
         self.0.recv().await.ok()
+    }
+
+    /// Closes event emitter.
+    pub async fn close(&mut self) {
+        self.0.close();
     }
 }
 


### PR DESCRIPTION
dc_event_emitter_close() can be used to terminate
event loop from another thread without dereferencing the
context which may be in use by the event loop at the same time.

Closes #2280 