### PR TITLE
prepare 1.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
-## Unreleased
+## 1.80.0
 
-### Fixed
+### Changes
+- update provider database #3284
+- improve python bindings, tests and ci #3287 #3286 #3287 #3289 #3290 #3292
+
+### Fixes
 - fix escaping in generated QR-code-SVG #3295
+
 
 ## 1.79.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.79.0"
+version = "1.80.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.79.0"
+version = "1.80.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.79.0"
+version = "1.80.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.79.0"
+version = "1.80.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"


### PR DESCRIPTION
this is a small update for 1.79, that is already in testing. this pr mainly updates provider database. 

we can also get some more minor things and fixes in, but as we are short before a 1.30 release, it is probably wise to not merge larger refactorings with the potential to break things :)

~~i'd like to get https://github.com/deltachat/deltachat-core-rust/pull/3295 in as this is a highly visible bug :)~~ EDIT: done.

after commit, on master make sure to: 

   git tag -a 1.80.0
   git push origin 1.80.0
   git tag -a py-1.80.0
   git push origin py-1.80.0