### PR TITLE
fix "scheduler already started" log entry

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -378,7 +378,7 @@ impl Scheduler {
     /// Start the scheduler, returns error if it is already running.
     pub async fn start(&mut self, ctx: Context) -> Result<()> {
         if self.is_running() {
-            bail!("scheduler is already stopped");
+            bail!("scheduler is already started");
         }
 
         let (mvbox, mvbox_handlers) = ImapConnectionState::new(&ctx).await?;


### PR DESCRIPTION
i was wondering mainly about the whole line
"Failed to start IO: scheduler is already stopped".
i think it has to be "already started" and not "already stopped".

#skip-changelog