### PR TITLE
fix qr-code display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- fix escaping in generated QR-code-SVG #3295
+
 ## 1.79.0
 
 ### Changes

--- a/src/qr_code_generator.rs
+++ b/src/qr_code_generator.rs
@@ -261,3 +261,21 @@ fn inner_generate_secure_join_qr_code(
 
     Ok(svg)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[async_std::test]
+    async fn test_svg_escaping() {
+        let svg = inner_generate_secure_join_qr_code(
+            "descr123 \" < > &",
+            "qr-code-content",
+            "#000000",
+            None,
+            'X',
+        )
+        .unwrap();
+        assert!(svg.contains("descr123 &quot; &lt; &gt; &amp;"))
+    }
+}

--- a/src/qr_code_generator.rs
+++ b/src/qr_code_generator.rs
@@ -65,7 +65,7 @@ async fn generate_verification_qr(context: &Context) -> Result<String> {
 }
 
 fn inner_generate_secure_join_qr_code(
-    raw_qrcode_description: &str,
+    qrcode_description: &str,
     qrcode_content: &str,
     color: &str,
     avatar: Option<Vec<u8>>,
@@ -141,12 +141,12 @@ fn inner_generate_secure_join_qr_code(
         // Text
         const BIG_TEXT_CHARS_PER_LINE: usize = 32;
         const SMALL_TEXT_CHARS_PER_LINE: usize = 38;
-        let chars_per_line = if raw_qrcode_description.len() > SMALL_TEXT_CHARS_PER_LINE * 2 {
+        let chars_per_line = if qrcode_description.len() > SMALL_TEXT_CHARS_PER_LINE * 2 {
             SMALL_TEXT_CHARS_PER_LINE
         } else {
             BIG_TEXT_CHARS_PER_LINE
         };
-        let lines = textwrap::fill(raw_qrcode_description, chars_per_line);
+        let lines = textwrap::fill(qrcode_description, chars_per_line);
         let (text_font_size, text_y_shift) = if lines.split('\n').count() <= 2 {
             (27.0, 0.0)
         } else {

--- a/src/qr_code_generator.rs
+++ b/src/qr_code_generator.rs
@@ -71,7 +71,6 @@ fn inner_generate_secure_join_qr_code(
     avatar: Option<Vec<u8>>,
     avatar_letter: char,
 ) -> Result<String> {
-    let qrcode_description = &escaper::encode_minimal(raw_qrcode_description);
     // config
     let width = 515.0;
     let height = 630.0;
@@ -142,12 +141,12 @@ fn inner_generate_secure_join_qr_code(
         // Text
         const BIG_TEXT_CHARS_PER_LINE: usize = 32;
         const SMALL_TEXT_CHARS_PER_LINE: usize = 38;
-        let chars_per_line = if qrcode_description.len() > SMALL_TEXT_CHARS_PER_LINE * 2 {
+        let chars_per_line = if raw_qrcode_description.len() > SMALL_TEXT_CHARS_PER_LINE * 2 {
             SMALL_TEXT_CHARS_PER_LINE
         } else {
             BIG_TEXT_CHARS_PER_LINE
         };
-        let lines = textwrap::fill(qrcode_description, chars_per_line);
+        let lines = textwrap::fill(raw_qrcode_description, chars_per_line);
         let (text_font_size, text_y_shift) = if lines.split('\n').count() <= 2 {
             (27.0, 0.0)
         } else {


### PR DESCRIPTION
`tagger.put_raw()` has changes semantics and escapes strings on its own now

an explicit escaping leads to double escaping and to wrong display.

this should also improve lenght calculation,
as a quote and other specials counts as 1 character and not as 4-6.

closes https://github.com/deltachat/deltachat-core-rust/issues/3293