### PR TITLE
actually enable online account caching. 

### DIFF
--- a/python/src/deltachat/direct_imap.py
+++ b/python/src/deltachat/direct_imap.py
@@ -177,6 +177,9 @@ class IdleManager:
     def __init__(self, direct_imap):
         self.direct_imap = direct_imap
         self.log = direct_imap.account.log
+        # fetch latest messages before starting idle so that it only
+        # returns messages that arrive anew
+        self.direct_imap.conn.fetch("1:*")
         self.direct_imap.conn.idle.start()
 
     def check(self, timeout=None) -> List[bytes]:

--- a/python/tests/bench_test_setup.py
+++ b/python/tests/bench_test_setup.py
@@ -8,11 +8,13 @@ to see timings of test setups.
 
 import pytest
 
+BENCH_NUM = 3
+
 
 class TestEmpty:
     def test_prepare_setup_measurings(self, acfactory):
-        acfactory.get_online_accounts(5)
+        acfactory.get_online_accounts(BENCH_NUM)
 
-    @pytest.mark.parametrize("num", range(0, 5))
+    @pytest.mark.parametrize("num", range(0, BENCH_NUM + 1))
     def test_setup_online_accounts(self, acfactory, num):
         acfactory.get_online_accounts(num)

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -419,8 +419,8 @@ def test_send_and_receive_message_markseen(acfactory, lp):
             assert msg2.chat.id == msg4.chat.id
             assert ev.data1 == msg2.chat.id
             assert ev.data2 == 0
+            idle2.wait_for_seen()
 
-            idle2.wait_for_new_message()
         lp.step("1")
         for i in range(2):
             ev = ac1._evtracker.get_matching("DC_EVENT_MSG_READ")


### PR DESCRIPTION
previously it was creating (>100) online test accounts 8)
also slight refinements on idle waiting, and on the benchmark for setting up tests
#skip-changelog 