### PR TITLE
bubble up signing error instead of panicing

### DIFF
--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -190,7 +190,9 @@ pub(crate) fn create_keypair(
     let key = key_params
         .generate()
         .map_err(|err| PgpKeygenError::new("invalid params", err))?;
-    let private_key = key.sign(|| "".into()).expect("failed to sign secret key");
+    let private_key = key
+        .sign(|| "".into())
+        .map_err(|err| PgpKeygenError::new("failed to sign secret key", err))?;
 
     let public_key = private_key.public_key();
     let public_key = public_key


### PR DESCRIPTION
.expect() may panic, which is probably not what we want here.
it seems better to bubble up the error (as we are doing in the other cases).

or is it on purpose for some reason? then we should maybe add a comment as create_keypair() bubbles up errors in the other cases.

we do not had issues with that in practise, however,
i was just checking some .expect usages after we had a similar issue at #3264

#skip-changelog