### PR TITLE
add source_code_url to manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 - send normal messages with higher priority than MDNs #3243
 - make Scheduler stateless #3302
+- support `source_code_url` from Webxdc manifests #3314
 
 
 ## 1.80.0

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3733,6 +3733,10 @@ char*             dc_msg_get_webxdc_blob      (const dc_msg_t* msg, const char* 
  * - summary: short string describing the state of the app,
  *   sth. as "2 votes", "Highscore: 123",
  *   can be changed by the apps and defaults to an empty string.
+ * - source_code_url:
+ *   URL where the source code of the Webxdc and other information can be found;
+ *   defaults to an empty string.
+ *   Implementations may offer an menu or a button to open this URL.
  *
  * @memberof dc_msg_t
  * @param msg The webxdc instance.

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -51,6 +51,7 @@ const WEBXDC_RECEIVING_LIMIT: u64 = 4194304;
 struct WebxdcManifest {
     name: Option<String>,
     min_api: Option<u32>,
+    source_code_url: Option<String>,
 }
 
 /// Parsed information from WebxdcManifest and fallbacks.
@@ -59,6 +60,7 @@ pub struct WebxdcInfo {
     pub name: String,
     pub icon: String,
     pub summary: String,
+    pub source_code_url: String,
 }
 
 /// Status Update ID.
@@ -538,12 +540,14 @@ impl Message {
                 WebxdcManifest {
                     name: None,
                     min_api: None,
+                    source_code_url: None,
                 }
             }
         } else {
             WebxdcManifest {
                 name: None,
                 min_api: None,
+                source_code_url: None,
             }
         };
 
@@ -573,6 +577,11 @@ impl Message {
                 .get(Param::WebxdcSummary)
                 .unwrap_or_default()
                 .to_string(),
+            source_code_url: if let Some(url) = manifest.source_code_url {
+                url
+            } else {
+                "".to_string()
+            },
         })
     }
 }
@@ -1339,6 +1348,21 @@ sth_for_the = "future""#
 
         let result = parse_webxdc_manifest(r#"min_api = 1.2"#.as_bytes()).await;
         assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_parse_webxdc_manifest_source_code_url() -> Result<()> {
+        let result = parse_webxdc_manifest(r#"source_code_url = 3"#.as_bytes()).await;
+        assert!(result.is_err());
+
+        let manifest =
+            parse_webxdc_manifest(r#"source_code_url = "https://foo.bar""#.as_bytes()).await?;
+        assert_eq!(
+            manifest.source_code_url,
+            Some("https://foo.bar".to_string())
+        );
 
         Ok(())
     }


### PR DESCRIPTION
this allows webxdc to set a source-code-url which can then be read by the implementations, offered as a menu entry with the title "Source Code" or so.

closes #3313 