### PR TITLE
allow webxdc document names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - send normal messages with higher priority than MDNs #3243
 - make Scheduler stateless #3302
 - support `source_code_url` from Webxdc manifests #3314
+- support Webxdc document names and add `document` to `dc_msg_get_webxdc_info()` #3317
 - improve chat encryption info, make it easier to find contacts without keys #3318
 
 ### API-Changes

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3728,6 +3728,8 @@ char*             dc_msg_get_webxdc_blob      (const dc_msg_t* msg, const char* 
  *   To get the file, use dc_msg_get_webxdc_blob().
  *   App icons should should be square,
  *   the implementations will add round corners etc. as needed.
+ * - document: if the Webxdc represents a document, this is the name of the document,
+ *   otherwise, this is an empty string.
  * - summary: short string describing the state of the app,
  *   sth. as "2 votes", "Highscore: 123",
  *   can be changed by the apps and defaults to an empty string.

--- a/draft/webxdc-dev-reference.md
+++ b/draft/webxdc-dev-reference.md
@@ -37,6 +37,8 @@ To get a shared state, the peers use `sendUpdate()` to send updates to each othe
        eg. "Alice voted" or "Bob scored 123 in MyGame";
        usually only one line of text is shown,
        use this option sparingly to not spam the chat.
+    - `update.document`: optional, name of the document in edit,
+       must not be used eg. in games where the Webxdc does not create documents
     - `update.summary`: optional, short text, shown beside app icon;
        it is recommended to use some aggregated value,  eg. "8 votes", "Highscore: 123"
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -169,6 +169,12 @@ pub enum Param {
     /// For Chats: timestamp of protection settings update.
     ProtectionSettingsTimestamp = b'L',
 
+    /// For Webxdc Message Instances: Current document name
+    WebxdcDocument = b'R',
+
+    /// For Webxdc Message Instances: timestamp of document name update.
+    WebxdcDocumentTimestamp = b'W',
+
     /// For Webxdc Message Instances: Current summary
     WebxdcSummary = b'N',
 


### PR DESCRIPTION
some webxdc are more document-based than application based, eg. in contrast to a game, for an webxdc editor, the "document name" is an important property.

 current implementation use the "summary" property to show the document name, which, however, is not super-nice as the less important thing is shown in bold: 

<img width="286" alt="Screen Shot 2022-05-13 at 21 05 45" src="https://user-images.githubusercontent.com/9800740/168373459-52bd8cfd-92a0-4bdc-a21f-fee24f7f936a.png">

this pr adds a "document" property that, if set, contains the name  of the document. the property is sent around similar to the summary, so that it can be shown even without opening the webxdc.

UI implementation should show the document name in front (or, on few space, instead of) of the webxdc name, eg. the title could be  `DocumentName - WebxdcName - ChatName`.