### PR TITLE
Improve Chat.get_encryption_info() format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - send normal messages with higher priority than MDNs #3243
 - make Scheduler stateless #3302
 - support `source_code_url` from Webxdc manifests #3314
+- improve chat encryption info, make it easier to find contacts without keys #3318
 
 ### API-Changes
 - deprecate unused `marker1before` argument of `dc_get_chat_msgs`

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -689,7 +689,7 @@ def test_gossip_encryption_preference(acfactory, lp):
     msg = ac1._evtracker.wait_next_incoming_message()
     assert msg.text == "first message"
     assert not msg.is_encrypted()
-    res = "{} End-to-end encryption preferred.".format(ac2.get_config('addr'))
+    res = "End-to-end encryption preferred:\n{}\n".format(ac2.get_config('addr'))
     assert msg.chat.get_encryption_info() == res
     lp.sec("ac2 learns that ac3 prefers encryption")
     ac2.create_chat(ac3)
@@ -701,7 +701,7 @@ def test_gossip_encryption_preference(acfactory, lp):
     lp.sec("ac3 does not know that ac1 prefers encryption")
     ac1.create_chat(ac3)
     chat = ac3.create_chat(ac1)
-    res = "{} No encryption.".format(ac1.get_config('addr'))
+    res = "No encryption:\n{}\n".format(ac1.get_config('addr'))
     assert chat.get_encryption_info() == res
     msg = chat.send_text("not encrypted")
     msg = ac1._evtracker.wait_next_incoming_message()
@@ -712,7 +712,7 @@ def test_gossip_encryption_preference(acfactory, lp):
     group_chat = ac1.create_group_chat("hello")
     group_chat.add_contact(ac2)
     encryption_info = group_chat.get_encryption_info()
-    res = "{} End-to-end encryption preferred.".format(ac2.get_config("addr"))
+    res = "End-to-end encryption preferred:\n{}\n".format(ac2.get_config("addr"))
     assert encryption_info == res
     msg = group_chat.send_text("hi")
 
@@ -727,10 +727,9 @@ def test_gossip_encryption_preference(acfactory, lp):
     lp.sec("ac3 learns that ac1 prefers encryption")
     msg = ac3._evtracker.wait_next_incoming_message()
     encryption_info = msg.chat.get_encryption_info().splitlines()
-    res = "{} End-to-end encryption preferred.".format(ac1.get_config("addr"))
-    assert res in encryption_info
-    res = "{} End-to-end encryption preferred.".format(ac2.get_config("addr"))
-    assert res in encryption_info
+    assert encryption_info[0] == "End-to-end encryption preferred:"
+    assert ac1.get_config("addr") in encryption_info[1:]
+    assert ac2.get_config("addr") in encryption_info[1:]
     msg = chat.send_text("encrypted")
     assert msg.is_encrypted()
 

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -889,7 +889,7 @@ impl Contact {
                 };
 
                 ret += &format!(
-                    "{}\n{}:",
+                    "{}.\n{}:",
                     stock_message,
                     stock_str::finger_prints(context).await
                 );
@@ -1961,7 +1961,7 @@ mod tests {
                 .await?;
 
         let encrinfo = Contact::get_encrinfo(&alice, contact_bob_id).await?;
-        assert_eq!(encrinfo, "No encryption.");
+        assert_eq!(encrinfo, "No encryption");
 
         let bob = TestContext::new_bob().await;
         let chat_alice = bob

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -73,10 +73,10 @@ pub enum StockMessage {
     #[strum(props(fallback = "Encrypted message"))]
     EncryptedMsg = 24,
 
-    #[strum(props(fallback = "End-to-end encryption available."))]
+    #[strum(props(fallback = "End-to-end encryption available"))]
     E2eAvailable = 25,
 
-    #[strum(props(fallback = "No encryption."))]
+    #[strum(props(fallback = "No encryption"))]
     EncrNone = 28,
 
     #[strum(props(fallback = "This message was encrypted for another setup."))]
@@ -94,7 +94,7 @@ pub enum StockMessage {
     #[strum(props(fallback = "Group image deleted."))]
     MsgGrpImgDeleted = 33,
 
-    #[strum(props(fallback = "End-to-end encryption preferred."))]
+    #[strum(props(fallback = "End-to-end encryption preferred"))]
     E2ePreferred = 34,
 
     #[strum(props(fallback = "%1$s verified."))]


### PR DESCRIPTION
Group contacts by peerstate and make it easier
to find contacts that prevent encryption by sorting them
to the top of the list.