### PR TITLE
Fix race condition in alloc_ongoing()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@
 - node: throw error when getting context with an invalid account id
 - node: throw error when instanciating a wrapper class on `null` (Context, Message, Chat, ChatList and so on)
 - use same contact-color if email address differ only in upper-/lowercase #3327
+- fix race condition in ongoing process (import/export, configuration) allocation
 - repair encrypted mails "mixed up" by Google Workspace "Append footer" function #3315
+
+### Removed
+- node: remove unmaintained coverage scripts
 
 
 ## 1.80.0

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -741,7 +741,6 @@ mod tests {
         );
 
         let sent = bob.pop_sent_msg().await;
-        assert!(!bob.ctx.has_ongoing().await);
         assert_eq!(sent.recipient(), "alice@example.org".parse().unwrap());
         let msg = alice.parse_msg(&sent).await;
         assert!(!msg.was_encrypted());
@@ -1291,7 +1290,6 @@ mod tests {
         let bob_chat = Chat::load_from_db(&bob.ctx, bob_chatid).await?;
         assert!(bob_chat.is_protected());
         assert!(bob_chat.typ == Chattype::Group);
-        assert!(!bob.ctx.has_ongoing().await);
 
         // On this "happy path", Alice and Bob get only a group-chat where all information are added to.
         // The one-to-one chats are used internally for the hidden handshake messages,


### PR DESCRIPTION
Hold the same write lock while checking if ongoing
process is already allocated and while allocating it.
Otherwise it is possible for two parallel processes
running alloc_ongoing() to decide that no ongoing
process is allocated and allocate two ongoing processes.