### PR TITLE
create same contact-colors when addresses differ in upper-/lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 ### Fixes
 - node: throw error when getting context with an invalid account id
 - node: throw error when instanciating a wrapper class on `null` (Context, Message, Chat, ChatList and so on)
+- use same contact-color if email address differ only in upper-/lowercase #3327
 
 ### Removed
 - node: remove unmaintained coverage scripts

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4905,6 +4905,22 @@ mod tests {
         Ok(())
     }
 
+    #[async_std::test]
+    async fn test_chat_get_color() -> Result<()> {
+        let t = TestContext::new().await;
+        let chat_id = create_group_chat(&t, ProtectionStatus::Unprotected, "a chat").await?;
+        let color1 = Chat::load_from_db(&t, chat_id).await?.get_color(&t).await?;
+        assert_eq!(color1, 0x008772);
+
+        // upper-/lowercase makes a difference for the colors, these are different groups
+        // (in contrast to email addresses, where upper-/lowercase is ignored in practise)
+        let t = TestContext::new().await;
+        let chat_id = create_group_chat(&t, ProtectionStatus::Unprotected, "A CHAT").await?;
+        let color2 = Chat::load_from_db(&t, chat_id).await?.get_color(&t).await?;
+        assert_ne!(color2, color1);
+        Ok(())
+    }
+
     async fn test_sticker(filename: &str, bytes: &[u8], w: i32, h: i32) -> Result<()> {
         let alice = TestContext::new_alice().await;
         let bob = TestContext::new_bob().await;

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1082,7 +1082,7 @@ impl Contact {
     /// and can be used for an fallback avatar with white initials
     /// as well as for headlines in bubbles of group chats.
     pub fn get_color(&self) -> u32 {
-        str_to_color(&self.addr)
+        str_to_color(&self.addr.to_lowercase())
     }
 
     /// Gets the contact's status.
@@ -1944,6 +1944,25 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(id, Some(ContactId::SELF));
+    }
+
+    #[async_std::test]
+    async fn test_contact_get_color() -> Result<()> {
+        let t = TestContext::new().await;
+        let contact_id = Contact::create(&t, "name", "name@example.net").await?;
+        let color1 = Contact::get_by_id(&t, contact_id).await?.get_color();
+        assert_eq!(color1, 0xA739FF);
+
+        let t = TestContext::new().await;
+        let contact_id = Contact::create(&t, "prename name", "name@example.net").await?;
+        let color2 = Contact::get_by_id(&t, contact_id).await?.get_color();
+        assert_eq!(color2, color1);
+
+        let t = TestContext::new().await;
+        let contact_id = Contact::create(&t, "Name", "nAme@exAmple.NET").await?;
+        let color3 = Contact::get_by_id(&t, contact_id).await?.get_color();
+        assert_eq!(color3, color1);
+        Ok(())
     }
 
     #[async_std::test]


### PR DESCRIPTION
this leaves group-colors based on group names as is,
so, "MY GROUP" creates a different color than "my group",
as these names are better synced and also not an ID in this sense,
this is probably fine here.
(also when looking at the examples from
https://xmpp.org/extensions/xep-0392.html#testvectors-fullrange-no-cvd ,
case-sensistifity for group names seems to be fine)