### PR TITLE
re-add removed DC_MSG_ID_MARKER1 as in use on iOS

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3446,6 +3446,7 @@ int64_t          dc_chat_get_remaining_mute_duration (const dc_chat_t* chat);
  */
 
 
+#define         DC_MSG_ID_MARKER1            1 // this is used by iOS to mark things in the message list
 #define         DC_MSG_ID_DAYMARKER          9
 #define         DC_MSG_ID_LAST_SPECIAL       9
 


### PR DESCRIPTION
in fact, `get_chat_msgs()` with `marker1before` is not used on iOS,
however, iOS  [needs the special msg-id](https://github.com/deltachat/deltachat-ios/search?q=DC_MSG_ID_MARKER1).

in #3274 we did not check this possibility.

it may be changed, of course, however, that would reqiore some refactorings
in an anyway complicated area and is probably not worth the effort.