### PR TITLE
imap: do not unnecessarily SELECT folder in move_delete_messages()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- do not unnecessarily SELECT folders if there are no operations planned on
+  them #3333
+
+
 ## 1.83.0
 
 ### Fixes


### PR DESCRIPTION
If there are no MOVE/DELETE operations pending, the folder
should not be SELECTed.

When `only_fetch_mvbox` is enabled, `fetch_new_messages` skips
most folders, but `move_delete_messages` always selects the
folder even if there are no operations pending. Selecting
all folders wastes time during folder scan and turns
recent messages into non-recent.

Fixes #3332