### PR TITLE
Fix github action to publish node bindings

### DIFF
--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -151,7 +151,7 @@ jobs:
         run: |
           echo -e "${{ secrets.SSH_KEY }}" >__TEMP_INPUT_KEY_FILE
           chmod 600 __TEMP_INPUT_KEY_FILE
-          if [[ -z ${{ steps.prepare.outputs.prid }} ]]
+          if [[ -z "${{ steps.prepare.outputs.prid }}" ]]
           then
             exit 1
           fi

--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -171,4 +171,4 @@ jobs:
         run: |
           echo -e "${{ secrets.SSH_KEY }}" >__TEMP_INPUT_KEY_FILE
           chmod 600 __TEMP_INPUT_KEY_FILE
-          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r deltachat-node-${{ steps.prepare.outputs.prid }}.tar.gz "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/"
+          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r deltachat-node-${{ steps.tag.outputs.tag }}.tar.gz "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/"

--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -151,6 +151,10 @@ jobs:
         run: |
           echo -e "${{ secrets.SSH_KEY }}" >__TEMP_INPUT_KEY_FILE
           chmod 600 __TEMP_INPUT_KEY_FILE
+          if [[ -z ${{ steps.prepare.outputs.prid }} ]]
+          then
+            exit 1
+          fi
           scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r deltachat-node-${{ steps.prepare.outputs.prid }}.tar.gz "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/preview/"
         continue-on-error: true
       - name: "Post links to details"

--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -171,4 +171,5 @@ jobs:
         run: |
           echo -e "${{ secrets.SSH_KEY }}" >__TEMP_INPUT_KEY_FILE
           chmod 600 __TEMP_INPUT_KEY_FILE
+          mv deltachat-node-${{ steps.prepare.outputs.prid }}.tar.gz deltachat-node-${{ steps.tag.outputs.tag }}.tar.gz
           scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r deltachat-node-${{ steps.tag.outputs.tag }}.tar.gz "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/"


### PR DESCRIPTION
I tested this already in https://github.com/missytake/deltachat-core-rust/pull/1, this is why this PR is on a fork, because I was afraid to create tags in the origin repository.

It works now [both when it's executed on a tag](https://github.com/missytake/deltachat-core-rust/actions/runs/2351997572) and [when it's executed on a commit to a PR](https://github.com/missytake/deltachat-core-rust/runs/6507054640).

So when it's executed on a tag (like `test-tag2`), this file is uploaded:
- https://download.delta.chat/node/deltachat-node-test-tag2.tar.gz

And when it's executed by a PR (https://github.com/missytake/deltachat-core-rust/pull/1 in this case), this file is uploaded:
- https://download.delta.chat/node/preview/deltachat-node-1.tar.gz