### PR TITLE
Improve node publish ci

### DIFF
--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -115,6 +115,7 @@ jobs:
           tar -xvzf macos-latest/macos-latest.tar.gz -C node/prebuilds
           tar -xvzf windows-latest/windows-latest.tar.gz -C node/prebuilds
           tree node/prebuilds
+          rm -rf ubuntu-18.04 macos-latest windows-latest
       - name: install dependencies without running scripts
         run: |
           npm install --ignore-scripts

--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
     - '*'
+    - '!py-*'
 
 
 jobs:

--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   prebuild:
-    name: 'Tests & Prebuild'
+    name: 'prebuild'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -51,20 +51,6 @@ jobs:
           cd node
           npm install --verbose
 
-      - name: Test
-        if: runner.os != 'Windows'
-        run: |
-          cd node
-          npm run test
-        env:
-          DCC_NEW_TMP_EMAIL: ${{ secrets.DCC_NEW_TMP_EMAIL }}
-      - name: Run tests on Windows, except lint
-        if: runner.os == 'Windows'
-        run: |
-          cd node
-          npm run test:mocha
-        env:
-          DCC_NEW_TMP_EMAIL: ${{ secrets.DCC_NEW_TMP_EMAIL }}
       - name: Build Prebuild
         run: |
           cd node

--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -125,6 +125,7 @@ jobs:
       - name: package
         shell: bash
         run: |
+          mv node/README.md README.md
           npm pack .
           ls -lah
           mv $(find deltachat-node-*) $DELTACHAT_NODE_TAR_GZ

--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           tag=${{ steps.tag.outputs.tag }}
           if [ -z "$tag" ]; then
-            node -e "console.log('::set-output name=prid::' + '${{ github.ref }}'.split('/')[2])"
+            node -e "console.log('DELTACHAT_NODE_TAR_GZ=deltachat-node-' + '${{ github.ref }}'.split('/')[2]) + '.tar.gz'" >> $GITHUB_ENV
           else
             echo "No preview will be uploaded this time, but the $tag release"
           fi
@@ -125,12 +125,12 @@ jobs:
         run: |
           npm pack .
           ls -lah
-          mv $(find deltachat-node-*) deltachat-node-${{ steps.prepare.outputs.prid }}.tar.gz
+          mv $(find deltachat-node-*) $DELTACHAT_NODE_TAR_GZ
       - name: Upload Prebuild
         uses: actions/upload-artifact@v1
         with:
           name: deltachat-node.tgz
-          path: deltachat-node-${{ steps.prepare.outputs.prid }}.tar.gz
+          path: ${{ env.DELTACHAT_NODE_TAR_GZ }}
       # Upload to download.delta.chat/node/preview/
       - name: Upload deltachat-node preview to download.delta.chat/node/preview/
         id: upload-preview
@@ -138,17 +138,17 @@ jobs:
         run: |
           echo -e "${{ secrets.SSH_KEY }}" >__TEMP_INPUT_KEY_FILE
           chmod 600 __TEMP_INPUT_KEY_FILE
-          if [[ -z "${{ steps.prepare.outputs.prid }}" ]]
+          if [[ -z "$DELTACHAT_NODE_TAR_GZ" ]]
           then
             exit 1
           fi
-          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r deltachat-node-${{ steps.prepare.outputs.prid }}.tar.gz "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/preview/"
+          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r $DELTACHAT_NODE_TAR_GZ "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/preview/"
         continue-on-error: true
       - name: "Post links to details"
         if: steps.upload-preview.outcome == 'success'
         run: node ./node/scripts/postLinksToDetails.js
         env:
-         URL: preview/deltachat-node-${{ steps.prepare.outputs.prid }}
+         URL: preview/${{ env.DELTACHAT_NODE_TAR_GZ }}
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Upload to download.delta.chat/node/
       - name: Upload deltachat-node build to download.delta.chat/node/
@@ -158,5 +158,6 @@ jobs:
         run: |
           echo -e "${{ secrets.SSH_KEY }}" >__TEMP_INPUT_KEY_FILE
           chmod 600 __TEMP_INPUT_KEY_FILE
-          mv deltachat-node-${{ steps.prepare.outputs.prid }}.tar.gz deltachat-node-${{ steps.tag.outputs.tag }}.tar.gz
-          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r deltachat-node-${{ steps.tag.outputs.tag }}.tar.gz "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/"
+          $DELTACHAT_NODE_TAG_TAR_GZ=deltachat-node-${{ steps.tag.outputs.tag }}.tar.gz
+          mv $DELTACHAT_NODE_TAR_GZ $DELTACHAT_NODE_TAG_TAR_GZ
+          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r $DELTACHAT_NODE_TAG_TAR_GZ "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/"

--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           tag=${{ steps.tag.outputs.tag }}
           if [ -z "$tag" ]; then
-            node -e "console.log('DELTACHAT_NODE_TAR_GZ=deltachat-node-' + '${{ github.ref }}'.split('/')[2]) + '.tar.gz'" >> $GITHUB_ENV
+            node -e "console.log('DELTACHAT_NODE_TAR_GZ=deltachat-node-' + '${{ github.ref }}'.split('/')[2] + '.tar.gz')" >> $GITHUB_ENV
           else
             echo "No preview will be uploaded this time, but the $tag release"
           fi
@@ -95,6 +95,7 @@ jobs:
           cargo -vV
           npm --version
           node --version
+          echo $DELTACHAT_NODE_TAR_GZ
       - name: Download ubuntu prebuild
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,0 +1,63 @@
+name: 'node.js'
+on:
+  pull_request:
+
+
+jobs:
+  prebuild:
+    name: 'tests'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-latest, windows-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - name: System info
+        run: |
+          rustc -vV
+          rustup -vV
+          cargo -vV
+          npm --version
+          node --version
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ env.APPDATA }}/npm-cache
+            ~/.npm
+          key: ${{ matrix.os }}-node-${{ hashFiles('**/package.json') }}
+
+      - name: Cache cargo index
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/
+            ~/.cargo/git
+            target
+          key: ${{ matrix.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}-2
+
+      - name: Install dependencies & build
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          cd node
+          npm install --verbose
+
+      - name: Test
+        if: runner.os != 'Windows'
+        run: |
+          cd node
+          npm run test
+        env:
+          DCC_NEW_TMP_EMAIL: ${{ secrets.DCC_NEW_TMP_EMAIL }}
+      - name: Run tests on Windows, except lint
+        if: runner.os == 'Windows'
+        run: |
+          cd node
+          npm run test:mocha
+        env:
+          DCC_NEW_TMP_EMAIL: ${{ secrets.DCC_NEW_TMP_EMAIL }}

--- a/node/scripts/postLinksToDetails.js
+++ b/node/scripts/postLinksToDetails.js
@@ -17,7 +17,7 @@ const STATUS_DATA = {
   state: 'success',
   description: '⏩ Click on "Details" to download →',
   context: 'Download the node-bindings.tar.gz',
-  target_url: base_url + file_url + '.tar.gz',
+  target_url: base_url + file_url,
 }
 
 const http = require('https')


### PR DESCRIPTION
some refactoring mostly;

- [x] don't upload node.js prebuilds on py- tags (tested with my fork repository)
- [x] move tests to a separate job, so prebuilds are still uploaded even if the tests fail for negligible reasons
- [x] use environment variables across different workflow steps
- [x] remove unnecessary tar.gz files from prebuilds