### PR TITLE
Reduce number of possible ongoing process states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## Unreleased
 
 ### Changes
-- refactorings #3373
+- refactorings #3373 #3345
 - delete outgoing MDNs found in the Sent folder on Gmail #3372
+
 
 ## 1.84.0
 


### PR DESCRIPTION
This ensures that no invalid states are possible,
like the one where cancel channel exists, but
no ongoing process is running, or the one where
the ongoing process is not allocated, but
should not be stopped.