### PR TITLE
python: fix Chat.is_group() documentation

### DIFF
--- a/python/src/deltachat/chat.py
+++ b/python/src/deltachat/chat.py
@@ -64,7 +64,7 @@ class Chat(object):
     def is_group(self) -> bool:
         """ return true if this chat is a group chat.
 
-        :returns: True if chat is a group-chat, false if it's a contact 1:1 chat.
+        :returns: True if chat is a group-chat, false otherwise
         """
         return lib.dc_chat_get_type(self._dc_chat) == const.DC_CHAT_TYPE_GROUP
 


### PR DESCRIPTION
False is returned not only for 1:1 chat, but also in
other cases, such as mailing lists.

Fixes #3343 