### PR TITLE
Trim last newline in the chat encryption info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 - do not unnecessarily SELECT folders if there are no operations planned on
   them #3333
+- trim chat encryption info #3350
 
 
 ## 1.83.0

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -689,7 +689,7 @@ def test_gossip_encryption_preference(acfactory, lp):
     msg = ac1._evtracker.wait_next_incoming_message()
     assert msg.text == "first message"
     assert not msg.is_encrypted()
-    res = "End-to-end encryption preferred:\n{}\n".format(ac2.get_config('addr'))
+    res = "End-to-end encryption preferred:\n{}".format(ac2.get_config('addr'))
     assert msg.chat.get_encryption_info() == res
     lp.sec("ac2 learns that ac3 prefers encryption")
     ac2.create_chat(ac3)
@@ -701,7 +701,7 @@ def test_gossip_encryption_preference(acfactory, lp):
     lp.sec("ac3 does not know that ac1 prefers encryption")
     ac1.create_chat(ac3)
     chat = ac3.create_chat(ac1)
-    res = "No encryption:\n{}\n".format(ac1.get_config('addr'))
+    res = "No encryption:\n{}".format(ac1.get_config('addr'))
     assert chat.get_encryption_info() == res
     msg = chat.send_text("not encrypted")
     msg = ac1._evtracker.wait_next_incoming_message()
@@ -712,7 +712,7 @@ def test_gossip_encryption_preference(acfactory, lp):
     group_chat = ac1.create_group_chat("hello")
     group_chat.add_contact(ac2)
     encryption_info = group_chat.get_encryption_info()
-    res = "End-to-end encryption preferred:\n{}\n".format(ac2.get_config("addr"))
+    res = "End-to-end encryption preferred:\n{}".format(ac2.get_config("addr"))
     assert encryption_info == res
     msg = group_chat.send_text("hi")
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -895,7 +895,7 @@ impl ChatId {
             ret += &ret_mutual;
         }
 
-        Ok(ret)
+        Ok(ret.trim().to_string())
     }
 
     /// Bad evil escape hatch.
@@ -5429,7 +5429,7 @@ mod tests {
         assert_eq!(
             chat_id.get_encryption_info(&alice).await?,
             "No encryption:\n\
-            bob@example.net\n"
+            bob@example.net"
         );
 
         add_contact_to_chat(&alice, chat_id, contact_fiona).await?;
@@ -5437,7 +5437,7 @@ mod tests {
             chat_id.get_encryption_info(&alice).await?,
             "No encryption:\n\
             bob@example.net\n\
-            fiona@example.net\n"
+            fiona@example.net"
         );
 
         let direct_chat = bob.create_chat(&alice).await;
@@ -5450,7 +5450,7 @@ mod tests {
             fiona@example.net\n\
             \n\
             End-to-end encryption preferred:\n\
-            bob@example.net\n"
+            bob@example.net"
         );
 
         bob.set_config(Config::E2eeEnabled, Some("0")).await?;
@@ -5463,7 +5463,7 @@ mod tests {
             fiona@example.net\n\
             \n\
             End-to-end encryption available:\n\
-            bob@example.net\n"
+            bob@example.net"
         );
 
         Ok(())


### PR DESCRIPTION
Android seems to display it, making the message box larger.