### PR TITLE
Fix failure to decrypt first message to self after key synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - do not unnecessarily SELECT folders if there are no operations planned on
   them #3333
 - trim chat encryption info #3350
+- fix failure to decrypt first message to self after key synchronization
+  via Autocrypt Setup Message #3352
 
 
 ## 1.83.0

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -267,6 +267,11 @@ impl Peerstate {
         context: &Context,
         timestamp: i64,
     ) -> Result<()> {
+        if context.is_self_addr(&self.addr).await? {
+            // Do not try to search all the chats with self.
+            return Ok(());
+        }
+
         if self.fingerprint_changed {
             if let Some(contact_id) = context
                 .sql


### PR DESCRIPTION
The problem was in the handle_fingerprint_change() function which
attempted to add a warning about fingerprint change to all chats with
the contact.

This failed because of the SQL query failing to find the contact for
self in the `contacts` table. So the warning was not added, but at the
same time the whole decryption process failed.

The fix is to skip handle_fingerprint_change() for self addreses.

Fixes #3291 