### PR TITLE
Remove some AsRef<str>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changes
+- refactorings #3354
+
 ### Fixes
 - do not unnecessarily SELECT folders if there are no operations planned on
   them #3333

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -786,7 +786,7 @@ impl ChatId {
         );
         let row = sql
             .query_row_optional(
-                query,
+                &query,
                 paramsv![
                     self,
                     MessageState::OutPreparing,
@@ -3061,7 +3061,7 @@ pub async fn forward_msgs(context: &Context, msg_ids: &[MsgId], chat_id: ChatId)
         let ids = context
             .sql
             .query_map(
-                format!(
+                &format!(
                     "SELECT id FROM msgs WHERE id IN({}) ORDER BY timestamp,id",
                     sql::repeat_vars(msg_ids.len())
                 ),

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -699,7 +699,7 @@ impl Contact {
             context
                 .sql
                 .query_map(
-                    format!(
+                    &format!(
                         "SELECT c.id FROM contacts c \
                  LEFT JOIN acpeerstates ps ON c.addr=ps.addr  \
                  WHERE c.addr NOT IN ({})
@@ -754,7 +754,7 @@ impl Contact {
             context
                 .sql
                 .query_map(
-                    format!(
+                    &format!(
                         "SELECT id FROM contacts
                  WHERE addr NOT IN ({})
                  AND id>?

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2008,7 +2008,7 @@ async fn check_verified_properties(
     let rows = context
         .sql
         .query_map(
-            format!(
+            &format!(
                 "SELECT c.addr, LENGTH(ps.verified_key_fingerprint)  FROM contacts c  \
              LEFT JOIN acpeerstates ps ON c.addr=ps.addr  WHERE c.id IN({}) ",
                 sql::repeat_vars(to_ids.len())

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -307,7 +307,7 @@ pub(crate) async fn start_ephemeral_timers_msgids(
     let count = context
         .sql
         .execute(
-            format!(
+            &format!(
                 "UPDATE msgs SET ephemeral_timestamp = ? + ephemeral_timer
          WHERE (ephemeral_timestamp == 0 OR ephemeral_timestamp > ? + ephemeral_timer) AND ephemeral_timer > 0
          AND id IN ({})",

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -910,7 +910,7 @@ impl Imap {
         context
             .sql
             .execute(
-                format!(
+                &format!(
                     "DELETE FROM imap WHERE id IN ({})",
                     sql::repeat_vars(row_ids.len())
                 ),
@@ -947,7 +947,7 @@ impl Imap {
                     context
                         .sql
                         .execute(
-                            format!(
+                            &format!(
                                 "DELETE FROM imap WHERE id IN ({})",
                                 sql::repeat_vars(row_ids.len())
                             ),
@@ -989,7 +989,7 @@ impl Imap {
                 context
                     .sql
                     .execute(
-                        format!(
+                        &format!(
                             "UPDATE imap SET target='' WHERE id IN ({})",
                             sql::repeat_vars(row_ids.len())
                         ),
@@ -1106,7 +1106,7 @@ impl Imap {
                 context
                     .sql
                     .execute(
-                        format!(
+                        &format!(
                             "DELETE FROM imap_markseen WHERE id IN ({})",
                             sql::repeat_vars(rowid_set.len())
                         ),

--- a/src/message.rs
+++ b/src/message.rs
@@ -1283,7 +1283,7 @@ pub async fn markseen_msgs(context: &Context, msg_ids: Vec<MsgId>) -> Result<()>
     let msgs = context
         .sql
         .query_map(
-            format!(
+            &format!(
                 "SELECT
                     m.id AS id,
                     m.chat_id AS chat_id,

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -593,7 +593,7 @@ async fn send_mdn_msg_id(
                 );
                 context
                     .sql
-                    .execute(q, rusqlite::params_from_iter(additional_msg_ids))
+                    .execute(&q, rusqlite::params_from_iter(additional_msg_ids))
                     .await?;
             }
             Ok(())

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -199,7 +199,7 @@ impl Context {
     pub(crate) async fn delete_sync_ids(&self, ids: String) -> Result<()> {
         self.sql
             .execute(
-                format!("DELETE FROM multi_device_sync WHERE id IN ({});", ids),
+                &format!("DELETE FROM multi_device_sync WHERE id IN ({});", ids),
                 paramsv![],
             )
             .await?;


### PR DESCRIPTION
Using &str instead of AsRef<str> is better for compile times, binary size and code complexity.

#skip-changelog