### PR TITLE
Do not skip Sent and Spam folders on Gmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - fix failure to decrypt first message to self after key synchronization
   via Autocrypt Setup Message #3352
 - Keep pgp key when you change your own email address #3351
+- Do not ignore Sent and Spam folders on Gmail #3369
 
 
 ## 1.83.0

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -125,6 +125,14 @@ enum FolderMeaning {
     Sent,
     Drafts,
     Other,
+
+    /// Virtual folders.
+    ///
+    /// On Gmail there are virtual folders marked as \\All, \\Important and \\Flagged.
+    /// Delta Chat ignores these folders because the same messages can be fetched
+    /// from the real folder and the result of moving and deleting messages via
+    /// virtual folder is unclear.
+    Virtual,
 }
 
 impl FolderMeaning {
@@ -135,6 +143,7 @@ impl FolderMeaning {
             FolderMeaning::Sent => Some(Config::ConfiguredSentboxFolder),
             FolderMeaning::Drafts => None,
             FolderMeaning::Other => None,
+            FolderMeaning::Virtual => None,
         }
     }
 }
@@ -1888,6 +1897,7 @@ fn get_folder_meaning(folder_name: &Name) -> FolderMeaning {
                 "\\Sent" => return FolderMeaning::Sent,
                 "\\Spam" | "\\Junk" => return FolderMeaning::Spam,
                 "\\Drafts" => return FolderMeaning::Drafts,
+                "\\All" | "\\Important" | "\\Flagged" => return FolderMeaning::Virtual,
                 _ => {}
             };
         }

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -35,16 +35,14 @@ impl Imap {
         let mut folder_configs = BTreeMap::new();
 
         for folder in folders {
-            // Gmail labels are not folders and should be skipped. For example,
-            // emails appear in the inbox and under "All Mail" as soon as it is
-            // received. The code used to wrongly conclude that the email had
-            // already been moved and left it in the inbox.
-            let folder_name = folder.name();
-            if folder_name.starts_with("[Gmail]") {
+            let folder_meaning = get_folder_meaning(&folder);
+            if folder_meaning == FolderMeaning::Virtual {
+                // Gmail has virtual folders that should be skipped. For example,
+                // emails appear in the inbox and under "All Mail" as soon as it is
+                // received. The code used to wrongly conclude that the email had
+                // already been moved and left it in the inbox.
                 continue;
             }
-
-            let folder_meaning = get_folder_meaning(&folder);
             let folder_name_meaning = get_folder_meaning_by_name(folder.name());
 
             if let Some(config) = folder_meaning.to_config() {


### PR DESCRIPTION
Skipping of all [Gmail] folders was introduced to avoid scanning
virtual "[Gmail]/All Mail" folder. However, it also skips Sent and
Spam folders which reside inside [Gmail]. As a result
configured_sentbox_folder becomes unset after folder scan, making it
impossible to watch Sent folder, and Spam folder is never scanned.

This change makes Delta Chat identify virtual Gmail folders by their
flags, so virtual folders are skipped while Sent and Spam folders are
still scanned.