### PR TITLE
Delete outgoing MDNs detected in the Sent folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 - refactorings #3373
+- delete outgoing MDNs found in the Sent folder on Gmail #3372
 
 ## 1.84.0
 

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -1174,6 +1174,13 @@ INSERT INTO msgs
         }
     }
 
+    if !incoming && is_mdn && is_dc_message == MessengerMessage::Yes {
+        // Normally outgoing MDNs sent by us never appear in mailboxes, but Gmail saves all
+        // outgoing messages, including MDNs, to the Sent folder. If we detect such saved MDN,
+        // delete it.
+        needs_delete_job = true;
+    }
+
     Ok(ReceivedMsg {
         chat_id,
         state,


### PR DESCRIPTION
Gmail saves all outgoing messages to the Sent folder,
including MDNs. Delete MDNs sent by Delta Chat immediately
to keep DeltaChat or INBOX clean.

Fixes #3349