### PR TITLE
mimeparser: explicitly handle decryption errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   via Autocrypt Setup Message #3352
 - Keep pgp key when you change your own email address #3351
 - Do not ignore Sent and Spam folders on Gmail #3369
+- handle decryption errors explicitly and don't get confused by encrypted mail attachments #3374
 
 
 ## 1.83.0


### PR DESCRIPTION
mimeparser now handles try_decrypt() errors instead of simply logging
them. If try_decrypt() returns an error, a single message bubble
with an error is added to the chat.

The case when encrypted part is found in a non-standard MIME structure
is not treated as an encryption failure anymore. Instead, encrypted
MIME part is presented as a file to the user, so they can download the
part and decrypt it manually.

Because try_decrypt() errors are handled by mimeparser now,
try_decrypt() was fixed to avoid trying to load private_keyring if the
message is not encrypted. In tests the context receiving message
usually does not have self address configured, so loading private
keyring via Keyring::new_self() fails together with the try_decrypt().