### PR TITLE
make chat names always searchable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ### Changes
 - refactorings #3373 #3345
+
+### Fixes
 - delete outgoing MDNs found in the Sent folder on Gmail #3372
+- fix searching one-to-one chats #3377
 
 
 ## 1.84.0

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1041,7 +1041,9 @@ impl Chat {
         if chat.id.is_archived_link() {
             chat.name = stock_str::archived_chats(context).await;
         } else {
-            if chat.typ == Chattype::Single {
+            if chat.typ == Chattype::Single && chat.name.is_empty() {
+                // chat.name is set to contact.display_name on changes,
+                // however, if things went wrong somehow, we do this here explicitly.
                 let mut chat_name = "Err [Name not found]".to_owned();
                 match get_chat_contacts(context, chat.id).await {
                     Ok(contacts) => {

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -562,7 +562,7 @@ impl Contact {
                     .await
                     .ok();
 
-                if update_name {
+                if update_name || update_authname {
                     // Update the contact name also if it is used as a group name.
                     // This is one of the few duplicated data, however, getting the chat list is easier this way.
                     let chat_id: Option<i32> = context.sql.query_get_value(


### PR DESCRIPTION
current master does not update `chat.name` when authname of a contact changes - for reproducing the bug:

- add a contact manually without setting a name
- receive a message from that contact that includes a name

the name is now shown in the chatlist as expected, but you will not be able to discover that chat using the global search.

fixes https://github.com/deltachat/deltachat-core-rust/issues/3376