### PR TITLE
test_utils.rs / TestContext: Remove poison channel, don't fail test if events loop panics (because it can't panic anymore)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Changes
-- refactorings #3373 #3345
+- refactorings #3373 #3345 #3380
 
 ### Fixes
 - delete outgoing MDNs found in the Sent folder on Gmail #3372


### PR DESCRIPTION
I added this poison_sender and poison_receiver stuff back when we had event listeners (which were called "sinks", too, but anyway), i.e. user-definable closures that were run in the events loop. This was to make sure that the test fails if the closure panics. But since we don't have them anymore and this code isn't supposed to panic anyway:
```rust
            while let Some(event) = events.recv().await {
                for sender in senders.read().await.iter() {
                    sender.try_send(event.clone()).ok();
                }
            }
```