### PR TITLE
CI fix: node.js upload action control flow

### DIFF
--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -1,4 +1,4 @@
-name: 'node.js'
+name: 'node.js build'
 on:
   pull_request:
   push:

--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -137,7 +137,7 @@ jobs:
           path: ${{ env.DELTACHAT_NODE_TAR_GZ }}
       # Upload to download.delta.chat/node/preview/
       - name: Upload deltachat-node preview to download.delta.chat/node/preview/
-        if: ! steps.tag.outputs.tag
+        if: ${{ ! steps.tag.outputs.tag }}
         id: upload-preview
         shell: bash
         run: |

--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -86,7 +86,7 @@ jobs:
           if [ -z "$tag" ]; then
             node -e "console.log('DELTACHAT_NODE_TAR_GZ=deltachat-node-' + '${{ github.ref }}'.split('/')[2] + '.tar.gz')" >> $GITHUB_ENV
           else
-            node -e "console.log('DELTACHAT_NODE_TAG_TAR_GZ=deltachat-node-' + '${{ steps.tag.outputs.tag }}'.split('/')[2] + '.tar.gz')" >> $GITHUB_ENV
+            node -e "console.log('DELTACHAT_NODE_TAR_GZ=deltachat-node-' + '${{ steps.tag.outputs.tag }}'.split('/')[2] + '.tar.gz')" >> $GITHUB_ENV
             echo "No preview will be uploaded this time, but the $tag release"
           fi
       - name: System info
@@ -97,7 +97,6 @@ jobs:
           npm --version
           node --version
           echo $DELTACHAT_NODE_TAR_GZ
-          echo $DELTACHAT_NODE_TAG_TAR_GZ
       - name: Download ubuntu prebuild
         uses: actions/download-artifact@v1
         with:
@@ -130,7 +129,7 @@ jobs:
           mv node/README.md README.md
           npm pack .
           ls -lah
-          mv $(find deltachat-node-*) $DELTACHAT_NODE_TAR_GZ || mv $(find deltachat-node-*) $DELTACHAT_NODE_TAG_TAR_GZ
+          mv $(find deltachat-node-*) $DELTACHAT_NODE_TAR_GZ
       - name: Upload Prebuild
         uses: actions/upload-artifact@v1
         with:
@@ -138,15 +137,12 @@ jobs:
           path: ${{ env.DELTACHAT_NODE_TAR_GZ }}
       # Upload to download.delta.chat/node/preview/
       - name: Upload deltachat-node preview to download.delta.chat/node/preview/
+        if: ! steps.tag.outputs.tag
         id: upload-preview
         shell: bash
         run: |
           echo -e "${{ secrets.SSH_KEY }}" >__TEMP_INPUT_KEY_FILE
           chmod 600 __TEMP_INPUT_KEY_FILE
-          if [[ -z "$DELTACHAT_NODE_TAR_GZ" ]]
-          then
-            exit 1
-          fi
           scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r $DELTACHAT_NODE_TAR_GZ "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/preview/"
         continue-on-error: true
       - name: "Post links to details"
@@ -163,4 +159,4 @@ jobs:
         run: |
           echo -e "${{ secrets.SSH_KEY }}" >__TEMP_INPUT_KEY_FILE
           chmod 600 __TEMP_INPUT_KEY_FILE
-          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r $DELTACHAT_NODE_TAG_TAR_GZ "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/"
+          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r $DELTACHAT_NODE_TAR_GZ "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/"

--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -86,7 +86,7 @@ jobs:
           if [ -z "$tag" ]; then
             node -e "console.log('DELTACHAT_NODE_TAR_GZ=deltachat-node-' + '${{ github.ref }}'.split('/')[2] + '.tar.gz')" >> $GITHUB_ENV
           else
-            node -e "console.log('DELTACHAT_NODE_TAR_GZ=deltachat-node-' + '${{ steps.tag.outputs.tag }}'.split('/')[2] + '.tar.gz')" >> $GITHUB_ENV
+            echo "DELTACHAT_NODE_TAR_GZ=deltachat-node-${{ steps.tag.outputs.tag }}.tar.gz" >> $GITHUB_ENV
             echo "No preview will be uploaded this time, but the $tag release"
           fi
       - name: System info

--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -86,6 +86,7 @@ jobs:
           if [ -z "$tag" ]; then
             node -e "console.log('DELTACHAT_NODE_TAR_GZ=deltachat-node-' + '${{ github.ref }}'.split('/')[2] + '.tar.gz')" >> $GITHUB_ENV
           else
+            node -e "console.log('DELTACHAT_NODE_TAG_TAR_GZ=deltachat-node-' + '${{ steps.tag.outputs.tag }}'.split('/')[2] + '.tar.gz')" >> $GITHUB_ENV
             echo "No preview will be uploaded this time, but the $tag release"
           fi
       - name: System info
@@ -96,6 +97,7 @@ jobs:
           npm --version
           node --version
           echo $DELTACHAT_NODE_TAR_GZ
+          echo $DELTACHAT_NODE_TAG_TAR_GZ
       - name: Download ubuntu prebuild
         uses: actions/download-artifact@v1
         with:
@@ -128,7 +130,7 @@ jobs:
           mv node/README.md README.md
           npm pack .
           ls -lah
-          mv $(find deltachat-node-*) $DELTACHAT_NODE_TAR_GZ
+          mv $(find deltachat-node-*) $DELTACHAT_NODE_TAR_GZ || mv $(find deltachat-node-*) $DELTACHAT_NODE_TAG_TAR_GZ
       - name: Upload Prebuild
         uses: actions/upload-artifact@v1
         with:
@@ -161,6 +163,4 @@ jobs:
         run: |
           echo -e "${{ secrets.SSH_KEY }}" >__TEMP_INPUT_KEY_FILE
           chmod 600 __TEMP_INPUT_KEY_FILE
-          $DELTACHAT_NODE_TAG_TAR_GZ=deltachat-node-${{ steps.tag.outputs.tag }}.tar.gz
-          mv $DELTACHAT_NODE_TAR_GZ $DELTACHAT_NODE_TAG_TAR_GZ
           scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r $DELTACHAT_NODE_TAG_TAR_GZ "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/"

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -1,4 +1,4 @@
-name: 'node.js'
+name: 'node.js tests'
 on:
   pull_request:
   push:
@@ -8,7 +8,7 @@ on:
       - trying
 
 jobs:
-  prebuild:
+  tests:
     name: 'tests'
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
This is a rework of the node.js build action, which is responsible for uploading the npm build. If you would tag it, this would result in this workflow: https://github.com/missytake/deltachat-core-rust/actions/runs/2410044484 (I tested it on my fork)

