### PR TITLE
Remove msgs_mdns references to deleted messages during housekeeping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 - limit the rate of MDN sending #3402
+- remove `msgs_mdns` references to deleted messages during housekeeping #3387
 
 ### Fixes
 - set a default error if NDN does not provide an error


### PR DESCRIPTION
Fix for https://support.delta.chat/t/bug-report-data-not-deleted/2107