### PR TITLE
python: build wheels for python 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 - refactorings #3373 #3345 #3380 #3382
 - node: move split2 to devDependencies
+- python: build Python 3.10 wheels #3392
 
 
 ### Fixes

--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -28,6 +28,8 @@ rm -f python3.8
 ln -s /opt/python/cp38-cp38/bin/python3.8
 rm -f python3.9
 ln -s /opt/python/cp39-cp39/bin/python3.9
+rm -f python3.10
+ln -s /opt/python/cp310-cp310/bin/python3.10
 popd
 
 pushd python
@@ -41,7 +43,7 @@ mkdir -p $TOXWORKDIR
 # Note that the independent remote_tests_python step does all kinds of
 # live-testing already. 
 unset DCC_NEW_TMP_EMAIL
-tox --workdir "$TOXWORKDIR" -e py37,py38,py39,auditwheels
+tox --workdir "$TOXWORKDIR" -e py37,py38,py39,py310,auditwheels
 popd
 
 


### PR DESCRIPTION
Recent manylinux2014 images contain Python 3.10 and Python 3.11.
Python 3.11 is in beta, so adding only Python 3.10.