### PR TITLE
cleanup series of webxdc info messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Changes
 
+- clean up series of webxdc info messages #3395
+
 ## Fixes
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ## Changes
 
-- clean up series of webxdc info messages #3395
+- clean up series of webxdc info messages;
+  `DC_EVENT_MSGS_CHANGED` is emitted on changes of existing info messages #3395
 
 ## Fixes
 

--- a/draft/webxdc-dev-reference.md
+++ b/draft/webxdc-dev-reference.md
@@ -34,8 +34,9 @@ To get a shared state, the peers use `sendUpdate()` to send updates to each othe
 - `update`: an object with the following properties:  
     - `update.payload`: any javascript primitive, array or object.
     - `update.info`: optional, short, informational message that will be added to the chat,
-       eg. "Alice voted" or "Bob scored 123 in MyGame";
-       usually only one line of text is shown,
+       eg. "Alice voted" or "Bob scored 123 in MyGame".
+       usually only one line of text is shown
+       and if there are series of info messages, older ones may be dropped.
        use this option sparingly to not spam the chat.
     - `update.document`: optional, name of the document in edit,
        must not be used eg. in games where the Webxdc does not create documents

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3448,7 +3448,7 @@ pub(crate) async fn add_info_msg(
     .await
 }
 
-pub(crate) async fn update_info_msg(
+pub(crate) async fn update_msg_text_and_timestamp(
     context: &Context,
     chat_id: ChatId,
     msg_id: MsgId,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3381,6 +3381,7 @@ pub(crate) async fn delete_and_reset_all_device_msgs(context: &Context) -> Resul
 /// Adds an informational message to chat.
 ///
 /// For example, it can be a message showing that a member was added to a group.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn add_info_msg_with_cmd(
     context: &Context,
     chat_id: ChatId,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3447,6 +3447,24 @@ pub(crate) async fn add_info_msg(
     .await
 }
 
+pub(crate) async fn update_info_msg(
+    context: &Context,
+    chat_id: ChatId,
+    msg_id: MsgId,
+    text: &str,
+    timestamp: i64,
+) -> Result<()> {
+    context
+        .sql
+        .execute(
+            "UPDATE msgs SET txt=?, timestamp=? WHERE id=?;",
+            paramsv![text, timestamp, msg_id],
+        )
+        .await?;
+    context.emit_msgs_changed(chat_id, msg_id);
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -438,6 +438,7 @@ impl ChatId {
                 dc_create_smeared_timestamp(context).await,
                 None,
                 None,
+                None,
             )
             .await?;
         }
@@ -3389,6 +3390,7 @@ pub(crate) async fn add_info_msg_with_cmd(
     // Timestamp to show to the user (if this is None, `timestamp_sort` will be shown to the user)
     timestamp_sent_rcvd: Option<i64>,
     parent: Option<&Message>,
+    from_id: Option<ContactId>,
 ) -> Result<MsgId> {
     let rfc724_mid = dc_create_outgoing_rfc724_mid(None, "@device");
     let ephemeral_timer = chat_id.get_ephemeral_timer(context).await?;
@@ -3404,7 +3406,7 @@ pub(crate) async fn add_info_msg_with_cmd(
         VALUES (?,?,?, ?,?,?,?,?, ?,?,?, ?,?);",
         paramsv![
             chat_id,
-            ContactId::INFO,
+            from_id.unwrap_or(ContactId::INFO),
             ContactId::INFO,
             timestamp_sort,
             timestamp_sent_rcvd.unwrap_or(0),
@@ -3438,6 +3440,7 @@ pub(crate) async fn add_info_msg(
         text,
         SystemMessage::Unknown,
         timestamp,
+        None,
         None,
         None,
     )
@@ -4518,6 +4521,7 @@ mod tests {
             "foo bar info",
             SystemMessage::EphemeralTimerChanged,
             10000,
+            None,
             None,
             None,
         )

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -245,8 +245,9 @@ pub(crate) async fn dc_receive_imf_inner(
     }
 
     if let Some(ref status_update) = mime_parser.webxdc_status_update {
+        // the explicit `from_id` parameter is needed as `insert_msg_id.from_id` may be set to 0 by trashing
         if let Err(err) = context
-            .receive_status_update(insert_msg_id, status_update)
+            .receive_status_update(from_id, insert_msg_id, status_update)
             .await
         {
             warn!(context, "receive_imf cannot update status: {}", err);

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -245,7 +245,6 @@ pub(crate) async fn dc_receive_imf_inner(
     }
 
     if let Some(ref status_update) = mime_parser.webxdc_status_update {
-        // the explicit `from_id` parameter is needed as `insert_msg_id.from_id` may be set to 0 by trashing
         if let Err(err) = context
             .receive_status_update(from_id, insert_msg_id, status_update)
             .await

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -140,7 +140,11 @@ pub enum SystemMessage {
 
     // Sync message that contains a json payload
     // sent to the other webxdc instances
+    // These messages are not shown in the chat.
     WebxdcStatusUpdate = 30,
+
+    // Webxdc info added with `info` set in `send_webxdc_status_update()`.
+    WebxdcInfoMessage = 32,
 }
 
 impl Default for SystemMessage {

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -302,6 +302,7 @@ impl Peerstate {
                         timestamp_sort,
                         Some(timestamp),
                         None,
+                        None,
                     )
                     .await?;
                     context.emit_event(EventType::ChatModified(*chat_id));

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -222,7 +222,7 @@ impl Context {
                     self,
                     instance.chat_id,
                     info.as_str(),
-                    SystemMessage::Unknown,
+                    SystemMessage::WebxdcInfoMessage,
                     timestamp,
                     None,
                     Some(instance),

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -1727,6 +1727,8 @@ sth_for_the = "future""#
         assert_eq!(alice_chat.id.get_msg_cnt(&alice).await?, 2);
         let info_msg = alice.get_last_msg().await;
         assert!(info_msg.is_info());
+        assert_eq!(info_msg.get_info_type(), SystemMessage::WebxdcInfoMessage);
+        assert_eq!(info_msg.from_id, ContactId::SELF);
         assert_eq!(
             info_msg.get_text(),
             Some("this appears in-chat".to_string())
@@ -1750,6 +1752,8 @@ sth_for_the = "future""#
         assert_eq!(bob_chat_id.get_msg_cnt(&bob).await?, 2);
         let info_msg = bob.get_last_msg().await;
         assert!(info_msg.is_info());
+        assert_eq!(info_msg.get_info_type(), SystemMessage::WebxdcInfoMessage);
+        assert!(!info_msg.from_id.is_special());
         assert_eq!(
             info_msg.get_text(),
             Some("this appears in-chat".to_string())
@@ -1770,6 +1774,8 @@ sth_for_the = "future""#
         assert_eq!(alice2_chat_id.get_msg_cnt(&alice2).await?, 2);
         let info_msg = alice2.get_last_msg().await;
         assert!(info_msg.is_info());
+        assert_eq!(info_msg.get_info_type(), SystemMessage::WebxdcInfoMessage);
+        assert_eq!(info_msg.from_id, ContactId::SELF);
         assert_eq!(
             info_msg.get_text(),
             Some("this appears in-chat".to_string())

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -7,6 +7,7 @@ use crate::dc_tools::{dc_create_smeared_timestamp, dc_open_file_std};
 use crate::message::{Message, MessageState, MsgId, Viewtype};
 use crate::mimeparser::SystemMessage;
 use crate::param::Param;
+use crate::param::Params;
 use crate::{chat, EventType};
 use anyhow::{bail, ensure, format_err, Result};
 use async_std::path::PathBuf;
@@ -196,6 +197,41 @@ impl Context {
         Ok(())
     }
 
+    /// Check if the last message of a chat is an info message belonging to the given instance and sender.
+    /// If so, the id of this message is returned.
+    async fn get_overwritable_info_msg(
+        &self,
+        instance: &Message,
+        from_id: ContactId,
+    ) -> Result<Option<MsgId>> {
+        if let Some((last_msg_id, last_from_id, last_param, last_in_repl_to)) = self
+            .sql
+            .query_row_optional(
+                r#"SELECT id, from_id, param, mime_in_reply_to
+                    FROM msgs
+                    WHERE chat_id=?1 AND hidden=0
+                    ORDER BY timestamp DESC, id DESC LIMIT 1"#,
+                paramsv![instance.chat_id],
+                |row| {
+                    let last_msg_id: MsgId = row.get(0)?;
+                    let last_from_id: ContactId = row.get(1)?;
+                    let last_param: Params = row.get::<_, String>(2)?.parse().unwrap_or_default();
+                    let last_in_repl_to: String = row.get(3)?;
+                    Ok((last_msg_id, last_from_id, last_param, last_in_repl_to))
+                },
+            )
+            .await?
+        {
+            if last_from_id == from_id
+                && last_param.get_cmd() == SystemMessage::WebxdcInfoMessage
+                && last_in_repl_to == instance.rfc724_mid
+            {
+                return Ok(Some(last_msg_id));
+            }
+        }
+        Ok(None)
+    }
+
     /// Takes an update-json as `{payload: PAYLOAD}`
     /// writes it to the database and handles events, info-messages, document name and summary.
     async fn create_status_update_record(
@@ -220,17 +256,29 @@ impl Context {
 
         if can_info_msg {
             if let Some(ref info) = status_update_item.info {
-                chat::add_info_msg_with_cmd(
-                    self,
-                    instance.chat_id,
-                    info.as_str(),
-                    SystemMessage::WebxdcInfoMessage,
-                    timestamp,
-                    None,
-                    Some(instance),
-                    Some(from_id),
-                )
-                .await?;
+                if let Some(info_msg_id) = self.get_overwritable_info_msg(instance, from_id).await?
+                {
+                    chat::update_info_msg(
+                        self,
+                        instance.chat_id,
+                        info_msg_id,
+                        info.as_str(),
+                        timestamp,
+                    )
+                    .await?;
+                } else {
+                    chat::add_info_msg_with_cmd(
+                        self,
+                        instance.chat_id,
+                        info.as_str(),
+                        SystemMessage::WebxdcInfoMessage,
+                        timestamp,
+                        None,
+                        Some(instance),
+                        Some(from_id),
+                    )
+                    .await?;
+                }
             }
         }
 

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -226,6 +226,7 @@ impl Context {
                     timestamp,
                     None,
                     Some(instance),
+                    None,
                 )
                 .await?;
             }

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -199,7 +199,7 @@ impl Context {
 
     /// Check if the last message of a chat is an info message belonging to the given instance and sender.
     /// If so, the id of this message is returned.
-    async fn get_overwritable_info_msg(
+    async fn get_overwritable_info_msg_id(
         &self,
         instance: &Message,
         from_id: ContactId,
@@ -256,9 +256,10 @@ impl Context {
 
         if can_info_msg {
             if let Some(ref info) = status_update_item.info {
-                if let Some(info_msg_id) = self.get_overwritable_info_msg(instance, from_id).await?
+                if let Some(info_msg_id) =
+                    self.get_overwritable_info_msg_id(instance, from_id).await?
                 {
-                    chat::update_info_msg(
+                    chat::update_msg_text_and_timestamp(
                         self,
                         instance.chat_id,
                         info_msg_id,
@@ -409,7 +410,7 @@ impl Context {
     /// Receives status updates from receive_imf to the database
     /// and sends out an event.
     ///
-    /// `from_id` is the sender; this may or may not be the same as in `msg_id.from_id`
+    /// `from_id` is the sender
     ///
     /// `msg_id` may be an instance (in case there are initial status updates)
     /// or a reply to an instance (for all other updates).


### PR DESCRIPTION
this pr combines series of webxdc info messages to one message.

<img width=300 src=https://user-images.githubusercontent.com/9800740/171855520-d9875a3f-68a3-4f27-a585-c4fc29662104.png>

cleaning-up approach is:
- if on adding a new info message, the last message is an info message from the same sender _and_ for the same webxdc instance ...
- ... replace the text of the existing info message instead of adding a new one

i assume, this works out of the box on all platforms.

this will solve all issues we currently have with the existing highscores (only the last highscore is shown, that's fine) and "edited" information (they often have the same text anyway). 

of course, one can imagine situations where the cleaning up is not what is optimal for the webxdc, however, i think, the advantages of a cleaned up chat are much bigger.

and webxdc can deal with that, therefore, i added a hint to the reference (should go to the book or so as well, but that is not part of this pr)