### PR TITLE
node: remove `npx` from build script,

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ## Fixes
 - do not reset our database if imported backup cannot be decrypted #3397
+- node: remove `npx` from build script, this broke flathub build
 
 
 ## 1.85.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,12 @@
 
 ## Changes
 - refactorings #3375
-
 - clean up series of webxdc info messages;
   `DC_EVENT_MSGS_CHANGED` is emitted on changes of existing info messages #3395
 
 ## Fixes
 - do not reset our database if imported backup cannot be decrypted #3397
-- node: remove `npx` from build script, this broke flathub build
+- node: remove `npx` from build script, this broke flathub build #3396
 
 
 ## 1.85.0

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "build": "npm run build:core && npm run build:bindings",
     "build:bindings": "npm run build:bindings:c && npm run build:bindings:ts",
     "build:bindings:c": "npm run build:bindings:c:c && npm run build:bindings:c:postinstall",
-    "build:bindings:c:c": "cd node && npx node-gyp rebuild",
+    "build:bindings:c:c": "cd node && node-gyp rebuild",
     "build:bindings:c:postinstall": "node node/scripts/postinstall.js",
     "build:bindings:ts": "cd node && tsc",
     "build:core": "npm run build:core:rust && npm run build:core:constants",


### PR DESCRIPTION
this broke flathub build. (it tried to download node gyp again, but flathub builds are offline).

I need a new tag with this merged to continue fixing the flathub build.