### PR TITLE
Leave greater-than characters alone

### DIFF
--- a/src/format_flowed.rs
+++ b/src/format_flowed.rs
@@ -30,13 +30,6 @@ fn format_line_flowed(line: &str, prefix: &str) -> String {
         if c == ' ' {
             buffer.push(c);
             after_space = true;
-        } else if c == '>' {
-            if buffer.is_empty() {
-                // Space stuffing, see RFC 3676
-                buffer.push(' ');
-            }
-            buffer.push(c);
-            after_space = false;
         } else {
             if after_space && buffer.len() >= 72 && !c.is_whitespace() {
                 // Flush the buffer and insert soft break (SP CRLF).
@@ -62,12 +55,7 @@ fn format_flowed_prefix(text: &str, prefix: &str) -> String {
         if prefix.len() + line.len() > 78 {
             result += &format_line_flowed(line, prefix);
         } else {
-            result += prefix;
-            if prefix.is_empty() && line.starts_with('>') {
-                // Space stuffing, see RFC 3676
-                result.push(' ');
-            }
-            result += line;
+            result += prefix + line;
         }
     }
     result


### PR DESCRIPTION
Space stuffing a la RFC 3676 is a wonderful thing to handle `>` that aren't quotes but usually they actually are, as they are on Reddit, Mattermost, Slack, Discourse etc, and in traditional email.

If a user enters a `>` at the start of a line just let it be. Chances are it's intentional.

See also https://support.delta.chat/t/lines-starting-with-a-greater-than-symbol/1987

I love Delta Chat ♥  
This is easily the number one thing that's bugging me.

Consider how seldom people actually want their `>` space stuffed (which would be still easy enough to do manually) vs how often people want to put a `>` in there with the traditional meaning.