### PR TITLE
force a reason when calling `set_msg_failed()`

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2068,7 +2068,7 @@ async fn create_send_msg_job(context: &Context, msg_id: MsgId) -> Result<Option<
     let rendered_msg = match mimefactory.render(context).await {
         Ok(res) => Ok(res),
         Err(err) => {
-            message::set_msg_failed(context, msg_id, Some(err.to_string())).await;
+            message::set_msg_failed(context, msg_id, &err.to_string()).await;
             Err(err)
         }
     }?;
@@ -2078,7 +2078,7 @@ async fn create_send_msg_job(context: &Context, msg_id: MsgId) -> Result<Option<
         message::set_msg_failed(
             context,
             msg_id,
-            Some("End-to-end-encryption unavailable unexpectedly."),
+            "End-to-end-encryption unavailable unexpectedly.",
         )
         .await;
         bail!(

--- a/src/dc_receive_imf.rs
+++ b/src/dc_receive_imf.rs
@@ -2650,7 +2650,7 @@ mod tests {
             "shenauithz@testrun.org",
             "Mr.un2NYERi1RM.lbQ5F9q-QyJ@tiscali.it",
             include_bytes!("../test-data/message/tiscali_ndn.eml"),
-            None,
+            Some("Non-Delivery-Notification without further details."),
         )
         .await;
     }

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1401,8 +1401,9 @@ impl MimeMessage {
             let error = parts
                 .iter()
                 .find(|p| p.typ == Viewtype::Text)
-                .map(|p| p.msg.clone());
-            if let Err(e) = message::handle_ndn(context, failure_report, error).await {
+                .map(|p| p.msg.clone())
+                .unwrap_or("Non-Delivery-Notification without further details.".to_string());
+            if let Err(e) = message::handle_ndn(context, failure_report, &error).await {
                 warn!(context, "Could not handle ndn: {}", e);
             }
         }

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -360,7 +360,7 @@ pub(crate) async fn smtp_send(
 
     if let SendResult::Failure(err) = &status {
         // We couldn't send the message, so mark it as failed
-        message::set_msg_failed(context, msg_id, Some(err.to_string())).await;
+        message::set_msg_failed(context, msg_id, &err.to_string()).await;
     }
     status
 }
@@ -410,12 +410,7 @@ pub(crate) async fn send_msg_to_smtp(
         )
         .await?;
     if retries > 6 {
-        message::set_msg_failed(
-            context,
-            msg_id,
-            Some("Number of retries exceeded the limit."),
-        )
-        .await;
+        message::set_msg_failed(context, msg_id, "Number of retries exceeded the limit.").await;
         context
             .sql
             .execute("DELETE FROM smtp WHERE id=?", paramsv![rowid])


### PR DESCRIPTION
the string is displayed to the user,
so even _some_ context as "NDN without further details"
is better than an empty string.

came over that when getting reports about empty error messages in the testing group
(this pr does not fix that, however)