### PR TITLE
move isort configuration to pyproject.toml

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,3 +9,6 @@ git_describe_command = "git describe --dirty --tags --long --match py-*.*"
 
 [tool.black]
 line-length = 120
+
+[tool.isort]
+profile = "black"

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -42,7 +42,7 @@ deps =
     pygments
     restructuredtext_lint 
 commands =
-    isort --check --profile black src/deltachat examples/ tests/
+    isort --check src/deltachat examples/ tests/
     black --check src/deltachat examples/ tests/
     flake8 src/deltachat
     flake8 tests/ examples/


### PR DESCRIPTION
 instead of passing it in command line usage in tox.ini, this allows isort usage with editors to pick the right configuration without manually tweaking it in the editors