### PR TITLE
configure: emit errors via DC_EVENT_CONFIGURE_PROGRESS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - set a default error if NDN does not provide an error
 - python: avoid exceptions when messages/contacts/chats are compared with `None`
 - node: wait for the event loop to stop before destroying contexts #3431
+- emit configuration errors via event on failure #3433
 
 ### API-Changes
 - python: added `Message.get_status_updates()`  #3416

--- a/node/test/test.js
+++ b/node/test/test.js
@@ -128,7 +128,7 @@ describe('Basic offline Tests', function () {
 
     await expect(
       context.configure({ addr: 'delta1@delta.localhost' })
-    ).to.eventually.be.rejectedWith('Please enter a password.')
+    ).to.eventually.be.rejectedWith('Missing (IMAP) password.')
     await expect(context.configure({ mailPw: 'delta1' })).to.eventually.be
       .rejected
 


### PR DESCRIPTION
Node test expects progress to report either success or error
eventually.

Also update the error text expected by node test.

Fixes #3432 