### PR TITLE
Format message lines starting with > as quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - limit the rate of MDN sending #3402
 - ignore ratelimits for bots #3439
 - remove `msgs_mdns` references to deleted messages during housekeeping #3387
+- format message lines starting with `>` as quotes #3434
 
 ### Fixes
 - set a default error if NDN does not provide an error

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1085,10 +1085,15 @@ impl<'a> MimeFactory<'a> {
             }
         };
 
-        let quoted_text = self
+        let mut quoted_text = self
             .msg
             .quoted_text()
             .map(|quote| format_flowed_quote(&quote) + "\r\n\r\n");
+        if quoted_text.is_none() && final_text.starts_with('>') {
+            // Insert empty line to avoid receiver treating user-sent quote as topquote inserted by
+            // Delta Chat.
+            quoted_text = Some("\r\n".to_string());
+        }
         let flowed_text = format_flowed(final_text);
 
         let footer = &self.selfstatus;

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -204,13 +204,11 @@ fn remove_top_quote<'a>(lines: &'a [&str]) -> (&'a [&'a str], Option<String>) {
                 first_quoted_line = l;
             }
             last_quoted_line = Some(l)
-        } else if !is_empty_line(line) {
-            if is_quoted_headline(line) && !has_quoted_headline && last_quoted_line.is_none() {
-                has_quoted_headline = true
-            } else {
-                /* non-quoting line found */
-                break;
-            }
+        } else if is_quoted_headline(line) && !has_quoted_headline && last_quoted_line.is_none() {
+            has_quoted_headline = true
+        } else {
+            /* non-quoting line found */
+            break;
         }
     }
     if let Some(last_quoted_line) = last_quoted_line {


### PR DESCRIPTION
This makes quotes created by user display properly in other MUAs like
Thunderbird and not start with space in MUAs that don't support format=flowed.

To distinguish user-created quotes from top-quote inserted by Delta
Chat, a newline is inserted if there is no top-quote and the first
line starts with ">".

Nested quotes are not supported, e.g. line starting with "> >" will
start with ">" on the next line if wrapped.