### PR TITLE
Simplify ratelimiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Changes
+- refactorings #3437
 
 ### Fixes
 


### PR DESCRIPTION
Just an idea to stop returning boolean from `send_smtp_messages`.