### PR TITLE
python: display configuration failure error

### DIFF
--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -271,7 +271,8 @@ class EventThread(threading.Thread):
             data1 = ffi_event.data1
             if data1 == 0 or data1 == 1000:
                 success = data1 == 1000
-                yield "ac_configure_completed", dict(success=success)
+                comment = ffi_event.data2
+                yield "ac_configure_completed", dict(success=success, comment=comment)
         elif name == "DC_EVENT_INCOMING_MSG":
             msg = account.get_message_by_id(ffi_event.data2)
             yield map_system_message(msg) or ("ac_incoming_message", dict(message=msg))

--- a/python/src/deltachat/hookspec.py
+++ b/python/src/deltachat/hookspec.py
@@ -38,7 +38,7 @@ class PerAccount:
         """log a message related to the account."""
 
     @account_hookspec
-    def ac_configure_completed(self, success):
+    def ac_configure_completed(self, success, comment):
         """Called after a configure process completed."""
 
     @account_hookspec

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -294,8 +294,8 @@ class ACSetup:
 
         class PendingTracker:
             @account_hookimpl
-            def ac_configure_completed(this, success):
-                self._configured_events.put((account, success))
+            def ac_configure_completed(this, success: bool, comment: Optional[str]) -> None:
+                self._configured_events.put((account, success, comment))
 
         account.add_account_plugin(PendingTracker(), name="pending_tracker")
         self._account2state[account] = self.CONFIGURING
@@ -333,9 +333,9 @@ class ACSetup:
         print("finished, account2state", self._account2state)
 
     def _pop_config_success(self):
-        acc, success = self._configured_events.get()
+        acc, success, comment = self._configured_events.get()
         if not success:
-            pytest.fail("configuring online account failed: {}".format(acc))
+            pytest.fail("configuring online account {} failed: {}".format(acc, comment))
         self._account2state[acc] = self.CONFIGURED
         return acc
 

--- a/python/tests/test_4_lowlevel.py
+++ b/python/tests/test_4_lowlevel.py
@@ -35,7 +35,7 @@ class TestACSetup:
         monkeypatch.setattr(acc, "configure", lambda **kwargs: None)
         pc.start_configure(acc)
         assert pc._account2state[acc] == pc.CONFIGURING
-        pc._configured_events.put((acc, True))
+        pc._configured_events.put((acc, True, None))
         monkeypatch.setattr(pc, "init_imap", lambda *args, **kwargs: None)
         pc.wait_one_configured(acc)
         assert pc._account2state[acc] == pc.CONFIGURED
@@ -55,11 +55,11 @@ class TestACSetup:
         pc.start_configure(ac2)
         assert pc._account2state[ac1] == pc.CONFIGURING
         assert pc._account2state[ac2] == pc.CONFIGURING
-        pc._configured_events.put((ac1, True))
+        pc._configured_events.put((ac1, True, None))
         pc.wait_one_configured(ac1)
         assert pc._account2state[ac1] == pc.CONFIGURED
         assert pc._account2state[ac2] == pc.CONFIGURING
-        pc._configured_events.put((ac2, True))
+        pc._configured_events.put((ac2, True, None))
         pc.bring_online()
         assert pc._account2state[ac1] == pc.IDLEREADY
         assert pc._account2state[ac2] == pc.IDLEREADY


### PR DESCRIPTION
When configure fails, display error comment in pytest failure message.