### PR TITLE
do not use ratelimiter for bots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 - limit the rate of MDN sending #3402
+- ignore ratelimits for bots #3439
 - remove `msgs_mdns` references to deleted messages during housekeeping #3387
 
 ### Fixes

--- a/src/smtp/send.rs
+++ b/src/smtp/send.rs
@@ -3,6 +3,7 @@
 use super::Smtp;
 use async_smtp::{EmailAddress, Envelope, SendableEmail, Transport};
 
+use crate::config::Config;
 use crate::constants::DEFAULT_MAX_SMTP_RCPT_TO;
 use crate::context::Context;
 use crate::events::EventType;
@@ -32,10 +33,12 @@ impl Smtp {
         message: &[u8],
         rowid: i64,
     ) -> Result<()> {
-        // Notify ratelimiter about sent message regardless of whether quota is exceeded or not.
-        // Checking whether sending is allowed for low-priority messages should be done by the
-        // caller.
-        context.ratelimit.write().await.send();
+        if !context.get_config_bool(Config::Bot).await? {
+            // Notify ratelimiter about sent message regardless of whether quota is exceeded or not.
+            // Checking whether sending is allowed for low-priority messages should be done by the
+            // caller.
+            context.ratelimit.write().await.send();
+        }
 
         let message_len_bytes = message.len();
 


### PR DESCRIPTION
i tried some other approaches as having optional ratelimiter
or handle `can_send()` for bots differently,
but all that results in _far_ more code and/or indirections -
esp. as the "bot" config can change and is also persisted -
and the ratelimiter is created
at a point where the database is not yet available ...

of course, all that could be refactored as well,
but this two-liner also does the job :)

closes #3436 