### PR TITLE
Turn off hard errors for lints

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(unused, clippy::all)]
+#![warn(unused, clippy::all)]
 #![allow(
     non_camel_case_types,
     non_snake_case,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! # Delta Chat Core Library.
 
 #![forbid(unsafe_code)]
-#![deny(
+#![warn(
     unused,
     clippy::correctness,
     missing_debug_implementations,

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -510,6 +510,8 @@ impl Peerstate {
             )
             .await?;
         }
+        let a = vec!['a'];
+        let _b = a[0]; // Should trigger indexing_slicing warning
 
         Ok(())
     }

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -510,8 +510,6 @@ impl Peerstate {
             )
             .await?;
         }
-        let a = vec!['a'];
-        let _b = a[0]; // Should trigger indexing_slicing warning
 
         Ok(())
     }


### PR DESCRIPTION
It happened multiple times now that I wanted to quickly execute a test, but because of a warning that had become an error, it didn't execute.

This turns warnings into warnings again; our CI will fail if there is a warning, anyway (because of `RUSTFLAGS: -Dwarnings`)

#skip-changelog