### PR TITLE
Report imex and configure success/failure after freeing ongoing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - python: avoid exceptions when messages/contacts/chats are compared with `None`
 - node: wait for the event loop to stop before destroying contexts #3431
 - emit configuration errors via event on failure #3433
+- report configure and imex success/failure after freeing ongoing process #3442
 
 ### API-Changes
 - python: added `Message.get_status_updates()`  #3416

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -75,6 +75,8 @@ impl Context {
             }))
             .await;
 
+        self.free_ongoing().await;
+
         if let Err(err) = res.as_ref() {
             progress!(
                 self,
@@ -92,8 +94,6 @@ impl Context {
         } else {
             progress!(self, 1000);
         }
-
-        self.free_ongoing().await;
 
         res
     }


### PR DESCRIPTION
Otherwise it's possible that library user (e.g. test)
tries to start another ongoing process when previous one is
not freed yet.