### PR TITLE
python: enable certificate checks in cloned accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Fixes
 - improved error handling for account setup from qrcode #3474
+- python: enable certificate checks in cloned accounts #3443
 
 ## 1.92.0
 

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -497,6 +497,8 @@ class ACFactory:
             configdict = dict(
                 addr=cloned_from.get_config("addr"),
                 mail_pw=cloned_from.get_config("mail_pw"),
+                imap_certificate_checks=cloned_from.get_config("imap_certificate_checks"),
+                smtp_certificate_checks=cloned_from.get_config("smtp_certificate_checks"),
             )
         configdict.update(kwargs)
         ac = self._get_cached_account(addr=configdict["addr"]) if cache else None


### PR DESCRIPTION
Clone certificate check configuration