### PR TITLE
forward_msgs(): add a test, refine docs

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1791,6 +1791,11 @@ void            dc_delete_msgs               (dc_context_t* context, const uint3
 /**
  * Forward messages to another chat.
  *
+ * All types of messages can be forwarded,
+ * however, they will be flagged as such (dc_msg_is_forwarded() is set).
+ *
+ * Original sender, info-state and webxdc updates are not forwarded on purpose.
+ *
  * @memberof dc_context_t
  * @param context The context object.
  * @param msg_ids An array of uint32_t containing all message IDs that should be forwarded.
@@ -3979,7 +3984,7 @@ int             dc_msg_is_sent                (const dc_msg_t* msg);
  *
  * For privacy reasons, we do not provide the name or the e-mail address of the
  * original author (in a typical GUI, you select the messages text and click on
- * "forwared"; you won't expect other data to be send to the new recipient,
+ * "forwarded"; you won't expect other data to be send to the new recipient,
  * esp. as the new recipient may not be in any relationship to the original author)
  *
  * @memberof dc_msg_t


### PR DESCRIPTION
this pr does not change any functionality.

when working on forwarding on ios, the question came up what to do with info messages:
- desktop allows forwarding single info-messages (there is no multi-select)
- android has some logic that hides the forwarding option when in multi-select contains info-messages
- core allows forwarding, however, removes the `is_info` flag

i think, desktop and core is just fine - however, we should make sure, that a forwarded info-message is no info-message in the destination chat - therefore, this pr added a test for exactly that.

for android, i did a pr to remove the extra check, so that all messages can be forwarded.

allowing forwarding info-messages seems also be nicer ux-wise - less to explain, simple, user can forward what is shown on the screen, simpler multi-select implementation (we can just offer delete and forward).  
and, with webxdc, info message become more frequent and contain more/different texts that makes forwarding useful.

in any case, the behavior should the same on the platforms.

#skip-changelog