### PR TITLE
node: stop IO on unref only if we own event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 ### Fixes
 - set a default error if NDN does not provide an error
 - python: avoid exceptions when messages/contacts/chats are compared with `None`
-- node: wait for the event loop to stop before destroying contexts #3431
+- node: wait for the event loop to stop before destroying contexts #3431 #3451
 - emit configuration errors via event on failure #3433
 - report configure and imex success/failure after freeing ongoing process #3442
 

--- a/node/src/module.c
+++ b/node/src/module.c
@@ -371,8 +371,8 @@ NAPI_METHOD(dcn_context_unref) {
 
   TRACE("Unrefing dc_context");
   dcn_context->gc = 1;
-  dc_stop_io(dcn_context->dc_context);
   if (dcn_context->event_handler_thread != 0) {
+    dc_stop_io(dcn_context->dc_context);
     uv_thread_join(&dcn_context->event_handler_thread);
     dcn_context->event_handler_thread = 0;
   }
@@ -2927,8 +2927,8 @@ NAPI_METHOD(dcn_accounts_unref) {
 
   TRACE("Unrefing dc_accounts");
   dcn_accounts->gc = 1;
-  dc_accounts_stop_io(dcn_accounts->dc_accounts);
   if (dcn_accounts->event_handler_thread != 0) {
+    dc_accounts_stop_io(dcn_accounts->dc_accounts);
     uv_thread_join(&dcn_accounts->event_handler_thread);
     dcn_accounts->event_handler_thread = 0;
   }


### PR DESCRIPTION
Otherwise unrefing context stops its IO even
when we use account manager, e.g. in desktop client.

Fixes #3450 