### PR TITLE
smarter mailinglist's square bracket prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - switch from `async-std` to `tokio` as the async runtime #3449
 
 ### Fixes
+- mailing list: remove square-brackets only for first name #3452
 
 
 ## 1.87.0


### PR DESCRIPTION
some mailinglists have their name in square brackets prepended to the subject.

we pick up that name and remove the square brackets,
as these do not look good as the chat name in delta chat.

if a mailing list has a sequence of square brackets, we use all of them
(this seems to be okayish, i do not know of any complains).

however, the removal of square brackets was not nice for sequences,
resulting in `ml topic] [sub topic`.

this pr removes the square brackets only for the first name
and leave the other ones as is: `ml topic [sub topic]`