### PR TITLE
add more details to fallback NDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - add IMAP ID extension support #3468
 - configure DeltaChat folder by selecting it, so it is configured even if not LISTed #3371
 - build PyPy wheels #6683
+- improve default error if NDN does not provide an error #3456
 
 ### Fixes
 - mailing list: remove square-brackets only for first name #3452
@@ -26,7 +27,7 @@
 - limit the rate of webxdc update sending #3417
 
 ### Fixes
-- set a default error if NDN does not provide an error
+- set a default error if NDN does not provide an error #3410
 - python: avoid exceptions when messages/contacts/chats are compared with `None`
 - node: wait for the event loop to stop before destroying contexts #3431 #3451
 - emit configuration errors via event on failure #3433

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1401,11 +1401,11 @@ impl MimeMessage {
         }
 
         if let Some(failure_report) = &self.failure_report {
-            let error = parts.iter().find(|p| p.typ == Viewtype::Text).map_or_else(
-                || "Non-Delivery-Notification without further details.".to_string(),
-                |p| p.msg.clone(),
-            );
-            if let Err(e) = message::handle_ndn(context, failure_report, &error).await {
+            let error = parts
+                .iter()
+                .find(|p| p.typ == Viewtype::Text)
+                .map(|p| p.msg.clone());
+            if let Err(e) = message::handle_ndn(context, failure_report, error).await {
                 warn!(context, "Could not handle ndn: {}", e);
             }
         }

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2647,7 +2647,7 @@ mod tests {
             "shenauithz@testrun.org",
             "Mr.un2NYERi1RM.lbQ5F9q-QyJ@tiscali.it",
             include_bytes!("../test-data/message/tiscali_ndn.eml"),
-            Some("Non-Delivery-Notification without further details."),
+            Some("Delivery to at least one recipient failed."),
         )
         .await;
     }


### PR DESCRIPTION
if the NDN has no specific error text,
but we know the failed recipient address,
add these information the final message.

successor of https://github.com/deltachat/deltachat-core-rust/pull/3410

@adbenitez this should further improve the originally empty error message you (?)  encountered in some testing delta group, if you have further infomation or mail `.eml` ource code, please add :) 

