### PR TITLE
Fix two tests (Tokio)

### DIFF
--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -477,14 +477,14 @@ mod tests {
         futures_lite::future::block_on(pk_encrypt(CLEARTEXT, keyring, None)).unwrap()
     });
 
-    #[test]
-    fn test_encrypt_signed() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_encrypt_signed() {
         assert!(!CTEXT_SIGNED.is_empty());
         assert!(CTEXT_SIGNED.starts_with("-----BEGIN PGP MESSAGE-----"));
     }
 
-    #[test]
-    fn test_encrypt_unsigned() {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_encrypt_unsigned() {
         assert!(!CTEXT_UNSIGNED.is_empty());
         assert!(CTEXT_UNSIGNED.starts_with("-----BEGIN PGP MESSAGE-----"));
     }


### PR DESCRIPTION
Without this fix, running `cargo nextest run` or `cargo test test_encrypt_signed` fails.

Is this the right fix?

I guess that thing is that the lazy `CTEXT_SIGNED` uses `futures_lite::future::block_on(pk_encrypt...`.