### PR TITLE
allow quotes without a real parent

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -779,11 +779,11 @@ impl Message {
     /// it may even be deleted from the database by the time the message is prepared.
     pub async fn set_quote(&mut self, context: &Context, quote: Option<&Message>) -> Result<()> {
         if let Some(quote) = quote {
-            ensure!(
-                !quote.rfc724_mid.is_empty(),
-                "Message without Message-Id cannot be quoted"
-            );
-            self.in_reply_to = Some(quote.rfc724_mid.clone());
+            self.in_reply_to = if quote.rfc724_mid.is_empty() {
+                None
+            } else {
+                Some(quote.rfc724_mid.clone())
+            };
 
             if quote
                 .param


### PR DESCRIPTION
there was the question if it is possible to allow
dc_msg_set_quote() to accept a quoted text but no parent set
(so, RFC Message-ID unset).

while writing tests,
however, it turns out, this is not possible with the current data fields:
- replies in a chat always result in "parent" aka "In-Reply-To" being set -
  this parent is either the last message or the quoted message
- when a quoted text is found _and_ the parent is set,
  this one is used to enrich the quote.
- there is no field for "Quoted from" or so
  that can be set independently of "Parent" -
  so, having a "unparented" quote, shown in grey in the UI,
  is currently only possible if the original message is deleted

tl;dr: random quotes, not referring to an existing message
would probably require more work and states to be tracked,

not sure if that is worth the effort,
also as this openes another possibility of bugs on another area.
maybe just create these quotes by a `>` as the first character,
currently, this is not rendered great in Delta Chat,
but still.