### PR TITLE
improve error handling for account setup from qrcode closes #3192

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
 - mailing list: remove square-brackets only for first name #3452
 - do not use footers from mailinglists as the contact status #3460
 - don't ignore KML parsing errors #3473
-- improved error handling for account setup from qrcode (issue #3192)
+- improved error handling for account setup from qrcode #3474
 
 
 ## 1.87.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Changes
 
 ### Fixes
-
+- improved error handling for account setup from qrcode #3474
 
 ## 1.92.0
 
@@ -72,7 +72,6 @@
 - mailing list: remove square-brackets only for first name #3452
 - do not use footers from mailinglists as the contact status #3460
 - don't ignore KML parsing errors #3473
-- improved error handling for account setup from qrcode #3474
 
 
 ## 1.87.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - mailing list: remove square-brackets only for first name #3452
 - do not use footers from mailinglists as the contact status #3460
 - don't ignore KML parsing errors #3473
+- improved error handling for account setup from qrcode (issue #3192)
 
 
 ## 1.87.0

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -387,7 +387,7 @@ async fn set_account_from_qr(context: &Context, qr: &str) -> Result<()> {
                     parse_error, response_text
                 )));
                 bail!(
-                    "Cannot create account, unexpected server response:\n {:?}",
+                    "Cannot create account, unexpected server response:\n{:?}",
                     response_text
                 )
             }

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -1,6 +1,6 @@
 //! # QR code module.
 
-use anyhow::{bail, ensure, Context as _, Error, Result};
+use anyhow::{anyhow, bail, ensure, Context as _, Error, Result};
 use once_cell::sync::Lazy;
 use percent_encoding::percent_decode_str;
 use serde::Deserialize;
@@ -14,8 +14,8 @@ use crate::context::Context;
 use crate::key::Fingerprint;
 use crate::message::Message;
 use crate::peerstate::Peerstate;
-use crate::token;
 use crate::tools::time;
+use crate::{token, EventType};
 
 const OPENPGP4FPR_SCHEME: &str = "OPENPGP4FPR:"; // yes: uppercase
 const DCACCOUNT_SCHEME: &str = "DCACCOUNT:";
@@ -344,9 +344,13 @@ fn decode_webrtc_instance(_context: &Context, qr: &str) -> Result<Qr> {
 }
 
 #[derive(Debug, Deserialize)]
-struct CreateAccountResponse {
+struct CreateAccountSuccessResponse {
     email: String,
     password: String,
+}
+#[derive(Debug, Deserialize)]
+struct CreateAccountErrorResponse {
+    reason: String,
 }
 
 /// take a qr of the type DC_QR_ACCOUNT, parse it's parameters,
@@ -355,23 +359,40 @@ struct CreateAccountResponse {
 #[allow(clippy::indexing_slicing)]
 async fn set_account_from_qr(context: &Context, qr: &str) -> Result<()> {
     let url_str = &qr[DCACCOUNT_SCHEME.len()..];
+    let response = reqwest::Client::new().post(url_str).send().await?;
 
-    let parsed: CreateAccountResponse = reqwest::Client::new()
-        .post(url_str)
-        .send()
-        .await?
-        .json()
-        .await
-        .with_context(|| format!("Cannot create account, request to {:?} failed", url_str))?;
+    if response.status().is_success() {
+        let CreateAccountSuccessResponse { password, email } =
+            response.json().await.with_context(|| {
+                format!(
+                    "Cannot create account, response from {:?} is malformed",
+                    url_str
+                )
+            })?;
+        context.set_config(Config::Addr, Some(&email)).await?;
+        context.set_config(Config::MailPw, Some(&password)).await?;
 
-    context
-        .set_config(Config::Addr, Some(&parsed.email))
-        .await?;
-    context
-        .set_config(Config::MailPw, Some(&parsed.password))
-        .await?;
+        Ok(())
+    } else {
+        let response_text = response
+            .text()
+            .await
+            .with_context(|| format!("Cannot create account, request to {:?} failed", url_str))?;
 
-    Ok(())
+        match serde_json::from_str::<CreateAccountErrorResponse>(&response_text) {
+            Ok(error) => Err(anyhow!(error.reason)),
+            Err(parse_error) => {
+                context.emit_event(EventType::Error(format!(
+                    "Cannot create account, server response could not be parsed:\n{:#}\nraw response:\n{}",
+                    parse_error, response_text
+                )));
+                bail!(
+                    "Cannot create account, unexpected server response:\n {:?}",
+                    response_text
+                )
+            }
+        }
+    }
 }
 
 pub async fn set_config_from_qr(context: &Context, qr: &str) -> Result<()> {


### PR DESCRIPTION
This pr improves the error handling of create account from arcade generated/powered by mailadm.
missytake did the mailadm part: https://github.com/deltachat/mailadm/pull/39
This pr represents the core part.

I’m not glad on the error wording, so I'd be happy to hear some suggestions.

This will close: https://github.com/deltachat/deltachat-core-rust/issues/3192

## No Json
The old version of mailadm that is still deployed to test run at time of writing.

Before:
```
> setqr DCACCOUNT:https://testrun.org/new_email?t=wrong
Cannot set config from QR code: Cannot create account, request to 
"https://testrun.org/new_email?t=wrong" failed

Caused by:
    0: error decoding response body: expected ident at line 1 column 2
    1: expected ident at line 1 column 2
```
After:
```
> setqr DCACCOUNT:https://testrun.org/new_email?t=wrong
Cannot set config from QR code: Cannot create account, unexpected server response:
 "token wrong is invalid"
```

Currently it displays the full server response to the user, but we could hide it and just show it in 
the logs (or only show first 100 chars of it): 
```
>setqr DCACCOUNT:http://127.0.0.1:5000/invalid
Cannot set config from QR code: Cannot create account, unexpected server response:
 "<!doctype html>\n<html lang=en>\n<title>404 Not Found</title>\n<h1>Not Found</h1>\n<p>The requested 
URL was not found on the server. If you entered the URL manually please check your spelling and try 
again.</p>\n“
```

## valid error json
The new upcoming version of mailadm with https://github.com/deltachat/mailadm/pull/39 merged.

Before:
```
> setqr DCACCOUNT:http://127.0.0.1:5000
Cannot set config from QR code: Cannot create account, request to "http://127.0.0.1:5000" failed

Caused by:
    0: error decoding response body: missing field `email` at line 1 column 80
    1: missing field `email` at line 1 column 80
```

After
```
> setqr DCACCOUNT:http://127.0.0.1:5000
Cannot set config from QR code: ?t (token) parameter not specified
```

