### PR TITLE
truncate incoming messages by lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   this affects `dc_get_chat_contacts()`, `dc_get_contacts()` and `dc_get_blocked_contacts()` #3562
 - add `internet_access` flag to `dc_msg_get_webxdc_info()` #3516
 - `DC_EVENT_WEBXDC_INSTANCE_DELETED` is emitted when a message containing a webxdc gets deleted #3105
+- truncate incoming messages by lines instead of just length #3480
 
 ### Fixes
 - do not emit notifications for blocked chats #3557

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -168,6 +168,13 @@ pub const DC_MSG_ID_LAST_SPECIAL: u32 = 9;
 /// String that indicates that something is left out or truncated.
 pub const DC_ELLIPSIS: &str = "[...]";
 
+/// If text is under this limit it skips the check
+pub const DC_DESIRED_TEXT_LINES_THRESHOLD: usize = 400;
+// how many lines desktop displays when fullscreen
+pub const DC_DESIRED_TEXT_LINES: usize = 38;
+// how many chars desktop displays per line
+pub const DC_DESIRED_TEXT_LINE_LEN: usize = 100;
+
 /// Message length limit.
 ///
 /// To keep bubbles and chat flow usable and to avoid problems with controls using very long texts,
@@ -176,7 +183,7 @@ pub const DC_ELLIPSIS: &str = "[...]";
 ///
 /// Note that for simplicity maximum length is defined as the number of Unicode Scalar Values (Rust
 /// `char`s), not Unicode Grapheme Clusters.
-pub const DC_DESIRED_TEXT_LEN: usize = 5000;
+pub const DC_DESIRED_TEXT_LEN: usize = DC_DESIRED_TEXT_LINE_LEN * DC_DESIRED_TEXT_LINES; // was 5000 now is 3800
 
 // Flags for empty server job
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -167,9 +167,6 @@ pub const DC_MSG_ID_LAST_SPECIAL: u32 = 9;
 
 /// String that indicates that something is left out or truncated.
 pub const DC_ELLIPSIS: &str = "[...]";
-
-/// If text is under this limit it skips the check
-pub const DC_DESIRED_TEXT_LINES_THRESHOLD: usize = 400;
 // how many lines desktop displays when fullscreen
 pub const DC_DESIRED_TEXT_LINES: usize = 38;
 // how many chars desktop displays per line

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -167,9 +167,10 @@ pub const DC_MSG_ID_LAST_SPECIAL: u32 = 9;
 
 /// String that indicates that something is left out or truncated.
 pub const DC_ELLIPSIS: &str = "[...]";
-// how many lines desktop displays when fullscreen
+// how many lines desktop can display when fullscreen (fullscreen at zoomlevel 1x)
+// (taken from "subjective" testing what looks ok)
 pub const DC_DESIRED_TEXT_LINES: usize = 38;
-// how many chars desktop displays per line
+// how many chars desktop can display per line (from "subjective" testing)
 pub const DC_DESIRED_TEXT_LINE_LEN: usize = 100;
 
 /// Message length limit.
@@ -180,7 +181,7 @@ pub const DC_DESIRED_TEXT_LINE_LEN: usize = 100;
 ///
 /// Note that for simplicity maximum length is defined as the number of Unicode Scalar Values (Rust
 /// `char`s), not Unicode Grapheme Clusters.
-pub const DC_DESIRED_TEXT_LEN: usize = DC_DESIRED_TEXT_LINE_LEN * DC_DESIRED_TEXT_LINES; // was 5000 now is 3800
+pub const DC_DESIRED_TEXT_LEN: usize = DC_DESIRED_TEXT_LINE_LEN * DC_DESIRED_TEXT_LINES;
 
 // Flags for empty server job
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -12,7 +12,9 @@ use once_cell::sync::Lazy;
 
 use crate::aheader::Aheader;
 use crate::blob::BlobObject;
-use crate::constants::{DC_DESIRED_TEXT_LINES, DC_DESIRED_TEXT_LINES_THRESHOLD, DC_DESIRED_TEXT_LINE_LEN,};
+use crate::constants::{
+    DC_DESIRED_TEXT_LINES, DC_DESIRED_TEXT_LINES_THRESHOLD, DC_DESIRED_TEXT_LINE_LEN,
+};
 use crate::contact::{addr_cmp, addr_normalize, ContactId};
 use crate::context::Context;
 use crate::decrypt::{create_decryption_info, try_decrypt};

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -12,9 +12,7 @@ use once_cell::sync::Lazy;
 
 use crate::aheader::Aheader;
 use crate::blob::BlobObject;
-use crate::constants::{
-    DC_DESIRED_TEXT_LINES, DC_DESIRED_TEXT_LINES_THRESHOLD, DC_DESIRED_TEXT_LINE_LEN,
-};
+use crate::constants::{DC_DESIRED_TEXT_LINES, DC_DESIRED_TEXT_LINE_LEN};
 use crate::contact::{addr_cmp, addr_normalize, ContactId};
 use crate::context::Context;
 use crate::decrypt::{create_decryption_info, try_decrypt};
@@ -1014,18 +1012,15 @@ impl MimeMessage {
                             (simplified_txt, top_quote)
                         };
 
-                        let simplified_txt =
-                            if simplified_txt.chars().count() > DC_DESIRED_TEXT_LINES_THRESHOLD {
-                                self.is_mime_modified = true;
-                                truncate_by_lines(
-                                    &*simplified_txt,
-                                    DC_DESIRED_TEXT_LINES,
-                                    DC_DESIRED_TEXT_LINE_LEN,
-                                )
-                                .to_string()
-                            } else {
-                                simplified_txt
-                            };
+                        // Truncate text if it has too many lines
+                        let (simplified_txt, was_truncated) = truncate_by_lines(
+                            simplified_txt,
+                            DC_DESIRED_TEXT_LINES,
+                            DC_DESIRED_TEXT_LINE_LEN,
+                        );
+                        if was_truncated {
+                            self.is_mime_modified = was_truncated;
+                        }
 
                         if !simplified_txt.is_empty() || simplified_quote.is_some() {
                             let mut part = Part {

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -12,7 +12,7 @@ use once_cell::sync::Lazy;
 
 use crate::aheader::Aheader;
 use crate::blob::BlobObject;
-use crate::constants::{DC_DESIRED_TEXT_LEN, DC_ELLIPSIS};
+use crate::constants::{DC_DESIRED_TEXT_LINES, DC_DESIRED_TEXT_LINES_THRESHOLD, DC_DESIRED_TEXT_LINE_LEN,};
 use crate::contact::{addr_cmp, addr_normalize, ContactId};
 use crate::context::Context;
 use crate::decrypt::{create_decryption_info, try_decrypt};
@@ -28,7 +28,7 @@ use crate::peerstate::Peerstate;
 use crate::simplify::{simplify, SimplifiedText};
 use crate::stock_str;
 use crate::sync::SyncItems;
-use crate::tools::{get_filemeta, parse_receive_headers, truncate};
+use crate::tools::{get_filemeta, parse_receive_headers, truncate_by_lines};
 
 /// A parsed MIME message.
 ///
@@ -1012,14 +1012,18 @@ impl MimeMessage {
                             (simplified_txt, top_quote)
                         };
 
-                        let simplified_txt = if simplified_txt.chars().count()
-                            > DC_DESIRED_TEXT_LEN + DC_ELLIPSIS.len()
-                        {
-                            self.is_mime_modified = true;
-                            truncate(&*simplified_txt, DC_DESIRED_TEXT_LEN).to_string()
-                        } else {
-                            simplified_txt
-                        };
+                        let simplified_txt =
+                            if simplified_txt.chars().count() > DC_DESIRED_TEXT_LINES_THRESHOLD {
+                                self.is_mime_modified = true;
+                                truncate_by_lines(
+                                    &*simplified_txt,
+                                    DC_DESIRED_TEXT_LINES,
+                                    DC_DESIRED_TEXT_LINE_LEN,
+                                )
+                                .to_string()
+                            } else {
+                                simplified_txt
+                            };
 
                         if !simplified_txt.is_empty() || simplified_quote.is_some() {
                             let mut part = Part {
@@ -1817,7 +1821,7 @@ mod tests {
     use crate::{
         chatlist::Chatlist,
         config::Config,
-        constants::Blocked,
+        constants::{Blocked, DC_DESIRED_TEXT_LEN, DC_ELLIPSIS},
         message::{Message, MessageState, MessengerMessage},
         receive_imf::receive_imf,
         test_utils::TestContext,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -840,7 +840,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
             let s = "hello\n world !".to_string();
             assert_eq!(
                 truncate_by_lines(s, 2, 8),
-                ("hello\n world !".to_string(), true)
+                ("hello\n world !".to_string(), false)
             );
         }
 
@@ -857,7 +857,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
             );
             assert_eq!(
                 truncate_by_lines("𐠈0Aᝮa𫝀®!ꫛa¡0A𐢧00𐹠®A  丽ⷐએ".to_string(), 1, 2),
-                ("𐠈[...]".to_string(), true)
+                ("𐠈0[...]".to_string(), true)
             );
             assert_eq!(
                 truncate_by_lines("𐠈0Aᝮa𫝀®!ꫛa¡0A𐢧00𐹠®A  丽ⷐએ".to_string(), 1, 0),
@@ -873,7 +873,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
             // 12 characters, truncation
             assert_eq!(
                 truncate_by_lines("𑒀ὐ￠🜀\u{1e01b}A a🟠bcd".to_string(), 1, 7),
-                ("𑒀ὐ￠🜀\u{1e01b}A[...]".to_string(), true),
+                ("𑒀ὐ￠🜀\u{1e01b}A [...]".to_string(), true),
             );
         }
     }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -80,10 +80,6 @@ pub(crate) fn truncate_by_lines(
     }
 
     if let Some(end_pos) = break_point {
-        if end_pos.saturating_add(1) == buf.len() {
-            // text is unchanged
-            return (buf, false);
-        }
         // text has to many lines and needs to be truncated
         let text = {
             if let Some(buffer) = buf.get(..end_pos) {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -80,7 +80,7 @@ pub(crate) fn truncate_by_lines(
     }
 
     if let Some(end_pos) = break_point {
-        // text has to many lines and needs to be truncated
+        // Text has too many lines and needs to be truncated.
         let text = {
             if let Some(buffer) = buf.get(..end_pos) {
                 if let Some(index) = buffer.rfind(|c| c == ' ' || c == '\n') {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -817,10 +817,7 @@ Hop: From: hq5.example.org; By: hq5.example.org; Date: Mon, 27 Dec 2021 11:21:22
         fn test_edge() {
             assert_eq!(truncate_by_lines("", 2, 4), "");
 
-            assert_eq!(
-                truncate_by_lines("\n  hello \n world", 2, 4),
-                "\n  [...]"
-            );
+            assert_eq!(truncate_by_lines("\n  hello \n world", 2, 4), "\n  [...]");
             assert_eq!(
                 truncate_by_lines("𐠈0Aᝮa𫝀®!ꫛa¡0A𐢧00𐹠®A  丽ⷐએ", 1, 2),
                 "𐠈[...]"

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -100,9 +100,11 @@ pub(crate) fn truncate_by_lines(
         if let Some(truncated_text) = text {
             (format!("{}{}", truncated_text, DC_ELLIPSIS), true)
         } else {
-            // this case should not happen, only if code above broke with updates.
-            // to make it obvious we put an error message here, the true ensures there is still a button to open it in full
-            ("[truncation/preview of this message failed, this is a bug in the core of DeltaChat, please report it.\n you can still view the original message by opening the html version]".to_string(), true)
+            // In case of indexing/slicing error, we return an error
+            // message as a preview and add HTML version. This should
+            // never happen.
+            let error_text = "[Truncation of the message failed, this is a bug in the Delta Chat core. Please report it.\nYou can still open the full text to view the original message.]";
+            (error_text.to_string(), true)
         }
     } else {
         // text is unchanged


### PR DESCRIPTION
because many line-breaks seem to cause the chat open delay on deltachat-ios. (https://github.com/deltachat/deltachat-core-rust/issues/3478)

I only starts counting lines if text is longer than `DC_DESIRED_TEXT_LINES_THRESHOLD`, so should not have an speed impact for most messages.

I already tested this on iOS and it worked as expected there.

The old truncate function is still used for message-info(we might remove message text there) and chat summary (will stay for summary).

### TODO / Things to consider:
- [ ] I'm did not do any benchmarks, maybe there are some rust tricks to make it more performant, but its probably already fast enough
- [ ] I'm not sure if I converted @dignifiedquire's unicode edge texts correctly

Related to #3478, but does not fully fix it.