### PR TITLE
increase ratelimit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - configure DeltaChat folder by selecting it, so it is configured even if not LISTed #3371
 - build PyPy wheels #6683
 - improve default error if NDN does not provide an error #3456
+- increase ratelimit from 3 to 6 messages per 60 seconds #3481
 
 ### Fixes
 - mailing list: remove square-brackets only for first name #3452

--- a/src/context.rs
+++ b/src/context.rs
@@ -193,7 +193,7 @@ impl Context {
             translated_stockstrings: RwLock::new(HashMap::new()),
             events,
             scheduler: RwLock::new(None),
-            ratelimit: RwLock::new(Ratelimit::new(Duration::new(60, 0), 3.0)), // Allow to send 3 messages immediately, no more than once every 20 seconds.
+            ratelimit: RwLock::new(Ratelimit::new(Duration::new(60, 0), 6.0)), // Allow to send 6 messages immediately, no more than once every 10 seconds.
             quota: RwLock::new(None),
             server_id: RwLock::new(None),
             creation_time: std::time::SystemTime::now(),


### PR DESCRIPTION
we want to prevent runaway things,
not restrict normal usage too much,
this limit seems to be more reasonable
also for most round-based games.