### PR TITLE
Accept more error variants in `nicer_configuration_error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 ### Fixes
+- replace musl libc name resolution errors with a better message #3485
 
 
 ## 1.88.0

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1854,7 +1854,7 @@ def test_configure_error_msgs_invalid_server(acfactory):
     # Can't connect so it probably should say something about "internet"
     # again, should not repeat itself
     # If this fails then probably `e.msg.to_lowercase().contains("could not resolve")`
-    # in configure/mod.rs returned false because the error message was changed
+    # in configure.rs returned false because the error message was changed
     # (i.e. did not contain "could not resolve" anymore)
     assert (ev.data2.count("internet") + ev.data2.count("network")) == 1
     # Should mention that it can't connect:

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -642,6 +642,9 @@ async fn nicer_configuration_error(context: &Context, errors: Vec<ConfigurationE
                 .to_lowercase()
                 .contains("temporary failure in name resolution")
             || e.msg.to_lowercase().contains("name or service not known")
+            || e.msg
+                .to_lowercase()
+                .contains("failed to lookup address information")
     }) {
         return stock_str::error_no_network(context).await;
     }


### PR DESCRIPTION
musl libc returns "failed to lookup address information: Name does not resolve" in some cases.