### PR TITLE
Cleanup doxygen CI

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,11 +14,7 @@ and an own build machine.
 - `remote_tests_rust.sh` rsyncs to the build machine and runs
   `run-rust-test.sh` remotely on the build machine. 
 
-- `doxygen/Dockerfile` specifies an image that contains
-  the doxygen tool which is used by `run-doxygen.sh` 
-  to generate C-docs which are then uploaded 
-  via `ci_upload.sh` to `https://c.delta.chat/_unofficial_unreleased_docs/<BRANCH>`
-  (and the master branch is linked to https://c.delta.chat proper). 
+- `run-doxygen.sh` generates C-docs which are then uploaded to https://c.delta.chat/
 
 
 ## Triggering runs on the build machine locally (fast!)

--- a/scripts/concourse/docs_wheels.yml
+++ b/scripts/concourse/docs_wheels.yml
@@ -29,16 +29,17 @@ jobs:
         - name: c-docs
       image_resource:
         source:
-          repository: hrektts/doxygen
+          repository: alpine
         type: registry-image
       platform: linux
       run:
-        path: bash
+        path: sh
         args:
-        - -exc
+        - -ec
         - |
+          apk add --no-cache doxygen git
           cd deltachat-core-rust
-          bash scripts/run-doxygen.sh
+          scripts/run-doxygen.sh
           cd ..
           cp -av deltachat-core-rust/deltachat-ffi/{html,xml} c-docs/
 

--- a/scripts/docker-doxygen/Dockerfile
+++ b/scripts/docker-doxygen/Dockerfile
@@ -1,5 +1,0 @@
-FROM debian:stable
-
-# this is tagged as deltachat/doxygen 
-
-RUN apt-get update && apt-get install -y doxygen 

--- a/scripts/run-doxygen.sh
+++ b/scripts/run-doxygen.sh
@@ -1,6 +1,5 @@
-#!/usr/bin/env bash
-
-set -ex
+#!/bin/sh
+set -e
 
 cd deltachat-ffi 
 PROJECT_NUMBER=$(git log -1 --format="%h (%cd)") doxygen


### PR DESCRIPTION
Remove unused docker-doxygen Dockerfile.
Switch scripts/run-doxygen.sh from bash to sh.
Use docker.io/alpine image instead of unsupported hrektts/doxygen