### PR TITLE
handle webxdc updates for not downloaded instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 - replace musl libc name resolution errors with a better message #3485
+- handle updates for not yet downloaded webxdc instances #3487
 
 
 ## 1.88.0

--- a/src/download.rs
+++ b/src/download.rs
@@ -70,16 +70,21 @@ impl Context {
         }
     }
 
-    // Sets msg_id of message `full` to `placeholder`.
-    // Message `full` does not longer exist afterwards.
-    pub(crate) async fn merge_msg_id(&self, full: MsgId, placeholder: MsgId) -> Result<()> {
+    // Merges the two messages to `placeholder_msg_id`;
+    // `full_msg_id` is no longer used afterwards.
+    pub(crate) async fn merge_msg_id(
+        &self,
+        full_msg_id: MsgId,
+        placeholder_msg_id: MsgId,
+    ) -> Result<()> {
         // TODO: use webxdc summary and document from placeholder
         self.sql
             .transaction(move |transaction| {
-                transaction.execute("DELETE FROM msgs WHERE id=?;", paramsv![placeholder])?;
+                transaction
+                    .execute("DELETE FROM msgs WHERE id=?;", paramsv![placeholder_msg_id])?;
                 transaction.execute(
                     "UPDATE msgs SET id=? WHERE id=?",
-                    paramsv![placeholder, full],
+                    paramsv![placeholder_msg_id, full_msg_id],
                 )?;
                 Ok(())
             })

--- a/src/download.rs
+++ b/src/download.rs
@@ -69,6 +69,23 @@ impl Context {
             Ok(Some(max(MIN_DOWNLOAD_LIMIT, download_limit as u32)))
         }
     }
+
+    // Sets msg_id of message `full` to `placeholder`.
+    // Message `full` does not longer exist afterwards.
+    pub(crate) async fn merge_msg_id(&self, full: MsgId, placeholder: MsgId) -> Result<()> {
+        // TODO: use webxdc summary and document from placeholder
+        self.sql
+            .transaction(move |transaction| {
+                transaction.execute("DELETE FROM msgs WHERE id=?;", paramsv![placeholder])?;
+                transaction.execute(
+                    "UPDATE msgs SET id=? WHERE id=?",
+                    paramsv![placeholder, full],
+                )?;
+                Ok(())
+            })
+            .await?;
+        Ok(())
+    }
 }
 
 impl MsgId {

--- a/src/download.rs
+++ b/src/download.rs
@@ -72,7 +72,7 @@ impl Context {
 
     // Merges the two messages to `placeholder_msg_id`;
     // `full_msg_id` is no longer used afterwards.
-    pub(crate) async fn merge_msg_id(
+    pub(crate) async fn merge_messages(
         &self,
         full_msg_id: MsgId,
         placeholder_msg_id: MsgId,

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1148,7 +1148,9 @@ INSERT INTO msgs
 
     if let Some(replace_msg_id) = replace_msg_id {
         if let Some(created_msg_id) = created_db_entries.pop() {
-            context.merge_msg_id(created_msg_id, replace_msg_id).await?;
+            context
+                .merge_messages(created_msg_id, replace_msg_id)
+                .await?;
             created_db_entries.push(replace_msg_id);
         } else {
             replace_msg_id.delete_from_db(context).await?;

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -130,15 +130,14 @@ pub(crate) async fn receive_imf_inner(
                     context,
                     "Message already partly in DB, replacing by full message."
                 );
-                old_msg_id.delete_from_db(context).await?;
-                true
+                Some(old_msg_id)
             } else {
                 // the message was probably moved around.
                 info!(context, "Message already in DB, doing nothing.");
                 return Ok(None);
             }
         } else {
-            false
+            None
         };
 
     // the function returns the number of created messages in the database
@@ -189,8 +188,9 @@ pub(crate) async fn receive_imf_inner(
         sent_timestamp,
         rcvd_timestamp,
         from_id,
-        seen || replace_partial_download,
+        seen || replace_partial_download.is_some(),
         is_partial_download,
+        replace_partial_download,
         fetching_existing_messages,
         prevent_rename,
     )
@@ -322,7 +322,7 @@ pub(crate) async fn receive_imf_inner(
         }
     }
 
-    if replace_partial_download {
+    if replace_partial_download.is_some() {
         context.emit_msgs_changed(chat_id, MsgId::new(0));
     } else if !chat_id.is_trash() {
         let fresh = received_msg.state == MessageState::InFresh;
@@ -401,6 +401,7 @@ async fn add_parts(
     from_id: ContactId,
     seen: bool,
     is_partial_download: Option<u32>,
+    replace_msg_id: Option<MsgId>,
     fetching_existing_messages: bool,
     prevent_rename: bool,
 ) -> Result<ReceivedMsg> {
@@ -1144,6 +1145,25 @@ INSERT INTO msgs
         created_db_entries.push(MsgId::new(u32::try_from(row_id)?));
     }
     drop(conn);
+
+    if let Some(replace_msg_id) = replace_msg_id {
+        if let Some(created_msg_id) = created_db_entries.pop() {
+            context
+                .sql
+                .execute("DELETE FROM msgs WHERE id=?;", paramsv![replace_msg_id])
+                .await?;
+            context
+                .sql
+                .execute(
+                    "UPDATE msgs SET id=? WHERE id=?",
+                    paramsv![replace_msg_id, created_msg_id],
+                )
+                .await?;
+            created_db_entries.push(replace_msg_id);
+        } else {
+            replace_msg_id.delete_from_db(context).await?;
+        }
+    }
 
     chat_id.unarchive_if_not_muted(context).await?;
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1148,17 +1148,7 @@ INSERT INTO msgs
 
     if let Some(replace_msg_id) = replace_msg_id {
         if let Some(created_msg_id) = created_db_entries.pop() {
-            context
-                .sql
-                .execute("DELETE FROM msgs WHERE id=?;", paramsv![replace_msg_id])
-                .await?;
-            context
-                .sql
-                .execute(
-                    "UPDATE msgs SET id=? WHERE id=?",
-                    paramsv![replace_msg_id, created_msg_id],
-                )
-                .await?;
+            context.merge_msg_id(created_msg_id, replace_msg_id).await?;
             created_db_entries.push(replace_msg_id);
         } else {
             replace_msg_id.delete_from_db(context).await?;

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -14,6 +14,7 @@ use tokio::io::AsyncReadExt;
 use crate::chat::Chat;
 use crate::contact::ContactId;
 use crate::context::Context;
+use crate::download::DownloadState;
 use crate::message::{Message, MessageState, MsgId, Viewtype};
 use crate::mimeparser::SystemMessage;
 use crate::param::Param;
@@ -475,6 +476,8 @@ impl Context {
         } else if let Some(parent) = msg.parent(self).await? {
             if parent.viewtype == Viewtype::Webxdc {
                 (msg.timestamp_sort, parent, true)
+            } else if parent.download_state() != DownloadState::Done {
+                (msg.timestamp_sort, parent, false)
             } else {
                 bail!("receive_status_update: message is not the child of a webxdc message.")
             }

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -1059,7 +1059,11 @@ mod tests {
         let sent1 = alice.send_msg(chat.id, &mut alice_instance).await;
         let alice_instance = Message::load_from_db(&alice, sent1.sender_msg_id).await?;
         alice
-            .send_webxdc_status_update(alice_instance.id, r#"{"payload": 7}"#, "bla")
+            .send_webxdc_status_update(
+                alice_instance.id,
+                r#"{"payload": 7, "summary":"sum", "document":"doc"}"#,
+                "bla",
+            )
             .await?;
         alice.flush_status_updates().await?;
         let sent2 = alice.pop_sent_msg().await;
@@ -1095,8 +1099,11 @@ mod tests {
         assert_eq!(
             bob.get_webxdc_status_updates(bob_instance.id, StatusUpdateSerial(0))
                 .await?,
-            r#"[{"payload":7,"serial":1,"max_serial":1}]"#
+            r#"[{"payload":7,"document":"doc","summary":"sum","serial":1,"max_serial":1}]"#
         );
+        let info = bob_instance.get_webxdc_info(&bob).await?;
+        assert_eq!(info.document, "doc");
+        assert_eq!(info.summary, "sum");
 
         Ok(())
     }

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -331,10 +331,12 @@ impl Context {
 
         let status_update_serial = StatusUpdateSerial(u32::try_from(rowid)?);
 
-        self.emit_event(EventType::WebxdcStatusUpdate {
-            msg_id: instance.id,
-            status_update_serial,
-        });
+        if instance.viewtype == Viewtype::Webxdc {
+            self.emit_event(EventType::WebxdcStatusUpdate {
+                msg_id: instance.id,
+                status_update_serial,
+            });
+        }
 
         Ok(status_update_serial)
     }


### PR DESCRIPTION
with this pr, received webxdc status updates are handled if the webxdc instance is not yet downloaded.

as the updates in `msgs_status_updates` are identified by `msg_id`, this id must not change on download (changing `msg_id` on download was just done because it was easier to implement that time) (if a download expands to multiple messages, they get additional ids then, of course, but this does not affect webxdc instances or other messages sent by Delta Chat)

the method to keep the `msg_id` is not super-elegant, but working - i tried some alternatives to keep the `msg_id` (UPDATE etc.), but all of them result in much more complicated code. maybe someone has a nicer idea :)

closes #3262