### PR TITLE
ratelimit: do not overflow leaky bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 - handle drafts from mailto links in scanned QR #3492
+- do not overflow ratelimiter leaky bucket #3496
 
 ### Fixes
 - don't squash text parts of NDN into attachments #3497


### PR DESCRIPTION
This way the time to wait until next message can
be sent is always limited.