### PR TITLE
mimeparser: do not squash NDN text parts into attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - handle drafts from mailto links in scanned QR #3492
 
 ### Fixes
+- don't squash text parts of NDN into attachments #3497
 
 
 ## 1.89.0

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -535,7 +535,9 @@ impl MimeMessage {
         self.parse_system_message_headers(context);
         self.parse_avatar_headers(context).await;
         self.parse_videochat_headers();
-        self.squash_attachment_parts();
+        if self.failure_report.is_none() {
+            self.squash_attachment_parts();
+        }
 
         if let Some(ref subject) = self.get_subject() {
             let mut prepend_subject = true;

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2659,7 +2659,7 @@ mod tests {
             "shenauithz@testrun.org",
             "Mr.un2NYERi1RM.lbQ5F9q-QyJ@tiscali.it",
             include_bytes!("../test-data/message/tiscali_ndn.eml"),
-            Some("Delivery to at least one recipient failed."),
+            Some("Delivery status notification –       This is an automatically generated Delivery Status Notification.      \n\nDelivery to the following recipients was aborted after 2 second(s):\n\n  * shenauithz@testrun.org"),
         )
         .await;
     }
@@ -2732,6 +2732,19 @@ mod tests {
             "Mr.5xqflwt0YFv.IXDFfHauvWx@testrun.org",
             include_bytes!("../test-data/message/testrun_ndn_2.eml"),
             Some("Undelivered Mail Returned to Sender – This is the mail system at host hq5.merlinux.eu.\n\nI'm sorry to have to inform you that your message could not\nbe delivered to one or more recipients. It's attached below.\n\nFor further assistance, please send mail to postmaster.\n\nIf you do so, please include this problem report. You can\ndelete your own text from the attached returned message.\n\n                   The mail system\n\n<bob@example.org>: Host or domain name not found. Name service error for\n    name=echedelyr.tk type=AAAA: Host not found"),
+        )
+        .await;
+    }
+
+    /// Tests that text part is not squashed into OpenPGP attachment.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_parse_ndn_with_attachment() {
+        test_parse_ndn(
+            "alice@example.org",
+            "bob@example.net",
+            "Mr.I6Da6dXcTel.TroC5J3uSDH@example.org",
+            include_bytes!("../test-data/message/ndn_with_attachment.eml"),
+            Some("Undelivered Mail Returned to Sender – This is the mail system at host relay01.example.org.\n\nI'm sorry to have to inform you that your message could not\nbe delivered to one or more recipients. It's attached below.\n\nFor further assistance, please send mail to postmaster.\n\nIf you do so, please include this problem report. You can\ndelete your own text from the attached returned message.\n\n                   The mail system\n\n<bob@example.net>: host mx2.example.net[80.241.60.215] said: 552 5.2.2\n    <bob@example.net>: Recipient address rejected: Mailbox quota exceeded (in\n    reply to RCPT TO command)\n\n<bob2@example.net>: host mx1.example.net[80.241.60.212] said: 552 5.2.2\n    <bob2@example.net>: Recipient address rejected: Mailbox quota\n    exceeded (in reply to RCPT TO command)")
         )
         .await;
     }

--- a/test-data/message/ndn_with_attachment.eml
+++ b/test-data/message/ndn_with_attachment.eml
@@ -1,0 +1,123 @@
+Return-Path: <>
+Delivered-To: <alice@example.org>
+Date: Sat, 25 Jun 2022 21:35:33 -0400 (CDT)
+From: MAILER-DAEMON@example.org (Mail Delivery System)
+Subject: Undelivered Mail Returned to Sender
+To: alice@example.org
+Auto-Submitted: auto-replied
+MIME-Version: 1.0
+Content-Type: multipart/report; report-type=delivery-status;
+	boundary="C06EAE01B0.1656207333/relay01.example.org"
+Content-Transfer-Encoding: 7bit
+Message-Id: <20220626013533.5F0E5E0180@relay01.example.org>
+
+This is a MIME-encapsulated message.
+
+--C06EAE01B0.1656207333/relay01.example.org
+Content-Description: Notification
+Content-Type: text/plain; charset=us-ascii
+
+This is the mail system at host relay01.example.org.
+
+I'm sorry to have to inform you that your message could not
+be delivered to one or more recipients. It's attached below.
+
+For further assistance, please send mail to postmaster.
+
+If you do so, please include this problem report. You can
+delete your own text from the attached returned message.
+
+                   The mail system
+
+<bob@example.net>: host mx2.example.net[80.241.60.215] said: 552 5.2.2
+    <bob@example.net>: Recipient address rejected: Mailbox quota exceeded (in
+    reply to RCPT TO command)
+
+<bob2@example.net>: host mx1.example.net[80.241.60.212] said: 552 5.2.2
+    <bob2@example.net>: Recipient address rejected: Mailbox quota
+    exceeded (in reply to RCPT TO command)
+
+--C06EAE01B0.1656207333/relay01.example.org
+Content-Description: Delivery report
+Content-Type: message/delivery-status
+
+Reporting-MTA: dns; relay01.example.org
+X-Postfix-Queue-ID: C06EAE01B0
+X-Postfix-Sender: rfc822; alice@example.org
+Arrival-Date: Sat, 25 Jun 2022 21:35:23 -0400 (CDT)
+
+Final-Recipient: rfc822; bob@example.org
+Original-Recipient: rfc822;bob@example.org
+Action: failed
+Status: 5.2.2
+Remote-MTA: dns; mx2.example.net
+Diagnostic-Code: smtp; 552 5.2.2 <bob@example.org>: Recipient address
+    rejected: Mailbox quota exceeded
+
+Final-Recipient: rfc822; bob2@example.net
+Original-Recipient: rfc822;bob2@example.net
+Action: failed
+Status: 5.2.2
+Remote-MTA: dns; mx1.example.net
+Diagnostic-Code: smtp; 552 5.2.2 <bob2@example.net>: Recipient address
+    rejected: Mailbox quota exceeded
+
+--C06EAE01B0.1656207333/relay01.example.org
+Content-Description: Undelivered Message
+Content-Type: message/rfc822
+Content-Transfer-Encoding: 7bit
+
+Return-Path: <alice@example.org>
+Received: from smtp-gw01.enet.cu (unknown [172.29.8.31])
+	by relay01.example.org (Postfix) with ESMTP id C06EAE01B0;
+	Sat, 25 Jun 2022 21:35:23 -0400 (CDT)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.org; s=nauta;
+	t=1656207323; bh=c0t8muX/2spIAQ/MRxSXsZ/ljSWP8uTxPcM5fqYC6qg=;
+	h=Subject:From:To:Date:In-Reply-To:References;
+	b=fggUmxnR3RjNfxO4S460fvxfenu3eUPvsGjldIGQeApxT508qGctJZ0tzYiFelOAu
+	 4zL8+VhlX0KdnrvRXo2/00O9U2kM8gpRLE9tIR0Rn6FyWM4nU5rcvAJp3oiUWxYzPt
+	 NMlzFeUsBvwFCJCEmZllSHaAyt/HTvWe68sGQsu8=
+Received: from amavis4.example.org (unknown [172.29.8.235])
+	by smtp-gw01.enet.cu (Postfix) with ESMTP id ECFE9180004D;
+	Sat, 25 Jun 2022 21:35:18 -0400 (CDT)
+Received: from smtp.example.org ([172.29.8.248])
+	by amavis4.example.org  with ESMTP id 25Q1ZNDW016368-25Q1ZNDX016368;
+	Sat, 25 Jun 2022 21:35:23 -0400
+Received: from [127.0.0.1] (unknown [10.59.196.114])
+	by smtp.example.org (Postfix) with ESMTPSA id E07E79F110;
+	Sat, 25 Jun 2022 21:35:21 -0400 (CDT)
+Subject: ...
+From: Alice <alice@example.org>
+To: <bob@example.net>, <bob2@example.net>
+Date: Sun, 26 Jun 2022 01:35:20 +0000
+Message-ID: <Mr.I6Da6dXcTel.TroC5J3uSDH@example.org>
+In-Reply-To: <Mr.I6Da6dXcTel.-qoK1IWpqby@example.org>
+References: <Mr.I6Da6dXcTel.TroC5J3uSDH@example.org>
+Chat-Version: 1.0
+MIME-Version: 1.0
+Content-Type: multipart/encrypted; protocol="application/pgp-encrypted";
+	boundary="OOGjcgxCkv3w8d1thY6jg0b8O0NFJE"
+
+
+--OOGjcgxCkv3w8d1thY6jg0b8O0NFJE
+Content-Type: application/pgp-encrypted
+Content-Description: PGP/MIME version identification
+
+Version: 1
+
+
+--OOGjcgxCkv3w8d1thY6jg0b8O0NFJE
+Content-Type: application/octet-stream; name="encrypted.asc"
+Content-Description: OpenPGP encrypted message
+Content-Disposition: inline; filename="encrypted.asc";
+
+-----BEGIN PGP MESSAGE-----
+
+REMOVED
+-----END PGP MESSAGE-----
+
+
+--OOGjcgxCkv3w8d1thY6jg0b8O0NFJE--
+
+
+--C06EAE01B0.1656207333/relay01.example.org--


### PR DESCRIPTION
Text part usually contains an error message that we want to display in
the UI.