### PR TITLE
package_wheels.py: get version from setuptools_scm without using setup.py

### DIFF
--- a/python/tests/package_wheels.py
+++ b/python/tests/package_wheels.py
@@ -8,6 +8,6 @@ if __name__ == "__main__":
     # pip wheel will build in an isolated tmp dir that does not have git
     # history so setuptools_scm can not automatically determine a
     # version there. So pass in the version through an env var.
-    version = subprocess.check_output(["python", "setup.py", "--version"]).strip().split(b"\n")[-1]
+    version = subprocess.check_output(["python", "-m", "setuptools_scm"])
     os.environ["SETUPTOOLS_SCM_PRETEND_VERSION"] = version.decode("ascii")
-    subprocess.check_call(("pip wheel . -w %s" % wheelhousedir).split())
+    subprocess.check_call(["pip", "wheel", ".", "-w", wheelhousedir])

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -17,6 +17,7 @@ passenv =
     CARGO_TARGET_DIR
     RUSTC_WRAPPER
 deps = 
+    setuptools_scm
     pytest
     pytest-rerunfailures
     pytest-timeout


### PR DESCRIPTION
`python -m setuptools_scm` is a documented (in setuptools_scm README)
way to get version and it does not print any other output
that has to be filtered out.