### PR TITLE
Add API versioning to the JSON-RPC API

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -4442,12 +4442,12 @@ pub unsafe extern "C" fn dc_accounts_get_next_event(
 #[cfg(feature = "jsonrpc")]
 mod jsonrpc {
     use super::*;
-    use deltachat_jsonrpc::api::CommandApi;
+    use deltachat_jsonrpc::api::DeltaChatApiV0;
     use deltachat_jsonrpc::yerpc::{OutReceiver, RpcClient, RpcSession};
 
     pub struct dc_jsonrpc_instance_t {
         receiver: OutReceiver,
-        handle: RpcSession<CommandApi>,
+        handle: RpcSession<DeltaChatApiV0>,
     }
 
     #[no_mangle]

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -4461,14 +4461,14 @@ mod jsonrpc {
         }
         let api_version = to_string_lossy(api_version);
 
-        let rpc_api = match &api_version {
+        let rpc_api = match api_version.as_str() {
             "v0" => {
                 deltachat_jsonrpc::api::DeltaChatApiV0::from_arc((*account_manager).inner.clone())
             }
-            _ => {
-                error!(
-                    ctx,
-                    "The requested JSON-RPC API version is not supported.", err
+            version => {
+                eprintln!(
+                    "Error initializing JSON-RPC API: API version {} is not supported.",
+                    version
                 );
                 return ptr::null_mut();
             }

--- a/deltachat-jsonrpc/src/api/mod.rs
+++ b/deltachat-jsonrpc/src/api/mod.rs
@@ -34,20 +34,20 @@ use types::webxdc::WebxdcMessageInfo;
 use self::types::message::MessageViewtype;
 
 #[derive(Clone, Debug)]
-pub struct CommandApi {
+pub struct DeltaChatApiV0 {
     pub(crate) accounts: Arc<RwLock<Accounts>>,
 }
 
-impl CommandApi {
+impl DeltaChatApiV0 {
     pub fn new(accounts: Accounts) -> Self {
-        CommandApi {
+        DeltaChatApiV0 {
             accounts: Arc::new(RwLock::new(accounts)),
         }
     }
 
     #[allow(dead_code)]
     pub fn from_arc(accounts: Arc<RwLock<Accounts>>) -> Self {
-        CommandApi { accounts }
+        DeltaChatApiV0 { accounts }
     }
 
     async fn get_context(&self, id: u32) -> Result<deltachat::context::Context> {
@@ -63,7 +63,7 @@ impl CommandApi {
 }
 
 #[rpc(all_positional, ts_outdir = "typescript/generated")]
-impl CommandApi {
+impl DeltaChatApiV0 {
     // ---------------------------------------------
     //  Misc top level functions
     // ---------------------------------------------

--- a/deltachat-jsonrpc/src/api/types/account.rs
+++ b/deltachat-jsonrpc/src/api/types/account.rs
@@ -19,9 +19,7 @@ pub enum Account {
         color: String,
     },
     #[serde(rename_all = "camelCase")]
-    Unconfigured {
-        id: u32,
-    },
+    Unconfigured { id: u32 },
 }
 
 impl Account {

--- a/deltachat-jsonrpc/src/lib.rs
+++ b/deltachat-jsonrpc/src/lib.rs
@@ -15,7 +15,7 @@ mod tests {
     async fn basic_json_rpc_functionality() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new().unwrap().path().into();
         let accounts = Accounts::new(tmp_dir).await?;
-        let api = CommandApi::new(accounts);
+        let api = DeltaChatApiV0::new(accounts);
 
         let (sender, mut receiver) = unbounded::<String>();
 
@@ -56,7 +56,7 @@ mod tests {
     async fn test_batch_set_config() -> anyhow::Result<()> {
         let tmp_dir = TempDir::new().unwrap().path().into();
         let accounts = Accounts::new(tmp_dir).await?;
-        let api = CommandApi::new(accounts);
+        let api = DeltaChatApiV0::new(accounts);
 
         let (sender, mut receiver) = unbounded::<String>();
 

--- a/deltachat-jsonrpc/src/lib.rs
+++ b/deltachat-jsonrpc/src/lib.rs
@@ -1,10 +1,11 @@
 pub mod api;
 pub use api::events;
+pub use api::{Accounts, DeltaChatApiV0};
 pub use yerpc;
 
 #[cfg(test)]
 mod tests {
-    use super::api::{Accounts, CommandApi};
+    use super::api::{Accounts, DeltaChatApiV0};
     use async_channel::unbounded;
     use futures::StreamExt;
     use tempfile::TempDir;

--- a/deltachat-jsonrpc/src/webserver.rs
+++ b/deltachat-jsonrpc/src/webserver.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), std::io::Error> {
     Ok(())
 }
 
-async fn handler(ws: WebSocketUpgrade, Extension(api): Extension<CommandApi>) -> Response {
+async fn handler(ws: WebSocketUpgrade, Extension(api): Extension<DeltaChatApiV0>) -> Response {
     let (client, out_receiver) = RpcClient::new();
     let session = RpcSession::new(client.clone(), api.clone());
     tokio::spawn(async move {

--- a/deltachat-jsonrpc/src/webserver.rs
+++ b/deltachat-jsonrpc/src/webserver.rs
@@ -6,7 +6,7 @@ use yerpc::{RpcClient, RpcSession};
 
 mod api;
 use api::events::event_to_json_rpc_notification;
-use api::{Accounts, CommandApi};
+use api::{Accounts, DeltaChatApiV0};
 
 const DEFAULT_PORT: u16 = 20808;
 
@@ -20,10 +20,10 @@ async fn main() -> Result<(), std::io::Error> {
         .unwrap_or(DEFAULT_PORT);
     log::info!("Starting with accounts directory `{path}`.");
     let accounts = Accounts::new(PathBuf::from(&path)).await.unwrap();
-    let state = CommandApi::new(accounts);
+    let state = DeltaChatApiV0::new(accounts);
 
     let app = Router::new()
-        .route("/ws", get(handler))
+        .route("/rpc/v0", get(handler))
         .layer(Extension(state.clone()));
 
     tokio::spawn(async move {

--- a/node/lib/deltachat.ts
+++ b/node/lib/deltachat.ts
@@ -115,7 +115,7 @@ export class AccountManager extends EventEmitter {
     debug('Started event handler')
   }
 
-  startJsonRpcHandler(callback: ((response: string) => void) | null) {
+  startJsonRpcHandler(callback: ((response: string) => void) | null, apiVersion: string = "v0") {
     if (this.dcn_accounts === null) {
       throw new Error('dcn_account is null')
     }
@@ -126,7 +126,7 @@ export class AccountManager extends EventEmitter {
       throw new Error('jsonrpc was started already')
     }
 
-    binding.dcn_accounts_start_jsonrpc(this.dcn_accounts, callback.bind(this))
+    binding.dcn_accounts_start_jsonrpc(this.dcn_accounts, apiVersion, callback.bind(this))
     debug('Started JSON-RPC handler')
     this.jsonRpcStarted = true
   }

--- a/node/src/module.c
+++ b/node/src/module.c
@@ -3313,9 +3313,10 @@ static void call_accounts_js_jsonrpc_handler(napi_env env, napi_value js_callbac
 }
 
 NAPI_METHOD(dcn_accounts_start_jsonrpc) {
-  NAPI_ARGV(2);
+  NAPI_ARGV(3);
   NAPI_DCN_ACCOUNTS();
-  napi_value callback = argv[1];
+  NAPI_ARGV_UTF8_MALLOC(api_version, 1);
+  napi_value callback = argv[2];
 
   TRACE("calling..");
   napi_value async_resource_name;
@@ -3338,7 +3339,7 @@ NAPI_METHOD(dcn_accounts_start_jsonrpc) {
   TRACE("done");
 
   dcn_accounts->gc = 0;
-  dcn_accounts->jsonrpc_instance = dc_jsonrpc_init(dcn_accounts->dc_accounts);
+  dcn_accounts->jsonrpc_instance = dc_jsonrpc_init(dcn_accounts->dc_accounts, api_version);
 
   TRACE("creating uv thread..");
   uv_thread_create(&dcn_accounts->jsonrpc_thread, accounts_jsonrpc_thread_func, dcn_accounts);


### PR DESCRIPTION
Hi,
this PR adds API versioning to the JSON-RPC API. I'm not super sure if this is needed, but maybe it's better to future-proof this now so that a new API version could be introduced without a breaking change?
Maybe @Simon-Laux @dignifiedquire @link2xt could give feedback if we want this?
If so please just merge this into the `jsonrpc-new` branch to combine with the other PR. I thought I'd open this first to get feedback if we want this.
Best,
Frando