### PR TITLE
(AEAP) Revert #3491, instead only replace contacts in verified groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - handle drafts from mailto links in scanned QR #3492
 - do not overflow ratelimiter leaky bucket #3496
 - (AEAP) Add device message after you changed your address #3505
+- (AEAP) Revert #3491, instead only replace contacts in verified groups #3510
 
 ### Fixes
 - don't squash text parts of NDN into attachments #3497

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -6377,8 +6377,9 @@ void dc_event_unref(dc_event_t* event);
 /// Otherwise you might miss messages of contacts who did not get your new 
 /// address yet." + the link to the AEAP blog post
 /// 
-/// The UIs have to add the link:
+/// As soon as there is a post about AEAP, the UIs should add it:
 /// set_stock_translation(123, getString(aeap_explanation) + "\n\n" + AEAP_BLOG_LINK)
+///
 /// Used in a device message that explains AEAP.
 #define DC_STR_AEAP_EXPLANATION_AND_LINK  123
 

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -149,11 +149,13 @@ pub(crate) async fn get_autocrypt_peerstate(
 
     // Apply Autocrypt header
     if let Some(header) = autocrypt_header {
-        // The "from_nongossiped_fingerprint" part is for AEAP:
+        // The "from_verified_fingerprint" part is for AEAP:
         // If we know this fingerprint from another addr,
         // we may want to do a transition from this other addr
         // (and keep its peerstate)
-        peerstate = Peerstate::from_nongossiped_fingerprint_or_addr(
+        // For security reasons, for now, we only do a transition
+        // if the fingerprint is verified.
+        peerstate = Peerstate::from_verified_fingerprint_or_addr(
             context,
             &header.public_key.fingerprint(),
             from,

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -635,7 +635,7 @@ pub async fn maybe_do_aeap_transition(
                 && mime_parser.from_is_signed
                 && info.message_time > peerstate.last_seen
             {
-                // Add an info messages to all chats with this contact
+                // Add info messages to chats with this (verified) contact
                 //
                 peerstate
                     .handle_setup_change(

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 use std::fmt;
 
 use crate::aheader::{Aheader, EncryptPreference};
-use crate::chat::{self, is_contact_in_chat, Chat, ChatId};
+use crate::chat::{self, is_contact_in_chat, Chat};
 use crate::chatlist::Chatlist;
 use crate::constants::Chattype;
 use crate::contact::{addr_cmp, Contact, Origin};
@@ -644,12 +644,6 @@ pub async fn maybe_do_aeap_transition(
                         PeerstateChange::Aeap(info.from.clone()),
                     )
                     .await?;
-
-                // Create a chat with the new address with the same blocked-level as the old chat
-                let new_chat_id =
-                    ChatId::create_for_contact_with_blocked(context, new_contact_id, chat.blocked)
-                        .await?;
-                chat::add_info_msg(context, new_chat_id, &msg, info.message_time).await?;
 
                 peerstate.addr = info.from.clone();
                 let header = info.autocrypt_header.as_ref().context(

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -337,7 +337,7 @@ pub enum StockMessage {
     AeapAddrChanged = 122,
 
     #[strum(props(
-        fallback = "You changed your email address from %1$s to %2$s.\n\nIf you now send a message to a group, contacts there will automatically replace the old with your new address.\n\nIt's highly advised to set up your old email provider to forward all emails to your new email address. Otherwise you might miss messages of contacts who did not get your new address yet."
+        fallback = "You changed your email address from %1$s to %2$s.\n\nIf you now send a message to a verified group, contacts there will automatically replace the old with your new address.\n\nIt's highly advised to set up your old email provider to forward all emails to your new email address. Otherwise you might miss messages of contacts who did not get your new address yet."
     ))]
     AeapExplanationAndLink = 123,
 }

--- a/src/tests/aeap.rs
+++ b/src/tests/aeap.rs
@@ -69,24 +69,24 @@ Message w/out In-Reply-To
 }
 
 enum ChatForTransition {
-    // OneToOne,
+    OneToOne,
     GroupChat,
     VerifiedGroup,
 }
 use ChatForTransition::*;
 
-// #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-// async fn test_aeap_transition_0() {
-//     check_aeap_transition(OneToOne, false, false).await;
-// }
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_aeap_transition_0() {
+    check_aeap_transition(OneToOne, false, false).await;
+}
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_aeap_transition_1() {
     check_aeap_transition(GroupChat, false, false).await;
 }
-// #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-// async fn test_aeap_transition_0_verified() {
-//     check_aeap_transition(OneToOne, true, false).await;
-// }
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_aeap_transition_0_verified() {
+    check_aeap_transition(OneToOne, true, false).await;
+}
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_aeap_transition_1_verified() {
     check_aeap_transition(GroupChat, true, false).await;
@@ -96,18 +96,18 @@ async fn test_aeap_transition_2_verified() {
     check_aeap_transition(VerifiedGroup, true, false).await;
 }
 
-// #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-// async fn test_aeap_transition_0_bob_knew_new_addr() {
-//     check_aeap_transition(OneToOne, false, true).await;
-// }
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_aeap_transition_0_bob_knew_new_addr() {
+    check_aeap_transition(OneToOne, false, true).await;
+}
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_aeap_transition_1_bob_knew_new_addr() {
     check_aeap_transition(GroupChat, false, true).await;
 }
-// #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-// async fn test_aeap_transition_0_verified_bob_knew_new_addr() {
-//     check_aeap_transition(OneToOne, true, true).await;
-// }
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_aeap_transition_0_verified_bob_knew_new_addr() {
+    check_aeap_transition(OneToOne, true, true).await;
+}
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_aeap_transition_1_verified_bob_knew_new_addr() {
     check_aeap_transition(GroupChat, true, true).await;
@@ -206,7 +206,7 @@ async fn check_aeap_transition(
     tcm.section("Alice sends another message to Bob, this time from her new addr");
     // No matter which chat Alice sends to, the transition should be done in all groups
     let chat_to_send = match chat_for_transition {
-        // OneToOne => alice.create_chat(&bob).await.id,
+        OneToOne => alice.create_chat(&bob).await.id,
         GroupChat => group1_alice,
         VerifiedGroup => group3_alice.expect("No verified group"),
     };
@@ -219,8 +219,7 @@ async fn check_aeap_transition(
 
     tcm.section("Check that the AEAP transition worked");
     check_that_transition_worked(
-        // The transition is only done in the chat where the message was sent for now:
-        &[recvd.chat_id],
+        &groups,
         &alice,
         "alice@example.org",
         ALICE_NEW_ADDR,
@@ -247,8 +246,7 @@ async fn check_aeap_transition(
     assert_eq!(recvd.text.unwrap(), "Hello from my old addr!");
 
     check_that_transition_worked(
-        // The transition is only done in the chat where the message was sent for now:
-        &[recvd.chat_id],
+        &groups,
         &alice,
         // Note that "alice@example.org" and ALICE_NEW_ADDR are switched now:
         ALICE_NEW_ADDR,


### PR DESCRIPTION
#3491 introduced a bug that your address is only replaced in the first group you write to, which was rather hard to fix. In order to be able to release something, we agreed to revert it and instead only replace the contacts in verified groups (and in broadcast lists, if the signing key is verified).

More ideas for later:

- dkim verification to generally make from-forgery harder (and we could use it as a neccessary signal for autocrypt key changes) (see #3507 and #3508)
- making the AEAP change into an interactive UX: if you change your address and post to an opportunistic group, someone will have to say "ok, perform the transition" and will then send an added/removed message. this requires UI changes/additions.
- tracking when autocrypt keys changed and how often a key was used -- if it's not used enough AEAP-transition will be rejected on the receiving side.

(partly quoting @hpk42 here)

Depends on #3505.