### PR TITLE
python bindings: move account initialization to separate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Adds
+- python bindings: extra method to get an account running
+
 ### Changes
 - refactorings #3437
 

--- a/python/src/deltachat/__init__.py
+++ b/python/src/deltachat/__init__.py
@@ -60,29 +60,10 @@ def run_cmdline(argv=None, account_plugins=None):
 
     ac = Account(args.db)
 
-    if args.show_ffi:
-        ac.set_config("displayname", "bot")
-        log = events.FFIEventLogger(ac)
-        ac.add_account_plugin(log)
-
-    for plugin in account_plugins or []:
-        print("adding plugin", plugin)
-        ac.add_account_plugin(plugin)
-
-    if not ac.is_configured():
-        assert (
-            args.email and args.password
-        ), "you must specify --email and --password once to configure this database/account"
-        ac.set_config("addr", args.email)
-        ac.set_config("mail_pw", args.password)
-        ac.set_config("mvbox_move", "0")
-        ac.set_config("sentbox_watch", "0")
-        ac.set_config("bot", "1")
-        configtracker = ac.configure()
-        configtracker.wait_finish()
-
-    # start IO threads and configure if neccessary
-    ac.start_io()
+    ac.run_account(addr=args.email,
+                   password=args.password,
+                   account_plugins=account_plugins,
+                   show_ffi=args.show_ffi)
 
     print("{}: waiting for message".format(ac.get_config("addr")))
 

--- a/python/src/deltachat/__init__.py
+++ b/python/src/deltachat/__init__.py
@@ -60,10 +60,7 @@ def run_cmdline(argv=None, account_plugins=None):
 
     ac = Account(args.db)
 
-    ac.run_account(addr=args.email,
-                   password=args.password,
-                   account_plugins=account_plugins,
-                   show_ffi=args.show_ffi)
+    ac.run_account(addr=args.email, password=args.password, account_plugins=account_plugins, show_ffi=args.show_ffi)
 
     print("{}: waiting for message".format(ac.get_config("addr")))
 

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -616,9 +616,7 @@ class Account(object):
             self.add_account_plugin(plugin)
 
         if not self.is_configured():
-            assert (
-                    addr and password
-            ), "you must specify email and password once to configure this database/account"
+            assert addr and password, "you must specify email and password once to configure this database/account"
             self.set_config("addr", addr)
             self.set_config("mail_pw", password)
             self.set_config("mvbox_move", "0")

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -20,7 +20,7 @@ from .cutil import (
     from_optional_dc_charpointer,
     iter_array,
 )
-from .events import EventThread
+from .events import EventThread, FFIEventLogger
 from .message import Message
 from .tracker import ConfigureTracker, ImexTracker
 
@@ -597,6 +597,38 @@ class Account(object):
     #
     # meta API for start/stop and event based processing
     #
+
+    def run_account(self, addr=None, password=None, account_plugins=None, show_ffi=False):
+        """get the account running, configure it if necessary. add plugins if provided.
+
+        :param addr: the email address of the account
+        :param password: the password of the account
+        :param account_plugins: a list of plugins to add
+        :param show_ffi: show low level ffi events
+        """
+        if show_ffi:
+            self.set_config("displayname", "bot")
+            log = FFIEventLogger(self)
+            self.add_account_plugin(log)
+
+        for plugin in account_plugins or []:
+            print("adding plugin", plugin)
+            self.add_account_plugin(plugin)
+
+        if not self.is_configured():
+            assert (
+                    addr and password
+            ), "you must specify email and password once to configure this database/account"
+            self.set_config("addr", addr)
+            self.set_config("mail_pw", password)
+            self.set_config("mvbox_move", "0")
+            self.set_config("sentbox_watch", "0")
+            self.set_config("bot", "1")
+            configtracker = self.configure()
+            configtracker.wait_finish()
+
+        # start IO threads and configure if neccessary
+        self.start_io()
 
     def add_account_plugin(self, plugin, name=None):
         """add an account plugin which implements one or more of


### PR DESCRIPTION
`run_cmdline()` is a really useful function - so useful that I re-implemented it two times already:

- https://github.com/deltachat/eppdperf/blob/main/src/eppdperf/analysis.py#L288
- https://github.com/deltachat/mailadm/blob/bot-refactored/src/mailadm/cmdline.py#L69

In both cases I would have loved to use it, but as the bot was only part of a larger project and was started from python code instead of a bash command line, I couldn't use it.

This PR reduces `run_cmdline()` to a thin wrapper, which only calls `account.run_account()`, the function which now does the useful configure and start_io calls.

`tests/test_1_online.py::test_set_get_group_image` also fails on master, don't know what's up there.