### PR TITLE
add ffi to get mailinglist post address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### API-Changes
+- add `dc_chat_get_mailinglist_addr()` #3520
+
 ### Added
 
 ### Changes

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3258,6 +3258,19 @@ int             dc_chat_get_type             (const dc_chat_t* chat);
 
 
 /**
+ * Returns the address where messages are sent to if the chat is a mailing list.
+ * If you just want to know if a mailing list can be written,
+ * use dc_chat_can_send() instead.
+ *
+ * @memberof dc_chat_t
+ * @param chat The chat object.
+ * @return The mailing list address. Must be released using dc_str_unref() after usage.
+ *     If there is no such address, an empty string is returned, NULL is never returned.
+ */
+char*           dc_chat_get_mailinglist_addr (const dc_chat_t* chat);
+
+
+/**
  * Get name of a chat. For one-to-one chats, this is the name of the contact.
  * For group chats, this is the name given e.g. to dc_create_group_chat() or
  * received by a group-creation message.

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3259,7 +3259,7 @@ int             dc_chat_get_type             (const dc_chat_t* chat);
 
 /**
  * Returns the address where messages are sent to if the chat is a mailing list.
- * If you just want to know if a mailing list can be written,
+ * If you just want to know if a mailing list can be written to,
  * use dc_chat_can_send() instead.
  *
  * @memberof dc_chat_t

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2782,6 +2782,16 @@ pub unsafe extern "C" fn dc_chat_get_name(chat: *mut dc_chat_t) -> *mut libc::c_
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_chat_get_mailinglist_addr(chat: *mut dc_chat_t) -> *mut libc::c_char {
+    if chat.is_null() {
+        eprintln!("ignoring careless call to dc_chat_get_mailinglist_addr()");
+        return "".strdup();
+    }
+    let ffi_chat = &*chat;
+    ffi_chat.chat.get_mailinglist_addr().strdup()
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_chat_get_profile_image(chat: *mut dc_chat_t) -> *mut libc::c_char {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_get_profile_image()");

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1129,6 +1129,11 @@ impl Chat {
         &self.name
     }
 
+    /// Returns mailing list address where messages are sent to.
+    pub fn get_mailinglist_addr(&self) -> &str {
+        self.param.get(Param::ListPost).unwrap_or_default()
+    }
+
     /// Returns profile image path for the chat.
     pub async fn get_profile_image(&self, context: &Context) -> Result<Option<PathBuf>> {
         if let Some(image_rel) = self.param.get(Param::ProfileImage) {

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2932,6 +2932,10 @@ mod tests {
 
         assert!(chat.is_mailing_list());
         assert!(chat.can_send(&t.ctx).await?);
+        assert_eq!(
+            chat.get_mailinglist_addr(),
+            "reply+elernshsetushoyseshetihseusaferuhsedtisneu@reply.github.com"
+        );
         assert_eq!(chat.name, "deltachat/deltachat-core-rust");
         assert_eq!(chat::get_chat_contacts(&t.ctx, chat_id).await?.len(), 1);
 
@@ -2939,6 +2943,7 @@ mod tests {
 
         let chat = chat::Chat::load_from_db(&t.ctx, chat_id).await?;
         assert!(!chat.can_send(&t.ctx).await?);
+        assert_eq!(chat.get_mailinglist_addr(), "");
 
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await?;
         assert_eq!(chats.len(), 1);
@@ -2997,6 +3002,7 @@ mod tests {
         let chat = Chat::load_from_db(&t.ctx, chat_id).await.unwrap();
         assert_eq!(chat.name, "delta-dev");
         assert!(chat.can_send(&t).await?);
+        assert_eq!(chat.get_mailinglist_addr(), "delta@codespeak.net");
 
         let msg = get_chat_msg(&t, chat_id, 0, 1).await;
         let contact1 = Contact::load_from_db(&t.ctx, msg.from_id).await.unwrap();
@@ -3225,7 +3231,7 @@ Hello mailinglist!\r\n"
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_majordomo_mailing_list() {
+    async fn test_majordomo_mailing_list() -> Result<()> {
         let t = TestContext::new_alice().await;
         t.set_config(Config::ShowEmails, Some("2")).await.unwrap();
 
@@ -3252,6 +3258,8 @@ Hello mailinglist!\r\n"
         assert_eq!(chat.grpid, "mylist@bar.org");
         assert_eq!(chat.name, "ola");
         assert_eq!(chat::get_chat_msgs(&t, chat.id, 0).await.unwrap().len(), 1);
+        assert!(!chat.can_send(&t).await?);
+        assert_eq!(chat.get_mailinglist_addr(), "");
 
         // receive another message with no sender name but the same address,
         // make sure this lands in the same chat
@@ -3271,10 +3279,12 @@ Hello mailinglist!\r\n"
         .await
         .unwrap();
         assert_eq!(chat::get_chat_msgs(&t, chat.id, 0).await.unwrap().len(), 2);
+
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_mailchimp_mailing_list() {
+    async fn test_mailchimp_mailing_list() -> Result<()> {
         let t = TestContext::new_alice().await;
         t.set_config(Config::ShowEmails, Some("2")).await.unwrap();
 
@@ -3301,10 +3311,14 @@ Hello mailinglist!\r\n"
             "399fc0402f1b154b67965632e.100761.list-id.mcsv.net"
         );
         assert_eq!(chat.name, "Atlas Obscura");
+        assert!(!chat.can_send(&t).await?);
+        assert_eq!(chat.get_mailinglist_addr(), "");
+
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_dhl_mailing_list() {
+    async fn test_dhl_mailing_list() -> Result<()> {
         let t = TestContext::new_alice().await;
         t.set_config(Config::ShowEmails, Some("2")).await.unwrap();
 
@@ -3326,10 +3340,14 @@ Hello mailinglist!\r\n"
         assert_eq!(chat.blocked, Blocked::Request);
         assert_eq!(chat.grpid, "1234ABCD-123LMNO.mailing.dhl.de");
         assert_eq!(chat.name, "DHL Paket");
+        assert!(!chat.can_send(&t).await?);
+        assert_eq!(chat.get_mailinglist_addr(), "");
+
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_dpd_mailing_list() {
+    async fn test_dpd_mailing_list() -> Result<()> {
         let t = TestContext::new_alice().await;
         t.set_config(Config::ShowEmails, Some("2")).await.unwrap();
 
@@ -3351,6 +3369,10 @@ Hello mailinglist!\r\n"
         assert_eq!(chat.blocked, Blocked::Request);
         assert_eq!(chat.grpid, "dpdde.mxmail.service.dpd.de");
         assert_eq!(chat.name, "DPD");
+        assert!(!chat.can_send(&t).await?);
+        assert_eq!(chat.get_mailinglist_addr(), "");
+
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -3368,6 +3390,8 @@ Hello mailinglist!\r\n"
         assert_eq!(chat.typ, Chattype::Mailinglist);
         assert_eq!(chat.grpid, "96540.xt.local");
         assert_eq!(chat.name, "Microsoft Store");
+        assert!(!chat.can_send(&t).await?);
+        assert_eq!(chat.get_mailinglist_addr(), "");
 
         receive_imf(
             &t,
@@ -3379,6 +3403,8 @@ Hello mailinglist!\r\n"
         assert_eq!(chat.typ, Chattype::Mailinglist);
         assert_eq!(chat.grpid, "121231234.xt.local");
         assert_eq!(chat.name, "DER SPIEGEL Kundenservice");
+        assert!(!chat.can_send(&t).await?);
+        assert_eq!(chat.get_mailinglist_addr(), "");
 
         Ok(())
     }
@@ -3400,6 +3426,8 @@ Hello mailinglist!\r\n"
         assert_eq!(chat.typ, Chattype::Mailinglist);
         assert_eq!(chat.grpid, "51231231231231231231231232869f58.xing.com");
         assert_eq!(chat.name, "xing.com");
+        assert!(!chat.can_send(&t).await?);
+        assert_eq!(chat.get_mailinglist_addr(), "");
 
         Ok(())
     }


### PR DESCRIPTION
that bit was missing. in the ui, the address could be shown in the profile somewhere, this is how it looks like on ios with https://github.com/deltachat/deltachat-ios/pull/1654:

<img width=320 src=https://user-images.githubusercontent.com/9800740/180881594-4773b3db-1713-4eec-8a61-dd6c54719fd6.jpg>

if it turns out, the addresses are quite readable most times, on desktop, maybe we can add them to the chat's subtitle directly eg. as `Mailing list - delta@codespeak.net` in this case.