### PR TITLE
prepare 1.92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,17 @@
 
 ## Unreleased
 
-### API-Changes
-- add `dc_chat_get_mailinglist_addr()` #3520
-
 ### Added
 
 ### Changes
 
 ### Fixes
+
+
+## 1.92.0
+
+### API-Changes
+- add `dc_chat_get_mailinglist_addr()` #3520
 
 
 ## 1.91.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.91.0"
+version = "1.92.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.91.0"
+version = "1.92.0"
 dependencies = [
  "anyhow",
  "deltachat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.91.0"
+version = "1.92.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.91.0"
+version = "1.92.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"

--- a/package.json
+++ b/package.json
@@ -60,5 +60,5 @@
     "test:mocha": "mocha -r esm node/test/test.js --growl --reporter=spec --bail"
   },
   "types": "node/dist/index.d.ts",
-  "version": "1.91.0"
+  "version": "1.92.0"
 }


### PR DESCRIPTION
this pulls in the mailinglist api from https://github.com/deltachat/deltachat-core-rust/pull/3524, we'd like to have that feature in the currently prepared ios 1.32 version.

after commit, on master make sure to: 

   git tag -a 1.92.0
   git push origin 1.92.0
   git tag -a py-1.92.0
   git push origin py-1.92.0