### PR TITLE
python: don't raise an error if addr changes

### DIFF
--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -169,8 +169,6 @@ class Account(object):
         """
         self._check_config_key(name)
         namebytes = name.encode("utf8")
-        if namebytes == b"addr" and self.is_configured():
-            raise ValueError("can not change 'addr' after account is configured.")
         if isinstance(value, (int, bool)):
             value = str(int(value))
         if value is not None:

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -708,8 +708,9 @@ class Account(object):
         """Start configuration process and return a Configtracker instance
         on which you can block with wait_finish() to get a True/False success
         value for the configuration process.
+
+        :param reconfigure: deprecated, doesn't need to be checked anymore.
         """
-        assert self.is_configured() == reconfigure
         if not self.get_config("addr") or not self.get_config("mail_pw"):
             raise MissingCredentials("addr or mail_pwd not set in config")
         configtracker = ConfigureTracker(self)

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -2075,6 +2075,7 @@ def test_aeap_flow_verified(acfactory, lp):
     ac2._evtracker.wait_next_incoming_message()  # member added message
     msg_in_1 = ac2._evtracker.wait_next_incoming_message()
     assert msg_in_1.text == msg_out.text
+    contact_of_1 = msg_in_1.get_sender_contact()
 
     lp.sec("changing email account")
     ac1.set_config("addr", ac1new.get_config("addr"))
@@ -2092,6 +2093,7 @@ def test_aeap_flow_verified(acfactory, lp):
     assert msg_in_2.text == msg_out.text
     assert msg_in_2.chat.id == msg_in_1.chat.id
     assert msg_in_2.get_sender_contact().addr == ac1new.get_config("addr")
+    assert msg_in_2.get_sender_contact().id is contact_of_1.id
     assert len(msg_in_2.chat.get_contacts()) == 2
     assert ac1new.get_config("addr") in [contact.addr for contact in msg_in_2.chat.get_contacts()]
 

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -2075,7 +2075,6 @@ def test_aeap_flow_verified(acfactory, lp):
     ac2._evtracker.wait_next_incoming_message()  # member added message
     msg_in_1 = ac2._evtracker.wait_next_incoming_message()
     assert msg_in_1.text == msg_out.text
-    contact_of_1 = msg_in_1.get_sender_contact()
 
     lp.sec("changing email account")
     ac1.set_config("addr", ac1new.get_config("addr"))
@@ -2093,7 +2092,6 @@ def test_aeap_flow_verified(acfactory, lp):
     assert msg_in_2.text == msg_out.text
     assert msg_in_2.chat.id == msg_in_1.chat.id
     assert msg_in_2.get_sender_contact().addr == ac1new.get_config("addr")
-    assert msg_in_2.get_sender_contact().id is contact_of_1.id
     assert len(msg_in_2.chat.get_contacts()) == 2
     assert ac1new.get_config("addr") in [contact.addr for contact in msg_in_2.chat.get_contacts()]
 

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -2055,15 +2055,24 @@ def test_delete_deltachat_folder(acfactory):
     assert "DeltaChat" in ac1.direct_imap.list_folders()
 
 
-def test_aeap_flow_unverified(acfactory, lp):
+def test_aeap_flow_verified(acfactory, lp):
     """Test that a new address is added to a contact when it changes its address."""
     ac1, ac2, ac1new = acfactory.get_online_accounts(3)
-    chat = acfactory.get_accepted_chat(ac1, ac2)
+
+    lp.sec("ac1: create verified-group QR, ac2 scans and joins")
+    chat = ac1.create_group_chat("hello", verified=True)
+    assert chat.is_protected()
+    qr = chat.get_join_qr()
+    lp.sec("ac2: start QR-code based join-group protocol")
+    chat2 = ac2.qr_join_chat(qr)
+    assert chat2.id >= 10
+    ac1._evtracker.wait_securejoin_inviter_progress(1000)
 
     lp.sec("sending first message")
     msg_out = chat.send_text("old address")
 
     lp.sec("receiving first message")
+    ac2._evtracker.wait_next_incoming_message()  # member added message
     msg_in_1 = ac2._evtracker.wait_next_incoming_message()
     assert msg_in_1.text == msg_out.text
 
@@ -2081,8 +2090,10 @@ def test_aeap_flow_unverified(acfactory, lp):
     lp.sec("receiving second message")
     msg_in_2 = ac2._evtracker.wait_next_incoming_message()
     assert msg_in_2.text == msg_out.text
-    #assert msg_in_2.chat.id == msg_in_1.chat.id
-    assert msg_in_2.get_sender_contact() == msg_in_1.get_sender_contact()
+    assert msg_in_2.chat.id == msg_in_1.chat.id
+    assert msg_in_2.get_sender_contact().addr == ac1new.get_config("addr")
+    assert len(msg_in_2.chat.get_contacts()) == 2
+    assert ac1new.get_config("addr") in [contact.addr for contact in msg_in_2.chat.get_contacts()]
 
 
 class TestOnlineConfigureFails:

--- a/python/tests/test_3_offline.py
+++ b/python/tests/test_3_offline.py
@@ -497,12 +497,6 @@ class TestOfflineChat:
         contact = msg.get_sender_contact()
         assert contact == ac1.get_self_contact()
 
-    def test_set_config_after_configure_is_forbidden(self, ac1):
-        assert ac1.get_config("mail_pw")
-        assert ac1.is_configured()
-        with pytest.raises(ValueError):
-            ac1.set_config("addr", "123@example.org")
-
     def test_import_export_on_unencrypted_acct(self, acfactory, tmpdir):
         backupdir = tmpdir.mkdir("backup")
         ac1 = acfactory.get_pseudo_configured_account()


### PR DESCRIPTION
closes #3529 

...actually, I'm not sure if it is this easy. Maybe we should add some more tests if the AEAP change goes fine. What would be proper test cases?