### PR TITLE
scripts/coverage.sh: enable -Cdebuginfo=2

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -17,7 +17,7 @@ export RUSTC_BOOTSTRAP=1
 # [2] https://github.com/mozilla/grcov/issues/595
 
 export CARGO_INCREMENTAL=0
-export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort"
+export RUSTFLAGS="-Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests -Cpanic=abort -Cdebuginfo=2"
 export RUSTDOCFLAGS="-Cpanic=abort"
 cargo clean
 cargo build


### PR DESCRIPTION
It is needed to generate .gcno and .gcda files.

Debug info has been disabled in a8c389c3b476a14f96453917622f1be1c7d69172
which broke coverage script.