### PR TITLE
rename strum::EnumProperty to avoid name conflict

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 //! # Key-value configuration management.
 
 use anyhow::{ensure, Context as _, Result};
-use strum::{EnumProperty, IntoEnumIterator};
+use strum::{EnumProperty as EnumPropertyTrait, IntoEnumIterator};
 use strum_macros::{AsRefStr, Display, EnumIter, EnumProperty, EnumString};
 
 use crate::blob::BlobObject;

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -4,7 +4,7 @@ use std::future::Future;
 use std::pin::Pin;
 
 use anyhow::{bail, Error};
-use strum::EnumProperty;
+use strum::EnumProperty as EnumPropertyTrait;
 use strum_macros::EnumProperty;
 
 use crate::blob::BlobObject;


### PR DESCRIPTION
My project uses `deltachat-core-rust` as a dependency and I encountered a build error in a specific situation.
When some crates in the dependency tree enables `derive` feature in `strum` crate, the following error occurs:

```
error[E0252]: the name `EnumProperty` is defined multiple times
 --> /home/picoHz/.cargo/git/checkouts/deltachat-core-rust-632648ad67f90089/50e53f2/src/config.rs:5:49
  |
4 | use strum::{EnumProperty, IntoEnumIterator};
  |             ------------ previous import of the macro `EnumProperty` here
5 | use strum_macros::{AsRefStr, Display, EnumIter, EnumProperty, EnumString};
  |                                                 ^^^^^^^^^^^^--
  |                                                 |
  |                                                 `EnumProperty` reimported here
  |                                                 help: remove unnecessary import
  |
  = note: `EnumProperty` must be defined only once in the macro namespace of this module

error[E0252]: the name `EnumProperty` is defined multiple times
 --> /home/picoHz/.cargo/git/checkouts/deltachat-core-rust-632648ad67f90089/50e53f2/src/stock_str.rs:8:5       
  |
7 | use strum::EnumProperty;
  |     ------------------- previous import of the macro `EnumProperty` here
8 | use strum_macros::EnumProperty;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^ `EnumProperty` reimported here
  |
  = note: `EnumProperty` must be defined only once in the macro namespace of this module
```

This issue is hard to fix when the dependency tree is complicated, so I made this PR to avoid the error.