### PR TITLE
Clippy fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --workspace --tests --examples --benches
+          args: --workspace --tests --examples --benches --features repl -- -D warnings
 
   docs:
     name: Rust doc comments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - added a JSON RPC API, accessible through a WebSocket server, the CFFI bindings and the Node.js bindings #3463
 
 ### Changes
-- refactorings #3545
+- refactorings #3545 #3551
 - use [pathlib](https://docs.python.org/3/library/pathlib.html) in provider update script #3543
 
 ### Fixes

--- a/examples/repl/cmdline.rs
+++ b/examples/repl/cmdline.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::format_push_string)]
 extern crate dirs;
 
 use std::path::Path;

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -33,7 +33,7 @@ impl Accounts {
     }
 
     /// Creates a new default structure.
-    pub async fn create(dir: &PathBuf) -> Result<()> {
+    pub async fn create(dir: &Path) -> Result<()> {
         fs::create_dir_all(dir)
             .await
             .context("failed to create folder")?;
@@ -580,7 +580,7 @@ mod tests {
             let ids = accounts.get_all().await;
             assert_eq!(ids.len(), 1);
 
-            let id0 = *ids.get(0).unwrap();
+            let id0 = *ids.first().unwrap();
             let ctx = accounts.get_account(id0).await.unwrap();
             ctx.set_config(crate::config::Config::Addr, Some("one@example.org"))
                 .await?;
@@ -620,7 +620,7 @@ mod tests {
             let ids = accounts.get_all().await;
             assert_eq!(ids.len(), 3);
 
-            let id0 = *ids.get(0).unwrap();
+            let id0 = *ids.first().unwrap();
             let ctx = accounts.get_account(id0).await.unwrap();
             assert_eq!(
                 ctx.get_config(crate::config::Config::Addr).await?,

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -738,7 +738,7 @@ mod tests {
         check_image_size(avatar_src, 1000, 1000);
         check_image_size(&avatar_blob, BALANCED_AVATAR_SIZE, BALANCED_AVATAR_SIZE);
 
-        async fn file_size(path_buf: &PathBuf) -> u64 {
+        async fn file_size(path_buf: &Path) -> u64 {
             let file = File::open(path_buf).await.unwrap();
             file.metadata().await.unwrap().len()
         }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -40,7 +40,7 @@ use crate::webxdc::WEBXDC_SUFFIX;
 use crate::{location, sql};
 
 /// An chat item, such as a message or a marker.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ChatItem {
     Message {
         msg_id: MsgId,
@@ -2786,7 +2786,7 @@ pub(crate) async fn shall_attach_selfavatar(context: &Context, chat_id: ChatId) 
     Ok(needs_attach)
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MuteDuration {
     NotMuted,
     Forever,

--- a/src/color.rs
+++ b/src/color.rs
@@ -11,7 +11,7 @@ use sha1::{Digest, Sha1};
 fn str_to_angle(s: &str) -> f64 {
     let bytes = s.as_bytes();
     let result = Sha1::digest(bytes);
-    let checksum: u16 = result.get(0).map_or(0, |&x| u16::from(x))
+    let checksum: u16 = result.first().map_or(0, |&x| u16::from(x))
         + 256 * result.get(1).map_or(0, |&x| u16::from(x));
     f64::from(checksum) / 65536.0 * 360.0
 }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1429,7 +1429,7 @@ fn split_address_book(book: &str) -> Vec<(&str, &str)> {
         .chunks(2)
         .into_iter()
         .filter_map(|chunk| {
-            let name = chunk.get(0)?;
+            let name = chunk.first()?;
             let addr = chunk.get(1)?;
             Some((*name, *addr))
         })

--- a/src/job.rs
+++ b/src/job.rs
@@ -69,7 +69,7 @@ pub enum Action {
     ResyncFolders = 300,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Job {
     pub job_id: u32,
     pub action: Action,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 )]
 #![allow(
     clippy::match_bool,
-    clippy::eval_order_dependence,
+    clippy::mixed_read_write_in_expression,
     clippy::bool_assert_comparison,
     clippy::manual_split_once,
     clippy::format_push_string

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -39,7 +39,7 @@ impl Default for CertificateChecks {
 }
 
 /// Login parameters for a single server, either IMAP or SMTP
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct ServerLoginParam {
     pub server: String,
     pub user: String,
@@ -53,7 +53,7 @@ pub struct ServerLoginParam {
     pub certificate_checks: CertificateChecks,
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct Socks5Config {
     pub host: String,
     pub port: u16,
@@ -128,7 +128,7 @@ impl fmt::Display for Socks5Config {
     }
 }
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct LoginParam {
     pub addr: String,
     pub imap: ServerLoginParam,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use chrono::{NaiveDateTime, NaiveTime};
 use trust_dns_resolver::{config, AsyncResolver, TokioAsyncResolver};
 
-#[derive(Debug, Display, Copy, Clone, PartialEq, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Display, Copy, Clone, PartialEq, Eq, FromPrimitive, ToPrimitive)]
 #[repr(u8)]
 pub enum Status {
     Ok = 1,
@@ -17,14 +17,14 @@ pub enum Status {
     Broken = 3,
 }
 
-#[derive(Debug, Display, PartialEq, Copy, Clone, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Display, PartialEq, Eq, Copy, Clone, FromPrimitive, ToPrimitive)]
 #[repr(u8)]
 pub enum Protocol {
     Smtp = 1,
     Imap = 2,
 }
 
-#[derive(Debug, Display, PartialEq, Copy, Clone, FromPrimitive, ToPrimitive)]
+#[derive(Debug, Display, PartialEq, Eq, Copy, Clone, FromPrimitive, ToPrimitive)]
 #[repr(u8)]
 pub enum Socket {
     Automatic = 0,
@@ -39,21 +39,21 @@ impl Default for Socket {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[repr(u8)]
 pub enum UsernamePattern {
     Email = 1,
     Emaillocalpart = 2,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Oauth2Authorizer {
     Yandex = 1,
     Gmail = 2,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Server {
     pub protocol: Protocol,
     pub socket: Socket,
@@ -62,13 +62,13 @@ pub struct Server {
     pub username_pattern: UsernamePattern,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ConfigDefault {
     pub key: Config,
     pub value: &'static str,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Provider {
     /// Unique ID, corresponding to provider database filename.
     pub id: &'static str,

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -27,7 +27,7 @@ const SMTP_SCHEME: &str = "SMTP:";
 const HTTP_SCHEME: &str = "http://";
 const HTTPS_SCHEME: &str = "https://";
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Qr {
     AskVerifyContact {
         contact_id: ContactId,

--- a/src/securejoin/bobstate.rs
+++ b/src/securejoin/bobstate.rs
@@ -342,20 +342,19 @@ impl BobState {
                 true
             }
             QrInvite::Group { ref grpid, .. } => {
-                // This is buggy, is_verified_group will always be
+                // This is buggy, result will always be
                 // false since the group is created by receive_imf for
                 // the very handshake message we're handling now.  But
                 // only after we have returned.  It does not impact
                 // the security invariants of secure-join however.
 
-                let is_verified_group = chat::get_chat_id_by_grpid(context, grpid)
+                chat::get_chat_id_by_grpid(context, grpid)
                     .await?
-                    .map_or(false, |(_chat_id, is_protected, _blocked)| is_protected);
+                    .map_or(false, |(_chat_id, is_protected, _blocked)| is_protected)
                 // when joining a non-verified group
                 // the vg-member-added message may be unencrypted
                 // when not all group members have keys or prefer encryption.
                 // So only expect encryption if this is a verified group
-                is_verified_group
             }
         };
         if vg_expect_encrypted
@@ -501,7 +500,7 @@ impl BobHandshakeMsg {
 }
 
 /// The next message expected by [`BobState`] in the setup-contact/secure-join protocol.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SecureJoinStep {
     /// Expecting the auth-required message.
     ///

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -1,7 +1,7 @@
 //! # Handle webxdc messages.
 
 use std::convert::TryFrom;
-use std::path::PathBuf;
+use std::path::Path;
 
 use anyhow::{anyhow, bail, ensure, format_err, Result};
 use deltachat_derive::FromSql;
@@ -171,7 +171,7 @@ impl Context {
 
     /// ensure that a file is an acceptable webxdc for sending
     /// (sending has more strict size limits).
-    pub(crate) async fn ensure_sendable_webxdc_file(&self, path: &PathBuf) -> Result<()> {
+    pub(crate) async fn ensure_sendable_webxdc_file(&self, path: &Path) -> Result<()> {
         let filename = path.to_str().unwrap_or_default();
         if !filename.ends_with(WEBXDC_SUFFIX) {
             bail!("{} is not a valid webxdc file", filename);


### PR DESCRIPTION
Turn clippy warnings into errors in CI, check `repl` feature and fix some warnings related to `PathBuf`.

I think the problem with warnings being ignored was introduced in #3441, which turned errors into warnings by default, but did not update CI to keep treating warnings as errors. `RUSTFLAGS=-Dwarnings` seems to affect compiler errors, but not clippy errors.