### PR TITLE
Make initiate_key_transfer() non-blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@
 - jsonrpc: add `last_seen` property to `Contact` #3590
 - breaking! jsonrpc: replace `Message.quoted_text` and `Message.quoted_message_id` with `Message.quote` #3590
 - add separate stock strings for actions done by contacts to make them easier to translate #3518
+- `dc_initiate_key_transfer()` is non-blocking now. #3553
+  UIs don't need to display a button to cancel sending Autocrypt Setup Message with
+  `dc_stop_ongoing_process()` anymore.
 
 ### Changes
 - order contact lists by "last seen";

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2174,11 +2174,10 @@ char*           dc_imex_has_backup           (dc_context_t* context, const char*
  * ~~~
  *
  * After that, this function should be called to send the Autocrypt Setup Message.
- * The function creates the setup message and waits until it is really sent.
- * As this may take a while, it is recommended to start the function in a separate thread;
- * to interrupt it, you can use dc_stop_ongoing_process().
+ * The function creates the setup message and adds it to outgoing message queue.
+ * The message is sent asynchronously.
  *
- * After everything succeeded, the required setup code is returned in the following format:
+ * The required setup code is returned in the following format:
  *
  * ~~~
  * 1234-1234-1234-1234-1234-1234-1234-1234-1234
@@ -2244,8 +2243,8 @@ int             dc_continue_key_transfer     (dc_context_t* context, uint32_t ms
  * The ongoing process will return ASAP then, however, it may
  * still take a moment.
  *
- * Typical ongoing processes are started by dc_configure(),
- * dc_initiate_key_transfer() or dc_imex(). As there is always at most only
+ * Typical ongoing processes are started by dc_configure()
+ * or dc_imex(). As there is always at most only
  * one onging process at the same time, there is no need to define _which_ process to exit.
  *
  * @memberof dc_context_t

--- a/src/context.rs
+++ b/src/context.rs
@@ -346,6 +346,7 @@ impl Context {
         }
     }
 
+    #[allow(unused)]
     pub(crate) async fn shall_stop_ongoing(&self) -> bool {
         match &*self.running_state.read().await {
             RunningState::Running { .. } => false,


### PR DESCRIPTION
This requires change in the UI to stop displaying a button for `dc_stop_ongoing_process()`. The message is simply added to the sending queue without waiting until the message is sent, so user is presented with the code immediately.

Waiting until the message is sent is not so useful because you have to wait until the message arrives on the other device anyway, and it may be disconnected, have bad connectivity etc. even if you made sure Autocrypt Setup Message got to the server.