### PR TITLE
prepare 1.93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,28 +3,37 @@
 ## Unreleased
 
 ### API-Changes
-- jsonrpc api over websocket server (basically a new api next to the cffi) #3463
-- jsonrpc methods in cffi #3463: 
+
+### Changes
+
+### Fixes
+
+
+## 1.93.0
+
+### API-Changes
+- added a JSON RPC API, accessible through a WebSocket server, the CFFI bindings and the Node.js bindings #3463 #3554 #3542
+- JSON RPC methods in CFFI #3463:
  - `dc_jsonrpc_instance_t* dc_jsonrpc_init(dc_accounts_t* account_manager);`
  - `void dc_jsonrpc_unref(dc_jsonrpc_instance_t* jsonrpc_instance);`
  - `void dc_jsonrpc_request(dc_jsonrpc_instance_t* jsonrpc_instance, char* request);`
  - `char* dc_jsonrpc_next_response(dc_jsonrpc_instance_t* jsonrpc_instance);`
-- node: json rpc methods #3463:
+- node: JSON RPC methods #3463:
  - `AccountManager.prototype.startJsonRpcHandler(callback: ((response: string) => void)): void`
  - `AccountManager.prototype.jsonRpcRequest(message: string): void`
 
-### Added
-- added a JSON RPC API, accessible through a WebSocket server, the CFFI bindings and the Node.js bindings #3463
-
 ### Changes
-- jsonrpc: auto restart io on setConfig for the following keys `sentbox_watch`, `mvbox_move` and `only_fetch_mvbox` #3542
-- refactorings #3545 #3551
 - use [pathlib](https://docs.python.org/3/library/pathlib.html) in provider update script #3543
 - `dc_get_chat_media()` can return media globally #3528
+- node: add `getMailinglistAddr()` #3524
+- avoid duplicate encoded-words package and test `cargo vendor` in ci #3549
+- python: don't raise an error if addr changes #3530
+- improve coverage script #3530
 
 ### Fixes
 - improved error handling for account setup from qrcode #3474
 - python: enable certificate checks in cloned accounts #3443
+
 
 ## 1.92.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.92.0"
+version = "1.93.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.92.0"
+version = "1.93.0"
 dependencies = [
  "anyhow",
  "deltachat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.92.0"
+version = "1.93.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.92.0"
+version = "1.93.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"

--- a/package.json
+++ b/package.json
@@ -61,5 +61,5 @@
     "test:mocha": "mocha -r esm node/test/test.js --growl --reporter=spec --bail"
   },
   "types": "node/dist/index.d.ts",
-  "version": "1.92.0"
+  "version": "1.93.0"
 }


### PR DESCRIPTION
this is mainly needed to release 1.32 for flathub, cmp. https://github.com/deltachat/deltachat-desktop/issues/2859 - but there are probably some more steps needed i am not aware of.

moreover, with 1.93 also JSON RPC gets released :)

after commit, on master make sure to: 

   git tag -a 1.93.0
   git push origin 1.93.0
   git tag -a py-1.93.0
   git push origin py-1.93.0