### PR TITLE
order contact lists by "last seen" instead of name/address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - add `dc_contact_was_seen_recently()` #3560
 
 ### Changes
+- order contact lists by "last seen";
+  this affects `dc_get_chat_contacts()`, `dc_get_contacts()` and `dc_get_blocked_contacts()` #3562
 
 ### Fixes
 - do not emit notifications for blocked chats #3557

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2525,7 +2525,7 @@ pub async fn get_chat_contacts(context: &Context, chat_id: ChatId) -> Result<Vec
                LEFT JOIN contacts c
                       ON c.id=cc.contact_id
               WHERE cc.chat_id=?
-              ORDER BY c.id=1, LOWER(c.name||c.addr), c.id;",
+              ORDER BY c.id=1, c.last_seen DESC, c.id DESC;",
             paramsv![chat_id],
             |row| row.get::<_, ContactId>(0),
             |ids| ids.collect::<Result<Vec<_>, _>>().map_err(Into::into),
@@ -5456,8 +5456,8 @@ mod tests {
         assert_eq!(
             chat_id.get_encryption_info(&alice).await?,
             "No encryption:\n\
-            bob@example.net\n\
-            fiona@example.net"
+            fiona@example.net\n\
+            bob@example.net"
         );
 
         let direct_chat = bob.create_chat(&alice).await;

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -716,7 +716,7 @@ impl Contact {
                  AND c.blocked=0 \
                  AND (iif(c.name='',c.authname,c.name) LIKE ? OR c.addr LIKE ?) \
                  AND (1=? OR LENGTH(ps.verified_key_fingerprint)!=0)  \
-                 ORDER BY LOWER(iif(c.name='',c.authname,c.name)||c.addr),c.id;",
+                 ORDER BY c.last_seen DESC, c.id DESC;",
                         sql::repeat_vars(self_addrs.len())
                     ),
                     rusqlite::params_from_iter(params_iter(&self_addrs).chain(params_iterv![
@@ -768,7 +768,7 @@ impl Contact {
                  AND id>?
                  AND origin>=?
                  AND blocked=0
-                 ORDER BY LOWER(iif(name='',authname,name)||addr),id;",
+                 ORDER BY last_seen DESC, id DESC;",
                         sql::repeat_vars(self_addrs.len())
                     ),
                     rusqlite::params_from_iter(params_iter(&self_addrs).chain(params_iterv![
@@ -857,7 +857,7 @@ impl Contact {
         let list = context
             .sql
             .query_map(
-                "SELECT id FROM contacts WHERE id>? AND blocked!=0 ORDER BY LOWER(iif(name='',authname,name)||addr),id;",
+                "SELECT id FROM contacts WHERE id>? AND blocked!=0 ORDER BY last_seen DESC, id DESC;",
                 paramsv![ContactId::LAST_SPECIAL],
                 |row| row.get::<_, ContactId>(0),
                 |ids| {


### PR DESCRIPTION
in several offline discussions, the idea shaped up to change the ordering of the contact lists from "a-z" to "last seen".

esp. with the new ["seen recently indicator"](https://github.com/deltachat/deltachat-android/pull/2371), the "new chat" and "member lists" seem to be more useful:

- no weird addresses/names as "-1" stucking atop of the "new chat" list forever
- recently used addresses are shown first, eg. when searching for @adbenitez , the first hit is the correct address (i have that with several ppl; when adding them to groups, it is always unclear what to use)
- together with the "seen recently indicator" you see with one glance, who is online - either in a group or globally
- just blocked contacts are shown atop of the list (important in case you accidentally blocked)
- the new ordering underlines the fact, that we actually do not have an "address book" - but more an "input helper" (less desires to delete weird, annoying entries as the top ones are usually known)
- EDIT: the "ordering by date" is already known from other lists - eg. also "chat list" and "shared chats" are ordered like that, so having all lists in a similar way feels quite natural

disadvantage, of course, is that you can no longer browse your contact list from "a" to "z" - however, tbh, i am not sure who ever did that and if this is a usecase we want to support. the contact list easily gets huge, and you typically need to use the search anyway - with the new ordering, i expect the search being used less often.  
of course, we could offer an option for getting the "a to z" ordering, however, it would be better without an option. maybe we should first use the new pr internally and maybe just see what happens if we release with the modification and if ppl really complain :)

as always, any comments welcome!

i am using this pr already locally on my ios installation and it already feels much more useful than before (although ios does not even have the "seen recently" indicator yet).