### PR TITLE
jsonrpc: add two functions, but they don't compile  yet, being not "threadsafe"

### DIFF
--- a/deltachat-jsonrpc/src/api/mod.rs
+++ b/deltachat-jsonrpc/src/api/mod.rs
@@ -793,6 +793,19 @@ impl CommandApi {
         }
         Ok(contacts)
     }
+
+    /// Get encryption info for a contact.
+    /// Get a multi-line encryption info, containing your fingerprint and the
+    /// fingerprint of the contact, used e.g. to compare the fingerprints for a simple out-of-band verification.
+    async fn get_contact_encryption_info(
+        &self,
+        account_id: u32,
+        contact_id: u32,
+    ) -> Result<String> {
+        let ctx = self.get_context(account_id).await?;
+        Contact::get_encrinfo(&ctx, ContactId::new(contact_id)).await
+    }
+
     // ---------------------------------------------
     //                   chat
     // ---------------------------------------------
@@ -856,6 +869,20 @@ impl CommandApi {
     async fn get_connectivity(&self, account_id: u32) -> Result<u32> {
         let ctx = self.get_context(account_id).await?;
         Ok(ctx.get_connectivity().await as u32)
+    }
+
+    /// Get an overview of the current connectivity, and possibly more statistics.
+    /// Meant to give the user more insight about the current status than
+    /// the basic connectivity info returned by get_connectivity(); show this
+    /// e.g., if the user taps on said basic connectivity info.
+    ///
+    /// If this page changes, a #DC_EVENT_CONNECTIVITY_CHANGED will be emitted.
+    ///
+    /// This comes as an HTML from the core so that we can easily improve it
+    /// and the improvement instantly reaches all UIs.
+    async fn get_connectivity_html(&self, account_id: u32) -> Result<String> {
+        let ctx = self.get_context(account_id).await?;
+        ctx.get_connectivity_html().await
     }
 
     // ---------------------------------------------

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -896,10 +896,11 @@ impl Contact {
                     EncryptPreference::Reset => stock_str::encr_none(context).await,
                 };
 
+                let finger_prints = stock_str::finger_prints(context).await;
                 ret += &format!(
                     "{}.\n{}:",
                     stock_message,
-                    stock_str::finger_prints(context).await
+                    finger_prints
                 );
 
                 let fingerprint_self = SignedPublicKey::load_self(context)

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -897,11 +897,7 @@ impl Contact {
                 };
 
                 let finger_prints = stock_str::finger_prints(context).await;
-                ret += &format!(
-                    "{}.\n{}:",
-                    stock_message,
-                    finger_prints
-                );
+                ret += &format!("{}.\n{}:", stock_message, finger_prints);
 
                 let fingerprint_self = SignedPublicKey::load_self(context)
                     .await?

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -434,10 +434,7 @@ impl Context {
         // =============================================================================================
 
         let outgoing_messages = stock_str::outgoing_messages(self).await;
-        ret += &format!(
-            "<h3>{}</h3><ul><li>",
-            outgoing_messages
-        );
+        ret += &format!("<h3>{}</h3><ul><li>", outgoing_messages);
         let detailed = smtp.get_detailed().await;
         ret += &*detailed.to_icon();
         ret += " ";
@@ -453,10 +450,7 @@ impl Context {
 
         let domain = tools::EmailAddress::new(&self.get_primary_self_addr().await?)?.domain;
         let storage_on_domain = stock_str::storage_on_domain(self, domain).await;
-        ret += &format!(
-            "<h3>{}</h3><ul>",
-            storage_on_domain
-        );
+        ret += &format!("<h3>{}</h3><ul>", storage_on_domain);
         let quota = self.quota.read().await;
         if let Some(quota) = &*quota {
             match &quota.recent {
@@ -478,11 +472,11 @@ impl Context {
 
                             let messages = stock_str::messages(self).await;
                             let part_of_total_used = stock_str::part_of_total_used(
-                                    self,
-                                    resource.usage.to_string(),
-                                    resource.limit.to_string()
-                                )
-                                .await;
+                                self,
+                                resource.usage.to_string(),
+                                resource.limit.to_string(),
+                            )
+                            .await;
                             ret += &match &resource.name {
                                 Atom(resource_name) => {
                                     format!(
@@ -492,11 +486,7 @@ impl Context {
                                     )
                                 }
                                 Message => {
-                                    format!(
-                                        "<b>{}:</b> {}",
-                                        part_of_total_used,
-                                        messages
-                                    )
+                                    format!("<b>{}:</b> {}", part_of_total_used, messages)
                                 }
                                 Storage => {
                                     // do not use a special title needed for "Storage":

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -390,7 +390,8 @@ impl Context {
         // =============================================================================================
 
         let watched_folders = get_watched_folder_configs(self).await?;
-        ret += &format!("<h3>{}</h3><ul>", stock_str::incoming_messages(self).await);
+        let incoming_messages = stock_str::incoming_messages(self).await;
+        ret += &format!("<h3>{}</h3><ul>", incoming_messages);
         for (folder, state) in &folders_states {
             let mut folder_added = false;
 
@@ -432,9 +433,10 @@ impl Context {
         //                                Your last message was sent successfully
         // =============================================================================================
 
+        let outgoing_messages = stock_str::outgoing_messages(self).await;
         ret += &format!(
             "<h3>{}</h3><ul><li>",
-            stock_str::outgoing_messages(self).await
+            outgoing_messages
         );
         let detailed = smtp.get_detailed().await;
         ret += &*detailed.to_icon();
@@ -450,9 +452,10 @@ impl Context {
         // =============================================================================================
 
         let domain = tools::EmailAddress::new(&self.get_primary_self_addr().await?)?.domain;
+        let storage_on_domain = stock_str::storage_on_domain(self, domain).await;
         ret += &format!(
             "<h3>{}</h3><ul>",
-            stock_str::storage_on_domain(self, domain).await
+            storage_on_domain
         );
         let quota = self.quota.read().await;
         if let Some(quota) = &*quota {
@@ -473,29 +476,26 @@ impl Context {
                                 info!(self, "connectivity: root name hidden: \"{}\"", root_name);
                             }
 
+                            let part_of_total_used = stock_str::part_of_total_used(
+                                    self,
+                                    resource.usage.to_string(),
+                                    resource.limit.to_string()
+                                )
+                                .await;
+                            let messages = stock_str::messages(self).await;
                             ret += &match &resource.name {
                                 Atom(resource_name) => {
                                     format!(
                                         "<b>{}:</b> {}",
                                         &*escaper::encode_minimal(resource_name),
-                                        stock_str::part_of_total_used(
-                                            self,
-                                            resource.usage.to_string(),
-                                            resource.limit.to_string()
-                                        )
-                                        .await,
+                                        part_of_total_used
                                     )
                                 }
                                 Message => {
                                     format!(
                                         "<b>{}:</b> {}",
-                                        stock_str::messages(self).await,
-                                        stock_str::part_of_total_used(
-                                            self,
-                                            resource.usage.to_string(),
-                                            resource.limit.to_string()
-                                        )
-                                        .await,
+                                        part_of_total_used,
+                                        messages
                                     )
                                 }
                                 Storage => {
@@ -538,7 +538,8 @@ impl Context {
                 self.schedule_quota_update().await?;
             }
         } else {
-            ret += &format!("<li>{}</li>", stock_str::not_connected(self).await);
+            let not_connected = stock_str::not_connected(self).await;
+            ret += &format!("<li>{}</li>", not_connected);
             self.schedule_quota_update().await?;
         }
         ret += "</ul>";

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -476,13 +476,13 @@ impl Context {
                                 info!(self, "connectivity: root name hidden: \"{}\"", root_name);
                             }
 
+                            let messages = stock_str::messages(self).await;
                             let part_of_total_used = stock_str::part_of_total_used(
                                     self,
                                     resource.usage.to_string(),
                                     resource.limit.to_string()
                                 )
                                 .await;
-                            let messages = stock_str::messages(self).await;
                             ret += &match &resource.name {
                                 Atom(resource_name) => {
                                     format!(


### PR DESCRIPTION
these two functions don't compile, I get this error:

```
error: generator cannot be sent between threads safely
  --> deltachat-jsonrpc/src/api/mod.rs:74:1
   |
74 | #[rpc(all_positional, ts_outdir = "typescript/generated")]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
   |
   = help: the trait `Sync` is not implemented for `core::fmt::Opaque`
   = note: required for the cast to the object type `dyn Future<Output = Result<Value, yerpc::Error>> + Send`
   = note: this error originates in the attribute macro `rpc` (in Nightly builds, run with -Z macro-backtrace for more info)

error: could not compile `deltachat-jsonrpc` due to previous error
cargo failed with code 101
```

any ideas what we need to change in order to fix it?

also if you try it out, I recommend uncommenting one of those functions because both have similar errors so you might not notice at a glance if you 
fixed it.
