### PR TITLE
enable `BccSelf` by default 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - truncate incoming messages by lines instead of just length #3480
 - emit separate `DC_EVENT_MSGS_CHANGED` for each expired message,
   and `DC_EVENT_WEBXDC_INSTANCE_DELETED` when a message contains a webxdc #3605
+- enable `bcc_self` by default #3612
 
 ### Fixes
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -55,7 +55,7 @@ pub enum Config {
     Selfstatus,
     Selfavatar,
 
-    #[strum(props(default = "0"))]
+    #[strum(props(default = "1"))]
     BccSelf,
 
     #[strum(props(default = "1"))]

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -948,6 +948,7 @@ mod tests {
     async fn test_resend_webxdc_instance_and_info() -> Result<()> {
         // Alice uses webxdc in a group
         let alice = TestContext::new_alice().await;
+        alice.set_config_bool(Config::BccSelf, false).await?;
         let alice_grp = create_group_chat(&alice, ProtectionStatus::Unprotected, "grp").await?;
         let alice_instance = send_webxdc_instance(&alice, alice_grp).await?;
         assert_eq!(alice_grp.get_msg_cnt(&alice).await?, 1);


### PR DESCRIPTION
enabling `BccSelf` improves user experience as
it is easier to set up another device
and ppl will also see "all" messages in other user agents directly.

for uncounted user problems, after diving into the issue,
the resulting device was "turn on BccSelf".
disabled `BccSelf` was probably the the number one single reason
of user problems.
(just recently again, this is the reason for this change, that, however, was discussed offline many times, but it never ends in a pr  :)

main drawback of the change are potentially double notifications
when using a shared account and having another mail app on the same device (see https://github.com/deltachat/deltachat-core-rust/pull/825).
however, we meanwhile do not recommend shared accounts at all,
the issue is also fixable by the other mail apps (as done by K-9)
and could be even regarded as a feature (you can decide which app to use for ansering).
but at the end the drawback is probably much smaller than the issues reported above.

@adbenitez if we want that change also for nauta, we also have to adapt [nauta's provider-db entry](https://github.com/deltachat/provider-db/blob/master/_providers/nauta.cu.md). 