### PR TITLE
prepare 1.95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,26 @@
 ## Unreleased
 
 ### API-Changes
+
+### Changes
+
+### Fixes
+
+
+## 1.95.0
+
+### API-Changes
 - jsonrpc: add `mailingListAddress` property to `FullChat` #3607
 - jsonrpc: add `MessageNotificationInfo` & `messageGetNotificationInfo()` #3614
 - jsonrpc: add `chat_get_neighboring_media` function #3610
 
-### Added
-- `dclogin:` scheme to allow configuration from a qr code (data inside qrcode, contrary to `dcaccount:` which points to an api to create an account) #3541
-
 ### Changes
+- added `dclogin:` scheme to allow configuration from a qr code
+  (data inside qrcode, contrary to `dcaccount:` which points to an API to create an account) #3541
 - truncate incoming messages by lines instead of just length #3480
 - emit separate `DC_EVENT_MSGS_CHANGED` for each expired message,
   and `DC_EVENT_WEBXDC_INSTANCE_DELETED` when a message contains a webxdc #3605
 - enable `bcc_self` by default #3612
-
-### Fixes
 
 
 ## 1.94.0
@@ -30,7 +36,7 @@
   and `dc_event_emitter_unref()` should be used instead of
   `dc_accounts_event_emitter_unref`.
 - add `dc_contact_was_seen_recently()` #3560
-- Fix get_connectivity_html and get_encrinfo futures not being Send. See rust-lang/rust#101650 for more information
+- Fix `get_connectivity_html` and `get_encrinfo` futures not being Send. See rust-lang/rust#101650 for more information
 - jsonrpc: add functions: #3586, #3587, #3590
   - `deleteChat()`
   - `getChatEncryptionInfo()`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.94.0"
+version = "1.95.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat-jsonrpc"
-version = "1.94.0"
+version = "1.95.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.94.0"
+version = "1.95.0"
 dependencies = [
  "anyhow",
  "deltachat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.94.0"
+version = "1.95.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.94.0"
+version = "1.95.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"

--- a/deltachat-jsonrpc/Cargo.toml
+++ b/deltachat-jsonrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat-jsonrpc"
-version = "1.94.0"
+version = "1.95.0"
 description = "DeltaChat JSON-RPC API"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2021"

--- a/deltachat-jsonrpc/typescript/package.json
+++ b/deltachat-jsonrpc/typescript/package.json
@@ -47,5 +47,5 @@
   },
   "type": "module",
   "types": "dist/deltachat.d.ts",
-  "version": "1.94.0"
+  "version": "1.95.0"
 }

--- a/package.json
+++ b/package.json
@@ -61,5 +61,5 @@
     "test:mocha": "mocha -r esm node/test/test.js --growl --reporter=spec --bail"
   },
   "types": "node/dist/index.d.ts",
-  "version": "1.94.0"
+  "version": "1.95.0"
 }


### PR DESCRIPTION
this is the core probably used for the approaching 1.34 releases.

after commit, on master make sure to: 

   git tag -a 1.95.0
   git push origin 1.95.0
   git tag -a py-1.95.0
   git push origin py-1.95.0