### PR TITLE
jsonrpc js client: ci upload and new name

### DIFF
--- a/.github/workflows/jsonrpc-client-npm-package.yml
+++ b/.github/workflows/jsonrpc-client-npm-package.yml
@@ -70,6 +70,7 @@ jobs:
         env:
          URL: preview/${{ env.DELTACHAT_JSONRPC_TAR_GZ }}
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         MSG_CONTEXT: Download the deltachat-jsonrpc-client.tgz
       # Upload to download.delta.chat/node/
       - name: Upload deltachat-jsonrpc-client build to download.delta.chat/node/
         if: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/jsonrpc-client-npm-package.yml
+++ b/.github/workflows/jsonrpc-client-npm-package.yml
@@ -41,26 +41,6 @@ jobs:
           npm --version
           node --version
           echo $DELTACHAT_JSONRPC_TAR_GZ
-      - name: Download ubuntu prebuild
-        uses: actions/download-artifact@v1
-        with:
-          name: ubuntu-18.04
-      - name: Download macos prebuild
-        uses: actions/download-artifact@v1
-        with:
-          name: macos-latest
-      - name: Download windows prebuild
-        uses: actions/download-artifact@v1
-        with:
-          name: windows-latest
-      - shell: bash
-        run: |
-          mkdir node/prebuilds
-          tar -xvzf ubuntu-18.04/ubuntu-18.04.tar.gz -C node/prebuilds
-          tar -xvzf macos-latest/macos-latest.tar.gz -C node/prebuilds
-          tar -xvzf windows-latest/windows-latest.tar.gz -C node/prebuilds
-          tree node/prebuilds
-          rm -rf ubuntu-18.04 macos-latest windows-latest
       - name: install dependencies without running scripts
         run: |
           npm install --ignore-scripts

--- a/.github/workflows/jsonrpc-client-npm-package.yml
+++ b/.github/workflows/jsonrpc-client-npm-package.yml
@@ -46,6 +46,7 @@ jobs:
         shell: bash
         run: |
           cd deltachat-jsonrpc/typescript
+          npm run build:tsc
           npm pack .
           ls -lah
           mv $(find deltachat-jsonrpc-client-*) $DELTACHAT_JSONRPC_TAR_GZ

--- a/.github/workflows/jsonrpc-client-npm-package.yml
+++ b/.github/workflows/jsonrpc-client-npm-package.yml
@@ -1,0 +1,103 @@
+name: 'jsonrpc js client build'
+on:
+  pull_request:
+  push:
+    tags:
+    - '*'
+    - '!py-*'
+
+
+jobs:
+  pack-module:
+    name: 'Package @deltachat/jsonrpc-client and upload to download.delta.chat'
+    runs-on: ubuntu-18.04
+    steps:
+      - name: install tree
+        run: sudo apt install tree
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - name: get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+        continue-on-error: true
+      - name: Get Pullrequest ID
+        id: prepare
+        run: |
+          tag=${{ steps.tag.outputs.tag }}
+          if [ -z "$tag" ]; then
+            node -e "console.log('DELTACHAT_JSONRPC_TAR_GZ=deltachat-jsonrpc-client-' + '${{ github.ref }}'.split('/')[2] + '.tar.gz')" >> $GITHUB_ENV
+          else
+            echo "DELTACHAT_JSONRPC_TAR_GZ=deltachat-jsonrpc-client-${{ steps.tag.outputs.tag }}.tar.gz" >> $GITHUB_ENV
+            echo "No preview will be uploaded this time, but the $tag release"
+          fi
+      - name: System info
+        run: |
+          rustc -vV
+          rustup -vV
+          cargo -vV
+          npm --version
+          node --version
+          echo $DELTACHAT_JSONRPC_TAR_GZ
+      - name: Download ubuntu prebuild
+        uses: actions/download-artifact@v1
+        with:
+          name: ubuntu-18.04
+      - name: Download macos prebuild
+        uses: actions/download-artifact@v1
+        with:
+          name: macos-latest
+      - name: Download windows prebuild
+        uses: actions/download-artifact@v1
+        with:
+          name: windows-latest
+      - shell: bash
+        run: |
+          mkdir node/prebuilds
+          tar -xvzf ubuntu-18.04/ubuntu-18.04.tar.gz -C node/prebuilds
+          tar -xvzf macos-latest/macos-latest.tar.gz -C node/prebuilds
+          tar -xvzf windows-latest/windows-latest.tar.gz -C node/prebuilds
+          tree node/prebuilds
+          rm -rf ubuntu-18.04 macos-latest windows-latest
+      - name: install dependencies without running scripts
+        run: |
+          npm install --ignore-scripts
+      - name: package
+        shell: bash
+        run: |
+          mv node/README.md README.md
+          npm pack .
+          ls -lah
+          mv $(find deltachat-jsonrpc-client-*) $DELTACHAT_JSONRPC_TAR_GZ
+      - name: Upload Prebuild
+        uses: actions/upload-artifact@v1
+        with:
+          name: deltachat-jsonrpc-client.tgz
+          path: ${{ env.DELTACHAT_JSONRPC_TAR_GZ }}
+      # Upload to download.delta.chat/node/preview/
+      - name: Upload deltachat-jsonrpc-client preview to download.delta.chat/node/preview/
+        if: ${{ ! steps.tag.outputs.tag }}
+        id: upload-preview
+        shell: bash
+        run: |
+          echo -e "${{ secrets.SSH_KEY }}" >__TEMP_INPUT_KEY_FILE
+          chmod 600 __TEMP_INPUT_KEY_FILE
+          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r $DELTACHAT_JSONRPC_TAR_GZ "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/preview/"
+        continue-on-error: true
+      - name: "Post links to details"
+        if: steps.upload-preview.outcome == 'success'
+        run: node ./node/scripts/postLinksToDetails.js
+        env:
+         URL: preview/${{ env.DELTACHAT_JSONRPC_TAR_GZ }}
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Upload to download.delta.chat/node/
+      - name: Upload deltachat-jsonrpc-client build to download.delta.chat/node/
+        if: ${{ steps.tag.outputs.tag }}
+        id: upload
+        shell: bash
+        run: |
+          echo -e "${{ secrets.SSH_KEY }}" >__TEMP_INPUT_KEY_FILE
+          chmod 600 __TEMP_INPUT_KEY_FILE
+          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r $DELTACHAT_JSONRPC_TAR_GZ "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/"

--- a/.github/workflows/jsonrpc-client-npm-package.yml
+++ b/.github/workflows/jsonrpc-client-npm-package.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: deltachat-jsonrpc-client.tgz
-          path: ${{ env.DELTACHAT_JSONRPC_TAR_GZ }}
+          path: deltachat-jsonrpc/typescript/${{ env.DELTACHAT_JSONRPC_TAR_GZ }}
       # Upload to download.delta.chat/node/preview/
       - name: Upload deltachat-jsonrpc-client preview to download.delta.chat/node/preview/
         if: ${{ ! steps.tag.outputs.tag }}
@@ -62,7 +62,7 @@ jobs:
         run: |
           echo -e "${{ secrets.SSH_KEY }}" >__TEMP_INPUT_KEY_FILE
           chmod 600 __TEMP_INPUT_KEY_FILE
-          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r $DELTACHAT_JSONRPC_TAR_GZ "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/preview/"
+          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r deltachat-jsonrpc/typescript/$DELTACHAT_JSONRPC_TAR_GZ "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/preview/"
         continue-on-error: true
       - name: "Post links to details"
         if: steps.upload-preview.outcome == 'success'
@@ -78,4 +78,4 @@ jobs:
         run: |
           echo -e "${{ secrets.SSH_KEY }}" >__TEMP_INPUT_KEY_FILE
           chmod 600 __TEMP_INPUT_KEY_FILE
-          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r $DELTACHAT_JSONRPC_TAR_GZ "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/"
+          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r deltachat-jsonrpc/typescript/$DELTACHAT_JSONRPC_TAR_GZ "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/node/"

--- a/.github/workflows/jsonrpc-client-npm-package.yml
+++ b/.github/workflows/jsonrpc-client-npm-package.yml
@@ -35,19 +35,17 @@ jobs:
           fi
       - name: System info
         run: |
-          rustc -vV
-          rustup -vV
-          cargo -vV
           npm --version
           node --version
           echo $DELTACHAT_JSONRPC_TAR_GZ
       - name: install dependencies without running scripts
         run: |
+          cd deltachat-jsonrpc/typescript
           npm install --ignore-scripts
       - name: package
         shell: bash
         run: |
-          mv node/README.md README.md
+          cd deltachat-jsonrpc/typescript
           npm pack .
           ls -lah
           mv $(find deltachat-jsonrpc-client-*) $DELTACHAT_JSONRPC_TAR_GZ

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### API-Changes
 
 ### Changes
+- jsonrpc js client:
+  - Change package name from `deltachat-jsonrpc-client` to `@deltachat/jsonrpc-client`
+  - remove relative file dependency to it from `deltachat-node` (because it did not work anyway and broke the nix build of desktop)
+  - ci: add github ci action to upload it to our download server automaticaly on realease
 
 ### Fixes
 

--- a/deltachat-jsonrpc/typescript/package.json
+++ b/deltachat-jsonrpc/typescript/package.json
@@ -26,7 +26,7 @@
   },
   "license": "MPL-2.0",
   "main": "dist/deltachat.js",
-  "name": "deltachat-jsonrpc-client",
+  "name": "@deltachat/jsonrpc-client",
   "scripts": {
     "build": "run-s generate-bindings build:tsc build:bundle",
     "build:bundle": "esbuild --format=esm --bundle dist/deltachat.js --outfile=dist/deltachat.bundle.js",

--- a/node/scripts/postLinksToDetails.js
+++ b/node/scripts/postLinksToDetails.js
@@ -12,11 +12,12 @@ const GITHUB_API_URL =
 
 const file_url = process.env['URL']
 const GITHUB_TOKEN = process.env['GITHUB_TOKEN']
+const context = process.env['MSG_CONTEXT']
 
 const STATUS_DATA = {
   state: 'success',
   description: '⏩ Click on "Details" to download →',
-  context: 'Download the node-bindings.tar.gz',
+  context: context || 'Download the node-bindings.tar.gz',
   target_url: base_url + file_url,
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "@deltachat/jsonrpc-client": "file:deltachat-jsonrpc/typescript",
     "debug": "^4.1.1",
     "napi-macros": "^2.0.0",
     "node-gyp-build": "^4.1.0"


### PR DESCRIPTION
npm does not really like importing it over deltachat-node, so this pr 
makes it a full dedicated package that we can upload to npm and 
import directly.

this will fix the nix build again and make other things easier as 
well.

TODO:
- [x] change label of details link so it says deltachat-jsonrpc-client.tar.gz instead of deltachat-node.tar.gz
