### PR TITLE
Share stock strings across accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changes
 
 ### Fixes
+- share stock string translations across accounts created by the same account manager #3640
 
 ## 1.96.0
 

--- a/benches/contacts.rs
+++ b/benches/contacts.rs
@@ -1,6 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use deltachat::contact::Contact;
 use deltachat::context::Context;
+use deltachat::stock_str::StockStrings;
 use deltachat::Events;
 use tempfile::tempdir;
 
@@ -8,7 +9,9 @@ async fn address_book_benchmark(n: u32, read_count: u32) {
     let dir = tempdir().unwrap();
     let dbfile = dir.path().join("db.sqlite");
     let id = 100;
-    let context = Context::new(&dbfile, id, Events::new()).await.unwrap();
+    let context = Context::new(&dbfile, id, Events::new(), StockStrings::new())
+        .await
+        .unwrap();
 
     let book = (0..n)
         .map(|i| format!("Name {}\naddr{}@example.org\n", i, i))

--- a/benches/get_chat_msgs.rs
+++ b/benches/get_chat_msgs.rs
@@ -5,11 +5,14 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use deltachat::chat::{self, ChatId};
 use deltachat::chatlist::Chatlist;
 use deltachat::context::Context;
+use deltachat::stock_str::StockStrings;
 use deltachat::Events;
 
 async fn get_chat_msgs_benchmark(dbfile: &Path, chats: &[ChatId]) {
     let id = 100;
-    let context = Context::new(dbfile, id, Events::new()).await.unwrap();
+    let context = Context::new(dbfile, id, Events::new(), StockStrings::new())
+        .await
+        .unwrap();
 
     for c in chats.iter().take(10) {
         black_box(chat::get_chat_msgs(&context, *c, 0).await.ok());
@@ -23,7 +26,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         let rt = tokio::runtime::Runtime::new().unwrap();
 
         let chats: Vec<_> = rt.block_on(async {
-            let context = Context::new(Path::new(&path), 100, Events::new())
+            let context = Context::new(Path::new(&path), 100, Events::new(), StockStrings::new())
                 .await
                 .unwrap();
             let chatlist = Chatlist::try_load(&context, 0, None, None).await.unwrap();

--- a/benches/get_chatlist.rs
+++ b/benches/get_chatlist.rs
@@ -4,6 +4,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use deltachat::chatlist::Chatlist;
 use deltachat::context::Context;
+use deltachat::stock_str::StockStrings;
 use deltachat::Events;
 
 async fn get_chat_list_benchmark(context: &Context) {
@@ -16,7 +17,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     if let Ok(path) = std::env::var("DELTACHAT_BENCHMARK_DATABASE") {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let context = rt.block_on(async {
-            Context::new(Path::new(&path), 100, Events::new())
+            Context::new(Path::new(&path), 100, Events::new(), StockStrings::new())
                 .await
                 .unwrap()
         });

--- a/benches/receive_emails.rs
+++ b/benches/receive_emails.rs
@@ -6,6 +6,7 @@ use deltachat::{
     context::Context,
     imex::{imex, ImexMode},
     receive_imf::receive_imf,
+    stock_str::StockStrings,
     Events,
 };
 use tempfile::tempdir;
@@ -41,7 +42,9 @@ async fn create_context() -> Context {
     let dir = tempdir().unwrap();
     let dbfile = dir.path().join("db.sqlite");
     let id = 100;
-    let context = Context::new(&dbfile, id, Events::new()).await.unwrap();
+    let context = Context::new(&dbfile, id, Events::new(), StockStrings::new())
+        .await
+        .unwrap();
 
     let backup: PathBuf = std::env::current_dir()
         .unwrap()

--- a/benches/search_msgs.rs
+++ b/benches/search_msgs.rs
@@ -1,11 +1,12 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use deltachat::context::Context;
+use deltachat::stock_str::StockStrings;
 use deltachat::Events;
 use std::path::Path;
 
 async fn search_benchmark(dbfile: impl AsRef<Path>) {
     let id = 100;
-    let context = Context::new(dbfile.as_ref(), id, Events::new())
+    let context = Context::new(dbfile.as_ref(), id, Events::new(), StockStrings::new())
         .await
         .unwrap();
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -38,6 +38,7 @@ use deltachat::ephemeral::Timer as EphemeralTimer;
 use deltachat::key::DcKey;
 use deltachat::message::MsgId;
 use deltachat::stock_str::StockMessage;
+use deltachat::stock_str::StockStrings;
 use deltachat::webxdc::StatusUpdateSerial;
 use deltachat::*;
 use deltachat::{accounts::Accounts, log::LogExt};
@@ -98,7 +99,12 @@ pub unsafe extern "C" fn dc_context_new(
     let ctx = if blobdir.is_null() || *blobdir == 0 {
         // generate random ID as this functionality is not yet available on the C-api.
         let id = rand::thread_rng().gen();
-        block_on(Context::new(as_path(dbfile), id, Events::new()))
+        block_on(Context::new(
+            as_path(dbfile),
+            id,
+            Events::new(),
+            StockStrings::new(),
+        ))
     } else {
         eprintln!("blobdir can not be defined explicitly anymore");
         return ptr::null_mut();
@@ -122,7 +128,12 @@ pub unsafe extern "C" fn dc_context_new_closed(dbfile: *const libc::c_char) -> *
     }
 
     let id = rand::thread_rng().gen();
-    match block_on(Context::new_closed(as_path(dbfile), id, Events::new())) {
+    match block_on(Context::new_closed(
+        as_path(dbfile),
+        id,
+        Events::new(),
+        StockStrings::new(),
+    )) {
         Ok(context) => Box::into_raw(Box::new(context)),
         Err(err) => {
             eprintln!("failed to create context: {:#}", err);

--- a/examples/repl/main.rs
+++ b/examples/repl/main.rs
@@ -20,6 +20,7 @@ use deltachat::context::*;
 use deltachat::oauth2::*;
 use deltachat::qr_code_generator::get_securejoin_qr_svg;
 use deltachat::securejoin::*;
+use deltachat::stock_str::StockStrings;
 use deltachat::{EventType, Events};
 use log::{error, info, warn};
 use rustyline::completion::{Completer, FilenameCompleter, Pair};
@@ -298,7 +299,7 @@ async fn start(args: Vec<String>) -> Result<(), Error> {
         println!("Error: Bad arguments, expected [db-name].");
         bail!("No db-name specified");
     }
-    let context = Context::new(Path::new(&args[1]), 0, Events::new()).await?;
+    let context = Context::new(Path::new(&args[1]), 0, Events::new(), StockStrings::new()).await?;
 
     let events = context.get_event_emitter();
     tokio::task::spawn(async move {

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -6,6 +6,7 @@ use deltachat::config;
 use deltachat::contact::*;
 use deltachat::context::*;
 use deltachat::message::Message;
+use deltachat::stock_str::StockStrings;
 use deltachat::{EventType, Events};
 
 fn cb(event: EventType) {
@@ -36,7 +37,7 @@ async fn main() {
     let dir = tempdir().unwrap();
     let dbfile = dir.path().join("db.sqlite");
     log::info!("creating database {:?}", dbfile);
-    let ctx = Context::new(&dbfile, 0, Events::new())
+    let ctx = Context::new(&dbfile, 0, Events::new(), StockStrings::new())
         .await
         .expect("Failed to create context");
     let info = ctx.get_info().await;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -29,6 +29,7 @@ use crate::key::{self, DcKey, KeyPair, KeyPairUse};
 use crate::message::{update_msg_state, Message, MessageState, MsgId, Viewtype};
 use crate::mimeparser::MimeMessage;
 use crate::receive_imf::receive_imf;
+use crate::stock_str::StockStrings;
 use crate::tools::EmailAddress;
 
 #[allow(non_upper_case_globals)]
@@ -277,7 +278,7 @@ impl TestContext {
             let mut context_names = CONTEXT_NAMES.write().unwrap();
             context_names.insert(id, name);
         }
-        let ctx = Context::new(&dbfile, id, Events::new())
+        let ctx = Context::new(&dbfile, id, Events::new(), StockStrings::new())
             .await
             .expect("failed to create context");
 


### PR DESCRIPTION
All contexts created by the same account manager
share stock string translations. Setting translation on a single context automatically sets translations for all other accounts, so it is enough to set translations on the active account.

Fixes #3615 