### PR TITLE
Suppress welcome device messages after account import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 - share stock string translations across accounts created by the same account manager #3640
+- suppress welcome device messages after account import #3642
 
 ## 1.96.0
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3369,6 +3369,15 @@ pub(crate) async fn delete_and_reset_all_device_msgs(context: &Context) -> Resul
         .sql
         .execute("DELETE FROM devmsglabels;", paramsv![])
         .await?;
+
+    // Insert labels for welcome messages to avoid them being readded on reconfiguration.
+    context
+        .sql
+        .execute(
+            r#"INSERT INTO devmsglabels (label) VALUES ("core-welcome-image"), ("core-welcome")"#,
+            paramsv![],
+        )
+        .await?;
     context.set_config(Config::QuotaExceeding, None).await?;
     Ok(())
 }

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -1306,6 +1306,7 @@ impl Context {
 mod tests {
     use num_traits::ToPrimitive;
 
+    use crate::chat::delete_and_reset_all_device_msgs;
     use crate::chat::Chat;
     use crate::chatlist::Chatlist;
     use crate::test_utils::TestContext;
@@ -1471,7 +1472,17 @@ mod tests {
         assert_eq!(chats.len(), 0);
 
         // a subsequent call to update_device_chats() must not re-add manally deleted messages or chats
-        t.update_device_chats().await.ok();
+        t.update_device_chats().await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
+        assert_eq!(chats.len(), 0);
+
+        // Reset all device messages. This normally happens due to account export and import.
+        // Check that update_device_chats() does not add welcome message for imported account.
+        delete_and_reset_all_device_msgs(&t).await.unwrap();
+        let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
+        assert_eq!(chats.len(), 0);
+
+        t.update_device_chats().await.unwrap();
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 0);
     }


### PR DESCRIPTION
Add dummy `devmsglabels` entries on import to avoid welcome messages being added when user runs reconfiguration on imported account.

Fixes #3342