### PR TITLE
Fix unix timestamp used for daymarker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ### Fixes
 - share stock string translations across accounts created by the same account manager #3640
 - suppress welcome device messages after account import #3642
+- fix unix timestamp used for daymarker #3660
 
 ## 1.96.0
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2254,7 +2254,7 @@ pub async fn get_chat_msgs(
                 let curr_day = curr_local_timestamp / 86400;
                 if curr_day != last_day {
                     ret.push(ChatItem::DayMarker {
-                        timestamp: curr_day,
+                        timestamp: curr_day * 86400, // Convert day back to Unix timestamp
                     });
                     last_day = curr_day;
                 }


### PR DESCRIPTION
I think it's just a mistake that nobody noticed because no platform uses daymarkers.