### PR TITLE
Don't use opt_level=1, instead box futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ rust-version = "1.56"
 [profile.dev]
 debug = 0
 panic = 'abort'
-opt-level = 1
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ rust-version = "1.56"
 [profile.dev]
 debug = 0
 panic = 'abort'
+opt-level = 1
+
+[profile.test]
+opt-level = 0
 
 [profile.release]
 lto = true


### PR DESCRIPTION
This PR more than halves the build time (test, debug, incremental; that's the one I build most often) from a bit more than 60s to a bit less than 30s.

Was there any other reason for opt_level=1 apart from these two tests failing?

~~The reason they failed is that Tokio's `block_on()` pins the future to the stack~~ _Edit: after looking at tokio's code, I'm not convinced anymore that this is the reason, but it doesn't matter for this PR here -_ and since these tests / securejoin have a huge future (probably they hold some big data structure across an await point), the stack overflowed. So, this PR pins them to the heap instead.

Other things we could do:

- Ask the tokio project to always pin the future to the heap in tests, the performance hit should be tiny (one allocation per test). Alternatively, write our own simple #[async_test] proc macro that does this, should be doable in ~50 lines.
- Keep opt_level=1 for dependencies, only use opt_level=0 for the deltachat crate - this alone already fixed one of the two tests:
```
[profile.dev.package."*"]
opt-level = 1
```

Since disabling optimizations for all debug builds would make my Android debug builds fail (and probably also Desktop/iOS/...), this PR now only disables them for tests.