### PR TITLE
set timeout for node ci tests to 10min

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -60,6 +60,7 @@ jobs:
         env:
           DCC_NEW_TMP_EMAIL: ${{ secrets.DCC_NEW_TMP_EMAIL }}
       - name: Run tests on Windows, except lint
+        timeout-minutes: 10
         if: runner.os == 'Windows'
         run: |
           cd node

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -52,6 +52,7 @@ jobs:
           npm install --verbose
 
       - name: Test
+        timeout-minutes: 10
         if: runner.os != 'Windows'
         run: |
           cd node


### PR DESCRIPTION
set timeout for node ci tests to 10min for the test step,
macOS takes 12min for the whole workflow with cached core build,
so 10min just for the test step should be plenty.
