### PR TITLE
pass correct chat_id to REACTIONS_CHANGED event, do not create chat by reaction

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -847,9 +847,17 @@ async fn add_parts(
         }
     }
 
-    if is_mdn || is_reaction {
+    if is_mdn {
         chat_id = Some(DC_CHAT_ID_TRASH);
     }
+
+    let orig_reaction_chat_id = if is_reaction {
+        let orig_reaction_chat_id = chat_id;
+        chat_id = Some(DC_CHAT_ID_TRASH);
+        orig_reaction_chat_id
+    } else {
+        None
+    };
 
     let chat_id = chat_id.unwrap_or_else(|| {
         info!(context, "No chat id for message (TRASH)");
@@ -1063,7 +1071,7 @@ async fn add_parts(
             set_msg_reaction(
                 context,
                 &mime_in_reply_to,
-                chat_id,
+                orig_reaction_chat_id.unwrap_or_default(),
                 from_id,
                 Reaction::from(part.msg.as_str()),
             )

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -455,7 +455,7 @@ async fn add_parts(
             ShowEmails::All => allow_creation = !is_mdn,
         }
     } else {
-        allow_creation = !is_mdn;
+        allow_creation = !is_mdn && !is_reaction;
     }
 
     // check if the message introduces a new chat:


### PR DESCRIPTION
this pr is for merging into https://github.com/deltachat/deltachat-core-rust/pull/3644

- the first commit avoids a chat being created by receiving a reaction (the chat would be empty which is a bit weird)

- the second commit makes sure that the correct chat_id is emmited in the REACTIONS_CHANGED event. unfortunately, this is done by a bit of spaghetti code - maybe this can be done better by moving some things around, however, i also did not want to do a larger change for that. if someone sees an easy and nicer solution, please directly push to this pr.

wondering, btw, how reactions relate to ephemeral-messages and partial-downloads. did we thought about that? is it potentially okay? the behavior is not changed by this pr, however the related code parts are just a few lines below :)