### PR TITLE
Allow sender timestamp to be in the future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### API-Changes
 
 ### Changes
+- allow sender timestamp to be in the future, but not too much
 
 ### Fixes
 - `dc_search_msgs()` returns unaccepted requests #3694

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -173,10 +173,13 @@ pub(crate) async fn receive_imf_inner(
     .await?;
 
     let rcvd_timestamp = smeared_time(context).await;
+
+    // Sender timestamp is allowed to be a bit in the future due to
+    // unsynchronized clocks, but not too much.
     let sent_timestamp = mime_parser
         .get_header(HeaderDef::Date)
         .and_then(|value| mailparse::dateparse(value).ok())
-        .map_or(rcvd_timestamp, |value| min(value, rcvd_timestamp));
+        .map_or(rcvd_timestamp, |value| min(value, rcvd_timestamp + 60));
 
     // Add parts
     let received_msg = add_parts(


### PR DESCRIPTION
This can happen due to unsynchronized clocks or
when "smeared" timestamp is used as the sender sends multiple messages without delay.

See discussion at https://support.delta.chat/t/deltachat-almost-unusable-for-me-due-to-out-of-order-message-delivery/2241