### PR TITLE
Accept ToString instead of AsRef<str> in Params.set()

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -726,7 +726,7 @@ impl Message {
         self.text = text;
     }
 
-    pub fn set_file(&mut self, file: impl AsRef<str>, filemime: Option<&str>) {
+    pub fn set_file(&mut self, file: impl ToString, filemime: Option<&str>) {
         self.param.set(Param::File, file);
         if let Some(filemime) = filemime {
             self.param.set(Param::MimeType, filemime);

--- a/src/param.rs
+++ b/src/param.rs
@@ -266,8 +266,8 @@ impl Params {
     }
 
     /// Set the given key to the passed in value.
-    pub fn set(&mut self, key: Param, value: impl AsRef<str>) -> &mut Self {
-        self.inner.insert(key, value.as_ref().to_string());
+    pub fn set(&mut self, key: Param, value: impl ToString) -> &mut Self {
+        self.inner.insert(key, value.to_string());
         self
     }
 


### PR DESCRIPTION
It was used as `.as_ref().to_string()`, so may as well just call `.to_string()` directly.

Addresses #3669 

#skip-changelog (refactoring)