### PR TITLE
Fix flaky test_block_mailing_list()

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -3149,6 +3149,7 @@ Hello mailinglist!\r\n"
             .unwrap();
 
         receive_imf(&t.ctx, DC_MAILINGLIST, false).await.unwrap();
+        t.evtracker.wait_next_incoming_message().await;
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         let chat_id = chats.get_chat_id(0).unwrap();
@@ -3161,7 +3162,6 @@ Hello mailinglist!\r\n"
         let chats = Chatlist::try_load(&t.ctx, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 0); // Test that the message disappeared
 
-        t.evtracker.consume_events();
         receive_imf(&t.ctx, DC_MAILINGLIST2, false).await.unwrap();
 
         // Check that no notification is displayed for blocked mailing list message.

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -876,9 +876,10 @@ impl EventTracker {
         .await
     }
 
-    /// Consumes all pending events.
-    pub fn consume_events(&self) {
-        while self.try_recv().is_ok() {}
+    /// Wait for the next IncomingMsg event.
+    pub async fn wait_next_incoming_message(&self) {
+        self.get_matching(|evt| matches!(evt, EventType::IncomingMsg { .. }))
+            .await;
     }
 }
 


### PR DESCRIPTION
Seems like consume_events() didn't work properly, i.e. in some cases it didn't see the latest events and failed to consume them. So, the IncomingMsg event from receiving the first mailinglist message stayed in the events channel, which made this fail:

```rust
        // Check that no notification is displayed for blocked mailing list message.
        while let Ok(event) = t.evtracker.try_recv() {
            assert!(!matches!(event.typ, EventType::IncomingMsg { .. }));
        }
```

Fix it by explicitly waiting for the first IncomingMsg event.

fix #3727 

#skip-changelog