### PR TITLE
Go back to standard async_zip, fix build failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345fd392ab01f746c717b1357165b76f0b67a60192007b234058c9045fdcf695"
+checksum = "942c7cd7ae39e91bde4820d74132e9862e62c2f386c3aa90ccf55949f5bad63a"
 dependencies = [
  "flate2",
  "futures-core",
@@ -197,16 +197,18 @@ dependencies = [
 
 [[package]]
 name = "async_io_utilities"
-version = "0.1.3"
-source = "git+https://github.com/Majored/rs-async-io-utilities#6661a0fb914ccc1f97a6acd446bc03e9547d64fc"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b20cffc5590f4bf33f05f97a3ea587feba9c50d20325b401daa096b92ff7da0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "async_zip"
-version = "0.0.8"
-source = "git+https://github.com/dignifiedquire/rs-async-zip?branch=main#5556c5ac5e0bbc89e2d440291a9a6b77c74070aa"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a36d43bdefc7215b2b3a97edd03b1553b7969ad76551025eedd3b913c645f6e"
 dependencies = [
  "async-compression",
  "async_io_utilities",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ async-channel = "1.6.1"
 futures-lite = "1.12.0"
 tokio-stream = { version = "0.1.11", features = ["fs"] }
 reqwest = { version = "0.11.12", features = ["json"] }
-async_zip = { git = "https://github.com/dignifiedquire/rs-async-zip", branch = "main", default-features = false, features = ["deflate"] }
+async_zip = { version = "0.0.9", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 ansi_term = "0.12.0"


### PR DESCRIPTION
If building DC failed for you with some long error message about "spurious network error" and "async_io_utilities", then this PR fixes that.

Majored deleted the rs-async-io-utilities repo because he [doesn't need it anymore](https://github.com/Majored/rs-async-zip/commit/618f700811362189bb46d9e736c7ea983ecf6266), so that https://github.com/dignifiedquire/rs-async-zip doesn't have its dependency anymore. The latter was a hotfix-fork of https://github.com/Majored/rs-async-zip because https://github.com/Majored/rs-async-zip/pull/27, fixing https://github.com/deltachat/deltachat-core-rust/issues/3476, wasn't merged.

But apparently the problem of https://github.com/deltachat/deltachat-core-rust/issues/3476 is fixed in `async_zip = "0.0.9"`, at least all the webxdcs from https://webxdc.org/ worked fine for me. So, let's just go back to the official async_zip.