### PR TITLE
use sender name instead of misleading 'you' for subjects displayed in non-dc MUA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 - fix detection of "All mail", "Trash", "Junk" etc folders. #3760
+- fix info messages shown for non-dc MUA #3754
 
 
 ## 1.101.0

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -415,7 +415,6 @@ impl ChatId {
         promote: bool,
         from_id: ContactId,
     ) -> Result<()> {
-        let msg_text = context.stock_protection_msg(protect, from_id).await;
         let cmd = match protect {
             ProtectionStatus::Protected => SystemMessage::ChatProtectionEnabled,
             ProtectionStatus::Unprotected => SystemMessage::ChatProtectionDisabled,
@@ -424,7 +423,11 @@ impl ChatId {
         if promote {
             let mut msg = Message {
                 viewtype: Viewtype::Text,
-                text: Some(msg_text),
+                text: Some(
+                    context
+                        .stock_protection_msg(protect, ByContact::SelfName)
+                        .await,
+                ),
                 ..Default::default()
             };
             msg.param.set_cmd(cmd);
@@ -433,7 +436,9 @@ impl ChatId {
             add_info_msg_with_cmd(
                 context,
                 self,
-                &msg_text,
+                &context
+                    .stock_protection_msg(protect, ByContact::YouOrName(from_id))
+                    .await,
                 cmd,
                 create_smeared_timestamp(context).await,
                 None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -282,6 +282,21 @@ impl Context {
         }
     }
 
+    pub async fn get_config_self_name(&self) -> String {
+        match self
+            .get_config(Config::Displayname)
+            .await
+            .unwrap_or_default()
+        {
+            Some(name) => name,
+            None => self
+                .get_config(Config::Addr)
+                .await
+                .unwrap_or_default()
+                .unwrap_or_default(),
+        }
+    }
+
     /// Set the given config key.
     /// If `None` is passed as a value the value is cleared and set to the default if there is one.
     pub async fn set_config(&self, key: Config, value: Option<&str>) -> Result<()> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -282,18 +282,21 @@ impl Context {
         }
     }
 
-    pub async fn get_config_self_name(&self) -> String {
-        match self
+    pub async fn get_config_name_and_addr(&self) -> String {
+        let name = self
             .get_config(Config::Displayname)
             .await
             .unwrap_or_default()
-        {
-            Some(name) => name,
-            None => self
-                .get_config(Config::Addr)
-                .await
-                .unwrap_or_default()
-                .unwrap_or_default(),
+            .unwrap_or_default();
+        let addr = self
+            .get_config(Config::Addr)
+            .await
+            .unwrap_or_default()
+            .unwrap_or_else(|| "unconfigured".to_string());
+        if !name.is_empty() {
+            format!("{} ({})", name, addr)
+        } else {
+            addr
         }
     }
 

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -83,6 +83,7 @@ use crate::message::{Message, MessageState, MsgId, Viewtype};
 use crate::mimeparser::SystemMessage;
 use crate::sql::{self, params_iter};
 use crate::stock_str;
+use crate::stock_str::ByContact;
 use crate::tools::{duration_to_str, time};
 use std::cmp::max;
 
@@ -204,7 +205,7 @@ impl ChatId {
         }
         self.inner_set_ephemeral_timer(context, timer).await?;
         let mut msg = Message::new(Viewtype::Text);
-        msg.text = Some(stock_ephemeral_timer_changed(context, timer, ContactId::SELF).await);
+        msg.text = Some(stock_ephemeral_timer_changed(context, timer, ByContact::SelfName).await);
         msg.param.set_cmd(SystemMessage::EphemeralTimerChanged);
         if let Err(err) = send_msg(context, self, &mut msg).await {
             error!(
@@ -220,7 +221,7 @@ impl ChatId {
 pub(crate) async fn stock_ephemeral_timer_changed(
     context: &Context,
     timer: Timer,
-    from_id: ContactId,
+    from_id: ByContact,
 ) -> String {
     match timer {
         Timer::Disabled => stock_str::msg_ephemeral_timer_disabled(context, from_id).await,
@@ -637,7 +638,12 @@ mod tests {
         let context = TestContext::new().await;
 
         assert_eq!(
-            stock_ephemeral_timer_changed(&context, Timer::Disabled, ContactId::SELF).await,
+            stock_ephemeral_timer_changed(
+                &context,
+                Timer::Disabled,
+                ByContact::YouOrName(ContactId::SELF)
+            )
+            .await,
             "You disabled message deletion timer."
         );
 
@@ -645,7 +651,7 @@ mod tests {
             stock_ephemeral_timer_changed(
                 &context,
                 Timer::Enabled { duration: 1 },
-                ContactId::SELF
+                ByContact::YouOrName(ContactId::SELF)
             )
             .await,
             "You set message deletion timer to 1 s."
@@ -654,7 +660,7 @@ mod tests {
             stock_ephemeral_timer_changed(
                 &context,
                 Timer::Enabled { duration: 30 },
-                ContactId::SELF
+                ByContact::YouOrName(ContactId::SELF)
             )
             .await,
             "You set message deletion timer to 30 s."
@@ -663,7 +669,7 @@ mod tests {
             stock_ephemeral_timer_changed(
                 &context,
                 Timer::Enabled { duration: 60 },
-                ContactId::SELF
+                ByContact::YouOrName(ContactId::SELF)
             )
             .await,
             "You set message deletion timer to 1 minute."
@@ -672,7 +678,7 @@ mod tests {
             stock_ephemeral_timer_changed(
                 &context,
                 Timer::Enabled { duration: 90 },
-                ContactId::SELF
+                ByContact::YouOrName(ContactId::SELF)
             )
             .await,
             "You set message deletion timer to 1.5 minutes."
@@ -681,7 +687,7 @@ mod tests {
             stock_ephemeral_timer_changed(
                 &context,
                 Timer::Enabled { duration: 30 * 60 },
-                ContactId::SELF
+                ByContact::YouOrName(ContactId::SELF)
             )
             .await,
             "You set message deletion timer to 30 minutes."
@@ -690,7 +696,7 @@ mod tests {
             stock_ephemeral_timer_changed(
                 &context,
                 Timer::Enabled { duration: 60 * 60 },
-                ContactId::SELF
+                ByContact::YouOrName(ContactId::SELF)
             )
             .await,
             "You set message deletion timer to 1 hour."
@@ -699,7 +705,7 @@ mod tests {
             stock_ephemeral_timer_changed(
                 &context,
                 Timer::Enabled { duration: 5400 },
-                ContactId::SELF
+                ByContact::YouOrName(ContactId::SELF)
             )
             .await,
             "You set message deletion timer to 1.5 hours."
@@ -710,7 +716,7 @@ mod tests {
                 Timer::Enabled {
                     duration: 2 * 60 * 60
                 },
-                ContactId::SELF
+                ByContact::YouOrName(ContactId::SELF)
             )
             .await,
             "You set message deletion timer to 2 hours."
@@ -721,7 +727,7 @@ mod tests {
                 Timer::Enabled {
                     duration: 24 * 60 * 60
                 },
-                ContactId::SELF
+                ByContact::YouOrName(ContactId::SELF)
             )
             .await,
             "You set message deletion timer to 1 day."
@@ -732,7 +738,7 @@ mod tests {
                 Timer::Enabled {
                     duration: 2 * 24 * 60 * 60
                 },
-                ContactId::SELF
+                ByContact::YouOrName(ContactId::SELF)
             )
             .await,
             "You set message deletion timer to 2 days."
@@ -743,7 +749,7 @@ mod tests {
                 Timer::Enabled {
                     duration: 7 * 24 * 60 * 60
                 },
-                ContactId::SELF
+                ByContact::YouOrName(ContactId::SELF)
             )
             .await,
             "You set message deletion timer to 1 week."
@@ -754,7 +760,7 @@ mod tests {
                 Timer::Enabled {
                     duration: 4 * 7 * 24 * 60 * 60
                 },
-                ContactId::SELF
+                ByContact::YouOrName(ContactId::SELF)
             )
             .await,
             "You set message deletion timer to 4 weeks."

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -934,7 +934,12 @@ async fn add_parts(
                     chat::add_info_msg(
                         context,
                         chat_id,
-                        &stock_ephemeral_timer_changed(context, ephemeral_timer, from_id).await,
+                        &stock_ephemeral_timer_changed(
+                            context,
+                            ephemeral_timer,
+                            ByContact::YouOrName(from_id),
+                        )
+                        .await,
                         sort_timestamp,
                     )
                     .await?;
@@ -949,7 +954,10 @@ async fn add_parts(
     }
 
     if mime_parser.is_system_message == SystemMessage::EphemeralTimerChanged {
-        better_msg = Some(stock_ephemeral_timer_changed(context, ephemeral_timer, from_id).await);
+        better_msg = Some(
+            stock_ephemeral_timer_changed(context, ephemeral_timer, ByContact::YouOrName(from_id))
+                .await,
+        );
 
         // Do not delete the system message itself.
         //

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1005,7 +1005,11 @@ async fn add_parts(
                             // do not return an error as this would result in retrying the message
                         }
                     }
-                    better_msg = Some(context.stock_protection_msg(new_status, from_id).await);
+                    better_msg = Some(
+                        context
+                            .stock_protection_msg(new_status, ByContact::YouOrName(from_id))
+                            .await,
+                    );
                 }
             }
         }

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -944,14 +944,21 @@ pub(crate) async fn failed_sending_to(context: &Context, name: impl AsRef<str>) 
 /// Stock string: `Message deletion timer is disabled.`.
 pub(crate) async fn msg_ephemeral_timer_disabled(
     context: &Context,
-    by_contact: ContactId,
+    by_contact: ByContact,
 ) -> String {
-    if by_contact == ContactId::SELF {
-        translated(context, StockMessage::MsgYouDisabledEphemeralTimer).await
-    } else {
-        translated(context, StockMessage::MsgEphemeralTimerDisabledBy)
+    match by_contact {
+        ByContact::YouOrName(by_contact) => {
+            if by_contact == ContactId::SELF {
+                translated(context, StockMessage::MsgYouDisabledEphemeralTimer).await
+            } else {
+                translated(context, StockMessage::MsgEphemeralTimerDisabledBy)
+                    .await
+                    .replace1(by_contact.get_stock_name(context).await)
+            }
+        }
+        ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerDisabledBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(context.get_config_self_name().await),
     }
 }
 
@@ -959,61 +966,97 @@ pub(crate) async fn msg_ephemeral_timer_disabled(
 pub(crate) async fn msg_ephemeral_timer_enabled(
     context: &Context,
     timer: impl AsRef<str>,
-    by_contact: ContactId,
+    by_contact: ByContact,
 ) -> String {
-    if by_contact == ContactId::SELF {
-        translated(context, StockMessage::MsgYouEnabledEphemeralTimer)
+    match by_contact {
+        ByContact::YouOrName(by_contact) => {
+            if by_contact == ContactId::SELF {
+                translated(context, StockMessage::MsgYouEnabledEphemeralTimer)
+                    .await
+                    .replace1(timer)
+            } else {
+                translated(context, StockMessage::MsgEphemeralTimerEnabledBy)
+                    .await
+                    .replace1(timer)
+                    .replace2(by_contact.get_stock_name(context).await)
+            }
+        }
+        ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerEnabledBy)
             .await
             .replace1(timer)
-    } else {
-        translated(context, StockMessage::MsgEphemeralTimerEnabledBy)
-            .await
-            .replace1(timer)
-            .replace2(by_contact.get_stock_name(context).await)
+            .replace2(context.get_config_self_name().await),
     }
 }
 
 /// Stock string: `Message deletion timer is set to 1 minute.`.
-pub(crate) async fn msg_ephemeral_timer_minute(context: &Context, by_contact: ContactId) -> String {
-    if by_contact == ContactId::SELF {
-        translated(context, StockMessage::MsgYouEphemeralTimerMinute).await
-    } else {
-        translated(context, StockMessage::MsgEphemeralTimerMinuteBy)
+pub(crate) async fn msg_ephemeral_timer_minute(context: &Context, by_contact: ByContact) -> String {
+    match by_contact {
+        ByContact::YouOrName(by_contact) => {
+            if by_contact == ContactId::SELF {
+                translated(context, StockMessage::MsgYouEphemeralTimerMinute).await
+            } else {
+                translated(context, StockMessage::MsgEphemeralTimerMinuteBy)
+                    .await
+                    .replace1(by_contact.get_stock_name(context).await)
+            }
+        }
+        ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerMinuteBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(context.get_config_self_name().await),
     }
 }
 
 /// Stock string: `Message deletion timer is set to 1 hour.`.
-pub(crate) async fn msg_ephemeral_timer_hour(context: &Context, by_contact: ContactId) -> String {
-    if by_contact == ContactId::SELF {
-        translated(context, StockMessage::MsgYouEphemeralTimerHour).await
-    } else {
-        translated(context, StockMessage::MsgEphemeralTimerHourBy)
+pub(crate) async fn msg_ephemeral_timer_hour(context: &Context, by_contact: ByContact) -> String {
+    match by_contact {
+        ByContact::YouOrName(by_contact) => {
+            if by_contact == ContactId::SELF {
+                translated(context, StockMessage::MsgYouEphemeralTimerHour).await
+            } else {
+                translated(context, StockMessage::MsgEphemeralTimerHourBy)
+                    .await
+                    .replace1(by_contact.get_stock_name(context).await)
+            }
+        }
+        ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerHourBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(context.get_config_self_name().await),
     }
 }
 
 /// Stock string: `Message deletion timer is set to 1 day.`.
-pub(crate) async fn msg_ephemeral_timer_day(context: &Context, by_contact: ContactId) -> String {
-    if by_contact == ContactId::SELF {
-        translated(context, StockMessage::MsgYouEphemeralTimerDay).await
-    } else {
-        translated(context, StockMessage::MsgEphemeralTimerDayBy)
+pub(crate) async fn msg_ephemeral_timer_day(context: &Context, by_contact: ByContact) -> String {
+    match by_contact {
+        ByContact::YouOrName(by_contact) => {
+            if by_contact == ContactId::SELF {
+                translated(context, StockMessage::MsgYouEphemeralTimerDay).await
+            } else {
+                translated(context, StockMessage::MsgEphemeralTimerDayBy)
+                    .await
+                    .replace1(by_contact.get_stock_name(context).await)
+            }
+        }
+        ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerDayBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(context.get_config_self_name().await),
     }
 }
 
 /// Stock string: `Message deletion timer is set to 1 week.`.
-pub(crate) async fn msg_ephemeral_timer_week(context: &Context, by_contact: ContactId) -> String {
-    if by_contact == ContactId::SELF {
-        translated(context, StockMessage::MsgYouEphemeralTimerWeek).await
-    } else {
-        translated(context, StockMessage::MsgEphemeralTimerWeekBy)
+pub(crate) async fn msg_ephemeral_timer_week(context: &Context, by_contact: ByContact) -> String {
+    match by_contact {
+        ByContact::YouOrName(by_contact) => {
+            if by_contact == ContactId::SELF {
+                translated(context, StockMessage::MsgYouEphemeralTimerWeek).await
+            } else {
+                translated(context, StockMessage::MsgEphemeralTimerWeekBy)
+                    .await
+                    .replace1(by_contact.get_stock_name(context).await)
+            }
+        }
+        ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerWeekBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(context.get_config_self_name().await),
     }
 }
 
@@ -1095,17 +1138,25 @@ pub(crate) async fn delete_server_turned_off(context: &Context) -> String {
 pub(crate) async fn msg_ephemeral_timer_minutes(
     context: &Context,
     minutes: impl AsRef<str>,
-    by_contact: ContactId,
+    by_contact: ByContact,
 ) -> String {
-    if by_contact == ContactId::SELF {
-        translated(context, StockMessage::MsgYouEphemeralTimerMinutes)
+    match by_contact {
+        ByContact::YouOrName(by_contact) => {
+            if by_contact == ContactId::SELF {
+                translated(context, StockMessage::MsgYouEphemeralTimerMinutes)
+                    .await
+                    .replace1(minutes)
+            } else {
+                translated(context, StockMessage::MsgEphemeralTimerMinutesBy)
+                    .await
+                    .replace1(minutes)
+                    .replace2(by_contact.get_stock_name(context).await)
+            }
+        }
+        ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerMinutesBy)
             .await
             .replace1(minutes)
-    } else {
-        translated(context, StockMessage::MsgEphemeralTimerMinutesBy)
-            .await
-            .replace1(minutes)
-            .replace2(by_contact.get_stock_name(context).await)
+            .replace2(context.get_config_self_name().await),
     }
 }
 
@@ -1113,17 +1164,25 @@ pub(crate) async fn msg_ephemeral_timer_minutes(
 pub(crate) async fn msg_ephemeral_timer_hours(
     context: &Context,
     hours: impl AsRef<str>,
-    by_contact: ContactId,
+    by_contact: ByContact,
 ) -> String {
-    if by_contact == ContactId::SELF {
-        translated(context, StockMessage::MsgYouEphemeralTimerHours)
+    match by_contact {
+        ByContact::YouOrName(by_contact) => {
+            if by_contact == ContactId::SELF {
+                translated(context, StockMessage::MsgYouEphemeralTimerHours)
+                    .await
+                    .replace1(hours)
+            } else {
+                translated(context, StockMessage::MsgEphemeralTimerHoursBy)
+                    .await
+                    .replace1(hours)
+                    .replace2(by_contact.get_stock_name(context).await)
+            }
+        }
+        ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerHoursBy)
             .await
             .replace1(hours)
-    } else {
-        translated(context, StockMessage::MsgEphemeralTimerHoursBy)
-            .await
-            .replace1(hours)
-            .replace2(by_contact.get_stock_name(context).await)
+            .replace2(context.get_config_self_name().await),
     }
 }
 
@@ -1131,17 +1190,25 @@ pub(crate) async fn msg_ephemeral_timer_hours(
 pub(crate) async fn msg_ephemeral_timer_days(
     context: &Context,
     days: impl AsRef<str>,
-    by_contact: ContactId,
+    by_contact: ByContact,
 ) -> String {
-    if by_contact == ContactId::SELF {
-        translated(context, StockMessage::MsgYouEphemeralTimerDays)
+    match by_contact {
+        ByContact::YouOrName(by_contact) => {
+            if by_contact == ContactId::SELF {
+                translated(context, StockMessage::MsgYouEphemeralTimerDays)
+                    .await
+                    .replace1(days)
+            } else {
+                translated(context, StockMessage::MsgEphemeralTimerDaysBy)
+                    .await
+                    .replace1(days)
+                    .replace2(by_contact.get_stock_name(context).await)
+            }
+        }
+        ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerDaysBy)
             .await
             .replace1(days)
-    } else {
-        translated(context, StockMessage::MsgEphemeralTimerDaysBy)
-            .await
-            .replace1(days)
-            .replace2(by_contact.get_stock_name(context).await)
+            .replace2(context.get_config_self_name().await),
     }
 }
 
@@ -1149,17 +1216,25 @@ pub(crate) async fn msg_ephemeral_timer_days(
 pub(crate) async fn msg_ephemeral_timer_weeks(
     context: &Context,
     weeks: impl AsRef<str>,
-    by_contact: ContactId,
+    by_contact: ByContact,
 ) -> String {
-    if by_contact == ContactId::SELF {
-        translated(context, StockMessage::MsgYouEphemeralTimerWeeks)
+    match by_contact {
+        ByContact::YouOrName(by_contact) => {
+            if by_contact == ContactId::SELF {
+                translated(context, StockMessage::MsgYouEphemeralTimerWeeks)
+                    .await
+                    .replace1(weeks)
+            } else {
+                translated(context, StockMessage::MsgEphemeralTimerWeeksBy)
+                    .await
+                    .replace1(weeks)
+                    .replace2(by_contact.get_stock_name(context).await)
+            }
+        }
+        ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerWeeksBy)
             .await
             .replace1(weeks)
-    } else {
-        translated(context, StockMessage::MsgEphemeralTimerWeeksBy)
-            .await
-            .replace1(weeks)
-            .replace2(by_contact.get_stock_name(context).await)
+            .replace2(context.get_config_self_name().await),
     }
 }
 

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -579,7 +579,7 @@ pub(crate) async fn msg_grp_name(
             .await
             .replace1(from_group)
             .replace2(to_group)
-            .replace3(context.get_config_self_name().await),
+            .replace3(context.get_config_name_and_addr().await),
     }
 }
 
@@ -596,7 +596,7 @@ pub(crate) async fn msg_grp_img_changed(context: &Context, by_contact: ByContact
         }
         ByContact::SelfName => translated(context, StockMessage::MsgGrpImgChangedBy)
             .await
-            .replace1(context.get_config_self_name().await),
+            .replace1(context.get_config_name_and_addr().await),
     }
 }
 
@@ -633,7 +633,7 @@ pub(crate) async fn msg_add_member(
         ByContact::SelfName => translated(context, StockMessage::MsgAddMemberBy)
             .await
             .replace1(who)
-            .replace2(context.get_config_self_name().await),
+            .replace2(context.get_config_name_and_addr().await),
     }
 }
 
@@ -670,7 +670,7 @@ pub(crate) async fn msg_del_member(
         ByContact::SelfName => translated(context, StockMessage::MsgDelMemberBy)
             .await
             .replace1(who)
-            .replace2(context.get_config_self_name().await),
+            .replace2(context.get_config_name_and_addr().await),
     }
 }
 
@@ -688,7 +688,7 @@ pub(crate) async fn msg_group_left(context: &Context, by_contact: ByContact) -> 
         }
         ByContact::SelfName => translated(context, StockMessage::MsgGroupLeftBy)
             .await
-            .replace1(context.get_config_self_name().await),
+            .replace1(context.get_config_name_and_addr().await),
     }
 }
 
@@ -748,7 +748,7 @@ pub(crate) async fn msg_grp_img_deleted(context: &Context, by_contact: ByContact
         }
         ByContact::SelfName => translated(context, StockMessage::MsgGrpImgDeletedBy)
             .await
-            .replace1(context.get_config_self_name().await),
+            .replace1(context.get_config_name_and_addr().await),
     }
 }
 
@@ -958,7 +958,7 @@ pub(crate) async fn msg_ephemeral_timer_disabled(
         }
         ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerDisabledBy)
             .await
-            .replace1(context.get_config_self_name().await),
+            .replace1(context.get_config_name_and_addr().await),
     }
 }
 
@@ -984,7 +984,7 @@ pub(crate) async fn msg_ephemeral_timer_enabled(
         ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerEnabledBy)
             .await
             .replace1(timer)
-            .replace2(context.get_config_self_name().await),
+            .replace2(context.get_config_name_and_addr().await),
     }
 }
 
@@ -1002,7 +1002,7 @@ pub(crate) async fn msg_ephemeral_timer_minute(context: &Context, by_contact: By
         }
         ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerMinuteBy)
             .await
-            .replace1(context.get_config_self_name().await),
+            .replace1(context.get_config_name_and_addr().await),
     }
 }
 
@@ -1020,7 +1020,7 @@ pub(crate) async fn msg_ephemeral_timer_hour(context: &Context, by_contact: ByCo
         }
         ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerHourBy)
             .await
-            .replace1(context.get_config_self_name().await),
+            .replace1(context.get_config_name_and_addr().await),
     }
 }
 
@@ -1038,7 +1038,7 @@ pub(crate) async fn msg_ephemeral_timer_day(context: &Context, by_contact: ByCon
         }
         ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerDayBy)
             .await
-            .replace1(context.get_config_self_name().await),
+            .replace1(context.get_config_name_and_addr().await),
     }
 }
 
@@ -1056,7 +1056,7 @@ pub(crate) async fn msg_ephemeral_timer_week(context: &Context, by_contact: ByCo
         }
         ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerWeekBy)
             .await
-            .replace1(context.get_config_self_name().await),
+            .replace1(context.get_config_name_and_addr().await),
     }
 }
 
@@ -1111,7 +1111,7 @@ pub(crate) async fn protection_enabled(context: &Context, by_contact: ByContact)
         }
         ByContact::SelfName => translated(context, StockMessage::ProtectionEnabledBy)
             .await
-            .replace1(context.get_config_self_name().await),
+            .replace1(context.get_config_name_and_addr().await),
     }
 }
 
@@ -1129,7 +1129,7 @@ pub(crate) async fn protection_disabled(context: &Context, by_contact: ByContact
         }
         ByContact::SelfName => translated(context, StockMessage::ProtectionDisabledBy)
             .await
-            .replace1(context.get_config_self_name().await),
+            .replace1(context.get_config_name_and_addr().await),
     }
 }
 
@@ -1170,7 +1170,7 @@ pub(crate) async fn msg_ephemeral_timer_minutes(
         ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerMinutesBy)
             .await
             .replace1(minutes)
-            .replace2(context.get_config_self_name().await),
+            .replace2(context.get_config_name_and_addr().await),
     }
 }
 
@@ -1196,7 +1196,7 @@ pub(crate) async fn msg_ephemeral_timer_hours(
         ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerHoursBy)
             .await
             .replace1(hours)
-            .replace2(context.get_config_self_name().await),
+            .replace2(context.get_config_name_and_addr().await),
     }
 }
 
@@ -1222,7 +1222,7 @@ pub(crate) async fn msg_ephemeral_timer_days(
         ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerDaysBy)
             .await
             .replace1(days)
-            .replace2(context.get_config_self_name().await),
+            .replace2(context.get_config_name_and_addr().await),
     }
 }
 
@@ -1248,7 +1248,7 @@ pub(crate) async fn msg_ephemeral_timer_weeks(
         ByContact::SelfName => translated(context, StockMessage::MsgEphemeralTimerWeeksBy)
             .await
             .replace1(weeks)
-            .replace2(context.get_config_self_name().await),
+            .replace2(context.get_config_name_and_addr().await),
     }
 }
 
@@ -1576,6 +1576,22 @@ mod tests {
             msg_add_member(&t, "alice@example.org", ByContact::YouOrName(contact_id)).await,
             "Member Alice (alice@example.org) added by Bob (bob@example.com)."
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_stock_system_msg_add_member_by_self_name() -> Result<()> {
+        let t = TestContext::new_bob().await;
+        assert_eq!(
+            msg_add_member(&t, "alice@example.org", ByContact::SelfName).await,
+            "Member alice@example.org added by bob@example.net."
+        );
+
+        t.set_config(Config::Displayname, Some("Bobby")).await?;
+        assert_eq!(
+            msg_add_member(&t, "alice@example.org", ByContact::SelfName).await,
+            "Member alice@example.org added by Bobby (bob@example.net)."
+        );
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
i did not find a way with less code changes and fewer code at all (apart from hacky ones ;)

unless @link2xt or someone else has a nicer idea, ~~i can finish this pr for the missing stock messages (ephemeral, maybe some more)~~ EDIT: finished, so, ready for review :)

for review, hiding whitespaces makes a difference.

successor of  #3518
closes #3750