### PR TITLE
fetch_new_messages(): fetch messages sequentially (#3688)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 - fix detection of "All mail", "Trash", "Junk" etc folders. #3760
+- fetch messages sequentially to fix reactions on partially downloaded messages #3688
 
 
 ## 1.101.0


### PR DESCRIPTION
Looks like this very simple commit does the job. But if you wish, i can simplify the whole fetch_new_messages() so it would do the only fetch (full or partial) in its run.
Tested it by hands now, using Gmail with mvbox_move disabled as @link2xt suggested