### PR TITLE
[wip] Mindful encryption modes for chats & messages

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -75,6 +75,29 @@ pub enum ProtectionStatus {
     Protected = 1,
 }
 
+#[derive(
+    Debug,
+    Display,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    FromPrimitive,
+    ToPrimitive,
+    FromSql,
+    ToSql,
+    IntoStaticStr,
+    Serialize,
+    Deserialize,
+)]
+#[repr(u32)]
+pub enum EncryptionModus {
+    Opportunistic = 0,
+    ForcePlaintext = 1,
+    ForceEncrypted = 2,
+    ForceVerified = 3,
+}
+
 impl Default for ProtectionStatus {
     fn default() -> Self {
         ProtectionStatus::Unprotected
@@ -897,6 +920,33 @@ impl ChatId {
 
         Ok(ret.trim().to_string())
     }
+
+    /// This sets a protection modus for the chat and enforces that messages are only send if they
+    /// meet the encryption modus (ForcePlaintext, Opportunistic, ForceEncrypted, ForceVerified)
+    pub async fn set_encryption_modus(self, context: &Context, modus: &EncryptionModus) -> Result<()> {
+        let encryption_modus: u32 = context
+            .sql
+            .query_get_value(
+                "SELECT encryption_modus FROM chats WHERE id=?;",
+                paramsv![self],
+            )
+            .await??;
+        Ok(encryption_modus.unwrap_or_default())
+    }
+
+    /// This sets a protection modus for the chat and enforces that messages are only send if they
+    /// meet the encryption modus (ForcePlaintext, Opportunistic, ForceEncrypted, ForceVerified)
+    pub async fn get_encryption_modus(self, context: &Context) -> Result<EncryptionModus> {
+        let encryption_modus: u32 = context
+            .sql
+            .query_get_value(
+                "SELECT encryption_modus FROM chats WHERE id=?;",
+                paramsv![self],
+            )
+            .await??;
+        Ok(encryption_modus.into())
+    }
+
 
     /// Bad evil escape hatch.
     ///

--- a/src/param.rs
+++ b/src/param.rs
@@ -51,6 +51,7 @@ pub enum Param {
     ErroneousE2ee = b'e',
 
     /// For Messages: force unencrypted message, a value from `ForcePlaintext` enum.
+    /// Deprecated: Use EncryptionModus::ForcePlaintext
     ForcePlaintext = b'u',
 
     /// For Messages: do not include Autocrypt header.

--- a/src/sql/tables.sql
+++ b/src/sql/tables.sql
@@ -38,7 +38,8 @@ CREATE TABLE chats (
     locations_last_sent INTEGER DEFAULT 0,
     created_timestamp INTEGER DEFAULT 0,
     muted_until INTEGER DEFAULT 0,
-    ephemeral_timer INTEGER
+    ephemeral_timer INTEGER,
+    encryption_modus INTEGER DEFAULT 0
 );
 CREATE INDEX chats_index1 ON chats (grpid);
 CREATE INDEX chats_index2 ON chats (archived);

--- a/src/sql/tables.sql
+++ b/src/sql/tables.sql
@@ -93,7 +93,8 @@ CREATE TABLE msgs (
 -- deleted. It is convenient to store it here because UI
 -- needs this value to display how much time is left until
 -- the message is deleted.
-    ephemeral_timestamp INTEGER DEFAULT 0
+    ephemeral_timestamp INTEGER DEFAULT 0,
+    encryption_modus INTEGER DEFAULT 0
 );
 
 CREATE INDEX msgs_index1 ON msgs (rfc724_mid);


### PR DESCRIPTION
This pr adds api methods to set one of four encryption modes to Chats & Messages (encryption mode of chat is propagated to messages send to this chat). An encryption mode is not propagated to other members of the chat.
There are four encryption modes:
- Opportunistic (Default)
- ForcePlaintext
- ForceEncryption
- ForceVerified