### PR TITLE
Add Python API to send reactions (#3762)

### DIFF
--- a/python/src/deltachat/_build.py
+++ b/python/src/deltachat/_build.py
@@ -156,6 +156,7 @@ def extract_defines(flags):
                 | DC_KEY_GEN
                 | DC_IMEX
                 | DC_CONNECTIVITY
+                | DC_DOWNLOAD
             )         # End of prefix matching
             _[\w_]+   # Match the suffix, e.g. _RSA2048 in DC_KEY_GEN_RSA2048
         )             # Close the capturing group, this contains

--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -192,6 +192,12 @@ class FFIEventTracker:
             return self.account.get_message_by_id(ev.data2)
         return None
 
+    def wait_next_reactions_changed(self):
+        """wait for and return next reactions-changed message"""
+        ev = self.get_matching("DC_EVENT_REACTIONS_CHANGED")
+        assert ev.data1 > 0
+        return self.account.get_message_by_id(ev.data2)
+
     def wait_msg_delivered(self, msg):
         ev = self.get_matching("DC_EVENT_MSG_DELIVERED")
         assert ev.data1 == msg.chat.id
@@ -296,6 +302,10 @@ class EventThread(threading.Thread):
                         "ac_incoming_message",
                         dict(message=msg),
                     )
+        elif name == "DC_EVENT_REACTIONS_CHANGED":
+            assert ffi_event.data1 > 0
+            msg = account.get_message_by_id(ffi_event.data2)
+            yield "ac_reactions_changed", dict(message=msg)
         elif name == "DC_EVENT_MSG_DELIVERED":
             msg = account.get_message_by_id(ffi_event.data2)
             yield "ac_message_delivered", dict(message=msg)

--- a/python/src/deltachat/hookspec.py
+++ b/python/src/deltachat/hookspec.py
@@ -50,6 +50,10 @@ class PerAccount:
         """Called on each outgoing message (both system and "normal")."""
 
     @account_hookspec
+    def ac_reactions_changed(self, message):
+        """Called when message reactions changed."""
+
+    @account_hookspec
     def ac_message_delivered(self, message):
         """Called when an outgoing message has been delivered to SMTP.
 

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -461,6 +461,17 @@ class Message(object):
         """mark this message as seen."""
         self.account.mark_seen_messages([self.id])
 
+    #
+    # Message download state
+    #
+    @property
+    def download_state(self):
+        assert self.id > 0
+
+        # load message from db to get a fresh/current state
+        dc_msg = ffi.gc(lib.dc_get_msg(self.account._dc_context, self.id), lib.dc_msg_unref)
+        return lib.dc_msg_get_download_state(dc_msg)
+
 
 # some code for handling DC_MSG_* view types
 

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -9,6 +9,7 @@ from typing import Optional, Union
 from . import const, props
 from .capi import ffi, lib
 from .cutil import as_dc_charpointer, from_dc_charpointer, from_optional_dc_charpointer
+from .reactions import Reactions
 
 
 class Message(object):
@@ -160,6 +161,17 @@ class Message(object):
                 self.account._dc_context, self.id, as_dc_charpointer(json_data), as_dc_charpointer(description)
             )
         )
+
+    def send_reaction(self, reaction: str):
+        """Send a reaction to message and return the resulting Message instance."""
+        msg_id = lib.dc_send_reaction(self.account._dc_context, self.id, as_dc_charpointer(reaction))
+        if msg_id == 0:
+            raise ValueError("reaction could not be send")
+        return Message.from_db(self.account, msg_id)
+
+    def get_reactions(self) -> Reactions:
+        """Get :class:`deltachat.reactions.Reactions` to the message."""
+        return Reactions.from_msg(self)
 
     def is_system_message(self):
         """return True if this message is a system/info message."""

--- a/python/src/deltachat/reactions.py
+++ b/python/src/deltachat/reactions.py
@@ -1,0 +1,43 @@
+""" The Reactions object. """
+
+from .capi import ffi, lib
+from .cutil import from_dc_charpointer, iter_array
+
+
+class Reactions(object):
+    """Reactions object.
+
+    You obtain instances of it through :class:`deltachat.message.Message`.
+    """
+
+    def __init__(self, account, dc_reactions):
+        assert isinstance(account._dc_context, ffi.CData)
+        assert isinstance(dc_reactions, ffi.CData)
+        assert dc_reactions != ffi.NULL
+        self.account = account
+        self._dc_reactions = dc_reactions
+
+    def __repr__(self):
+        return "<Reactions dc_reactions={}>".format(self._dc_reactions)
+
+    @classmethod
+    def from_msg(cls, msg):
+        assert msg.id > 0
+        return cls(
+            msg.account,
+            ffi.gc(lib.dc_get_msg_reactions(msg.account._dc_context, msg.id), lib.dc_reactions_unref),
+        )
+
+    def get_contacts(self) -> list:
+        """Get list of contacts reacted to the message.
+
+        :returns: list of :class:`deltachat.contact.Contact` objects for this reaction.
+        """
+        from .contact import Contact
+
+        dc_array = ffi.gc(lib.dc_reactions_get_contacts(self._dc_reactions), lib.dc_array_unref)
+        return list(iter_array(dc_array, lambda x: Contact(self.account, x)))
+
+    def get_by_contact(self, contact) -> str:
+        """Get a string containing space-separated reactions of a single :class:`deltachat.contact.Contact`."""
+        return from_dc_charpointer(lib.dc_reactions_get_by_contact_id(self._dc_reactions, contact.id))

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1237,6 +1237,66 @@ def test_send_and_receive_image(acfactory, lp, data):
     assert m == msg_in
 
 
+def test_reaction_to_partially_fetched_msg(acfactory, lp, tmpdir):
+    """See https://github.com/deltachat/deltachat-core-rust/issues/3688 "Partially downloaded
+    messages are received out of order".
+
+    If the Inbox contains X small messages followed by Y large messages followed by Z small
+    messages, Delta Chat first downloaded a batch of X+Z messages, and then a batch of Y messages.
+
+    This bug was discovered by @Simon-Laux while testing reactions PR #3644 and can be reproduced
+    with online test as follows:
+    - Bob enables download limit and goes offline.
+    - Alice sends a large message to Bob and reacts to this message with a thumbs-up.
+    - Bob goes online
+    - Bob first processes a reaction message and throws it away because there is no corresponding
+      message, then processes a partially downloaded message.
+    - As a result, Bob does not see a reaction
+    """
+    download_limit = 32768
+    ac1, ac2 = acfactory.get_online_accounts(2)
+    ac1_addr = ac1.get_config("addr")
+    chat = ac1.create_chat(ac2)
+    ac2.set_config("download_limit", str(download_limit))
+    ac2.stop_io()
+
+    reactions_queue = queue.Queue()
+
+    class InPlugin:
+        @account_hookimpl
+        def ac_reactions_changed(self, message):
+            reactions_queue.put(message)
+
+    ac2.add_account_plugin(InPlugin())
+
+    lp.sec("sending small+large messages from ac1 to ac2")
+    msgs = []
+    msgs.append(chat.send_text("hi"))
+    path = tmpdir.join("large")
+    with open(path, "wb") as fout:
+        fout.write(os.urandom(download_limit + 1))
+    msgs.append(chat.send_file(path.strpath))
+
+    lp.sec("sending a reaction to the large message from ac1 to ac2")
+    react_str = "\N{THUMBS UP SIGN}"
+    msgs.append(msgs[-1].send_reaction(react_str))
+
+    for m in msgs:
+        ac1._evtracker.wait_msg_delivered(m)
+    ac2.start_io()
+
+    lp.sec("wait for ac2 to receive a reaction")
+    msg2 = ac2._evtracker.wait_next_reactions_changed()
+    assert msg2.get_sender_contact().addr == ac1_addr
+    assert msg2.download_state == const.DC_DOWNLOAD_AVAILABLE
+    assert reactions_queue.get() == msg2
+    reactions = msg2.get_reactions()
+    contacts = reactions.get_contacts()
+    assert len(contacts) == 1
+    assert contacts[0].addr == ac1_addr
+    assert reactions.get_by_contact(contacts[0]) == react_str
+
+
 def test_import_export_online_all(acfactory, tmpdir, data, lp):
     (ac1,) = acfactory.get_online_accounts(1)
 


### PR DESCRIPTION
Hello! I have a couple of questions here:
- In the test, how do i check on a recipient side that it is a partially fetched message and that it is a file message? Looks like we should add an API for checking whether it is a partially or fully fetched message. Also i tried Message.is_file(), but it is likely not working for partially fetched messages. Does dc_msg_get_viewtype() return just 0 for them? I believe, in DC should be a way to see at least a type of message before downloading it. Also i see no API for checking that a received message is one that was sent, i.e. for comparing these Message-Id-s: Mr.MsE3xF0RQX8.zhUwsZ7n1sb@x.testrun.org
- I use in the test Account.stop_io() and .set_config() functions. Can i use acfactory.get_online_accounts() then? If my test finishes successfully, it doesn't change the state of account, but if it fails, the account may remain in invalid state. Also i don't want to break other tests running in parallel. There is at least one more test with the same question, test_import_export_online_all(). So, should i switch such tests to using acfactory.new_online_configuring_account() so they wouldn't use cached accounts?