### PR TITLE
Bugfix: Don't let malformed From: headers block the receiving pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixes
 - fix detection of "All mail", "Trash", "Junk" etc folders. #3760
 - fetch messages sequentially to fix reactions on partially downloaded messages #3688
+- Fix a bug where one malformed message blocked receiving any further messages #3769
 
 
 ## 1.101.0

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1754,9 +1754,13 @@ async fn should_move_out_of_spam(
             return Ok(false);
         }
     } else {
+        let from = match mimeparser::get_from(headers) {
+            Some(f) => f,
+            None => return Ok(false),
+        };
         // No chat found.
         let (from_id, blocked_contact, _origin) =
-            from_field_to_contact_id(context, mimeparser::get_from(headers).as_ref(), true).await?;
+            from_field_to_contact_id(context, &from, true).await?;
         if blocked_contact {
             // Contact is blocked, leave the message in spam.
             return Ok(false);
@@ -2041,8 +2045,12 @@ pub(crate) async fn prefetch_should_download(
         .get_header_value(HeaderDef::AutocryptSetupMessage)
         .is_some();
 
+    let from = match mimeparser::get_from(headers) {
+        Some(f) => f,
+        None => return Ok(false),
+    };
     let (_from_id, blocked_contact, origin) =
-        from_field_to_contact_id(context, mimeparser::get_from(headers).as_ref(), true).await?;
+        from_field_to_contact_id(context, &from, true).await?;
     // prevent_rename=true as this might be a mailing list message and in this case it would be bad if we rename the contact.
     // (prevent_rename is the last argument of from_field_to_contact_id())
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -172,7 +172,7 @@ pub(crate) async fn receive_imf_inner(
     // If this is a mailing list email (i.e. list_id_header is some), don't change the displayname because in
     // a mailing list the sender displayname sometimes does not belong to the sender email address.
     let (from_id, _from_id_blocked, incoming_origin) =
-        from_field_to_contact_id(context, Some(&mime_parser.from), prevent_rename).await?;
+        from_field_to_contact_id(context, &mime_parser.from, prevent_rename).await?;
 
     let incoming = from_id != ContactId::SELF;
 
@@ -370,17 +370,9 @@ pub(crate) async fn receive_imf_inner(
 /// * `prevent_rename`: passed through to `add_or_lookup_contacts_by_address_list()`
 pub async fn from_field_to_contact_id(
     context: &Context,
-    from: Option<&SingleInfo>,
+    from: &SingleInfo,
     prevent_rename: bool,
 ) -> Result<(ContactId, bool, Origin)> {
-    let from = match from {
-        Some(f) => f,
-        None => {
-            warn!(context, "mail has an empty From header");
-            return Ok((ContactId::UNDEFINED, false, Origin::Unknown));
-        }
-    };
-
     let display_name = if prevent_rename {
         Some("")
     } else {


### PR DESCRIPTION
That's a bug which @Simon-Laux and probably also @hpk42 had, where one malformed incoming (Spam-) mail blocked the receiving of all emails coming after it.

The problem was that from_field_to_contact_id() returned `ContactId::UNDEFINED`, and then `lookup_by_contact()` returned `Err`.