### PR TITLE
receive_imf: trim() "Chat-Group-Name{,-Changed}:" headers content (#3650)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fix detection of "All mail", "Trash", "Junk" etc folders. #3760
 - fetch messages sequentially to fix reactions on partially downloaded messages #3688
 - Fix a bug where one malformed message blocked receiving any further messages #3769
+- strip leading/trailing whitespace from "Chat-Group-Name{,-Changed}:" headers content #3650
 
 
 ## 1.101.0


### PR DESCRIPTION
It's a w/a for "Space added before long group names after MIME serialization/deserialization" issue. DC itself never creates group names with leading/trailing whitespace, so it can be safely removed.