### PR TITLE
feat(jsonrpc): generate openrpc definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,13 +909,14 @@ dependencies = [
  "log",
  "num-traits",
  "sanitize-filename",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
  "typescript-type-def",
  "walkdir",
- "yerpc",
+ "yerpc 0.3.1 (git+https://github.com/Frando/yerpc.git?branch=openrpc)",
 ]
 
 [[package]]
@@ -930,7 +931,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "yerpc",
+ "yerpc 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1069,6 +1070,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f94fa09c2aeea5b8839e414b7b841bf429fd25b9c522116ac97ee87856d88b2"
 
 [[package]]
 name = "ed25519"
@@ -3044,6 +3051,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a5fb6c61f29e723026dc8e923d94c694313212abbecbbe5f55a7748eec5b307"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f188d036977451159430f3b8dc82ec76364a42b7e289c2b18a9a18f4470058e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,6 +3127,17 @@ name = "serde_derive"
 version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4148,16 +4190,35 @@ dependencies = [
  "async-channel",
  "async-mutex",
  "async-trait",
- "axum",
  "futures",
  "futures-util",
  "log",
  "serde",
  "serde_json",
+ "typescript-type-def",
+ "yerpc_derive 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "yerpc"
+version = "0.3.1"
+source = "git+https://github.com/Frando/yerpc.git?branch=openrpc#2498ea057edd224bcded09f1da139576427e4cef"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "async-mutex",
+ "async-trait",
+ "axum",
+ "futures",
+ "futures-util",
+ "log",
+ "schemars",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "typescript-type-def",
- "yerpc_derive",
+ "yerpc_derive 0.3.0 (git+https://github.com/Frando/yerpc.git?branch=openrpc)",
 ]
 
 [[package]]
@@ -4165,6 +4226,18 @@ name = "yerpc_derive"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f944ca6789bc55ddc86839478f6d49c9d2a66e130f69fd1f8d171b3108990"
+dependencies = [
+ "convert_case",
+ "darling 0.14.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "yerpc_derive"
+version = "0.3.0"
+source = "git+https://github.com/Frando/yerpc.git?branch=openrpc#2498ea057edd224bcded09f1da139576427e4cef"
 dependencies = [
  "convert_case",
  "darling 0.14.1",

--- a/deltachat-jsonrpc/Cargo.toml
+++ b/deltachat-jsonrpc/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4"
 async-channel = { version = "1.6.1" }
 futures = { version = "0.3.25" }
 serde_json = "1.0.87"
-yerpc = { version = "^0.3.1", features = ["anyhow_expose"] }
+yerpc = { git = "https://github.com/Frando/yerpc.git", branch = "openrpc", features = ["anyhow_expose"] }
 typescript-type-def = { version = "0.5.3", features = ["json_value"] }
 tokio = { version = "1.21.2" }
 sanitize-filename = "0.4"
@@ -31,6 +31,7 @@ walkdir = "2.3.2"
 # optional dependencies
 axum = { version = "0.5.17", optional = true, features = ["ws"] }
 env_logger = { version = "0.9.1", optional = true }
+schemars = "0.8.11"
 
 [dev-dependencies]
 tokio = { version = "1.21.2", features = ["full", "rt-multi-thread"] }

--- a/deltachat-jsonrpc/openrpc/openrpc.json
+++ b/deltachat-jsonrpc/openrpc/openrpc.json
@@ -1,0 +1,7996 @@
+{
+  "openrpc": "1.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "CommandApi"
+  },
+  "methods": [
+    {
+      "name": "check_email_validity",
+      "description": " Check if an email address is valid.",
+      "params": [
+        {
+          "name": "email",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "CheckEmailValidityResult",
+        "schema": {
+          "title": "Boolean",
+          "type": "boolean"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_system_info",
+      "description": " Get general system info.",
+      "params": [],
+      "result": {
+        "name": "GetSystemInfoResult",
+        "schema": {
+          "title": "Map_of_String",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "add_account",
+      "params": [],
+      "result": {
+        "name": "AddAccountResult",
+        "schema": {
+          "title": "uint32",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "remove_account",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "RemoveAccountResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_all_account_ids",
+      "params": [],
+      "result": {
+        "name": "GetAllAccountIdsResult",
+        "schema": {
+          "title": "Array_of_uint32",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "select_account",
+      "description": " Select account id for internally selected state.\n TODO: Likely this is deprecated as all methods take an account id now.",
+      "params": [
+        {
+          "name": "id",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "SelectAccountResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_selected_account_id",
+      "description": " Get the selected account id of the internal state..\n TODO: Likely this is deprecated as all methods take an account id now.",
+      "params": [],
+      "result": {
+        "name": "GetSelectedAccountIdResult",
+        "schema": {
+          "title": "Nullable_uint32",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_all_accounts",
+      "description": " Get a list of all configured accounts.",
+      "params": [],
+      "result": {
+        "name": "GetAllAccountsResult",
+        "schema": {
+          "title": "Array_of_Account",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "color",
+                  "id",
+                  "type"
+                ],
+                "properties": {
+                  "addr": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "color": {
+                    "type": "string"
+                  },
+                  "displayName": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "id": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  },
+                  "profileImage": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "Configured"
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "id",
+                  "type"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "Unconfigured"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "start_io_for_all_accounts",
+      "params": [],
+      "result": {
+        "name": "StartIoForAllAccountsResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "stop_io_for_all_accounts",
+      "params": [],
+      "result": {
+        "name": "StopIoForAllAccountsResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "start_io",
+      "params": [
+        {
+          "name": "id",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "StartIoResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "stop_io",
+      "params": [
+        {
+          "name": "id",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "StopIoResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_account_info",
+      "description": " Get top-level info for an account.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetAccountInfoResult",
+        "schema": {
+          "title": "Account",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "color",
+                "id",
+                "type"
+              ],
+              "properties": {
+                "addr": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "color": {
+                  "type": "string"
+                },
+                "displayName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "id": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "profileImage": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Configured"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "id",
+                "type"
+              ],
+              "properties": {
+                "id": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "Unconfigured"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_account_file_size",
+      "description": " Get the combined filesize of an account in bytes",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetAccountFileSizeResult",
+        "schema": {
+          "title": "uint64",
+          "type": "integer",
+          "format": "uint64",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_provider_info",
+      "description": " Returns provider for the given domain.\n\n This function looks up domain in offline database.\n\n For compatibility, email address can be passed to this function\n instead of the domain.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "email",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "GetProviderInfoResult",
+        "schema": {
+          "title": "Nullable_ProviderInfo",
+          "type": [
+            "object",
+            "null"
+          ],
+          "required": [
+            "beforeLoginHint",
+            "overviewPage",
+            "status"
+          ],
+          "properties": {
+            "beforeLoginHint": {
+              "type": "string"
+            },
+            "overviewPage": {
+              "type": "string"
+            },
+            "status": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "is_configured",
+      "description": " Checks if the context is already configured.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "IsConfiguredResult",
+        "schema": {
+          "title": "Boolean",
+          "type": "boolean"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_info",
+      "description": " Get system info for an account.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetInfoResult",
+        "schema": {
+          "title": "Map_of_String",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "set_config",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "key",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        },
+        {
+          "name": "value",
+          "schema": {
+            "title": "Nullable_String",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "SetConfigResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "batch_set_config",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "config",
+          "schema": {
+            "title": "Map_of_Nullable_String",
+            "type": "object",
+            "additionalProperties": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "BatchSetConfigResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "set_config_from_qr",
+      "description": " Set configuration values from a QR code. (technically from the URI that is stored in the qrcode)\n Before this function is called, `checkQr()` should confirm the type of the\n QR code is `account` or `webrtcInstance`.\n\n Internally, the function will call dc_set_config() with the appropriate keys,",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "qrContent",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "SetConfigFromQrResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "check_qr",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "qrContent",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "CheckQrResult",
+        "schema": {
+          "title": "Qr",
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "authcode",
+                "contact_id",
+                "fingerprint",
+                "invitenumber",
+                "type"
+              ],
+              "properties": {
+                "authcode": {
+                  "type": "string"
+                },
+                "contact_id": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "fingerprint": {
+                  "type": "string"
+                },
+                "invitenumber": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "askVerifyContact"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "authcode",
+                "contact_id",
+                "fingerprint",
+                "grpid",
+                "grpname",
+                "invitenumber",
+                "type"
+              ],
+              "properties": {
+                "authcode": {
+                  "type": "string"
+                },
+                "contact_id": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "fingerprint": {
+                  "type": "string"
+                },
+                "grpid": {
+                  "type": "string"
+                },
+                "grpname": {
+                  "type": "string"
+                },
+                "invitenumber": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "askVerifyGroup"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "contact_id",
+                "type"
+              ],
+              "properties": {
+                "contact_id": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "fprOk"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "type"
+              ],
+              "properties": {
+                "contact_id": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "fprMismatch"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "fingerprint",
+                "type"
+              ],
+              "properties": {
+                "fingerprint": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "fprWithoutAddr"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "domain",
+                "type"
+              ],
+              "properties": {
+                "domain": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "account"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "domain",
+                "instance_pattern",
+                "type"
+              ],
+              "properties": {
+                "domain": {
+                  "type": "string"
+                },
+                "instance_pattern": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "webrtcInstance"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "contact_id",
+                "type"
+              ],
+              "properties": {
+                "contact_id": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "draft": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "addr"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "type",
+                "url"
+              ],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "url"
+                  ]
+                },
+                "url": {
+                  "type": "string"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "text",
+                "type"
+              ],
+              "properties": {
+                "text": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "text"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "authcode",
+                "contact_id",
+                "fingerprint",
+                "invitenumber",
+                "type"
+              ],
+              "properties": {
+                "authcode": {
+                  "type": "string"
+                },
+                "contact_id": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "fingerprint": {
+                  "type": "string"
+                },
+                "invitenumber": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "withdrawVerifyContact"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "authcode",
+                "contact_id",
+                "fingerprint",
+                "grpid",
+                "grpname",
+                "invitenumber",
+                "type"
+              ],
+              "properties": {
+                "authcode": {
+                  "type": "string"
+                },
+                "contact_id": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "fingerprint": {
+                  "type": "string"
+                },
+                "grpid": {
+                  "type": "string"
+                },
+                "grpname": {
+                  "type": "string"
+                },
+                "invitenumber": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "withdrawVerifyGroup"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "authcode",
+                "contact_id",
+                "fingerprint",
+                "invitenumber",
+                "type"
+              ],
+              "properties": {
+                "authcode": {
+                  "type": "string"
+                },
+                "contact_id": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "fingerprint": {
+                  "type": "string"
+                },
+                "invitenumber": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "reviveVerifyContact"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "authcode",
+                "contact_id",
+                "fingerprint",
+                "grpid",
+                "grpname",
+                "invitenumber",
+                "type"
+              ],
+              "properties": {
+                "authcode": {
+                  "type": "string"
+                },
+                "contact_id": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "fingerprint": {
+                  "type": "string"
+                },
+                "grpid": {
+                  "type": "string"
+                },
+                "grpname": {
+                  "type": "string"
+                },
+                "invitenumber": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "reviveVerifyGroup"
+                  ]
+                }
+              }
+            },
+            {
+              "type": "object",
+              "required": [
+                "address",
+                "type"
+              ],
+              "properties": {
+                "address": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "login"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_config",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "key",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "GetConfigResult",
+        "schema": {
+          "title": "Nullable_String",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "batch_get_config",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "keys",
+          "schema": {
+            "title": "Array_of_String",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "BatchGetConfigResult",
+        "schema": {
+          "title": "Map_of_Nullable_String",
+          "type": "object",
+          "additionalProperties": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "set_stock_strings",
+      "params": [
+        {
+          "name": "strings",
+          "schema": {
+            "title": "Map_of_String",
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "SetStockStringsResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "configure",
+      "description": " Configures this account with the currently set parameters.\n Setup the credential config before calling this.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "ConfigureResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "stop_ongoing_process",
+      "description": " Signal an ongoing process to stop.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "StopOngoingProcessResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "export_self_keys",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "path",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        },
+        {
+          "name": "passphrase",
+          "schema": {
+            "title": "Nullable_String",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "ExportSelfKeysResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "import_self_keys",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "path",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        },
+        {
+          "name": "passphrase",
+          "schema": {
+            "title": "Nullable_String",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "ImportSelfKeysResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_fresh_msgs",
+      "description": " Returns the message IDs of all _fresh_ messages of any chat.\n Typically used for implementing notification summaries\n or badge counters e.g. on the app icon.\n The list is already sorted and starts with the most recent fresh message.\n\n Messages belonging to muted chats or to the contact requests are not returned;\n these messages should not be notified\n and also badge counters should not include these messages.\n\n To get the number of fresh messages for a single chat, muted or not,\n use `get_fresh_msg_cnt()`.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetFreshMsgsResult",
+        "schema": {
+          "title": "Array_of_uint32",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_fresh_msg_cnt",
+      "description": " Get the number of _fresh_ messages in a chat.\n Typically used to implement a badge with a number in the chatlist.\n\n If the specified chat is muted,\n the UI should show the badge counter \"less obtrusive\",\n e.g. using \"gray\" instead of \"red\" color.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetFreshMsgCntResult",
+        "schema": {
+          "title": "uint",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "estimate_auto_deletion_count",
+      "description": " Estimate the number of messages that will be deleted\n by the set_config()-options `delete_device_after` or `delete_server_after`.\n This is typically used to show the estimated impact to the user\n before actually enabling deletion of old messages.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "fromServer",
+          "schema": {
+            "title": "Boolean",
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "seconds",
+          "schema": {
+            "title": "int64",
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      ],
+      "result": {
+        "name": "EstimateAutoDeletionCountResult",
+        "schema": {
+          "title": "uint",
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "initiate_autocrypt_key_transfer",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "InitiateAutocryptKeyTransferResult",
+        "schema": {
+          "title": "String",
+          "type": "string"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "continue_autocrypt_key_transfer",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "messageId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "setupCode",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "ContinueAutocryptKeyTransferResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_chatlist_entries",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "listFlags",
+          "schema": {
+            "title": "Nullable_uint32",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "queryString",
+          "schema": {
+            "title": "Nullable_String",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        {
+          "name": "queryContactId",
+          "schema": {
+            "title": "Nullable_uint32",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetChatlistEntriesResult",
+        "schema": {
+          "title": "Array_of_ChatListEntry",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": [
+              {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_chatlist_items_by_entries",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "entries",
+          "schema": {
+            "title": "Array_of_ChatListEntry",
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "GetChatlistItemsByEntriesResult",
+        "schema": {
+          "title": "Map_of_ChatListItemFetchResult",
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "color",
+                  "freshMessageCounter",
+                  "id",
+                  "isArchived",
+                  "isBroadcast",
+                  "isContactRequest",
+                  "isDeviceTalk",
+                  "isGroup",
+                  "isMuted",
+                  "isPinned",
+                  "isProtected",
+                  "isSelfInGroup",
+                  "isSelfTalk",
+                  "isSendingLocation",
+                  "name",
+                  "summaryStatus",
+                  "summaryText1",
+                  "summaryText2",
+                  "type",
+                  "wasSeenRecently"
+                ],
+                "properties": {
+                  "avatarPath": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "color": {
+                    "type": "string"
+                  },
+                  "dmChatContact": {
+                    "description": "contact id if this is a dm chat (for view profile entry in context menu)",
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "uint32",
+                    "minimum": 0.0
+                  },
+                  "freshMessageCounter": {
+                    "type": "integer",
+                    "format": "uint",
+                    "minimum": 0.0
+                  },
+                  "id": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  },
+                  "isArchived": {
+                    "type": "boolean"
+                  },
+                  "isBroadcast": {
+                    "description": "true when chat is a broadcastlist",
+                    "type": "boolean"
+                  },
+                  "isContactRequest": {
+                    "type": "boolean"
+                  },
+                  "isDeviceTalk": {
+                    "type": "boolean"
+                  },
+                  "isGroup": {
+                    "type": "boolean"
+                  },
+                  "isMuted": {
+                    "type": "boolean"
+                  },
+                  "isPinned": {
+                    "type": "boolean"
+                  },
+                  "isProtected": {
+                    "type": "boolean"
+                  },
+                  "isSelfInGroup": {
+                    "type": "boolean"
+                  },
+                  "isSelfTalk": {
+                    "type": "boolean"
+                  },
+                  "isSendingLocation": {
+                    "type": "boolean"
+                  },
+                  "lastUpdated": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ],
+                    "format": "int64"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "summaryStatus": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  },
+                  "summaryText1": {
+                    "type": "string"
+                  },
+                  "summaryText2": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "ChatListItem"
+                    ]
+                  },
+                  "wasSeenRecently": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "ArchiveLink"
+                    ]
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "required": [
+                  "error",
+                  "id",
+                  "type"
+                ],
+                "properties": {
+                  "error": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  },
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "Error"
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_full_chat_by_id",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetFullChatByIdResult",
+        "schema": {
+          "title": "FullChat",
+          "type": "object",
+          "required": [
+            "archived",
+            "canSend",
+            "chatType",
+            "color",
+            "contactIds",
+            "contacts",
+            "ephemeralTimer",
+            "freshMessageCounter",
+            "id",
+            "isContactRequest",
+            "isDeviceChat",
+            "isMuted",
+            "isProtected",
+            "isSelfTalk",
+            "isUnpromoted",
+            "name",
+            "selfInGroup",
+            "wasSeenRecently"
+          ],
+          "properties": {
+            "archived": {
+              "type": "boolean"
+            },
+            "canSend": {
+              "type": "boolean"
+            },
+            "chatType": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "color": {
+              "type": "string"
+            },
+            "contactIds": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              }
+            },
+            "contacts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "address",
+                  "authName",
+                  "color",
+                  "displayName",
+                  "id",
+                  "isBlocked",
+                  "isVerified",
+                  "lastSeen",
+                  "name",
+                  "nameAndAddr",
+                  "status",
+                  "wasSeenRecently"
+                ],
+                "properties": {
+                  "address": {
+                    "type": "string"
+                  },
+                  "authName": {
+                    "type": "string"
+                  },
+                  "color": {
+                    "type": "string"
+                  },
+                  "displayName": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  },
+                  "isBlocked": {
+                    "type": "boolean"
+                  },
+                  "isVerified": {
+                    "type": "boolean"
+                  },
+                  "lastSeen": {
+                    "description": "the contact's last seen timestamp",
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "nameAndAddr": {
+                    "type": "string"
+                  },
+                  "profileImage": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "status": {
+                    "type": "string"
+                  },
+                  "wasSeenRecently": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "ephemeralTimer": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "freshMessageCounter": {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            },
+            "id": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "isContactRequest": {
+              "type": "boolean"
+            },
+            "isDeviceChat": {
+              "type": "boolean"
+            },
+            "isMuted": {
+              "type": "boolean"
+            },
+            "isProtected": {
+              "type": "boolean"
+            },
+            "isSelfTalk": {
+              "type": "boolean"
+            },
+            "isUnpromoted": {
+              "type": "boolean"
+            },
+            "mailingListAddress": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            },
+            "profileImage": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "selfInGroup": {
+              "type": "boolean"
+            },
+            "wasSeenRecently": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_basic_chat_info",
+      "description": " get basic info about a chat,\n use chatlist_get_full_chat_by_id() instead if you need more information",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetBasicChatInfoResult",
+        "schema": {
+          "title": "BasicChat",
+          "description": "cheaper version of fullchat, omits: - contacts - contact_ids - fresh_message_counter - ephemeral_timer - self_in_group - was_seen_recently - can_send\n\nused when you only need the basic metadata of a chat like type, name, profile picture",
+          "type": "object",
+          "required": [
+            "archived",
+            "chatType",
+            "color",
+            "id",
+            "isContactRequest",
+            "isDeviceChat",
+            "isMuted",
+            "isProtected",
+            "isSelfTalk",
+            "isUnpromoted",
+            "name"
+          ],
+          "properties": {
+            "archived": {
+              "type": "boolean"
+            },
+            "chatType": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "color": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "isContactRequest": {
+              "type": "boolean"
+            },
+            "isDeviceChat": {
+              "type": "boolean"
+            },
+            "isMuted": {
+              "type": "boolean"
+            },
+            "isProtected": {
+              "type": "boolean"
+            },
+            "isSelfTalk": {
+              "type": "boolean"
+            },
+            "isUnpromoted": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "string"
+            },
+            "profileImage": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "accept_chat",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "AcceptChatResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "block_chat",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "BlockChatResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "delete_chat",
+      "description": " Delete a chat.\n\n Messages are deleted from the device and the chat database entry is deleted.\n After that, the event #DC_EVENT_MSGS_CHANGED is posted.\n\n Things that are _not done_ implicitly:\n\n - Messages are **not deleted from the server**.\n - The chat or the contact is **not blocked**, so new messages from the user/the group may appear as a contact request\n   and the user may create the chat again.\n - **Groups are not left** - this would\n   be unexpected as (1) deleting a normal chat also does not prevent new mails\n   from arriving, (2) leaving a group requires sending a message to\n   all group members - especially for groups not used for a longer time, this is\n   really unexpected when deletion results in contacting all members again,\n   (3) only leaving groups is also a valid usecase.\n\n To leave a chat explicitly, use leave_group()",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "DeleteChatResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_chat_encryption_info",
+      "description": " Get encryption info for a chat.\n Get a multi-line encryption info, containing encryption preferences of all members.\n Can be used to find out why messages sent to group are not encrypted.\n\n returns Multi-line text",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetChatEncryptionInfoResult",
+        "schema": {
+          "title": "String",
+          "type": "string"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_chat_securejoin_qr_code_svg",
+      "description": " Get QR code (text and SVG) that will offer an Setup-Contact or Verified-Group invitation.\n The QR code is compatible to the OPENPGP4FPR format\n so that a basic fingerprint comparison also works e.g. with OpenKeychain.\n\n The scanning device will pass the scanned content to `checkQr()` then;\n if `checkQr()` returns `askVerifyContact` or `askVerifyGroup`\n an out-of-band-verification can be joined using `secure_join()`\n\n chat_id: If set to a group-chat-id,\n     the Verified-Group-Invite protocol is offered in the QR code;\n     works for protected groups as well as for normal groups.\n     If not set, the Setup-Contact protocol is offered in the QR code.\n     See https://countermitm.readthedocs.io/en/latest/new.html\n     for details about both protocols.\n\n return format: `[code, svg]`",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "Nullable_uint32",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetChatSecurejoinQrCodeSvgResult",
+        "schema": {
+          "title": "Tuple_of_String_and_String",
+          "type": "array",
+          "items": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "secure_join",
+      "description": " Continue a Setup-Contact or Verified-Group-Invite protocol\n started on another device with `get_chat_securejoin_qr_code_svg()`.\n This function is typically called when `check_qr()` returns\n type=AskVerifyContact or type=AskVerifyGroup.\n\n The function returns immediately and the handshake runs in background,\n sending and receiving several messages.\n During the handshake, info messages are added to the chat,\n showing progress, success or errors.\n\n Subsequent calls of `secure_join()` will abort previous, unfinished handshakes.\n\n See https://countermitm.readthedocs.io/en/latest/new.html\n for details about both protocols.\n\n **qr**: The text of the scanned QR code. Typically, the same string as given\n     to `check_qr()`.\n\n **returns**: The chat ID of the joined chat, the UI may redirect to the this chat.\n         A returned chat ID does not guarantee that the chat is protected or the belonging contact is verified.\n",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "qr",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "SecureJoinResult",
+        "schema": {
+          "title": "uint32",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "leave_group",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "LeaveGroupResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "remove_contact_from_chat",
+      "description": " Remove a member from a group.\n\n If the group is already _promoted_ (any message was sent to the group),\n all group members are informed by a special status message that is sent automatically by this function.\n\n Sends out #DC_EVENT_CHAT_MODIFIED and #DC_EVENT_MSGS_CHANGED if a status message was sent.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "contactId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "RemoveContactFromChatResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "add_contact_to_chat",
+      "description": " Add a member to a group.\n\n If the group is already _promoted_ (any message was sent to the group),\n all group members are informed by a special status message that is sent automatically by this function.\n\n If the group has group protection enabled, only verified contacts can be added to the group.\n\n Sends out #DC_EVENT_CHAT_MODIFIED and #DC_EVENT_MSGS_CHANGED if a status message was sent.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "contactId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "AddContactToChatResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_chat_contacts",
+      "description": " Get the contact IDs belonging to a chat.\n\n - for normal chats, the function always returns exactly one contact,\n   DC_CONTACT_ID_SELF is returned only for SELF-chats.\n\n - for group chats all members are returned, DC_CONTACT_ID_SELF is returned\n   explicitly as it may happen that oneself gets removed from a still existing\n   group\n\n - for broadcasts, all recipients are returned, DC_CONTACT_ID_SELF is not included\n\n - for mailing lists, the behavior is not documented currently, we will decide on that later.\n   for now, the UI should not show the list for mailing lists.\n   (we do not know all members and there is not always a global mailing list address,\n   so we could return only SELF or the known members; this is not decided yet)",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetChatContactsResult",
+        "schema": {
+          "title": "Array_of_uint32",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "create_group_chat",
+      "description": " Create a new group chat.\n\n After creation,\n the group has one member with the ID DC_CONTACT_ID_SELF\n and is in _unpromoted_ state.\n This means, you can add or remove members, change the name,\n the group image and so on without messages being sent to all group members.\n\n This changes as soon as the first message is sent to the group members\n and the group becomes _promoted_.\n After that, all changes are synced with all group members\n by sending status message.\n\n To check, if a chat is still unpromoted, you can look at the `is_unpromoted` property of `BasicChat` or `FullChat`.\n This may be useful if you want to show some help for just created groups.\n\n @param protect If set to 1 the function creates group with protection initially enabled.\n     Only verified members are allowed in these groups\n     and end-to-end-encryption is always enabled.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "name",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        },
+        {
+          "name": "protect",
+          "schema": {
+            "title": "Boolean",
+            "type": "boolean"
+          }
+        }
+      ],
+      "result": {
+        "name": "CreateGroupChatResult",
+        "schema": {
+          "title": "uint32",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "create_broadcast_list",
+      "description": " Create a new broadcast list.\n\n Broadcast lists are similar to groups on the sending device,\n however, recipients get the messages in normal one-to-one chats\n and will not be aware of other members.\n\n Replies to broadcasts go only to the sender\n and not to all broadcast recipients.\n Moreover, replies will not appear in the broadcast list\n but in the one-to-one chat with the person answering.\n\n The name and the image of the broadcast list is set automatically\n and is visible to the sender only.\n Not asking for these data allows more focused creation\n and we bypass the question who will get which data.\n Also, many users will have at most one broadcast list\n so, a generic name and image is sufficient at the first place.\n\n Later on, however, the name can be changed using dc_set_chat_name().\n The image cannot be changed to have a unique, recognizable icon in the chat lists.\n All in all, this is also what other messengers are doing here.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "CreateBroadcastListResult",
+        "schema": {
+          "title": "uint32",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "set_chat_name",
+      "description": " Set group name.\n\n If the group is already _promoted_ (any message was sent to the group),\n all group members are informed by a special status message that is sent automatically by this function.\n\n Sends out #DC_EVENT_CHAT_MODIFIED and #DC_EVENT_MSGS_CHANGED if a status message was sent.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "newName",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "SetChatNameResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "set_chat_profile_image",
+      "description": " Set group profile image.\n\n If the group is already _promoted_ (any message was sent to the group),\n all group members are informed by a special status message that is sent automatically by this function.\n\n Sends out #DC_EVENT_CHAT_MODIFIED and #DC_EVENT_MSGS_CHANGED if a status message was sent.\n\n To find out the profile image of a chat, use dc_chat_get_profile_image()\n\n @param image_path Full path of the image to use as the group image. The image will immediately be copied to the\n     `blobdir`; the original image will not be needed anymore.\n      If you pass null here, the group image is deleted (for promoted groups, all members are informed about\n      this change anyway).",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "imagePath",
+          "schema": {
+            "title": "Nullable_String",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "SetChatProfileImageResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "set_chat_visibility",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "visibility",
+          "schema": {
+            "title": "ChatVisibility",
+            "type": "string",
+            "enum": [
+              "Normal",
+              "Archived",
+              "Pinned"
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "SetChatVisibilityResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "set_chat_ephemeral_timer",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "timer",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "SetChatEphemeralTimerResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_chat_ephemeral_timer",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetChatEphemeralTimerResult",
+        "schema": {
+          "title": "uint32",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "add_device_message",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "label",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        },
+        {
+          "name": "text",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "AddDeviceMessageResult",
+        "schema": {
+          "title": "uint32",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "marknoticed_chat",
+      "description": "  Mark all messages in a chat as _noticed_.\n  _Noticed_ messages are no longer _fresh_ and do not count as being unseen\n  but are still waiting for being marked as \"seen\" using markseen_msgs()\n  (IMAP/MDNs is not done for noticed messages).\n\n  Calling this function usually results in the event #DC_EVENT_MSGS_NOTICED.\n  See also markseen_msgs().",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "MarknoticedChatResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_first_unread_message_of_chat",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetFirstUnreadMessageOfChatResult",
+        "schema": {
+          "title": "Nullable_uint32",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "set_chat_mute_duration",
+      "description": " Set mute duration of a chat.\n\n The UI can then call is_chat_muted() when receiving a new message\n to decide whether it should trigger an notification.\n\n Muted chats should not sound or vibrate\n and should not show a visual notification in the system area.\n Moreover, muted chats should be excluded from global badge counter\n (get_fresh_msgs() skips muted chats therefore)\n and the in-app, per-chat badge counter should use a less obtrusive color.\n\n Sends out #DC_EVENT_CHAT_MODIFIED.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "duration",
+          "schema": {
+            "title": "MuteDuration",
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "NotMuted",
+                  "Forever"
+                ]
+              },
+              {
+                "type": "object",
+                "required": [
+                  "Until"
+                ],
+                "properties": {
+                  "Until": {
+                    "type": "integer",
+                    "format": "int64"
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "SetChatMuteDurationResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "is_chat_muted",
+      "description": " Check whether the chat is currently muted (can be changed by set_chat_mute_duration()).\n\n This is available as a standalone function outside of fullchat, because it might be only needed for notification",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "IsChatMutedResult",
+        "schema": {
+          "title": "Boolean",
+          "type": "boolean"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "markseen_msgs",
+      "description": " Mark messages as presented to the user.\n Typically, UIs call this function on scrolling through the message list,\n when the messages are presented at least for a little moment.\n The concrete action depends on the type of the chat and on the users settings\n (dc_msgs_presented() may be a better name therefore, but well. :)\n\n - For normal chats, the IMAP state is updated, MDN is sent\n   (if set_config()-options `mdns_enabled` is set)\n   and the internal state is changed to @ref DC_STATE_IN_SEEN to reflect these actions.\n\n - For contact requests, no IMAP or MDNs is done\n   and the internal state is not changed therefore.\n   See also marknoticed_chat().\n\n Moreover, timer is started for incoming ephemeral messages.\n This also happens for contact requests chats.\n\n One #DC_EVENT_MSGS_NOTICED event is emitted per modified chat.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "msgIds",
+          "schema": {
+            "title": "Array_of_uint32",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "MarkseenMsgsResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_message_ids",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "flags",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetMessageIdsResult",
+        "schema": {
+          "title": "Array_of_uint32",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_message_list_items",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "flags",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetMessageListItemsResult",
+        "schema": {
+          "title": "Array_of_MessageListItem",
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "kind",
+                  "msg_id"
+                ],
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "message"
+                    ]
+                  },
+                  "msg_id": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  }
+                }
+              },
+              {
+                "description": "Day marker, separating messages that correspond to different days according to local time.",
+                "type": "object",
+                "required": [
+                  "kind",
+                  "timestamp"
+                ],
+                "properties": {
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "dayMarker"
+                    ]
+                  },
+                  "timestamp": {
+                    "description": "Marker timestamp, for day markers, in unix milliseconds",
+                    "type": "integer",
+                    "format": "int64"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_message",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "messageId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetMessageResult",
+        "schema": {
+          "title": "Message",
+          "type": "object",
+          "required": [
+            "chatId",
+            "dimensionsHeight",
+            "dimensionsWidth",
+            "downloadState",
+            "duration",
+            "fileBytes",
+            "fromId",
+            "hasDeviatingTimestamp",
+            "hasHtml",
+            "hasLocation",
+            "id",
+            "isForwarded",
+            "isInfo",
+            "isSetupmessage",
+            "receivedTimestamp",
+            "sender",
+            "showPadlock",
+            "sortTimestamp",
+            "state",
+            "subject",
+            "systemMessageType",
+            "timestamp",
+            "viewType"
+          ],
+          "properties": {
+            "chatId": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "dimensionsHeight": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "dimensionsWidth": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "downloadState": {
+              "type": "string",
+              "enum": [
+                "Done",
+                "Available",
+                "Failure",
+                "InProgress"
+              ]
+            },
+            "duration": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "file": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "fileBytes": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "fileMime": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "fileName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "fromId": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "hasDeviatingTimestamp": {
+              "type": "boolean"
+            },
+            "hasHtml": {
+              "type": "boolean"
+            },
+            "hasLocation": {
+              "type": "boolean"
+            },
+            "id": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "isForwarded": {
+              "type": "boolean"
+            },
+            "isInfo": {
+              "type": "boolean"
+            },
+            "isSetupmessage": {
+              "type": "boolean"
+            },
+            "overrideSenderName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "parentId": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "quote": {
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "kind",
+                        "text"
+                      ],
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "JustText"
+                          ]
+                        },
+                        "text": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "authorDisplayColor",
+                        "authorDisplayName",
+                        "isForwarded",
+                        "kind",
+                        "messageId",
+                        "text",
+                        "viewType"
+                      ],
+                      "properties": {
+                        "authorDisplayColor": {
+                          "type": "string"
+                        },
+                        "authorDisplayName": {
+                          "type": "string"
+                        },
+                        "image": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "isForwarded": {
+                          "type": "boolean"
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "WithMessage"
+                          ]
+                        },
+                        "messageId": {
+                          "type": "integer",
+                          "format": "uint32",
+                          "minimum": 0.0
+                        },
+                        "overrideSenderName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "text": {
+                          "type": "string"
+                        },
+                        "viewType": {
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "Unknown"
+                              ]
+                            },
+                            {
+                              "description": "Text message.",
+                              "type": "string",
+                              "enum": [
+                                "Text"
+                              ]
+                            },
+                            {
+                              "description": "Image message. If the image is an animated GIF, the type `Viewtype.Gif` should be used.",
+                              "type": "string",
+                              "enum": [
+                                "Image"
+                              ]
+                            },
+                            {
+                              "description": "Animated GIF message.",
+                              "type": "string",
+                              "enum": [
+                                "Gif"
+                              ]
+                            },
+                            {
+                              "description": "Message containing a sticker, similar to image. If possible, the ui should display the image without borders in a transparent way. A click on a sticker will offer to install the sticker set in some future.",
+                              "type": "string",
+                              "enum": [
+                                "Sticker"
+                              ]
+                            },
+                            {
+                              "description": "Message containing an Audio file.",
+                              "type": "string",
+                              "enum": [
+                                "Audio"
+                              ]
+                            },
+                            {
+                              "description": "A voice message that was directly recorded by the user. For all other audio messages, the type `Viewtype.Audio` should be used.",
+                              "type": "string",
+                              "enum": [
+                                "Voice"
+                              ]
+                            },
+                            {
+                              "description": "Video messages.",
+                              "type": "string",
+                              "enum": [
+                                "Video"
+                              ]
+                            },
+                            {
+                              "description": "Message containing any file, eg. a PDF.",
+                              "type": "string",
+                              "enum": [
+                                "File"
+                              ]
+                            },
+                            {
+                              "description": "Message is an invitation to a videochat.",
+                              "type": "string",
+                              "enum": [
+                                "VideochatInvitation"
+                              ]
+                            },
+                            {
+                              "description": "Message is an webxdc instance.",
+                              "type": "string",
+                              "enum": [
+                                "Webxdc"
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "reactions": {
+              "description": "Structure representing all reactions to a particular message.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "required": [
+                "reactions",
+                "reactionsByContact"
+              ],
+              "properties": {
+                "reactions": {
+                  "description": "Unique reactions and their count",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  }
+                },
+                "reactionsByContact": {
+                  "description": "Map from a contact to it's reaction to message.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "receivedTimestamp": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "sender": {
+              "type": "object",
+              "required": [
+                "address",
+                "authName",
+                "color",
+                "displayName",
+                "id",
+                "isBlocked",
+                "isVerified",
+                "lastSeen",
+                "name",
+                "nameAndAddr",
+                "status",
+                "wasSeenRecently"
+              ],
+              "properties": {
+                "address": {
+                  "type": "string"
+                },
+                "authName": {
+                  "type": "string"
+                },
+                "color": {
+                  "type": "string"
+                },
+                "displayName": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "isBlocked": {
+                  "type": "boolean"
+                },
+                "isVerified": {
+                  "type": "boolean"
+                },
+                "lastSeen": {
+                  "description": "the contact's last seen timestamp",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "nameAndAddr": {
+                  "type": "string"
+                },
+                "profileImage": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "status": {
+                  "type": "string"
+                },
+                "wasSeenRecently": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "setupCodeBegin": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "showPadlock": {
+              "type": "boolean"
+            },
+            "sortTimestamp": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "state": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "subject": {
+              "type": "string"
+            },
+            "systemMessageType": {
+              "description": "when is_info is true this describes what type of system message it is",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "Unknown",
+                    "GroupNameChanged",
+                    "GroupImageChanged",
+                    "MemberAddedToGroup",
+                    "MemberRemovedFromGroup",
+                    "AutocryptSetupMessage",
+                    "SecurejoinMessage",
+                    "LocationStreamingEnabled",
+                    "LocationOnly",
+                    "ChatProtectionEnabled",
+                    "ChatProtectionDisabled",
+                    "WebxdcStatusUpdate"
+                  ]
+                },
+                {
+                  "description": "Chat ephemeral message timer is changed.",
+                  "type": "string",
+                  "enum": [
+                    "EphemeralTimerChanged"
+                  ]
+                },
+                {
+                  "description": "Self-sent-message that contains only json used for multi-device-sync; if possible, we attach that to other messages as for locations.",
+                  "type": "string",
+                  "enum": [
+                    "MultiDeviceSync"
+                  ]
+                },
+                {
+                  "description": "Webxdc info added with `info` set in `send_webxdc_status_update()`.",
+                  "type": "string",
+                  "enum": [
+                    "WebxdcInfoMessage"
+                  ]
+                }
+              ]
+            },
+            "text": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "timestamp": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "videochatType": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "videochatUrl": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "viewType": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "Unknown"
+                  ]
+                },
+                {
+                  "description": "Text message.",
+                  "type": "string",
+                  "enum": [
+                    "Text"
+                  ]
+                },
+                {
+                  "description": "Image message. If the image is an animated GIF, the type `Viewtype.Gif` should be used.",
+                  "type": "string",
+                  "enum": [
+                    "Image"
+                  ]
+                },
+                {
+                  "description": "Animated GIF message.",
+                  "type": "string",
+                  "enum": [
+                    "Gif"
+                  ]
+                },
+                {
+                  "description": "Message containing a sticker, similar to image. If possible, the ui should display the image without borders in a transparent way. A click on a sticker will offer to install the sticker set in some future.",
+                  "type": "string",
+                  "enum": [
+                    "Sticker"
+                  ]
+                },
+                {
+                  "description": "Message containing an Audio file.",
+                  "type": "string",
+                  "enum": [
+                    "Audio"
+                  ]
+                },
+                {
+                  "description": "A voice message that was directly recorded by the user. For all other audio messages, the type `Viewtype.Audio` should be used.",
+                  "type": "string",
+                  "enum": [
+                    "Voice"
+                  ]
+                },
+                {
+                  "description": "Video messages.",
+                  "type": "string",
+                  "enum": [
+                    "Video"
+                  ]
+                },
+                {
+                  "description": "Message containing any file, eg. a PDF.",
+                  "type": "string",
+                  "enum": [
+                    "File"
+                  ]
+                },
+                {
+                  "description": "Message is an invitation to a videochat.",
+                  "type": "string",
+                  "enum": [
+                    "VideochatInvitation"
+                  ]
+                },
+                {
+                  "description": "Message is an webxdc instance.",
+                  "type": "string",
+                  "enum": [
+                    "Webxdc"
+                  ]
+                }
+              ]
+            },
+            "webxdcInfo": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "required": [
+                "icon",
+                "internetAccess",
+                "name"
+              ],
+              "properties": {
+                "document": {
+                  "description": "if the Webxdc represents a document, then this is the name of the document",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "icon": {
+                  "description": "App icon file name. Defaults to an standard icon if nothing is set in the manifest.\n\nTo get the file, use dc_msg_get_webxdc_blob(). (not yet in jsonrpc, use rust api or cffi for it)\n\nApp icons should should be square, the implementations will add round corners etc. as needed.",
+                  "type": "string"
+                },
+                "internetAccess": {
+                  "description": "True if full internet access should be granted to the app.",
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "The name of the app.\n\nDefaults to the filename if not set in the manifest.",
+                  "type": "string"
+                },
+                "sourceCodeUrl": {
+                  "description": "URL where the source code of the Webxdc and other information can be found; defaults to an empty string. Implementations may offer an menu or a button to open this URL.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "summary": {
+                  "description": "short string describing the state of the app, sth. as \"2 votes\", \"Highscore: 123\", can be changed by the apps",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_message_html",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "messageId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetMessageHtmlResult",
+        "schema": {
+          "title": "Nullable_String",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_messages",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "messageIds",
+          "schema": {
+            "title": "Array_of_uint32",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "GetMessagesResult",
+        "schema": {
+          "title": "Map_of_Message",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": [
+              "chatId",
+              "dimensionsHeight",
+              "dimensionsWidth",
+              "downloadState",
+              "duration",
+              "fileBytes",
+              "fromId",
+              "hasDeviatingTimestamp",
+              "hasHtml",
+              "hasLocation",
+              "id",
+              "isForwarded",
+              "isInfo",
+              "isSetupmessage",
+              "receivedTimestamp",
+              "sender",
+              "showPadlock",
+              "sortTimestamp",
+              "state",
+              "subject",
+              "systemMessageType",
+              "timestamp",
+              "viewType"
+            ],
+            "properties": {
+              "chatId": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "dimensionsHeight": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "dimensionsWidth": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "downloadState": {
+                "type": "string",
+                "enum": [
+                  "Done",
+                  "Available",
+                  "Failure",
+                  "InProgress"
+                ]
+              },
+              "duration": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "file": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "fileBytes": {
+                "type": "integer",
+                "format": "uint64",
+                "minimum": 0.0
+              },
+              "fileMime": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "fileName": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "fromId": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "hasDeviatingTimestamp": {
+                "type": "boolean"
+              },
+              "hasHtml": {
+                "type": "boolean"
+              },
+              "hasLocation": {
+                "type": "boolean"
+              },
+              "id": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "isForwarded": {
+                "type": "boolean"
+              },
+              "isInfo": {
+                "type": "boolean"
+              },
+              "isSetupmessage": {
+                "type": "boolean"
+              },
+              "overrideSenderName": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "parentId": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "quote": {
+                "anyOf": [
+                  {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "kind",
+                          "text"
+                        ],
+                        "properties": {
+                          "kind": {
+                            "type": "string",
+                            "enum": [
+                              "JustText"
+                            ]
+                          },
+                          "text": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "authorDisplayColor",
+                          "authorDisplayName",
+                          "isForwarded",
+                          "kind",
+                          "messageId",
+                          "text",
+                          "viewType"
+                        ],
+                        "properties": {
+                          "authorDisplayColor": {
+                            "type": "string"
+                          },
+                          "authorDisplayName": {
+                            "type": "string"
+                          },
+                          "image": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "isForwarded": {
+                            "type": "boolean"
+                          },
+                          "kind": {
+                            "type": "string",
+                            "enum": [
+                              "WithMessage"
+                            ]
+                          },
+                          "messageId": {
+                            "type": "integer",
+                            "format": "uint32",
+                            "minimum": 0.0
+                          },
+                          "overrideSenderName": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "text": {
+                            "type": "string"
+                          },
+                          "viewType": {
+                            "oneOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "Unknown"
+                                ]
+                              },
+                              {
+                                "description": "Text message.",
+                                "type": "string",
+                                "enum": [
+                                  "Text"
+                                ]
+                              },
+                              {
+                                "description": "Image message. If the image is an animated GIF, the type `Viewtype.Gif` should be used.",
+                                "type": "string",
+                                "enum": [
+                                  "Image"
+                                ]
+                              },
+                              {
+                                "description": "Animated GIF message.",
+                                "type": "string",
+                                "enum": [
+                                  "Gif"
+                                ]
+                              },
+                              {
+                                "description": "Message containing a sticker, similar to image. If possible, the ui should display the image without borders in a transparent way. A click on a sticker will offer to install the sticker set in some future.",
+                                "type": "string",
+                                "enum": [
+                                  "Sticker"
+                                ]
+                              },
+                              {
+                                "description": "Message containing an Audio file.",
+                                "type": "string",
+                                "enum": [
+                                  "Audio"
+                                ]
+                              },
+                              {
+                                "description": "A voice message that was directly recorded by the user. For all other audio messages, the type `Viewtype.Audio` should be used.",
+                                "type": "string",
+                                "enum": [
+                                  "Voice"
+                                ]
+                              },
+                              {
+                                "description": "Video messages.",
+                                "type": "string",
+                                "enum": [
+                                  "Video"
+                                ]
+                              },
+                              {
+                                "description": "Message containing any file, eg. a PDF.",
+                                "type": "string",
+                                "enum": [
+                                  "File"
+                                ]
+                              },
+                              {
+                                "description": "Message is an invitation to a videochat.",
+                                "type": "string",
+                                "enum": [
+                                  "VideochatInvitation"
+                                ]
+                              },
+                              {
+                                "description": "Message is an webxdc instance.",
+                                "type": "string",
+                                "enum": [
+                                  "Webxdc"
+                                ]
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "reactions": {
+                "description": "Structure representing all reactions to a particular message.",
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "reactions",
+                  "reactionsByContact"
+                ],
+                "properties": {
+                  "reactions": {
+                    "description": "Unique reactions and their count",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "integer",
+                      "format": "uint32",
+                      "minimum": 0.0
+                    }
+                  },
+                  "reactionsByContact": {
+                    "description": "Map from a contact to it's reaction to message.",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              },
+              "receivedTimestamp": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "sender": {
+                "type": "object",
+                "required": [
+                  "address",
+                  "authName",
+                  "color",
+                  "displayName",
+                  "id",
+                  "isBlocked",
+                  "isVerified",
+                  "lastSeen",
+                  "name",
+                  "nameAndAddr",
+                  "status",
+                  "wasSeenRecently"
+                ],
+                "properties": {
+                  "address": {
+                    "type": "string"
+                  },
+                  "authName": {
+                    "type": "string"
+                  },
+                  "color": {
+                    "type": "string"
+                  },
+                  "displayName": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  },
+                  "isBlocked": {
+                    "type": "boolean"
+                  },
+                  "isVerified": {
+                    "type": "boolean"
+                  },
+                  "lastSeen": {
+                    "description": "the contact's last seen timestamp",
+                    "type": "integer",
+                    "format": "int64"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "nameAndAddr": {
+                    "type": "string"
+                  },
+                  "profileImage": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "status": {
+                    "type": "string"
+                  },
+                  "wasSeenRecently": {
+                    "type": "boolean"
+                  }
+                }
+              },
+              "setupCodeBegin": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "showPadlock": {
+                "type": "boolean"
+              },
+              "sortTimestamp": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "state": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "subject": {
+                "type": "string"
+              },
+              "systemMessageType": {
+                "description": "when is_info is true this describes what type of system message it is",
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "Unknown",
+                      "GroupNameChanged",
+                      "GroupImageChanged",
+                      "MemberAddedToGroup",
+                      "MemberRemovedFromGroup",
+                      "AutocryptSetupMessage",
+                      "SecurejoinMessage",
+                      "LocationStreamingEnabled",
+                      "LocationOnly",
+                      "ChatProtectionEnabled",
+                      "ChatProtectionDisabled",
+                      "WebxdcStatusUpdate"
+                    ]
+                  },
+                  {
+                    "description": "Chat ephemeral message timer is changed.",
+                    "type": "string",
+                    "enum": [
+                      "EphemeralTimerChanged"
+                    ]
+                  },
+                  {
+                    "description": "Self-sent-message that contains only json used for multi-device-sync; if possible, we attach that to other messages as for locations.",
+                    "type": "string",
+                    "enum": [
+                      "MultiDeviceSync"
+                    ]
+                  },
+                  {
+                    "description": "Webxdc info added with `info` set in `send_webxdc_status_update()`.",
+                    "type": "string",
+                    "enum": [
+                      "WebxdcInfoMessage"
+                    ]
+                  }
+                ]
+              },
+              "text": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "timestamp": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "videochatType": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "videochatUrl": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "viewType": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "Unknown"
+                    ]
+                  },
+                  {
+                    "description": "Text message.",
+                    "type": "string",
+                    "enum": [
+                      "Text"
+                    ]
+                  },
+                  {
+                    "description": "Image message. If the image is an animated GIF, the type `Viewtype.Gif` should be used.",
+                    "type": "string",
+                    "enum": [
+                      "Image"
+                    ]
+                  },
+                  {
+                    "description": "Animated GIF message.",
+                    "type": "string",
+                    "enum": [
+                      "Gif"
+                    ]
+                  },
+                  {
+                    "description": "Message containing a sticker, similar to image. If possible, the ui should display the image without borders in a transparent way. A click on a sticker will offer to install the sticker set in some future.",
+                    "type": "string",
+                    "enum": [
+                      "Sticker"
+                    ]
+                  },
+                  {
+                    "description": "Message containing an Audio file.",
+                    "type": "string",
+                    "enum": [
+                      "Audio"
+                    ]
+                  },
+                  {
+                    "description": "A voice message that was directly recorded by the user. For all other audio messages, the type `Viewtype.Audio` should be used.",
+                    "type": "string",
+                    "enum": [
+                      "Voice"
+                    ]
+                  },
+                  {
+                    "description": "Video messages.",
+                    "type": "string",
+                    "enum": [
+                      "Video"
+                    ]
+                  },
+                  {
+                    "description": "Message containing any file, eg. a PDF.",
+                    "type": "string",
+                    "enum": [
+                      "File"
+                    ]
+                  },
+                  {
+                    "description": "Message is an invitation to a videochat.",
+                    "type": "string",
+                    "enum": [
+                      "VideochatInvitation"
+                    ]
+                  },
+                  {
+                    "description": "Message is an webxdc instance.",
+                    "type": "string",
+                    "enum": [
+                      "Webxdc"
+                    ]
+                  }
+                ]
+              },
+              "webxdcInfo": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "required": [
+                  "icon",
+                  "internetAccess",
+                  "name"
+                ],
+                "properties": {
+                  "document": {
+                    "description": "if the Webxdc represents a document, then this is the name of the document",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "icon": {
+                    "description": "App icon file name. Defaults to an standard icon if nothing is set in the manifest.\n\nTo get the file, use dc_msg_get_webxdc_blob(). (not yet in jsonrpc, use rust api or cffi for it)\n\nApp icons should should be square, the implementations will add round corners etc. as needed.",
+                    "type": "string"
+                  },
+                  "internetAccess": {
+                    "description": "True if full internet access should be granted to the app.",
+                    "type": "boolean"
+                  },
+                  "name": {
+                    "description": "The name of the app.\n\nDefaults to the filename if not set in the manifest.",
+                    "type": "string"
+                  },
+                  "sourceCodeUrl": {
+                    "description": "URL where the source code of the Webxdc and other information can be found; defaults to an empty string. Implementations may offer an menu or a button to open this URL.",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "summary": {
+                    "description": "short string describing the state of the app, sth. as \"2 votes\", \"Highscore: 123\", can be changed by the apps",
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_message_notification_info",
+      "description": " Fetch info desktop needs for creating a notification for a message",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "messageId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetMessageNotificationInfoResult",
+        "schema": {
+          "title": "MessageNotificationInfo",
+          "type": "object",
+          "required": [
+            "accountId",
+            "chatId",
+            "chatName",
+            "id",
+            "summaryText"
+          ],
+          "properties": {
+            "accountId": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "chatId": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "chatName": {
+              "type": "string"
+            },
+            "chatProfileImage": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "image": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "imageMimeType": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "summaryPrefix": {
+              "description": "also known as summary_text1",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "summaryText": {
+              "description": "also known as summary_text2",
+              "type": "string"
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "delete_messages",
+      "description": " Delete messages. The messages are deleted on the current device and\n on the IMAP server.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "messageIds",
+          "schema": {
+            "title": "Array_of_uint32",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "DeleteMessagesResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_message_info",
+      "description": " Get an informational text for a single message. The text is multiline and may\n contain e.g. the raw text of the message.\n\n The max. text returned is typically longer (about 100000 characters) than the\n max. text returned by dc_msg_get_text() (about 30000 characters).",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "messageId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetMessageInfoResult",
+        "schema": {
+          "title": "String",
+          "type": "string"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "download_full_message",
+      "description": " Asks the core to start downloading a message fully.\n This function is typically called when the user hits the \"Download\" button\n that is shown by the UI in case `download_state` is `'Available'` or `'Failure'`\n\n On success, the @ref DC_MSG \"view type of the message\" may change\n or the message may be replaced completely by one or more messages with other message IDs.\n That may happen e.g. in cases where the message was encrypted\n and the type could not be determined without fully downloading.\n Downloaded content can be accessed as usual after download.\n\n To reflect these changes a @ref DC_EVENT_MSGS_CHANGED event will be emitted.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "messageId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "DownloadFullMessageResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "search_messages",
+      "description": " Search messages containing the given query string.\n Searching can be done globally (chat_id=0) or in a specified chat only (chat_id set).\n\n Global chat results are typically displayed using dc_msg_get_summary(), chat\n search results may just hilite the corresponding messages and present a\n prev/next button.\n\n For global search, result is limited to 1000 messages,\n this allows incremental search done fast.\n So, when getting exactly 1000 results, the result may be truncated;\n the UIs may display sth. as \"1000+ messages found\" in this case.\n Chat search (if a chat_id is set) is not limited.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "query",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "Nullable_uint32",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "SearchMessagesResult",
+        "schema": {
+          "title": "Array_of_uint32",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "message_ids_to_search_results",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "messageIds",
+          "schema": {
+            "title": "Array_of_uint32",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "MessageIdsToSearchResultsResult",
+        "schema": {
+          "title": "Map_of_MessageSearchResult",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": [
+              "authorColor",
+              "authorName",
+              "id",
+              "message",
+              "timestamp"
+            ],
+            "properties": {
+              "authorColor": {
+                "type": "string"
+              },
+              "authorName": {
+                "type": "string"
+              },
+              "authorProfileImage": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "chatName": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "id": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "message": {
+                "type": "string"
+              },
+              "timestamp": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_contact",
+      "description": " Get a single contact options by ID.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "contactId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetContactResult",
+        "schema": {
+          "title": "Contact",
+          "type": "object",
+          "required": [
+            "address",
+            "authName",
+            "color",
+            "displayName",
+            "id",
+            "isBlocked",
+            "isVerified",
+            "lastSeen",
+            "name",
+            "nameAndAddr",
+            "status",
+            "wasSeenRecently"
+          ],
+          "properties": {
+            "address": {
+              "type": "string"
+            },
+            "authName": {
+              "type": "string"
+            },
+            "color": {
+              "type": "string"
+            },
+            "displayName": {
+              "type": "string"
+            },
+            "id": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "isBlocked": {
+              "type": "boolean"
+            },
+            "isVerified": {
+              "type": "boolean"
+            },
+            "lastSeen": {
+              "description": "the contact's last seen timestamp",
+              "type": "integer",
+              "format": "int64"
+            },
+            "name": {
+              "type": "string"
+            },
+            "nameAndAddr": {
+              "type": "string"
+            },
+            "profileImage": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "status": {
+              "type": "string"
+            },
+            "wasSeenRecently": {
+              "type": "boolean"
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "create_contact",
+      "description": " Add a single contact as a result of an explicit user action.\n\n Returns contact id of the created or existing contact",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "email",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        },
+        {
+          "name": "name",
+          "schema": {
+            "title": "Nullable_String",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "CreateContactResult",
+        "schema": {
+          "title": "uint32",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "create_chat_by_contact_id",
+      "description": " Returns contact id of the created or existing DM chat with that contact",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "contactId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "CreateChatByContactIdResult",
+        "schema": {
+          "title": "uint32",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "block_contact",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "contactId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "BlockContactResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "unblock_contact",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "contactId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "UnblockContactResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_blocked_contacts",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetBlockedContactsResult",
+        "schema": {
+          "title": "Array_of_Contact",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "address",
+              "authName",
+              "color",
+              "displayName",
+              "id",
+              "isBlocked",
+              "isVerified",
+              "lastSeen",
+              "name",
+              "nameAndAddr",
+              "status",
+              "wasSeenRecently"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "authName": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "isBlocked": {
+                "type": "boolean"
+              },
+              "isVerified": {
+                "type": "boolean"
+              },
+              "lastSeen": {
+                "description": "the contact's last seen timestamp",
+                "type": "integer",
+                "format": "int64"
+              },
+              "name": {
+                "type": "string"
+              },
+              "nameAndAddr": {
+                "type": "string"
+              },
+              "profileImage": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": "string"
+              },
+              "wasSeenRecently": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_contact_ids",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "listFlags",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "query",
+          "schema": {
+            "title": "Nullable_String",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "GetContactIdsResult",
+        "schema": {
+          "title": "Array_of_uint32",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_contacts",
+      "description": " Get a list of contacts.\n (formerly called getContacts2 in desktop)",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "listFlags",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "query",
+          "schema": {
+            "title": "Nullable_String",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "GetContactsResult",
+        "schema": {
+          "title": "Array_of_Contact",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "address",
+              "authName",
+              "color",
+              "displayName",
+              "id",
+              "isBlocked",
+              "isVerified",
+              "lastSeen",
+              "name",
+              "nameAndAddr",
+              "status",
+              "wasSeenRecently"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "authName": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "isBlocked": {
+                "type": "boolean"
+              },
+              "isVerified": {
+                "type": "boolean"
+              },
+              "lastSeen": {
+                "description": "the contact's last seen timestamp",
+                "type": "integer",
+                "format": "int64"
+              },
+              "name": {
+                "type": "string"
+              },
+              "nameAndAddr": {
+                "type": "string"
+              },
+              "profileImage": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": "string"
+              },
+              "wasSeenRecently": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_contacts_by_ids",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "ids",
+          "schema": {
+            "title": "Array_of_uint32",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "GetContactsByIdsResult",
+        "schema": {
+          "title": "Map_of_Contact",
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": [
+              "address",
+              "authName",
+              "color",
+              "displayName",
+              "id",
+              "isBlocked",
+              "isVerified",
+              "lastSeen",
+              "name",
+              "nameAndAddr",
+              "status",
+              "wasSeenRecently"
+            ],
+            "properties": {
+              "address": {
+                "type": "string"
+              },
+              "authName": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string"
+              },
+              "displayName": {
+                "type": "string"
+              },
+              "id": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "isBlocked": {
+                "type": "boolean"
+              },
+              "isVerified": {
+                "type": "boolean"
+              },
+              "lastSeen": {
+                "description": "the contact's last seen timestamp",
+                "type": "integer",
+                "format": "int64"
+              },
+              "name": {
+                "type": "string"
+              },
+              "nameAndAddr": {
+                "type": "string"
+              },
+              "profileImage": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": "string"
+              },
+              "wasSeenRecently": {
+                "type": "boolean"
+              }
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "delete_contact",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "contactId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "DeleteContactResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "change_contact_name",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "contactId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "name",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "ChangeContactNameResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_contact_encryption_info",
+      "description": " Get encryption info for a contact.\n Get a multi-line encryption info, containing your fingerprint and the\n fingerprint of the contact, used e.g. to compare the fingerprints for a simple out-of-band verification.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "contactId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetContactEncryptionInfoResult",
+        "schema": {
+          "title": "String",
+          "type": "string"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "lookup_contact_id_by_addr",
+      "description": " Check if an e-mail address belongs to a known and unblocked contact.\n To get a list of all known and unblocked contacts, use contacts_get_contacts().\n\n To validate an e-mail address independently of the contact database\n use check_email_validity().",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "addr",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "LookupContactIdByAddrResult",
+        "schema": {
+          "title": "Nullable_uint32",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_chat_media",
+      "description": " Returns all message IDs of the given types in a chat.\n Typically used to show a gallery.\n\n The list is already sorted and starts with the oldest message.\n Clients should not try to re-sort the list as this would be an expensive action\n and would result in inconsistencies between clients.\n\n Setting `chat_id` to `None` (`null` in typescript) means get messages with media\n from any chat of the currently used account.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "Nullable_uint32",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "messageType",
+          "schema": {
+            "title": "Viewtype",
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "Unknown"
+                ]
+              },
+              {
+                "description": "Text message.",
+                "type": "string",
+                "enum": [
+                  "Text"
+                ]
+              },
+              {
+                "description": "Image message. If the image is an animated GIF, the type `Viewtype.Gif` should be used.",
+                "type": "string",
+                "enum": [
+                  "Image"
+                ]
+              },
+              {
+                "description": "Animated GIF message.",
+                "type": "string",
+                "enum": [
+                  "Gif"
+                ]
+              },
+              {
+                "description": "Message containing a sticker, similar to image. If possible, the ui should display the image without borders in a transparent way. A click on a sticker will offer to install the sticker set in some future.",
+                "type": "string",
+                "enum": [
+                  "Sticker"
+                ]
+              },
+              {
+                "description": "Message containing an Audio file.",
+                "type": "string",
+                "enum": [
+                  "Audio"
+                ]
+              },
+              {
+                "description": "A voice message that was directly recorded by the user. For all other audio messages, the type `Viewtype.Audio` should be used.",
+                "type": "string",
+                "enum": [
+                  "Voice"
+                ]
+              },
+              {
+                "description": "Video messages.",
+                "type": "string",
+                "enum": [
+                  "Video"
+                ]
+              },
+              {
+                "description": "Message containing any file, eg. a PDF.",
+                "type": "string",
+                "enum": [
+                  "File"
+                ]
+              },
+              {
+                "description": "Message is an invitation to a videochat.",
+                "type": "string",
+                "enum": [
+                  "VideochatInvitation"
+                ]
+              },
+              {
+                "description": "Message is an webxdc instance.",
+                "type": "string",
+                "enum": [
+                  "Webxdc"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "orMessageType2",
+          "schema": {
+            "title": "Nullable_Viewtype",
+            "anyOf": [
+              {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "Unknown"
+                    ]
+                  },
+                  {
+                    "description": "Text message.",
+                    "type": "string",
+                    "enum": [
+                      "Text"
+                    ]
+                  },
+                  {
+                    "description": "Image message. If the image is an animated GIF, the type `Viewtype.Gif` should be used.",
+                    "type": "string",
+                    "enum": [
+                      "Image"
+                    ]
+                  },
+                  {
+                    "description": "Animated GIF message.",
+                    "type": "string",
+                    "enum": [
+                      "Gif"
+                    ]
+                  },
+                  {
+                    "description": "Message containing a sticker, similar to image. If possible, the ui should display the image without borders in a transparent way. A click on a sticker will offer to install the sticker set in some future.",
+                    "type": "string",
+                    "enum": [
+                      "Sticker"
+                    ]
+                  },
+                  {
+                    "description": "Message containing an Audio file.",
+                    "type": "string",
+                    "enum": [
+                      "Audio"
+                    ]
+                  },
+                  {
+                    "description": "A voice message that was directly recorded by the user. For all other audio messages, the type `Viewtype.Audio` should be used.",
+                    "type": "string",
+                    "enum": [
+                      "Voice"
+                    ]
+                  },
+                  {
+                    "description": "Video messages.",
+                    "type": "string",
+                    "enum": [
+                      "Video"
+                    ]
+                  },
+                  {
+                    "description": "Message containing any file, eg. a PDF.",
+                    "type": "string",
+                    "enum": [
+                      "File"
+                    ]
+                  },
+                  {
+                    "description": "Message is an invitation to a videochat.",
+                    "type": "string",
+                    "enum": [
+                      "VideochatInvitation"
+                    ]
+                  },
+                  {
+                    "description": "Message is an webxdc instance.",
+                    "type": "string",
+                    "enum": [
+                      "Webxdc"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        {
+          "name": "orMessageType3",
+          "schema": {
+            "title": "Nullable_Viewtype",
+            "anyOf": [
+              {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "Unknown"
+                    ]
+                  },
+                  {
+                    "description": "Text message.",
+                    "type": "string",
+                    "enum": [
+                      "Text"
+                    ]
+                  },
+                  {
+                    "description": "Image message. If the image is an animated GIF, the type `Viewtype.Gif` should be used.",
+                    "type": "string",
+                    "enum": [
+                      "Image"
+                    ]
+                  },
+                  {
+                    "description": "Animated GIF message.",
+                    "type": "string",
+                    "enum": [
+                      "Gif"
+                    ]
+                  },
+                  {
+                    "description": "Message containing a sticker, similar to image. If possible, the ui should display the image without borders in a transparent way. A click on a sticker will offer to install the sticker set in some future.",
+                    "type": "string",
+                    "enum": [
+                      "Sticker"
+                    ]
+                  },
+                  {
+                    "description": "Message containing an Audio file.",
+                    "type": "string",
+                    "enum": [
+                      "Audio"
+                    ]
+                  },
+                  {
+                    "description": "A voice message that was directly recorded by the user. For all other audio messages, the type `Viewtype.Audio` should be used.",
+                    "type": "string",
+                    "enum": [
+                      "Voice"
+                    ]
+                  },
+                  {
+                    "description": "Video messages.",
+                    "type": "string",
+                    "enum": [
+                      "Video"
+                    ]
+                  },
+                  {
+                    "description": "Message containing any file, eg. a PDF.",
+                    "type": "string",
+                    "enum": [
+                      "File"
+                    ]
+                  },
+                  {
+                    "description": "Message is an invitation to a videochat.",
+                    "type": "string",
+                    "enum": [
+                      "VideochatInvitation"
+                    ]
+                  },
+                  {
+                    "description": "Message is an webxdc instance.",
+                    "type": "string",
+                    "enum": [
+                      "Webxdc"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "GetChatMediaResult",
+        "schema": {
+          "title": "Array_of_uint32",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_neighboring_chat_media",
+      "description": " Search next/previous message based on a given message and a list of types.\n Typically used to implement the \"next\" and \"previous\" buttons\n in a gallery or in a media player.\n\n one combined call for getting chat::get_next_media for both directions\n the manual chat::get_next_media in only one direction is not exposed by the jsonrpc yet",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "msgId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "messageType",
+          "schema": {
+            "title": "Viewtype",
+            "oneOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "Unknown"
+                ]
+              },
+              {
+                "description": "Text message.",
+                "type": "string",
+                "enum": [
+                  "Text"
+                ]
+              },
+              {
+                "description": "Image message. If the image is an animated GIF, the type `Viewtype.Gif` should be used.",
+                "type": "string",
+                "enum": [
+                  "Image"
+                ]
+              },
+              {
+                "description": "Animated GIF message.",
+                "type": "string",
+                "enum": [
+                  "Gif"
+                ]
+              },
+              {
+                "description": "Message containing a sticker, similar to image. If possible, the ui should display the image without borders in a transparent way. A click on a sticker will offer to install the sticker set in some future.",
+                "type": "string",
+                "enum": [
+                  "Sticker"
+                ]
+              },
+              {
+                "description": "Message containing an Audio file.",
+                "type": "string",
+                "enum": [
+                  "Audio"
+                ]
+              },
+              {
+                "description": "A voice message that was directly recorded by the user. For all other audio messages, the type `Viewtype.Audio` should be used.",
+                "type": "string",
+                "enum": [
+                  "Voice"
+                ]
+              },
+              {
+                "description": "Video messages.",
+                "type": "string",
+                "enum": [
+                  "Video"
+                ]
+              },
+              {
+                "description": "Message containing any file, eg. a PDF.",
+                "type": "string",
+                "enum": [
+                  "File"
+                ]
+              },
+              {
+                "description": "Message is an invitation to a videochat.",
+                "type": "string",
+                "enum": [
+                  "VideochatInvitation"
+                ]
+              },
+              {
+                "description": "Message is an webxdc instance.",
+                "type": "string",
+                "enum": [
+                  "Webxdc"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "name": "orMessageType2",
+          "schema": {
+            "title": "Nullable_Viewtype",
+            "anyOf": [
+              {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "Unknown"
+                    ]
+                  },
+                  {
+                    "description": "Text message.",
+                    "type": "string",
+                    "enum": [
+                      "Text"
+                    ]
+                  },
+                  {
+                    "description": "Image message. If the image is an animated GIF, the type `Viewtype.Gif` should be used.",
+                    "type": "string",
+                    "enum": [
+                      "Image"
+                    ]
+                  },
+                  {
+                    "description": "Animated GIF message.",
+                    "type": "string",
+                    "enum": [
+                      "Gif"
+                    ]
+                  },
+                  {
+                    "description": "Message containing a sticker, similar to image. If possible, the ui should display the image without borders in a transparent way. A click on a sticker will offer to install the sticker set in some future.",
+                    "type": "string",
+                    "enum": [
+                      "Sticker"
+                    ]
+                  },
+                  {
+                    "description": "Message containing an Audio file.",
+                    "type": "string",
+                    "enum": [
+                      "Audio"
+                    ]
+                  },
+                  {
+                    "description": "A voice message that was directly recorded by the user. For all other audio messages, the type `Viewtype.Audio` should be used.",
+                    "type": "string",
+                    "enum": [
+                      "Voice"
+                    ]
+                  },
+                  {
+                    "description": "Video messages.",
+                    "type": "string",
+                    "enum": [
+                      "Video"
+                    ]
+                  },
+                  {
+                    "description": "Message containing any file, eg. a PDF.",
+                    "type": "string",
+                    "enum": [
+                      "File"
+                    ]
+                  },
+                  {
+                    "description": "Message is an invitation to a videochat.",
+                    "type": "string",
+                    "enum": [
+                      "VideochatInvitation"
+                    ]
+                  },
+                  {
+                    "description": "Message is an webxdc instance.",
+                    "type": "string",
+                    "enum": [
+                      "Webxdc"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        {
+          "name": "orMessageType3",
+          "schema": {
+            "title": "Nullable_Viewtype",
+            "anyOf": [
+              {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "Unknown"
+                    ]
+                  },
+                  {
+                    "description": "Text message.",
+                    "type": "string",
+                    "enum": [
+                      "Text"
+                    ]
+                  },
+                  {
+                    "description": "Image message. If the image is an animated GIF, the type `Viewtype.Gif` should be used.",
+                    "type": "string",
+                    "enum": [
+                      "Image"
+                    ]
+                  },
+                  {
+                    "description": "Animated GIF message.",
+                    "type": "string",
+                    "enum": [
+                      "Gif"
+                    ]
+                  },
+                  {
+                    "description": "Message containing a sticker, similar to image. If possible, the ui should display the image without borders in a transparent way. A click on a sticker will offer to install the sticker set in some future.",
+                    "type": "string",
+                    "enum": [
+                      "Sticker"
+                    ]
+                  },
+                  {
+                    "description": "Message containing an Audio file.",
+                    "type": "string",
+                    "enum": [
+                      "Audio"
+                    ]
+                  },
+                  {
+                    "description": "A voice message that was directly recorded by the user. For all other audio messages, the type `Viewtype.Audio` should be used.",
+                    "type": "string",
+                    "enum": [
+                      "Voice"
+                    ]
+                  },
+                  {
+                    "description": "Video messages.",
+                    "type": "string",
+                    "enum": [
+                      "Video"
+                    ]
+                  },
+                  {
+                    "description": "Message containing any file, eg. a PDF.",
+                    "type": "string",
+                    "enum": [
+                      "File"
+                    ]
+                  },
+                  {
+                    "description": "Message is an invitation to a videochat.",
+                    "type": "string",
+                    "enum": [
+                      "VideochatInvitation"
+                    ]
+                  },
+                  {
+                    "description": "Message is an webxdc instance.",
+                    "type": "string",
+                    "enum": [
+                      "Webxdc"
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "GetNeighboringChatMediaResult",
+        "schema": {
+          "title": "Tuple_of_Nullable_uint32_and_Nullable_uint32",
+          "type": "array",
+          "items": [
+            {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "export_backup",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "destination",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        },
+        {
+          "name": "passphrase",
+          "schema": {
+            "title": "Nullable_String",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "ExportBackupResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "import_backup",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "path",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        },
+        {
+          "name": "passphrase",
+          "schema": {
+            "title": "Nullable_String",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "ImportBackupResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "maybe_network",
+      "description": " Indicate that the network likely has come back.\n or just that the network conditions might have changed",
+      "params": [],
+      "result": {
+        "name": "MaybeNetworkResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_connectivity",
+      "description": " Get the current connectivity, i.e. whether the device is connected to the IMAP server.\n One of:\n - DC_CONNECTIVITY_NOT_CONNECTED (1000-1999): Show e.g. the string \"Not connected\" or a red dot\n - DC_CONNECTIVITY_CONNECTING (2000-2999): Show e.g. the string \"Connecting…\" or a yellow dot\n - DC_CONNECTIVITY_WORKING (3000-3999): Show e.g. the string \"Getting new messages\" or a spinning wheel\n - DC_CONNECTIVITY_CONNECTED (>=4000): Show e.g. the string \"Connected\" or a green dot\n\n We don't use exact values but ranges here so that we can split up\n states into multiple states in the future.\n\n Meant as a rough overview that can be shown\n e.g. in the title of the main screen.\n\n If the connectivity changes, a #DC_EVENT_CONNECTIVITY_CHANGED will be emitted.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetConnectivityResult",
+        "schema": {
+          "title": "uint32",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_connectivity_html",
+      "description": " Get an overview of the current connectivity, and possibly more statistics.\n Meant to give the user more insight about the current status than\n the basic connectivity info returned by get_connectivity(); show this\n e.g., if the user taps on said basic connectivity info.\n\n If this page changes, a #DC_EVENT_CONNECTIVITY_CHANGED will be emitted.\n\n This comes as an HTML from the core so that we can easily improve it\n and the improvement instantly reaches all UIs.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetConnectivityHtmlResult",
+        "schema": {
+          "title": "String",
+          "type": "string"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_locations",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "Nullable_uint32",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "contactId",
+          "schema": {
+            "title": "Nullable_uint32",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "timestampBegin",
+          "schema": {
+            "title": "int64",
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "name": "timestampEnd",
+          "schema": {
+            "title": "int64",
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      ],
+      "result": {
+        "name": "GetLocationsResult",
+        "schema": {
+          "title": "Array_of_Location",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "accuracy",
+              "chatId",
+              "contactId",
+              "isIndependent",
+              "latitude",
+              "locationId",
+              "longitude",
+              "msgId",
+              "timestamp"
+            ],
+            "properties": {
+              "accuracy": {
+                "type": "number",
+                "format": "double"
+              },
+              "chatId": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "contactId": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "isIndependent": {
+                "type": "boolean"
+              },
+              "latitude": {
+                "type": "number",
+                "format": "double"
+              },
+              "locationId": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "longitude": {
+                "type": "number",
+                "format": "double"
+              },
+              "marker": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "msgId": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              },
+              "timestamp": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "send_webxdc_status_update",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "instanceMsgId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "updateStr",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        },
+        {
+          "name": "description",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "SendWebxdcStatusUpdateResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_webxdc_status_updates",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "instanceMsgId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "lastKnownSerial",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetWebxdcStatusUpdatesResult",
+        "schema": {
+          "title": "String",
+          "type": "string"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_webxdc_info",
+      "description": " Get info from a webxdc message",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "instanceMsgId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetWebxdcInfoResult",
+        "schema": {
+          "title": "WebxdcMessageInfo",
+          "type": "object",
+          "required": [
+            "icon",
+            "internetAccess",
+            "name"
+          ],
+          "properties": {
+            "document": {
+              "description": "if the Webxdc represents a document, then this is the name of the document",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "icon": {
+              "description": "App icon file name. Defaults to an standard icon if nothing is set in the manifest.\n\nTo get the file, use dc_msg_get_webxdc_blob(). (not yet in jsonrpc, use rust api or cffi for it)\n\nApp icons should should be square, the implementations will add round corners etc. as needed.",
+              "type": "string"
+            },
+            "internetAccess": {
+              "description": "True if full internet access should be granted to the app.",
+              "type": "boolean"
+            },
+            "name": {
+              "description": "The name of the app.\n\nDefaults to the filename if not set in the manifest.",
+              "type": "string"
+            },
+            "sourceCodeUrl": {
+              "description": "URL where the source code of the Webxdc and other information can be found; defaults to an empty string. Implementations may offer an menu or a button to open this URL.",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "summary": {
+              "description": "short string describing the state of the app, sth. as \"2 votes\", \"Highscore: 123\", can be changed by the apps",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "forward_messages",
+      "description": " Forward messages to another chat.\n\n All types of messages can be forwarded,\n however, they will be flagged as such (dc_msg_is_forwarded() is set).\n\n Original sender, info-state and webxdc updates are not forwarded on purpose.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "messageIds",
+          "schema": {
+            "title": "Array_of_uint32",
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            }
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "ForwardMessagesResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "send_sticker",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "stickerPath",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "SendStickerResult",
+        "schema": {
+          "title": "uint32",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "send_reaction",
+      "description": " Send a reaction to message.\n\n Reaction is a string of emojis separated by spaces. Reaction to a\n single message can be sent multiple times. The last reaction\n received overrides all previously received reactions. It is\n possible to remove all reactions by sending an empty string.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "messageId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "reaction",
+          "schema": {
+            "title": "Array_of_String",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "SendReactionResult",
+        "schema": {
+          "title": "uint32",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "remove_draft",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "RemoveDraftResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "get_draft",
+      "description": "  Get draft for a chat, if any.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "GetDraftResult",
+        "schema": {
+          "title": "Nullable_Message",
+          "type": [
+            "object",
+            "null"
+          ],
+          "required": [
+            "chatId",
+            "dimensionsHeight",
+            "dimensionsWidth",
+            "downloadState",
+            "duration",
+            "fileBytes",
+            "fromId",
+            "hasDeviatingTimestamp",
+            "hasHtml",
+            "hasLocation",
+            "id",
+            "isForwarded",
+            "isInfo",
+            "isSetupmessage",
+            "receivedTimestamp",
+            "sender",
+            "showPadlock",
+            "sortTimestamp",
+            "state",
+            "subject",
+            "systemMessageType",
+            "timestamp",
+            "viewType"
+          ],
+          "properties": {
+            "chatId": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "dimensionsHeight": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "dimensionsWidth": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "downloadState": {
+              "type": "string",
+              "enum": [
+                "Done",
+                "Available",
+                "Failure",
+                "InProgress"
+              ]
+            },
+            "duration": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "file": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "fileBytes": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "fileMime": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "fileName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "fromId": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "hasDeviatingTimestamp": {
+              "type": "boolean"
+            },
+            "hasHtml": {
+              "type": "boolean"
+            },
+            "hasLocation": {
+              "type": "boolean"
+            },
+            "id": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "isForwarded": {
+              "type": "boolean"
+            },
+            "isInfo": {
+              "type": "boolean"
+            },
+            "isSetupmessage": {
+              "type": "boolean"
+            },
+            "overrideSenderName": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "parentId": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "quote": {
+              "anyOf": [
+                {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "required": [
+                        "kind",
+                        "text"
+                      ],
+                      "properties": {
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "JustText"
+                          ]
+                        },
+                        "text": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "authorDisplayColor",
+                        "authorDisplayName",
+                        "isForwarded",
+                        "kind",
+                        "messageId",
+                        "text",
+                        "viewType"
+                      ],
+                      "properties": {
+                        "authorDisplayColor": {
+                          "type": "string"
+                        },
+                        "authorDisplayName": {
+                          "type": "string"
+                        },
+                        "image": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "isForwarded": {
+                          "type": "boolean"
+                        },
+                        "kind": {
+                          "type": "string",
+                          "enum": [
+                            "WithMessage"
+                          ]
+                        },
+                        "messageId": {
+                          "type": "integer",
+                          "format": "uint32",
+                          "minimum": 0.0
+                        },
+                        "overrideSenderName": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "text": {
+                          "type": "string"
+                        },
+                        "viewType": {
+                          "oneOf": [
+                            {
+                              "type": "string",
+                              "enum": [
+                                "Unknown"
+                              ]
+                            },
+                            {
+                              "description": "Text message.",
+                              "type": "string",
+                              "enum": [
+                                "Text"
+                              ]
+                            },
+                            {
+                              "description": "Image message. If the image is an animated GIF, the type `Viewtype.Gif` should be used.",
+                              "type": "string",
+                              "enum": [
+                                "Image"
+                              ]
+                            },
+                            {
+                              "description": "Animated GIF message.",
+                              "type": "string",
+                              "enum": [
+                                "Gif"
+                              ]
+                            },
+                            {
+                              "description": "Message containing a sticker, similar to image. If possible, the ui should display the image without borders in a transparent way. A click on a sticker will offer to install the sticker set in some future.",
+                              "type": "string",
+                              "enum": [
+                                "Sticker"
+                              ]
+                            },
+                            {
+                              "description": "Message containing an Audio file.",
+                              "type": "string",
+                              "enum": [
+                                "Audio"
+                              ]
+                            },
+                            {
+                              "description": "A voice message that was directly recorded by the user. For all other audio messages, the type `Viewtype.Audio` should be used.",
+                              "type": "string",
+                              "enum": [
+                                "Voice"
+                              ]
+                            },
+                            {
+                              "description": "Video messages.",
+                              "type": "string",
+                              "enum": [
+                                "Video"
+                              ]
+                            },
+                            {
+                              "description": "Message containing any file, eg. a PDF.",
+                              "type": "string",
+                              "enum": [
+                                "File"
+                              ]
+                            },
+                            {
+                              "description": "Message is an invitation to a videochat.",
+                              "type": "string",
+                              "enum": [
+                                "VideochatInvitation"
+                              ]
+                            },
+                            {
+                              "description": "Message is an webxdc instance.",
+                              "type": "string",
+                              "enum": [
+                                "Webxdc"
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "reactions": {
+              "description": "Structure representing all reactions to a particular message.",
+              "type": [
+                "object",
+                "null"
+              ],
+              "required": [
+                "reactions",
+                "reactionsByContact"
+              ],
+              "properties": {
+                "reactions": {
+                  "description": "Unique reactions and their count",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0.0
+                  }
+                },
+                "reactionsByContact": {
+                  "description": "Map from a contact to it's reaction to message.",
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "receivedTimestamp": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "sender": {
+              "type": "object",
+              "required": [
+                "address",
+                "authName",
+                "color",
+                "displayName",
+                "id",
+                "isBlocked",
+                "isVerified",
+                "lastSeen",
+                "name",
+                "nameAndAddr",
+                "status",
+                "wasSeenRecently"
+              ],
+              "properties": {
+                "address": {
+                  "type": "string"
+                },
+                "authName": {
+                  "type": "string"
+                },
+                "color": {
+                  "type": "string"
+                },
+                "displayName": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "isBlocked": {
+                  "type": "boolean"
+                },
+                "isVerified": {
+                  "type": "boolean"
+                },
+                "lastSeen": {
+                  "description": "the contact's last seen timestamp",
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "nameAndAddr": {
+                  "type": "string"
+                },
+                "profileImage": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "status": {
+                  "type": "string"
+                },
+                "wasSeenRecently": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "setupCodeBegin": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "showPadlock": {
+              "type": "boolean"
+            },
+            "sortTimestamp": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "state": {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "subject": {
+              "type": "string"
+            },
+            "systemMessageType": {
+              "description": "when is_info is true this describes what type of system message it is",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "Unknown",
+                    "GroupNameChanged",
+                    "GroupImageChanged",
+                    "MemberAddedToGroup",
+                    "MemberRemovedFromGroup",
+                    "AutocryptSetupMessage",
+                    "SecurejoinMessage",
+                    "LocationStreamingEnabled",
+                    "LocationOnly",
+                    "ChatProtectionEnabled",
+                    "ChatProtectionDisabled",
+                    "WebxdcStatusUpdate"
+                  ]
+                },
+                {
+                  "description": "Chat ephemeral message timer is changed.",
+                  "type": "string",
+                  "enum": [
+                    "EphemeralTimerChanged"
+                  ]
+                },
+                {
+                  "description": "Self-sent-message that contains only json used for multi-device-sync; if possible, we attach that to other messages as for locations.",
+                  "type": "string",
+                  "enum": [
+                    "MultiDeviceSync"
+                  ]
+                },
+                {
+                  "description": "Webxdc info added with `info` set in `send_webxdc_status_update()`.",
+                  "type": "string",
+                  "enum": [
+                    "WebxdcInfoMessage"
+                  ]
+                }
+              ]
+            },
+            "text": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "timestamp": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "videochatType": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            "videochatUrl": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "viewType": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": [
+                    "Unknown"
+                  ]
+                },
+                {
+                  "description": "Text message.",
+                  "type": "string",
+                  "enum": [
+                    "Text"
+                  ]
+                },
+                {
+                  "description": "Image message. If the image is an animated GIF, the type `Viewtype.Gif` should be used.",
+                  "type": "string",
+                  "enum": [
+                    "Image"
+                  ]
+                },
+                {
+                  "description": "Animated GIF message.",
+                  "type": "string",
+                  "enum": [
+                    "Gif"
+                  ]
+                },
+                {
+                  "description": "Message containing a sticker, similar to image. If possible, the ui should display the image without borders in a transparent way. A click on a sticker will offer to install the sticker set in some future.",
+                  "type": "string",
+                  "enum": [
+                    "Sticker"
+                  ]
+                },
+                {
+                  "description": "Message containing an Audio file.",
+                  "type": "string",
+                  "enum": [
+                    "Audio"
+                  ]
+                },
+                {
+                  "description": "A voice message that was directly recorded by the user. For all other audio messages, the type `Viewtype.Audio` should be used.",
+                  "type": "string",
+                  "enum": [
+                    "Voice"
+                  ]
+                },
+                {
+                  "description": "Video messages.",
+                  "type": "string",
+                  "enum": [
+                    "Video"
+                  ]
+                },
+                {
+                  "description": "Message containing any file, eg. a PDF.",
+                  "type": "string",
+                  "enum": [
+                    "File"
+                  ]
+                },
+                {
+                  "description": "Message is an invitation to a videochat.",
+                  "type": "string",
+                  "enum": [
+                    "VideochatInvitation"
+                  ]
+                },
+                {
+                  "description": "Message is an webxdc instance.",
+                  "type": "string",
+                  "enum": [
+                    "Webxdc"
+                  ]
+                }
+              ]
+            },
+            "webxdcInfo": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "required": [
+                "icon",
+                "internetAccess",
+                "name"
+              ],
+              "properties": {
+                "document": {
+                  "description": "if the Webxdc represents a document, then this is the name of the document",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "icon": {
+                  "description": "App icon file name. Defaults to an standard icon if nothing is set in the manifest.\n\nTo get the file, use dc_msg_get_webxdc_blob(). (not yet in jsonrpc, use rust api or cffi for it)\n\nApp icons should should be square, the implementations will add round corners etc. as needed.",
+                  "type": "string"
+                },
+                "internetAccess": {
+                  "description": "True if full internet access should be granted to the app.",
+                  "type": "boolean"
+                },
+                "name": {
+                  "description": "The name of the app.\n\nDefaults to the filename if not set in the manifest.",
+                  "type": "string"
+                },
+                "sourceCodeUrl": {
+                  "description": "URL where the source code of the Webxdc and other information can be found; defaults to an empty string. Implementations may offer an menu or a button to open this URL.",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "summary": {
+                  "description": "short string describing the state of the app, sth. as \"2 votes\", \"Highscore: 123\", can be changed by the apps",
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "send_videochat_invitation",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "SendVideochatInvitationResult",
+        "schema": {
+          "title": "uint32",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "misc_get_sticker_folder",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "MiscGetStickerFolderResult",
+        "schema": {
+          "title": "String",
+          "type": "string"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "misc_save_sticker",
+      "description": " save a sticker to a collection/folder in the account's sticker folder",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "msgId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "collection",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "MiscSaveStickerResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "misc_get_stickers",
+      "description": " for desktop, get stickers from stickers folder,\n grouped by the collection/folder they are in.",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "MiscGetStickersResult",
+        "schema": {
+          "title": "Map_of_Array_of_String",
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "misc_send_text_message",
+      "description": " Returns the messageid of the sent message",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "text",
+          "schema": {
+            "title": "String",
+            "type": "string"
+          }
+        }
+      ],
+      "result": {
+        "name": "MiscSendTextMessageResult",
+        "schema": {
+          "title": "uint32",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "misc_send_msg",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "text",
+          "schema": {
+            "title": "Nullable_String",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        {
+          "name": "file",
+          "schema": {
+            "title": "Nullable_String",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        {
+          "name": "location",
+          "schema": {
+            "title": "Nullable_Tuple_of_double_and_double",
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": [
+              {
+                "type": "number",
+                "format": "double"
+              },
+              {
+                "type": "number",
+                "format": "double"
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2
+          }
+        },
+        {
+          "name": "quotedMessageId",
+          "schema": {
+            "title": "Nullable_uint32",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "MiscSendMsgResult",
+        "schema": {
+          "title": "Tuple_of_uint32_and_Message",
+          "type": "array",
+          "items": [
+            {
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0
+            },
+            {
+              "type": "object",
+              "required": [
+                "chatId",
+                "dimensionsHeight",
+                "dimensionsWidth",
+                "downloadState",
+                "duration",
+                "fileBytes",
+                "fromId",
+                "hasDeviatingTimestamp",
+                "hasHtml",
+                "hasLocation",
+                "id",
+                "isForwarded",
+                "isInfo",
+                "isSetupmessage",
+                "receivedTimestamp",
+                "sender",
+                "showPadlock",
+                "sortTimestamp",
+                "state",
+                "subject",
+                "systemMessageType",
+                "timestamp",
+                "viewType"
+              ],
+              "properties": {
+                "chatId": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "dimensionsHeight": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "dimensionsWidth": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "downloadState": {
+                  "type": "string",
+                  "enum": [
+                    "Done",
+                    "Available",
+                    "Failure",
+                    "InProgress"
+                  ]
+                },
+                "duration": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "file": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "fileBytes": {
+                  "type": "integer",
+                  "format": "uint64",
+                  "minimum": 0.0
+                },
+                "fileMime": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "fileName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "fromId": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "hasDeviatingTimestamp": {
+                  "type": "boolean"
+                },
+                "hasHtml": {
+                  "type": "boolean"
+                },
+                "hasLocation": {
+                  "type": "boolean"
+                },
+                "id": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "isForwarded": {
+                  "type": "boolean"
+                },
+                "isInfo": {
+                  "type": "boolean"
+                },
+                "isSetupmessage": {
+                  "type": "boolean"
+                },
+                "overrideSenderName": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "parentId": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "quote": {
+                  "anyOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "required": [
+                            "kind",
+                            "text"
+                          ],
+                          "properties": {
+                            "kind": {
+                              "type": "string",
+                              "enum": [
+                                "JustText"
+                              ]
+                            },
+                            "text": {
+                              "type": "string"
+                            }
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "authorDisplayColor",
+                            "authorDisplayName",
+                            "isForwarded",
+                            "kind",
+                            "messageId",
+                            "text",
+                            "viewType"
+                          ],
+                          "properties": {
+                            "authorDisplayColor": {
+                              "type": "string"
+                            },
+                            "authorDisplayName": {
+                              "type": "string"
+                            },
+                            "image": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "isForwarded": {
+                              "type": "boolean"
+                            },
+                            "kind": {
+                              "type": "string",
+                              "enum": [
+                                "WithMessage"
+                              ]
+                            },
+                            "messageId": {
+                              "type": "integer",
+                              "format": "uint32",
+                              "minimum": 0.0
+                            },
+                            "overrideSenderName": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "text": {
+                              "type": "string"
+                            },
+                            "viewType": {
+                              "oneOf": [
+                                {
+                                  "type": "string",
+                                  "enum": [
+                                    "Unknown"
+                                  ]
+                                },
+                                {
+                                  "description": "Text message.",
+                                  "type": "string",
+                                  "enum": [
+                                    "Text"
+                                  ]
+                                },
+                                {
+                                  "description": "Image message. If the image is an animated GIF, the type `Viewtype.Gif` should be used.",
+                                  "type": "string",
+                                  "enum": [
+                                    "Image"
+                                  ]
+                                },
+                                {
+                                  "description": "Animated GIF message.",
+                                  "type": "string",
+                                  "enum": [
+                                    "Gif"
+                                  ]
+                                },
+                                {
+                                  "description": "Message containing a sticker, similar to image. If possible, the ui should display the image without borders in a transparent way. A click on a sticker will offer to install the sticker set in some future.",
+                                  "type": "string",
+                                  "enum": [
+                                    "Sticker"
+                                  ]
+                                },
+                                {
+                                  "description": "Message containing an Audio file.",
+                                  "type": "string",
+                                  "enum": [
+                                    "Audio"
+                                  ]
+                                },
+                                {
+                                  "description": "A voice message that was directly recorded by the user. For all other audio messages, the type `Viewtype.Audio` should be used.",
+                                  "type": "string",
+                                  "enum": [
+                                    "Voice"
+                                  ]
+                                },
+                                {
+                                  "description": "Video messages.",
+                                  "type": "string",
+                                  "enum": [
+                                    "Video"
+                                  ]
+                                },
+                                {
+                                  "description": "Message containing any file, eg. a PDF.",
+                                  "type": "string",
+                                  "enum": [
+                                    "File"
+                                  ]
+                                },
+                                {
+                                  "description": "Message is an invitation to a videochat.",
+                                  "type": "string",
+                                  "enum": [
+                                    "VideochatInvitation"
+                                  ]
+                                },
+                                {
+                                  "description": "Message is an webxdc instance.",
+                                  "type": "string",
+                                  "enum": [
+                                    "Webxdc"
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "reactions": {
+                  "description": "Structure representing all reactions to a particular message.",
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "required": [
+                    "reactions",
+                    "reactionsByContact"
+                  ],
+                  "properties": {
+                    "reactions": {
+                      "description": "Unique reactions and their count",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "integer",
+                        "format": "uint32",
+                        "minimum": 0.0
+                      }
+                    },
+                    "reactionsByContact": {
+                      "description": "Map from a contact to it's reaction to message.",
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "receivedTimestamp": {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "sender": {
+                  "type": "object",
+                  "required": [
+                    "address",
+                    "authName",
+                    "color",
+                    "displayName",
+                    "id",
+                    "isBlocked",
+                    "isVerified",
+                    "lastSeen",
+                    "name",
+                    "nameAndAddr",
+                    "status",
+                    "wasSeenRecently"
+                  ],
+                  "properties": {
+                    "address": {
+                      "type": "string"
+                    },
+                    "authName": {
+                      "type": "string"
+                    },
+                    "color": {
+                      "type": "string"
+                    },
+                    "displayName": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "integer",
+                      "format": "uint32",
+                      "minimum": 0.0
+                    },
+                    "isBlocked": {
+                      "type": "boolean"
+                    },
+                    "isVerified": {
+                      "type": "boolean"
+                    },
+                    "lastSeen": {
+                      "description": "the contact's last seen timestamp",
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "nameAndAddr": {
+                      "type": "string"
+                    },
+                    "profileImage": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "status": {
+                      "type": "string"
+                    },
+                    "wasSeenRecently": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "setupCodeBegin": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "showPadlock": {
+                  "type": "boolean"
+                },
+                "sortTimestamp": {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "state": {
+                  "type": "integer",
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "subject": {
+                  "type": "string"
+                },
+                "systemMessageType": {
+                  "description": "when is_info is true this describes what type of system message it is",
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "Unknown",
+                        "GroupNameChanged",
+                        "GroupImageChanged",
+                        "MemberAddedToGroup",
+                        "MemberRemovedFromGroup",
+                        "AutocryptSetupMessage",
+                        "SecurejoinMessage",
+                        "LocationStreamingEnabled",
+                        "LocationOnly",
+                        "ChatProtectionEnabled",
+                        "ChatProtectionDisabled",
+                        "WebxdcStatusUpdate"
+                      ]
+                    },
+                    {
+                      "description": "Chat ephemeral message timer is changed.",
+                      "type": "string",
+                      "enum": [
+                        "EphemeralTimerChanged"
+                      ]
+                    },
+                    {
+                      "description": "Self-sent-message that contains only json used for multi-device-sync; if possible, we attach that to other messages as for locations.",
+                      "type": "string",
+                      "enum": [
+                        "MultiDeviceSync"
+                      ]
+                    },
+                    {
+                      "description": "Webxdc info added with `info` set in `send_webxdc_status_update()`.",
+                      "type": "string",
+                      "enum": [
+                        "WebxdcInfoMessage"
+                      ]
+                    }
+                  ]
+                },
+                "text": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "timestamp": {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "videochatType": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ],
+                  "format": "uint32",
+                  "minimum": 0.0
+                },
+                "videochatUrl": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "viewType": {
+                  "oneOf": [
+                    {
+                      "type": "string",
+                      "enum": [
+                        "Unknown"
+                      ]
+                    },
+                    {
+                      "description": "Text message.",
+                      "type": "string",
+                      "enum": [
+                        "Text"
+                      ]
+                    },
+                    {
+                      "description": "Image message. If the image is an animated GIF, the type `Viewtype.Gif` should be used.",
+                      "type": "string",
+                      "enum": [
+                        "Image"
+                      ]
+                    },
+                    {
+                      "description": "Animated GIF message.",
+                      "type": "string",
+                      "enum": [
+                        "Gif"
+                      ]
+                    },
+                    {
+                      "description": "Message containing a sticker, similar to image. If possible, the ui should display the image without borders in a transparent way. A click on a sticker will offer to install the sticker set in some future.",
+                      "type": "string",
+                      "enum": [
+                        "Sticker"
+                      ]
+                    },
+                    {
+                      "description": "Message containing an Audio file.",
+                      "type": "string",
+                      "enum": [
+                        "Audio"
+                      ]
+                    },
+                    {
+                      "description": "A voice message that was directly recorded by the user. For all other audio messages, the type `Viewtype.Audio` should be used.",
+                      "type": "string",
+                      "enum": [
+                        "Voice"
+                      ]
+                    },
+                    {
+                      "description": "Video messages.",
+                      "type": "string",
+                      "enum": [
+                        "Video"
+                      ]
+                    },
+                    {
+                      "description": "Message containing any file, eg. a PDF.",
+                      "type": "string",
+                      "enum": [
+                        "File"
+                      ]
+                    },
+                    {
+                      "description": "Message is an invitation to a videochat.",
+                      "type": "string",
+                      "enum": [
+                        "VideochatInvitation"
+                      ]
+                    },
+                    {
+                      "description": "Message is an webxdc instance.",
+                      "type": "string",
+                      "enum": [
+                        "Webxdc"
+                      ]
+                    }
+                  ]
+                },
+                "webxdcInfo": {
+                  "type": [
+                    "object",
+                    "null"
+                  ],
+                  "required": [
+                    "icon",
+                    "internetAccess",
+                    "name"
+                  ],
+                  "properties": {
+                    "document": {
+                      "description": "if the Webxdc represents a document, then this is the name of the document",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "icon": {
+                      "description": "App icon file name. Defaults to an standard icon if nothing is set in the manifest.\n\nTo get the file, use dc_msg_get_webxdc_blob(). (not yet in jsonrpc, use rust api or cffi for it)\n\nApp icons should should be square, the implementations will add round corners etc. as needed.",
+                      "type": "string"
+                    },
+                    "internetAccess": {
+                      "description": "True if full internet access should be granted to the app.",
+                      "type": "boolean"
+                    },
+                    "name": {
+                      "description": "The name of the app.\n\nDefaults to the filename if not set in the manifest.",
+                      "type": "string"
+                    },
+                    "sourceCodeUrl": {
+                      "description": "URL where the source code of the Webxdc and other information can be found; defaults to an empty string. Implementations may offer an menu or a button to open this URL.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "summary": {
+                      "description": "short string describing the state of the app, sth. as \"2 votes\", \"Highscore: 123\", can be changed by the apps",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "maxItems": 2,
+          "minItems": 2
+        }
+      },
+      "paramStructure": "by-position"
+    },
+    {
+      "name": "misc_set_draft",
+      "params": [
+        {
+          "name": "accountId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "chatId",
+          "schema": {
+            "title": "uint32",
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        },
+        {
+          "name": "text",
+          "schema": {
+            "title": "Nullable_String",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        {
+          "name": "file",
+          "schema": {
+            "title": "Nullable_String",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        {
+          "name": "quotedMessageId",
+          "schema": {
+            "title": "Nullable_uint32",
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      ],
+      "result": {
+        "name": "MiscSetDraftResult",
+        "schema": {
+          "title": "Null",
+          "type": "null"
+        }
+      },
+      "paramStructure": "by-position"
+    }
+  ]
+}

--- a/deltachat-jsonrpc/src/api/mod.rs
+++ b/deltachat-jsonrpc/src/api/mod.rs
@@ -84,7 +84,7 @@ impl CommandApi {
     }
 }
 
-#[rpc(all_positional, ts_outdir = "typescript/generated")]
+#[rpc(all_positional, ts_outdir = "typescript/generated", openrpc_path = "openrpc")]
 impl CommandApi {
     // ---------------------------------------------
     //  Misc top level functions

--- a/deltachat-jsonrpc/src/api/types/account.rs
+++ b/deltachat-jsonrpc/src/api/types/account.rs
@@ -6,7 +6,7 @@ use typescript_type_def::TypeDef;
 
 use super::color_int_to_hex_string;
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(tag = "type")]
 pub enum Account {
     #[serde(rename_all = "camelCase")]

--- a/deltachat-jsonrpc/src/api/types/chat.rs
+++ b/deltachat-jsonrpc/src/api/types/chat.rs
@@ -13,7 +13,7 @@ use typescript_type_def::TypeDef;
 use super::color_int_to_hex_string;
 use super::contact::ContactObject;
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct FullChat {
     id: u32,
@@ -121,7 +121,7 @@ impl FullChat {
 /// - can_send
 ///
 /// used when you only need the basic metadata of a chat like type, name, profile picture
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct BasicChat {
     id: u32,
@@ -169,7 +169,7 @@ impl BasicChat {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, TypeDef)]
+#[derive(Clone, Serialize, Deserialize, TypeDef, schemars::JsonSchema)]
 pub enum MuteDuration {
     NotMuted,
     Forever,
@@ -194,7 +194,7 @@ impl MuteDuration {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, TypeDef)]
+#[derive(Clone, Serialize, Deserialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename = "ChatVisibility")]
 pub enum JSONRPCChatVisibility {
     Normal,

--- a/deltachat-jsonrpc/src/api/types/chat_list.rs
+++ b/deltachat-jsonrpc/src/api/types/chat_list.rs
@@ -15,10 +15,10 @@ use typescript_type_def::TypeDef;
 
 use super::color_int_to_hex_string;
 
-#[derive(Deserialize, Serialize, TypeDef)]
+#[derive(Deserialize, Serialize, TypeDef, schemars::JsonSchema)]
 pub struct ChatListEntry(pub u32, pub u32);
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(tag = "type")]
 pub enum ChatListItemFetchResult {
     #[serde(rename_all = "camelCase")]

--- a/deltachat-jsonrpc/src/api/types/contact.rs
+++ b/deltachat-jsonrpc/src/api/types/contact.rs
@@ -6,7 +6,7 @@ use typescript_type_def::TypeDef;
 
 use super::color_int_to_hex_string;
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename = "Contact", rename_all = "camelCase")]
 pub struct ContactObject {
     address: String,

--- a/deltachat-jsonrpc/src/api/types/location.rs
+++ b/deltachat-jsonrpc/src/api/types/location.rs
@@ -2,7 +2,7 @@ use deltachat::location::Location;
 use serde::Serialize;
 use typescript_type_def::TypeDef;
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename = "Location", rename_all = "camelCase")]
 pub struct JsonrpcLocation {
     pub location_id: u32,

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -19,7 +19,7 @@ use super::contact::ContactObject;
 use super::reactions::JSONRPCReactions;
 use super::webxdc::WebxdcMessageInfo;
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename = "Message", rename_all = "camelCase")]
 pub struct MessageObject {
     id: u32,
@@ -72,7 +72,7 @@ pub struct MessageObject {
     reactions: Option<JSONRPCReactions>,
 }
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(tag = "kind")]
 enum MessageQuote {
     JustText {
@@ -214,7 +214,7 @@ impl MessageObject {
     }
 }
 
-#[derive(Serialize, Deserialize, TypeDef)]
+#[derive(Serialize, Deserialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename = "Viewtype")]
 pub enum MessageViewtype {
     Unknown,
@@ -290,7 +290,7 @@ impl From<MessageViewtype> for Viewtype {
     }
 }
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 pub enum DownloadState {
     Done,
     Available,
@@ -309,7 +309,7 @@ impl From<download::DownloadState> for DownloadState {
     }
 }
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 pub enum SystemMessageType {
     Unknown,
     GroupNameChanged,
@@ -364,7 +364,7 @@ impl From<deltachat::mimeparser::SystemMessage> for SystemMessageType {
     }
 }
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageNotificationInfo {
     id: u32,
@@ -422,7 +422,7 @@ impl MessageNotificationInfo {
     }
 }
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageSearchResult {
     id: u32,
@@ -461,7 +461,7 @@ impl MessageSearchResult {
     }
 }
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase", rename = "MessageListItem", tag = "kind")]
 pub enum JSONRPCMessageListItem {
     Message {

--- a/deltachat-jsonrpc/src/api/types/provider_info.rs
+++ b/deltachat-jsonrpc/src/api/types/provider_info.rs
@@ -3,7 +3,7 @@ use num_traits::cast::ToPrimitive;
 use serde::Serialize;
 use typescript_type_def::TypeDef;
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderInfo {
     pub before_login_hint: String,

--- a/deltachat-jsonrpc/src/api/types/qr.rs
+++ b/deltachat-jsonrpc/src/api/types/qr.rs
@@ -2,7 +2,7 @@ use deltachat::qr::Qr;
 use serde::Serialize;
 use typescript_type_def::TypeDef;
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename = "Qr", rename_all = "camelCase")]
 #[serde(tag = "type")]
 pub enum QrObject {

--- a/deltachat-jsonrpc/src/api/types/reactions.rs
+++ b/deltachat-jsonrpc/src/api/types/reactions.rs
@@ -5,7 +5,7 @@ use serde::Serialize;
 use typescript_type_def::TypeDef;
 
 /// Structure representing all reactions to a particular message.
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename = "Reactions", rename_all = "camelCase")]
 pub struct JSONRPCReactions {
     /// Map from a contact to it's reaction to message.

--- a/deltachat-jsonrpc/src/api/types/webxdc.rs
+++ b/deltachat-jsonrpc/src/api/types/webxdc.rs
@@ -8,7 +8,7 @@ use typescript_type_def::TypeDef;
 
 use super::maybe_empty_string_to_option;
 
-#[derive(Serialize, TypeDef)]
+#[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename = "WebxdcMessageInfo", rename_all = "camelCase")]
 pub struct WebxdcMessageInfo {
     /// The name of the app.

--- a/deltachat-jsonrpc/src/lib.rs
+++ b/deltachat-jsonrpc/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod api;
-pub use api::events;
 pub use yerpc;
 
 #[cfg(test)]


### PR DESCRIPTION
When running `cargo test` in the deltachat-jsonrpc folder, a new file `openrpc/openrpc.json` will be created with a [OpenRPC](https://spec.open-rpc.org/) definition.

It can be copy-pasted into the
[OpenRPC playground](https://playground.open-rpc.org/) and used to auto-create clients in other languages.