### PR TITLE
 Add members to chats in a single sql transation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 - Refactor: Remove the remaining AsRef<str> #3669
+- Small speedup #3780
 
 ### API-Changes
 - Add Python API to send reactions #3762

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2624,7 +2624,7 @@ pub async fn create_broadcast_list(context: &Context) -> Result<ChatId> {
     Ok(chat_id)
 }
 
-/// Adds a contact to the `chats_contacts` table.
+/// Adds contacts to the `chats_contacts` table.
 pub(crate) async fn add_to_chat_contacts_table(
     context: &Context,
     chat_id: ChatId,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2563,7 +2563,7 @@ pub async fn create_group_chat(
 
     let chat_id = ChatId::new(u32::try_from(row_id)?);
     if !is_contact_in_chat(context, chat_id, ContactId::SELF).await? {
-        add_to_chat_contacts_table(context, chat_id, ContactId::SELF).await?;
+        add_to_chat_contacts_table(context, chat_id, &[ContactId::SELF]).await?;
     }
 
     context.emit_msgs_changed_without_ids();
@@ -2628,15 +2628,21 @@ pub async fn create_broadcast_list(context: &Context) -> Result<ChatId> {
 pub(crate) async fn add_to_chat_contacts_table(
     context: &Context,
     chat_id: ChatId,
-    contact_id: ContactId,
+    contact_ids: &[ContactId],
 ) -> Result<()> {
     context
         .sql
-        .execute(
-            "INSERT INTO chats_contacts (chat_id, contact_id) VALUES(?, ?)",
-            paramsv![chat_id, contact_id],
-        )
+        .transaction(move |transaction| {
+            for contact_id in contact_ids {
+                transaction.execute(
+                    "INSERT OR IGNORE INTO chats_contacts (chat_id, contact_id) VALUES(?, ?)",
+                    paramsv![chat_id, contact_id],
+                )?;
+            }
+            Ok(())
+        })
         .await?;
+
     Ok(())
 }
 
@@ -2738,7 +2744,7 @@ pub(crate) async fn add_contact_to_chat_ex(
         if is_contact_in_chat(context, chat_id, contact_id).await? {
             return Ok(false);
         }
-        add_to_chat_contacts_table(context, chat_id, contact_id).await?;
+        add_to_chat_contacts_table(context, chat_id, &[contact_id]).await?;
     }
     if chat.typ == Chattype::Group && chat.is_promoted() {
         msg.viewtype = Viewtype::Text;

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -4,7 +4,7 @@ use std::collections::HashSet;
 use std::fmt;
 
 use crate::aheader::{Aheader, EncryptPreference};
-use crate::chat::{self, is_contact_in_chat, Chat};
+use crate::chat::{self, Chat};
 use crate::chatlist::Chatlist;
 use crate::constants::Chattype;
 use crate::contact::{addr_cmp, Contact, Origin};
@@ -523,9 +523,7 @@ impl Peerstate {
                     let (new_contact_id, _) =
                         Contact::add_or_lookup(context, "", new_addr, Origin::IncomingUnknownFrom)
                             .await?;
-                    if !is_contact_in_chat(context, *chat_id, new_contact_id).await? {
-                        chat::add_to_chat_contacts_table(context, *chat_id, new_contact_id).await?;
-                    }
+                    chat::add_to_chat_contacts_table(context, *chat_id, &[new_contact_id]).await?;
 
                     context.emit_event(EventType::ChatModified(*chat_id));
                 }

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1530,19 +1530,13 @@ async fn create_or_lookup_group(
         chat_id_blocked = create_blocked;
 
         // Create initial member list.
-        chat::add_to_chat_contacts_table(context, new_chat_id, ContactId::SELF).await?;
-        if !from_id.is_special() && !chat::is_contact_in_chat(context, new_chat_id, from_id).await?
-        {
-            chat::add_to_chat_contacts_table(context, new_chat_id, from_id).await?;
+        let mut members = vec![ContactId::SELF];
+        if !from_id.is_special() {
+            members.push(from_id);
         }
-        for &to_id in to_ids.iter() {
-            info!(context, "adding to={:?} to chat id={}", to_id, new_chat_id);
-            if to_id != ContactId::SELF
-                && !chat::is_contact_in_chat(context, new_chat_id, to_id).await?
-            {
-                chat::add_to_chat_contacts_table(context, new_chat_id, to_id).await?;
-            }
-        }
+        members.extend(to_ids);
+        members.dedup();
+        chat::add_to_chat_contacts_table(context, new_chat_id, &members).await?;
 
         // once, we have protected-chats explained in UI, we can uncomment the following lines.
         // ("verified groups" did not add a message anyway)
@@ -1698,6 +1692,7 @@ async fn apply_group_changes(
             .update_timestamp(context, Param::MemberListTimestamp, sent_timestamp)
             .await?
         {
+            let mut members_to_add = vec![];
             if removed_id.is_some()
                 || !chat::is_contact_in_chat(context, chat_id, ContactId::SELF).await?
             {
@@ -1712,26 +1707,23 @@ async fn apply_group_changes(
                     )
                     .await?;
 
-                if removed_id != Some(ContactId::SELF) {
-                    chat::add_to_chat_contacts_table(context, chat_id, ContactId::SELF).await?;
-                }
+                members_to_add.push(ContactId::SELF);
             }
-            if !from_id.is_special()
-                && from_id != ContactId::SELF
-                && !chat::is_contact_in_chat(context, chat_id, from_id).await?
-                && removed_id != Some(from_id)
-            {
-                chat::add_to_chat_contacts_table(context, chat_id, from_id).await?;
+
+            if !from_id.is_special() {
+                members_to_add.push(from_id);
             }
-            for &to_id in to_ids.iter() {
-                if to_id != ContactId::SELF
-                    && !chat::is_contact_in_chat(context, chat_id, to_id).await?
-                    && removed_id != Some(to_id)
-                {
-                    info!(context, "adding to={:?} to chat id={}", to_id, chat_id);
-                    chat::add_to_chat_contacts_table(context, chat_id, to_id).await?;
-                }
+            members_to_add.extend(to_ids);
+            if let Some(removed_id) = removed_id {
+                members_to_add.retain(|id| *id != removed_id);
             }
+            members_to_add.dedup();
+
+            info!(
+                context,
+                "adding {:?} to chat id={}", members_to_add, chat_id
+            );
+            chat::add_to_chat_contacts_table(context, chat_id, &members_to_add).await?;
             send_event_chat_modified = true;
         }
     }
@@ -1883,7 +1875,7 @@ async fn create_or_lookup_mailinglist(
             )
         })?;
 
-        chat::add_to_chat_contacts_table(context, chat_id, ContactId::SELF).await?;
+        chat::add_to_chat_contacts_table(context, chat_id, &[ContactId::SELF]).await?;
         Ok(Some((chat_id, Blocked::Request)))
     } else {
         info!(context, "creating list forbidden by caller");
@@ -2013,9 +2005,7 @@ async fn create_adhoc_group(
         None,
     )
     .await?;
-    for &member_id in member_ids.iter() {
-        chat::add_to_chat_contacts_table(context, new_chat_id, member_id).await?;
-    }
+    chat::add_to_chat_contacts_table(context, new_chat_id, member_ids).await?;
 
     context.emit_event(EventType::ChatModified(new_chat_id));
 
@@ -5160,13 +5150,10 @@ Reply from different address
         chat::add_to_chat_contacts_table(
             &bob,
             group_id,
-            bob.add_or_lookup_contact(&alice1).await.id,
-        )
-        .await?;
-        chat::add_to_chat_contacts_table(
-            &bob,
-            group_id,
-            Contact::create(&bob, "", "charlie@example.org").await?,
+            &[
+                bob.add_or_lookup_contact(&alice1).await.id,
+                Contact::create(&bob, "", "charlie@example.org").await?,
+            ],
         )
         .await?;
 
@@ -5247,7 +5234,7 @@ Reply from different address
         chat::add_to_chat_contacts_table(
             &bob,
             group_id,
-            bob.add_or_lookup_contact(&alice).await.id,
+            &[bob.add_or_lookup_contact(&alice).await.id],
         )
         .await?;
 

--- a/src/securejoin/bob.rs
+++ b/src/securejoin/bob.rs
@@ -60,7 +60,7 @@ pub(super) async fn start_protocol(context: &Context, invite: QrInvite) -> Resul
             // TODO: how does this group become usable?
             let group_chat_id = state.joining_chat_id(context).await?;
             if !is_contact_in_chat(context, group_chat_id, invite.contact_id()).await? {
-                chat::add_to_chat_contacts_table(context, group_chat_id, invite.contact_id())
+                chat::add_to_chat_contacts_table(context, group_chat_id, &[invite.contact_id()])
                     .await?;
             }
             let msg = stock_str::secure_join_started(context, invite.contact_id()).await;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -432,7 +432,7 @@ impl Sql {
     pub async fn transaction<G, H>(&self, callback: G) -> Result<H>
     where
         H: Send + 'static,
-        G: Send + 'static + FnOnce(&mut rusqlite::Transaction<'_>) -> Result<H>,
+        G: Send + FnOnce(&mut rusqlite::Transaction<'_>) -> Result<H>,
     {
         let mut conn = self.get_conn().await?;
         tokio::task::block_in_place(move || {

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -651,10 +651,10 @@ CREATE INDEX smtp_messageid ON imap(rfc724_mid);
     }
     if dbversion < 95 {
         sql.execute_migration(
-            "CREATE TABLE chats_contacts_new (chat_id INTEGER, contact_id INTEGER, UNIQUE(chat_id, contact_id));\
-            INSERT OR IGNORE INTO chats_contacts_new SELECT * FROM chats_contacts;\
+            "CREATE TABLE new_chats_contacts (chat_id INTEGER, contact_id INTEGER, UNIQUE(chat_id, contact_id));\
+            INSERT OR IGNORE INTO new_chats_contacts SELECT * FROM chats_contacts;\
             DROP TABLE chats_contacts;\
-            ALTER TABLE chats_contacts_new RENAME TO chats_contacts;\
+            ALTER TABLE new_chats_contacts RENAME TO chats_contacts;\
             CREATE INDEX chats_contacts_index1 ON chats_contacts (chat_id);\
             CREATE INDEX chats_contacts_index2 ON chats_contacts (contact_id);",
             95

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -649,6 +649,17 @@ CREATE INDEX smtp_messageid ON imap(rfc724_mid);
         )
         .await?;
     }
+    if dbversion < 95 {
+        sql.execute_migration(
+            "CREATE TABLE chats_contacts_new (chat_id INTEGER, contact_id INTEGER, UNIQUE(chat_id, contact_id));\
+            INSERT OR IGNORE INTO chats_contacts_new SELECT * FROM chats_contacts;\
+            DROP TABLE chats_contacts;\
+            ALTER TABLE chats_contacts_new RENAME TO chats_contacts;\
+            CREATE INDEX chats_contacts_index1 ON chats_contacts (chat_id);\
+            CREATE INDEX chats_contacts_index2 ON chats_contacts (contact_id);",
+            95
+        ).await?;
+    }
 
     let new_version = sql
         .get_raw_config_int(VERSION_CFG)


### PR DESCRIPTION
This esp. speeds up receive_imf a bit when we recreate the member list (`recreate_member_list == true`).

It's a preparation for https://github.com/deltachat/deltachat-core-rust/issues/3768, which will be a one-line-fix, but recreate the member list more often, so that we want to optimize this case a bit.

It also adds a benchmark for this case. It's not that easy to make the benchmark non-flaky, but by closing all other programs and locking the CPU to 1.5GHz it worked. You can see that `./with-optim` is consistently a few percent faster than `./without-optim`:

<details>

<pre><font color="#00B400"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> cargo criterion --bench receive_emails --no-run -- &apos;Receive 100 Chat-Group-Member&apos;;pling
<font color="#00B400"><b>   Compiling</b></font> deltachat v1.102.0 (/home/jonathan/deltachat-android/jni/deltachat-core-rust)
<font color="#00B400"><b>    Finished</b></font> bench [optimized] target(s) in 2m 26s
<font color="#00B400"><b>  Executable</b></font> benches/receive_emails.rs (target/release/deps/receive_emails-077839ebe6a5c5fc)
<font color="#FF5555"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> mv target/release/deps/receive_emails-077839ebe6a5c5fc with-optim   
mv: overwrite &apos;with-optim&apos;? y
<font color="#00B400"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> stash src
Saved working directory and index state WIP on hoc/bulk-member-adding: d3c1cc6d Changelog
<font color="#00B400"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> cargo criterion --bench receive_emails --no-run -- &apos;Receive 100 Chat-Group-Member&apos;;pling
<font color="#00B400"><b>   Compiling</b></font> deltachat v1.102.0 (/home/jonathan/deltachat-android/jni/deltachat-core-rust)
<font color="#00B400"><b>    Finished</b></font> bench [optimized] target(s) in 2m 48s
<font color="#00B400"><b>  Executable</b></font> benches/receive_emails.rs (target/release/deps/receive_emails-077839ebe6a5c5fc)
<font color="#00B400"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> mv target/release/deps/receive_emails-077839ebe6a5c5fc without-optim
mv: overwrite &apos;without-optim&apos;? y
<font color="#00B400"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> git diff --no-ext-diff
<font color="#00B400"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> ./with-optim --bench -- &apos;Receive 100 Chat-Group-Member&apos;
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the &apos;html_reports&apos; feature in your Cargo.toml.

Benchmarking Receive messages/Receive 100 Chat-Group-Member-{Added|Removed} messages: Warming up for 3.0000 sImporting backup
create_dir_all &quot;/tmp/.tmppSlVm7/db.sqlite-blobs/blobs_backup&quot;
Importing backup
^C
<font color="#FF5555"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> mv delta-chat-backup.tar delta-chat-backup.tar-t                    
<font color="#00B400"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> ./with-optim --bench -- &apos;Receive 100 Chat-Group-Member&apos;
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the &apos;html_reports&apos; feature in your Cargo.toml.

<font color="#00AA00">Receive messages/Receive 100 Chat-Group-Member-{Added|Removed} messages</font>                                                                            
                        time:   [51.683 ms <b>51.966 ms</b> 52.295 ms]
                        change: [+32.647% <font color="#FF5555"><b>+33.831%</b></font> +34.955%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#AA0000">regressed</font>.
<font color="#AA5500">Found 11 outliers among 100 measurements (11.00%)</font>
  9 (9.00%) high mild
  2 (2.00%) high severe

<font color="#00B400"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> ./with-optim --bench -- &apos;Receive 100 Chat-Group-Member&apos;
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the &apos;html_reports&apos; feature in your Cargo.toml.

<font color="#00AA00">Receive messages/Receive 100 Chat-Group-Member-{Added|Removed} messages</font>                                                                            
                        time:   [52.353 ms <b>52.671 ms</b> 53.029 ms]
                        change: [+0.4662% +1.3565% +2.2554%] (p = 0.00 &lt; 0.05)
                        Change within noise threshold.
<font color="#AA5500">Found 8 outliers among 100 measurements (8.00%)</font>
  7 (7.00%) high mild
  1 (1.00%) high severe

<font color="#00B400"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> ./without-optim --bench -- &apos;Receive 100 Chat-Group-Member&apos;
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the &apos;html_reports&apos; feature in your Cargo.toml.

<font color="#00AA00">Receive messages/Receive 100 Chat-Group-Member-{Added|Removed} messages</font>                                                                            
                        time:   [53.619 ms <b>53.982 ms</b> 54.391 ms]
                        change: [+1.5238% <font color="#FF5555"><b>+2.4893%</b></font> +3.4660%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#AA0000">regressed</font>.
<font color="#AA5500">Found 6 outliers among 100 measurements (6.00%)</font>
  4 (4.00%) high mild
  2 (2.00%) high severe

<font color="#00B400"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> ./with-optim --bench -- &apos;Receive 100 Chat-Group-Member&apos;   
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the &apos;html_reports&apos; feature in your Cargo.toml.

<font color="#00AA00">Receive messages/Receive 100 Chat-Group-Member-{Added|Removed} messages</font>                                                                            
                        time:   [52.257 ms <b>52.569 ms</b> 52.941 ms]
                        change: [-3.5301% <font color="#00B400"><b>-2.6181%</b></font> -1.6697%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#00AA00">improved</font>.
<font color="#AA5500">Found 7 outliers among 100 measurements (7.00%)</font>
  4 (4.00%) high mild
  3 (3.00%) high severe

<font color="#00B400"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> ./with-optim --bench -- &apos;Receive 100 Chat-Group-Member&apos;
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the &apos;html_reports&apos; feature in your Cargo.toml.

<font color="#00AA00">Receive messages/Receive 100 Chat-Group-Member-{Added|Removed} messages</font>                                                                            
                        time:   [51.979 ms <b>52.205 ms</b> 52.494 ms]
                        change: [-1.5071% -0.6916% +0.0822%] (p = 0.10 &gt; 0.05)
                        No change in performance detected.
<font color="#AA5500">Found 11 outliers among 100 measurements (11.00%)</font>
  6 (6.00%) high mild
  5 (5.00%) high severe

<font color="#00B400"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> ./without-optim --bench -- &apos;Receive 100 Chat-Group-Member&apos;
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the &apos;html_reports&apos; feature in your Cargo.toml.

<font color="#00AA00">Receive messages/Receive 100 Chat-Group-Member-{Added|Removed} messages</font>                                                                            
                        time:   [53.562 ms <b>53.877 ms</b> 54.210 ms]
                        change: [+2.4141% <font color="#FF5555"><b>+3.2026%</b></font> +3.9829%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#AA0000">regressed</font>.
<font color="#AA5500">Found 3 outliers among 100 measurements (3.00%)</font>
  3 (3.00%) high mild

<font color="#00B400"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> ./with-optim --bench -- &apos;Receive 100 Chat-Group-Member&apos;   
WARNING: HTML report generation will become a non-default optional feature in Criterion.rs 0.4.0.
This feature is being moved to cargo-criterion (https://github.com/bheisler/cargo-criterion) and will be optional in a future version of Criterion.rs. To silence this warning, either switch to cargo-criterion or enable the &apos;html_reports&apos; feature in your Cargo.toml.

<font color="#00AA00">Receive messages/Receive 100 Chat-Group-Member-{Added|Removed} messages</font>                                                                            
                        time:   [52.041 ms <b>52.318 ms</b> 52.656 ms]
                        change: [-3.6759% <font color="#00B400"><b>-2.8952%</b></font> -2.0723%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#00AA00">improved</font>.
<font color="#AA5500">Found 9 outliers among 100 measurements (9.00%)</font>
  7 (7.00%) high mild
  2 (2.00%) high severe

<font color="#00B400"><b>➜  </b></font><font color="#55FFFF"><b>deltachat-core-rust</b></font> <font color="#5555FF"><b>git:(</b></font><font color="#FF5555"><b>hoc/bulk-member-adding</b></font><font color="#5555FF"><b>) </b></font><font color="#D9D900"><b>✗</b></font> 
</pre>

</details>

<pre>
<font color="#00AA00">Receive messages/Receive 100 Chat-Group-Member-{Added|Removed} messages</font>                                                                            
                        time:   [52.257 ms <b>52.569 ms</b> 52.941 ms]
                        change: [-3.5301% <font color="#00B400"><b>-2.6181%</b></font> -1.6697%] (p = 0.00 &lt; 0.05)
                        Performance has <font color="#00AA00">improved</font>.
<font color="#AA5500">Found 7 outliers among 100 measurements (7.00%)</font>
  4 (4.00%) high mild
  3 (3.00%) high severe
</pre>