### PR TITLE
Add new recipients of MUA emails to the group member list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changes
 - Don't use deprecated `chrono` functions #3798
 
+- If a classical-email-user sends an email to a group and adds new recipients,
+  add the new recipients as group members #3781
+
 ### API-Changes
 
 ### Fixes

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1352,13 +1352,6 @@ async fn lookup_chat_by_reply(
 ) -> Result<Option<(ChatId, Blocked)>> {
     // Try to assign message to the same chat as the parent message.
 
-    // If this was a private message just to self, it was probably a private reply.
-    // It should not go into the group then, but into the private chat.
-
-    // If the parent chat is a 1:1 chat, and the sender is a classical MUA and added
-    // a new person to TO/CC, then the message should not go to the 1:1 chat, but to a
-    // newly created ad-hoc group.
-
     if let Some(parent) = parent {
         let parent_chat = Chat::load_from_db(context, parent.chat_id).await?;
 
@@ -1374,10 +1367,15 @@ async fn lookup_chat_by_reply(
             return Ok(None);
         }
 
+        // If this was a private message just to self, it was probably a private reply.
+        // It should not go into the group then, but into the private chat.
         if is_probably_private_reply(context, to_ids, from_id, mime_parser, parent_chat.id).await? {
             return Ok(None);
         }
 
+        // If the parent chat is a 1:1 chat, and the sender is a classical MUA and added
+        // a new person to TO/CC, then the message should not go to the 1:1 chat, but to a
+        // newly created ad-hoc group.
         if parent_chat.typ == Chattype::Single
             && !mime_parser.has_chat_version()
             && to_ids.len() > 1


### PR DESCRIPTION
fix #3768

TODO:

- [x] Do we want to show this to the user in an info message? --> not for now, but let's do this when tackling #3780
- [x] What if a MUA user adds a new recipient in a 1:1 chat? --> at least show an error message; if possible without breaking stuff, then make this start a new group (related: https://github.com/deltachat/deltachat-core-rust/issues/2509) --> this is possible without breaking stuff

@Septias I also requested a review from you since that's relevant for https://github.com/deltachat/deltachat-core-rust/pull/3807 (idk if changes are necessary, just something to be aware of)