### PR TITLE
Remove the remaining AsRef<str> (#3669)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 ### Changes
+- Refactor: Remove the remaining AsRef<str> #3669
 
 ### API-Changes
 - Add Python API to send reactions #3762

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1659,7 +1659,7 @@ pub unsafe extern "C" fn dc_set_chat_profile_image(
     let ctx = &*context;
 
     block_on(async move {
-        chat::set_chat_profile_image(ctx, ChatId::new(chat_id), to_string_lossy(image))
+        chat::set_chat_profile_image(ctx, ChatId::new(chat_id), &to_string_lossy(image))
             .await
             .map(|_| 1)
             .unwrap_or_log_default(ctx, "Failed to set profile image")

--- a/deltachat-jsonrpc/src/api/mod.rs
+++ b/deltachat-jsonrpc/src/api/mod.rs
@@ -733,7 +733,7 @@ impl CommandApi {
         image_path: Option<String>,
     ) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
-        chat::set_chat_profile_image(&ctx, ChatId::new(chat_id), image_path.unwrap_or_default())
+        chat::set_chat_profile_image(&ctx, ChatId::new(chat_id), &image_path.unwrap_or_default())
             .await
     }
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2188,7 +2188,7 @@ pub async fn send_videochat_invitation(context: &Context, chat_id: ChatId) -> Re
     let mut msg = Message::new(Viewtype::VideochatInvitation);
     msg.param.set(Param::WebrtcRoom, &instance);
     msg.text = Some(
-        stock_str::videochat_invite_msg_body(context, Message::parse_webrtc_instance(&instance).1)
+        stock_str::videochat_invite_msg_body(context, &Message::parse_webrtc_instance(&instance).1)
             .await,
     );
     send_msg(context, chat_id, &mut msg).await
@@ -3005,7 +3005,7 @@ pub async fn set_chat_name(context: &Context, chat_id: ChatId, new_name: &str) -
 pub async fn set_chat_profile_image(
     context: &Context,
     chat_id: ChatId,
-    new_image: impl AsRef<str>, // XXX use PathBuf
+    new_image: &str, // XXX use PathBuf
 ) -> Result<()> {
     ensure!(!chat_id.is_special(), "Invalid chat ID");
     let mut chat = Chat::load_from_db(context, chat_id).await?;
@@ -3023,13 +3023,12 @@ pub async fn set_chat_profile_image(
     let mut msg = Message::new(Viewtype::Text);
     msg.param
         .set_int(Param::Cmd, SystemMessage::GroupImageChanged as i32);
-    if new_image.as_ref().is_empty() {
+    if new_image.is_empty() {
         chat.param.remove(Param::ProfileImage);
         msg.param.remove(Param::Arg);
         msg.text = Some(stock_str::msg_grp_img_deleted(context, ContactId::SELF).await);
     } else {
-        let mut image_blob =
-            BlobObject::new_from_path(context, Path::new(new_image.as_ref())).await?;
+        let mut image_blob = BlobObject::new_from_path(context, Path::new(new_image)).await?;
         image_blob.recode_to_avatar_size(context).await?;
         chat.param.set(Param::ProfileImage, image_blob.as_name());
         msg.param.set(Param::Arg, image_blob.as_name());

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -87,7 +87,7 @@ impl Context {
                         self,
                         // We are using Anyhow's .context() and to show the
                         // inner error, too, we need the {:#}:
-                        format!("{:#}", err),
+                        &format!("{:#}", err),
                     )
                     .await
                 )
@@ -153,7 +153,7 @@ async fn on_configure_completed(
             if !addr_cmp(&new_addr, &old_addr) {
                 let mut msg = Message::new(Viewtype::Text);
                 msg.text =
-                    Some(stock_str::aeap_explanation_and_link(context, old_addr, new_addr).await);
+                    Some(stock_str::aeap_explanation_and_link(context, &old_addr, &new_addr).await);
                 chat::add_device_msg(context, None, Some(&mut msg))
                     .await
                     .ok_or_log_msg(context, "Cannot add AEAP explanation");

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -226,13 +226,13 @@ pub(crate) async fn stock_ephemeral_timer_changed(
         Timer::Disabled => stock_str::msg_ephemeral_timer_disabled(context, from_id).await,
         Timer::Enabled { duration } => match duration {
             0..=59 => {
-                stock_str::msg_ephemeral_timer_enabled(context, timer.to_string(), from_id).await
+                stock_str::msg_ephemeral_timer_enabled(context, &timer.to_string(), from_id).await
             }
             60 => stock_str::msg_ephemeral_timer_minute(context, from_id).await,
             61..=3599 => {
                 stock_str::msg_ephemeral_timer_minutes(
                     context,
-                    format!("{}", (f64::from(duration) / 6.0).round() / 10.0),
+                    &format!("{}", (f64::from(duration) / 6.0).round() / 10.0),
                     from_id,
                 )
                 .await
@@ -241,7 +241,7 @@ pub(crate) async fn stock_ephemeral_timer_changed(
             3601..=86399 => {
                 stock_str::msg_ephemeral_timer_hours(
                     context,
-                    format!("{}", (f64::from(duration) / 360.0).round() / 10.0),
+                    &format!("{}", (f64::from(duration) / 360.0).round() / 10.0),
                     from_id,
                 )
                 .await
@@ -250,7 +250,7 @@ pub(crate) async fn stock_ephemeral_timer_changed(
             86401..=604_799 => {
                 stock_str::msg_ephemeral_timer_days(
                     context,
-                    format!("{}", (f64::from(duration) / 8640.0).round() / 10.0),
+                    &format!("{}", (f64::from(duration) / 8640.0).round() / 10.0),
                     from_id,
                 )
                 .await
@@ -259,7 +259,7 @@ pub(crate) async fn stock_ephemeral_timer_changed(
             _ => {
                 stock_str::msg_ephemeral_timer_weeks(
                     context,
-                    format!("{}", (f64::from(duration) / 60480.0).round() / 10.0),
+                    &format!("{}", (f64::from(duration) / 60480.0).round() / 10.0),
                     from_id,
                 )
                 .await

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -169,7 +169,7 @@ impl LoginParam {
     async fn from_database(context: &Context, prefix: &str) -> Result<Self> {
         let sql = &context.sql;
 
-        let key = format!("{}addr", prefix);
+        let key = &format!("{}addr", prefix);
         let addr = sql
             .get_raw_config(key)
             .await?
@@ -177,26 +177,26 @@ impl LoginParam {
             .trim()
             .to_string();
 
-        let key = format!("{}mail_server", prefix);
+        let key = &format!("{}mail_server", prefix);
         let mail_server = sql.get_raw_config(key).await?.unwrap_or_default();
 
-        let key = format!("{}mail_port", prefix);
+        let key = &format!("{}mail_port", prefix);
         let mail_port = sql.get_raw_config_int(key).await?.unwrap_or_default();
 
-        let key = format!("{}mail_user", prefix);
+        let key = &format!("{}mail_user", prefix);
         let mail_user = sql.get_raw_config(key).await?.unwrap_or_default();
 
-        let key = format!("{}mail_pw", prefix);
+        let key = &format!("{}mail_pw", prefix);
         let mail_pw = sql.get_raw_config(key).await?.unwrap_or_default();
 
-        let key = format!("{}mail_security", prefix);
+        let key = &format!("{}mail_security", prefix);
         let mail_security = sql
             .get_raw_config_int(key)
             .await?
             .and_then(num_traits::FromPrimitive::from_i32)
             .unwrap_or_default();
 
-        let key = format!("{}imap_certificate_checks", prefix);
+        let key = &format!("{}imap_certificate_checks", prefix);
         let imap_certificate_checks =
             if let Some(certificate_checks) = sql.get_raw_config_int(key).await? {
                 num_traits::FromPrimitive::from_i32(certificate_checks).unwrap()
@@ -204,26 +204,26 @@ impl LoginParam {
                 Default::default()
             };
 
-        let key = format!("{}send_server", prefix);
+        let key = &format!("{}send_server", prefix);
         let send_server = sql.get_raw_config(key).await?.unwrap_or_default();
 
-        let key = format!("{}send_port", prefix);
+        let key = &format!("{}send_port", prefix);
         let send_port = sql.get_raw_config_int(key).await?.unwrap_or_default();
 
-        let key = format!("{}send_user", prefix);
+        let key = &format!("{}send_user", prefix);
         let send_user = sql.get_raw_config(key).await?.unwrap_or_default();
 
-        let key = format!("{}send_pw", prefix);
+        let key = &format!("{}send_pw", prefix);
         let send_pw = sql.get_raw_config(key).await?.unwrap_or_default();
 
-        let key = format!("{}send_security", prefix);
+        let key = &format!("{}send_security", prefix);
         let send_security = sql
             .get_raw_config_int(key)
             .await?
             .and_then(num_traits::FromPrimitive::from_i32)
             .unwrap_or_default();
 
-        let key = format!("{}smtp_certificate_checks", prefix);
+        let key = &format!("{}smtp_certificate_checks", prefix);
         let smtp_certificate_checks =
             if let Some(certificate_checks) = sql.get_raw_config_int(key).await? {
                 num_traits::FromPrimitive::from_i32(certificate_checks).unwrap_or_default()
@@ -231,11 +231,11 @@ impl LoginParam {
                 Default::default()
             };
 
-        let key = format!("{}server_flags", prefix);
+        let key = &format!("{}server_flags", prefix);
         let server_flags = sql.get_raw_config_int(key).await?.unwrap_or_default();
         let oauth2 = matches!(server_flags & DC_LP_AUTH_FLAGS, DC_LP_AUTH_OAUTH2);
 
-        let key = format!("{}provider", prefix);
+        let key = &format!("{}provider", prefix);
         let provider = sql
             .get_raw_config(key)
             .await?
@@ -275,50 +275,50 @@ impl LoginParam {
 
         context.set_primary_self_addr(&self.addr).await?;
 
-        let key = format!("{}mail_server", prefix);
+        let key = &format!("{}mail_server", prefix);
         sql.set_raw_config(key, Some(&self.imap.server)).await?;
 
-        let key = format!("{}mail_port", prefix);
+        let key = &format!("{}mail_port", prefix);
         sql.set_raw_config_int(key, i32::from(self.imap.port))
             .await?;
 
-        let key = format!("{}mail_user", prefix);
+        let key = &format!("{}mail_user", prefix);
         sql.set_raw_config(key, Some(&self.imap.user)).await?;
 
-        let key = format!("{}mail_pw", prefix);
+        let key = &format!("{}mail_pw", prefix);
         sql.set_raw_config(key, Some(&self.imap.password)).await?;
 
-        let key = format!("{}mail_security", prefix);
+        let key = &format!("{}mail_security", prefix);
         sql.set_raw_config_int(key, self.imap.security as i32)
             .await?;
 
-        let key = format!("{}imap_certificate_checks", prefix);
+        let key = &format!("{}imap_certificate_checks", prefix);
         sql.set_raw_config_int(key, self.imap.certificate_checks as i32)
             .await?;
 
-        let key = format!("{}send_server", prefix);
+        let key = &format!("{}send_server", prefix);
         sql.set_raw_config(key, Some(&self.smtp.server)).await?;
 
-        let key = format!("{}send_port", prefix);
+        let key = &format!("{}send_port", prefix);
         sql.set_raw_config_int(key, i32::from(self.smtp.port))
             .await?;
 
-        let key = format!("{}send_user", prefix);
+        let key = &format!("{}send_user", prefix);
         sql.set_raw_config(key, Some(&self.smtp.user)).await?;
 
-        let key = format!("{}send_pw", prefix);
+        let key = &format!("{}send_pw", prefix);
         sql.set_raw_config(key, Some(&self.smtp.password)).await?;
 
-        let key = format!("{}send_security", prefix);
+        let key = &format!("{}send_security", prefix);
         sql.set_raw_config_int(key, self.smtp.security as i32)
             .await?;
 
-        let key = format!("{}smtp_certificate_checks", prefix);
+        let key = &format!("{}smtp_certificate_checks", prefix);
         sql.set_raw_config_int(key, self.smtp.certificate_checks as i32)
             .await?;
 
         // The OAuth2 flag is either set for both IMAP and SMTP or not at all.
-        let key = format!("{}server_flags", prefix);
+        let key = &format!("{}server_flags", prefix);
         let server_flags = match self.imap.oauth2 {
             true => DC_LP_AUTH_OAUTH2,
             false => DC_LP_AUTH_NORMAL,
@@ -326,7 +326,7 @@ impl LoginParam {
         sql.set_raw_config_int(key, server_flags).await?;
 
         if let Some(provider) = self.provider {
-            let key = format!("{}provider", prefix);
+            let key = &format!("{}provider", prefix);
             sql.set_raw_config(key, Some(provider.id)).await?;
         }
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -429,7 +429,7 @@ impl<'a> MimeFactory<'a> {
                     }
                 }
 
-                let self_name = match context.get_config(Config::Displayname).await? {
+                let self_name = &match context.get_config(Config::Displayname).await? {
                     Some(name) => name,
                     None => context.get_config(Config::Addr).await?.unwrap_or_default(),
                 };
@@ -1259,7 +1259,7 @@ impl<'a> MimeFactory<'a> {
                 .truncated_text(32)
                 .to_string()
         };
-        let p2 = stock_str::read_rcpt_mail_body(context, p1).await;
+        let p2 = stock_str::read_rcpt_mail_body(context, &p1).await;
         let message_text = format!("{}\r\n", format_flowed(&p2));
         message = message.child(
             PartBuilder::new()

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -474,7 +474,7 @@ impl Peerstate {
         let chats = Chatlist::try_load(context, 0, None, Some(contact_id)).await?;
         let msg = match &change {
             PeerstateChange::FingerprintChange => {
-                stock_str::contact_setup_changed(context, self.addr.clone()).await
+                stock_str::contact_setup_changed(context, &self.addr).await
             }
             PeerstateChange::Aeap(new_addr) => {
                 let old_contact = Contact::load_from_db(context, contact_id).await?;

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -448,7 +448,7 @@ impl Context {
         //                                [======67%=====       ]
         // =============================================================================================
 
-        let domain = tools::EmailAddress::new(&self.get_primary_self_addr().await?)?.domain;
+        let domain = &tools::EmailAddress::new(&self.get_primary_self_addr().await?)?.domain;
         let storage_on_domain = stock_str::storage_on_domain(self, domain).await;
         ret += &format!("<h3>{}</h3><ul>", storage_on_domain);
         let quota = self.quota.read().await;
@@ -473,8 +473,8 @@ impl Context {
                             let messages = stock_str::messages(self).await;
                             let part_of_total_used = stock_str::part_of_total_used(
                                 self,
-                                resource.usage.to_string(),
-                                resource.limit.to_string(),
+                                &resource.usage.to_string(),
+                                &resource.limit.to_string(),
                             )
                             .await;
                             ret += &match &resource.name {
@@ -495,8 +495,8 @@ impl Context {
                                     // - the string is not longer than the other strings that way (minus title, plus units) -
                                     //   additional linebreaks on small displays are unlikely therefore
                                     // - most times, this is the only item anyway
-                                    let usage = format_size(resource.usage * 1024, BINARY);
-                                    let limit = format_size(resource.limit * 1024, BINARY);
+                                    let usage = &format_size(resource.usage * 1024, BINARY);
+                                    let limit = &format_size(resource.limit * 1024, BINARY);
                                     stock_str::part_of_total_used(self, usage, limit).await
                                 }
                             };

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -320,11 +320,11 @@ ALTER TABLE msgs ADD COLUMN ephemeral_timestamp INTEGER DEFAULT 0;"#,
     if dbversion < 67 {
         for prefix in &["", "configured_"] {
             if let Some(server_flags) = sql
-                .get_raw_config_int(format!("{}server_flags", prefix))
+                .get_raw_config_int(&format!("{}server_flags", prefix))
                 .await?
             {
                 let imap_socket_flags = server_flags & 0x700;
-                let key = format!("{}mail_security", prefix);
+                let key = &format!("{}mail_security", prefix);
                 match imap_socket_flags {
                     0x100 => sql.set_raw_config_int(key, 2).await?, // STARTTLS
                     0x200 => sql.set_raw_config_int(key, 1).await?, // SSL/TLS
@@ -332,7 +332,7 @@ ALTER TABLE msgs ADD COLUMN ephemeral_timestamp INTEGER DEFAULT 0;"#,
                     _ => sql.set_raw_config_int(key, 0).await?,
                 }
                 let smtp_socket_flags = server_flags & 0x70000;
-                let key = format!("{}send_security", prefix);
+                let key = &format!("{}send_security", prefix);
                 match smtp_socket_flags {
                     0x10000 => sql.set_raw_config_int(key, 2).await?, // STARTTLS
                     0x20000 => sql.set_raw_config_int(key, 1).await?, // SSL/TLS

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -466,33 +466,33 @@ async fn translated(context: &Context, id: StockMessage) -> String {
 /// Helper trait only meant to be implemented for [`String`].
 trait StockStringMods: AsRef<str> + Sized {
     /// Substitutes the first replacement value if one is present.
-    fn replace1(&self, replacement: impl AsRef<str>) -> String {
+    fn replace1(&self, replacement: &str) -> String {
         self.as_ref()
-            .replacen("%1$s", replacement.as_ref(), 1)
-            .replacen("%1$d", replacement.as_ref(), 1)
-            .replacen("%1$@", replacement.as_ref(), 1)
+            .replacen("%1$s", replacement, 1)
+            .replacen("%1$d", replacement, 1)
+            .replacen("%1$@", replacement, 1)
     }
 
     /// Substitutes the second replacement value if one is present.
     ///
     /// Be aware you probably should have also called [`StockStringMods::replace1`] if
     /// you are calling this.
-    fn replace2(&self, replacement: impl AsRef<str>) -> String {
+    fn replace2(&self, replacement: &str) -> String {
         self.as_ref()
-            .replacen("%2$s", replacement.as_ref(), 1)
-            .replacen("%2$d", replacement.as_ref(), 1)
-            .replacen("%2$@", replacement.as_ref(), 1)
+            .replacen("%2$s", replacement, 1)
+            .replacen("%2$d", replacement, 1)
+            .replacen("%2$@", replacement, 1)
     }
 
     /// Substitutes the third replacement value if one is present.
     ///
     /// Be aware you probably should have also called [`StockStringMods::replace1`] and
     /// [`StockStringMods::replace2`] if you are calling this.
-    fn replace3(&self, replacement: impl AsRef<str>) -> String {
+    fn replace3(&self, replacement: &str) -> String {
         self.as_ref()
-            .replacen("%3$s", replacement.as_ref(), 1)
-            .replacen("%3$d", replacement.as_ref(), 1)
-            .replacen("%3$@", replacement.as_ref(), 1)
+            .replacen("%3$s", replacement, 1)
+            .replacen("%3$d", replacement, 1)
+            .replacen("%3$@", replacement, 1)
     }
 }
 
@@ -551,8 +551,8 @@ pub(crate) async fn file(context: &Context) -> String {
 /// Stock string: `Group name changed from "%1$s" to "%2$s".`.
 pub(crate) async fn msg_grp_name(
     context: &Context,
-    from_group: impl AsRef<str>,
-    to_group: impl AsRef<str>,
+    from_group: &str,
+    to_group: &str,
     by_contact: ContactId,
 ) -> String {
     if by_contact == ContactId::SELF {
@@ -565,7 +565,7 @@ pub(crate) async fn msg_grp_name(
             .await
             .replace1(from_group)
             .replace2(to_group)
-            .replace3(by_contact.get_stock_name(context).await)
+            .replace3(&by_contact.get_stock_name(context).await)
     }
 }
 
@@ -575,7 +575,7 @@ pub(crate) async fn msg_grp_img_changed(context: &Context, by_contact: ContactId
     } else {
         translated(context, StockMessage::MsgGrpImgChangedBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(&by_contact.get_stock_name(context).await)
     }
 }
 
@@ -585,11 +585,11 @@ pub(crate) async fn msg_grp_img_changed(context: &Context, by_contact: ContactId
 /// contacts to combine with the display name.
 pub(crate) async fn msg_add_member(
     context: &Context,
-    added_member_addr: impl AsRef<str>,
+    added_member_addr: &str,
     by_contact: ContactId,
 ) -> String {
-    let addr = added_member_addr.as_ref();
-    let who = match Contact::lookup_id_by_addr(context, addr, Origin::Unknown).await {
+    let addr = added_member_addr;
+    let who = &match Contact::lookup_id_by_addr(context, addr, Origin::Unknown).await {
         Ok(Some(contact_id)) => Contact::get_by_id(context, contact_id)
             .await
             .map(|contact| contact.get_name_n_addr())
@@ -604,7 +604,7 @@ pub(crate) async fn msg_add_member(
         translated(context, StockMessage::MsgAddMemberBy)
             .await
             .replace1(who)
-            .replace2(by_contact.get_stock_name(context).await)
+            .replace2(&by_contact.get_stock_name(context).await)
     }
 }
 
@@ -614,11 +614,11 @@ pub(crate) async fn msg_add_member(
 /// the contacts to combine with the display name.
 pub(crate) async fn msg_del_member(
     context: &Context,
-    removed_member_addr: impl AsRef<str>,
+    removed_member_addr: &str,
     by_contact: ContactId,
 ) -> String {
-    let addr = removed_member_addr.as_ref();
-    let who = match Contact::lookup_id_by_addr(context, addr, Origin::Unknown).await {
+    let addr = removed_member_addr;
+    let who = &match Contact::lookup_id_by_addr(context, addr, Origin::Unknown).await {
         Ok(Some(contact_id)) => Contact::get_by_id(context, contact_id)
             .await
             .map(|contact| contact.get_name_n_addr())
@@ -633,7 +633,7 @@ pub(crate) async fn msg_del_member(
         translated(context, StockMessage::MsgDelMemberBy)
             .await
             .replace1(who)
-            .replace2(by_contact.get_stock_name(context).await)
+            .replace2(&by_contact.get_stock_name(context).await)
     }
 }
 
@@ -644,7 +644,7 @@ pub(crate) async fn msg_group_left(context: &Context, by_contact: ContactId) -> 
     } else {
         translated(context, StockMessage::MsgGroupLeftBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(&by_contact.get_stock_name(context).await)
     }
 }
 
@@ -684,7 +684,7 @@ pub(crate) async fn read_rcpt(context: &Context) -> String {
 }
 
 /// Stock string: `This is a return receipt for the message "%1$s".`.
-pub(crate) async fn read_rcpt_mail_body(context: &Context, message: impl AsRef<str>) -> String {
+pub(crate) async fn read_rcpt_mail_body(context: &Context, message: &str) -> String {
     translated(context, StockMessage::ReadRcptMailBody)
         .await
         .replace1(message)
@@ -697,7 +697,7 @@ pub(crate) async fn msg_grp_img_deleted(context: &Context, by_contact: ContactId
     } else {
         translated(context, StockMessage::MsgGrpImgDeletedBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(&by_contact.get_stock_name(context).await)
     }
 }
 
@@ -714,7 +714,7 @@ pub(crate) async fn secure_join_started(
     if let Ok(contact) = Contact::get_by_id(context, inviter_contact_id).await {
         translated(context, StockMessage::SecureJoinStarted)
             .await
-            .replace1(contact.get_name_n_addr())
+            .replace1(&contact.get_name_n_addr())
             .replace2(contact.get_display_name())
     } else {
         format!(
@@ -741,7 +741,7 @@ pub(crate) async fn setup_contact_qr_description(
     display_name: &str,
     addr: &str,
 ) -> String {
-    let name = if display_name == addr {
+    let name = &if display_name == addr {
         addr.to_owned()
     } else {
         format!("{} ({})", display_name, addr)
@@ -760,7 +760,7 @@ pub(crate) async fn secure_join_group_qr_description(context: &Context, chat: &C
 
 /// Stock string: `%1$s verified.`.
 pub(crate) async fn contact_verified(context: &Context, contact: &Contact) -> String {
-    let addr = contact.get_name_n_addr();
+    let addr = &contact.get_name_n_addr();
     translated(context, StockMessage::ContactVerified)
         .await
         .replace1(addr)
@@ -768,17 +768,14 @@ pub(crate) async fn contact_verified(context: &Context, contact: &Contact) -> St
 
 /// Stock string: `Cannot verify %1$s`.
 pub(crate) async fn contact_not_verified(context: &Context, contact: &Contact) -> String {
-    let addr = contact.get_name_n_addr();
+    let addr = &contact.get_name_n_addr();
     translated(context, StockMessage::ContactNotVerified)
         .await
         .replace1(addr)
 }
 
 /// Stock string: `Changed setup for %1$s`.
-pub(crate) async fn contact_setup_changed(
-    context: &Context,
-    contact_addr: impl AsRef<str>,
-) -> String {
+pub(crate) async fn contact_setup_changed(context: &Context, contact_addr: &str) -> String {
     translated(context, StockMessage::ContactSetupChanged)
         .await
         .replace1(contact_addr)
@@ -810,7 +807,7 @@ pub(crate) async fn sync_msg_body(context: &Context) -> String {
 }
 
 /// Stock string: `Cannot login as \"%1$s\". Please check...`.
-pub(crate) async fn cannot_login(context: &Context, user: impl AsRef<str>) -> String {
+pub(crate) async fn cannot_login(context: &Context, user: &str) -> String {
     translated(context, StockMessage::CannotLogin)
         .await
         .replace1(user)
@@ -828,7 +825,7 @@ pub(crate) async fn msg_location_enabled_by(context: &Context, contact: ContactI
     } else {
         translated(context, StockMessage::MsgLocationEnabledBy)
             .await
-            .replace1(contact.get_stock_name(context).await)
+            .replace1(&contact.get_stock_name(context).await)
     }
 }
 
@@ -874,17 +871,14 @@ pub(crate) async fn unknown_sender_for_chat(context: &Context) -> String {
 
 /// Stock string: `Message from %1$s`.
 // TODO: This can compute `self_name` itself instead of asking the caller to do this.
-pub(crate) async fn subject_for_new_contact(
-    context: &Context,
-    self_name: impl AsRef<str>,
-) -> String {
+pub(crate) async fn subject_for_new_contact(context: &Context, self_name: &str) -> String {
     translated(context, StockMessage::SubjectForNewContact)
         .await
         .replace1(self_name)
 }
 
 /// Stock string: `Failed to send message to %1$s.`.
-pub(crate) async fn failed_sending_to(context: &Context, name: impl AsRef<str>) -> String {
+pub(crate) async fn failed_sending_to(context: &Context, name: &str) -> String {
     translated(context, StockMessage::FailedSendingTo)
         .await
         .replace1(name)
@@ -900,14 +894,14 @@ pub(crate) async fn msg_ephemeral_timer_disabled(
     } else {
         translated(context, StockMessage::MsgEphemeralTimerDisabledBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(&by_contact.get_stock_name(context).await)
     }
 }
 
 /// Stock string: `Message deletion timer is set to %1$s s.`.
 pub(crate) async fn msg_ephemeral_timer_enabled(
     context: &Context,
-    timer: impl AsRef<str>,
+    timer: &str,
     by_contact: ContactId,
 ) -> String {
     if by_contact == ContactId::SELF {
@@ -918,7 +912,7 @@ pub(crate) async fn msg_ephemeral_timer_enabled(
         translated(context, StockMessage::MsgEphemeralTimerEnabledBy)
             .await
             .replace1(timer)
-            .replace2(by_contact.get_stock_name(context).await)
+            .replace2(&by_contact.get_stock_name(context).await)
     }
 }
 
@@ -929,7 +923,7 @@ pub(crate) async fn msg_ephemeral_timer_minute(context: &Context, by_contact: Co
     } else {
         translated(context, StockMessage::MsgEphemeralTimerMinuteBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(&by_contact.get_stock_name(context).await)
     }
 }
 
@@ -940,7 +934,7 @@ pub(crate) async fn msg_ephemeral_timer_hour(context: &Context, by_contact: Cont
     } else {
         translated(context, StockMessage::MsgEphemeralTimerHourBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(&by_contact.get_stock_name(context).await)
     }
 }
 
@@ -951,7 +945,7 @@ pub(crate) async fn msg_ephemeral_timer_day(context: &Context, by_contact: Conta
     } else {
         translated(context, StockMessage::MsgEphemeralTimerDayBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(&by_contact.get_stock_name(context).await)
     }
 }
 
@@ -962,7 +956,7 @@ pub(crate) async fn msg_ephemeral_timer_week(context: &Context, by_contact: Cont
     } else {
         translated(context, StockMessage::MsgEphemeralTimerWeekBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(&by_contact.get_stock_name(context).await)
     }
 }
 
@@ -972,14 +966,14 @@ pub(crate) async fn videochat_invitation(context: &Context) -> String {
 }
 
 /// Stock string: `You are invited to a video chat, click %1$s to join.`.
-pub(crate) async fn videochat_invite_msg_body(context: &Context, url: impl AsRef<str>) -> String {
+pub(crate) async fn videochat_invite_msg_body(context: &Context, url: &str) -> String {
     translated(context, StockMessage::VideochatInviteMsgBody)
         .await
         .replace1(url)
 }
 
 /// Stock string: `Error:\n\n“%1$s”`.
-pub(crate) async fn configuration_failed(context: &Context, details: impl AsRef<str>) -> String {
+pub(crate) async fn configuration_failed(context: &Context, details: &str) -> String {
     translated(context, StockMessage::ConfigurationFailed)
         .await
         .replace1(details)
@@ -987,7 +981,7 @@ pub(crate) async fn configuration_failed(context: &Context, details: impl AsRef<
 
 /// Stock string: `⚠️ Date or time of your device seem to be inaccurate (%1$s)...`.
 // TODO: This could compute now itself.
-pub(crate) async fn bad_time_msg_body(context: &Context, now: impl AsRef<str>) -> String {
+pub(crate) async fn bad_time_msg_body(context: &Context, now: &str) -> String {
     translated(context, StockMessage::BadTimeMsgBody)
         .await
         .replace1(now)
@@ -1010,7 +1004,7 @@ pub(crate) async fn protection_enabled(context: &Context, by_contact: ContactId)
     } else {
         translated(context, StockMessage::ProtectionEnabledBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(&by_contact.get_stock_name(context).await)
     }
 }
 
@@ -1021,7 +1015,7 @@ pub(crate) async fn protection_disabled(context: &Context, by_contact: ContactId
     } else {
         translated(context, StockMessage::ProtectionDisabledBy)
             .await
-            .replace1(by_contact.get_stock_name(context).await)
+            .replace1(&by_contact.get_stock_name(context).await)
     }
 }
 
@@ -1043,7 +1037,7 @@ pub(crate) async fn delete_server_turned_off(context: &Context) -> String {
 /// Stock string: `Message deletion timer is set to %1$s minutes.`.
 pub(crate) async fn msg_ephemeral_timer_minutes(
     context: &Context,
-    minutes: impl AsRef<str>,
+    minutes: &str,
     by_contact: ContactId,
 ) -> String {
     if by_contact == ContactId::SELF {
@@ -1054,14 +1048,14 @@ pub(crate) async fn msg_ephemeral_timer_minutes(
         translated(context, StockMessage::MsgEphemeralTimerMinutesBy)
             .await
             .replace1(minutes)
-            .replace2(by_contact.get_stock_name(context).await)
+            .replace2(&by_contact.get_stock_name(context).await)
     }
 }
 
 /// Stock string: `Message deletion timer is set to %1$s hours.`.
 pub(crate) async fn msg_ephemeral_timer_hours(
     context: &Context,
-    hours: impl AsRef<str>,
+    hours: &str,
     by_contact: ContactId,
 ) -> String {
     if by_contact == ContactId::SELF {
@@ -1072,14 +1066,14 @@ pub(crate) async fn msg_ephemeral_timer_hours(
         translated(context, StockMessage::MsgEphemeralTimerHoursBy)
             .await
             .replace1(hours)
-            .replace2(by_contact.get_stock_name(context).await)
+            .replace2(&by_contact.get_stock_name(context).await)
     }
 }
 
 /// Stock string: `Message deletion timer is set to %1$s days.`.
 pub(crate) async fn msg_ephemeral_timer_days(
     context: &Context,
-    days: impl AsRef<str>,
+    days: &str,
     by_contact: ContactId,
 ) -> String {
     if by_contact == ContactId::SELF {
@@ -1090,14 +1084,14 @@ pub(crate) async fn msg_ephemeral_timer_days(
         translated(context, StockMessage::MsgEphemeralTimerDaysBy)
             .await
             .replace1(days)
-            .replace2(by_contact.get_stock_name(context).await)
+            .replace2(&by_contact.get_stock_name(context).await)
     }
 }
 
 /// Stock string: `Message deletion timer is set to %1$s weeks.`.
 pub(crate) async fn msg_ephemeral_timer_weeks(
     context: &Context,
-    weeks: impl AsRef<str>,
+    weeks: &str,
     by_contact: ContactId,
 ) -> String {
     if by_contact == ContactId::SELF {
@@ -1108,7 +1102,7 @@ pub(crate) async fn msg_ephemeral_timer_weeks(
         translated(context, StockMessage::MsgEphemeralTimerWeeksBy)
             .await
             .replace1(weeks)
-            .replace2(by_contact.get_stock_name(context).await)
+            .replace2(&by_contact.get_stock_name(context).await)
     }
 }
 
@@ -1121,13 +1115,13 @@ pub(crate) async fn forwarded(context: &Context) -> String {
 pub(crate) async fn quota_exceeding(context: &Context, highest_usage: u64) -> String {
     translated(context, StockMessage::QuotaExceedingMsgBody)
         .await
-        .replace1(format!("{}", highest_usage))
+        .replace1(&format!("{}", highest_usage))
         .replace("%%", "%")
 }
 
 /// Stock string: `%1$s message` with placeholder replaced by human-readable size.
 pub(crate) async fn partial_download_msg_body(context: &Context, org_bytes: u32) -> String {
-    let size = format_size(org_bytes, BINARY);
+    let size = &format_size(org_bytes, BINARY);
     translated(context, StockMessage::PartialDownloadMsgBody)
         .await
         .replace1(size)
@@ -1137,7 +1131,7 @@ pub(crate) async fn partial_download_msg_body(context: &Context, org_bytes: u32)
 pub(crate) async fn download_availability(context: &Context, timestamp: i64) -> String {
     translated(context, StockMessage::DownloadAvailability)
         .await
-        .replace1(timestamp_to_str(timestamp))
+        .replace1(&timestamp_to_str(timestamp))
 }
 
 /// Stock string: `Incoming Messages`.
@@ -1152,7 +1146,7 @@ pub(crate) async fn outgoing_messages(context: &Context) -> String {
 
 /// Stock string: `Storage on %1$s`.
 /// `%1$s` will be replaced by the domain of the configured email-address.
-pub(crate) async fn storage_on_domain(context: &Context, domain: impl AsRef<str>) -> String {
+pub(crate) async fn storage_on_domain(context: &Context, domain: &str) -> String {
     translated(context, StockMessage::StorageOnDomain)
         .await
         .replace1(domain)
@@ -1190,7 +1184,7 @@ pub(crate) async fn last_msg_sent_successfully(context: &Context) -> String {
 
 /// Stock string: `Error: %1$s…`.
 /// `%1$s` will be replaced by a possibly more detailed, typically english, error description.
-pub(crate) async fn error(context: &Context, error: impl AsRef<str>) -> String {
+pub(crate) async fn error(context: &Context, error: &str) -> String {
     translated(context, StockMessage::Error)
         .await
         .replace1(error)
@@ -1208,11 +1202,7 @@ pub(crate) async fn messages(context: &Context) -> String {
 }
 
 /// Stock string: `%1$s of %2$s used`.
-pub(crate) async fn part_of_total_used(
-    context: &Context,
-    part: impl AsRef<str>,
-    total: impl AsRef<str>,
-) -> String {
+pub(crate) async fn part_of_total_used(context: &Context, part: &str, total: &str) -> String {
     translated(context, StockMessage::PartOfTotallUsed)
         .await
         .replace1(part)
@@ -1228,9 +1218,9 @@ pub(crate) async fn broadcast_list(context: &Context) -> String {
 /// Stock string: `%1$s changed their address from %2$s to %3$s`.
 pub(crate) async fn aeap_addr_changed(
     context: &Context,
-    contact_name: impl AsRef<str>,
-    old_addr: impl AsRef<str>,
-    new_addr: impl AsRef<str>,
+    contact_name: &str,
+    old_addr: &str,
+    new_addr: &str,
 ) -> String {
     translated(context, StockMessage::AeapAddrChanged)
         .await
@@ -1241,8 +1231,8 @@ pub(crate) async fn aeap_addr_changed(
 
 pub(crate) async fn aeap_explanation_and_link(
     context: &Context,
-    old_addr: impl AsRef<str>,
-    new_addr: impl AsRef<str>,
+    old_addr: &str,
+    new_addr: &str,
 ) -> String {
     translated(context, StockMessage::AeapExplanationAndLink)
         .await

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -979,7 +979,7 @@ fn print_event(event: &Event) {
 /// Logs an individual message to stdout.
 ///
 /// This includes a bunch of the message meta-data as well.
-async fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
+async fn log_msg(context: &Context, prefix: &str, msg: &Message) {
     let contact = match Contact::get_by_id(context, msg.get_from_id()).await {
         Ok(contact) => contact,
         Err(e) => {
@@ -1001,7 +1001,7 @@ async fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
     let msgtext = msg.get_text();
     println!(
         "{}{}{}{}: {} (Contact#{}): {} {}{}{}{}{}",
-        prefix.as_ref(),
+        prefix,
         msg.get_id(),
         if msg.get_showpadlock() { "🔒" } else { "" },
         if msg.has_location() { "📍" } else { "" },

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -206,7 +206,7 @@ async fn maybe_warn_on_bad_time(context: &Context, now: i64, known_past_timestam
         msg.text = Some(
             stock_str::bad_time_msg_body(
                 context,
-                Local
+                &Local
                     .timestamp(now, 0)
                     .format("%Y-%m-%d %H:%M:%S")
                     .to_string(),
@@ -319,8 +319,8 @@ pub(crate) fn extract_grpid_from_rfc724_mid(mid: &str) -> Option<&str> {
 }
 
 // the returned suffix is lower-case
-pub fn get_filesuffix_lc(path_filename: impl AsRef<str>) -> Option<String> {
-    Path::new(path_filename.as_ref())
+pub fn get_filesuffix_lc(path_filename: &str) -> Option<String> {
+    Path::new(path_filename)
         .extension()
         .map(|p| p.to_string_lossy().to_lowercase())
 }


### PR DESCRIPTION
Using &str instead of AsRef is better for compile times, binary size and code complexity.

The only place it's left is tools.rs:595 (`impl<T> IsNoneOrEmpty<T> for Option<T>`), but i think it is too common place to change T to String/&str there (and to struggle with lifetimes in case of &str)