### PR TITLE
jsonrpc: add message errors to MessageObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### API-Changes
 - Add Python API to send reactions #3762
+- jsonrpc: add message errors to MessageObject #3788
 
 ### Fixes
 - Make sure malformed messsages will never block receiving further messages anymore #3771

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -34,6 +34,9 @@ pub struct MessageObject {
     view_type: MessageViewtype,
     state: u32,
 
+    /// An error text, if there is one.
+    error: Option<String>,
+
     timestamp: i64,
     sort_timestamp: i64,
     received_timestamp: i64,
@@ -167,6 +170,7 @@ impl MessageObject {
                 .get_state()
                 .to_u32()
                 .ok_or_else(|| anyhow!("state conversion to number failed"))?,
+            error: message.error(),
 
             timestamp: message.get_timestamp(),
             sort_timestamp: message.get_sort_timestamp(),


### PR DESCRIPTION
I need it for #3734 so echo bot can skip undecipherable messages etc.