### PR TITLE
python: do not pass NULL to ffi.gc if the context can't be created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Assume all Thunderbird users prefer encryption #3774
 - refactor peerstate handling to ensure no duplicate peerstates #3776
 - Fetch messages in order of their INTERNALDATE (fixes reactions for Gmail f.e.) #3789
+- python: do not pass NULL to ffi.gc if the context can't be created #3818
 
 
 ## 1.102.0

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -82,12 +82,13 @@ class Account(object):
         if hasattr(db_path, "encode"):
             db_path = db_path.encode("utf8")
 
-        self._dc_context = ffi.gc(
-            lib.dc_context_new_closed(db_path) if closed else lib.dc_context_new(ffi.NULL, db_path, ffi.NULL),
-            lib.dc_context_unref,
-        )
+        ptr = lib.dc_context_new_closed(db_path) if closed else lib.dc_context_new(ffi.NULL, db_path, ffi.NULL)
         if self._dc_context == ffi.NULL:
             raise ValueError("Could not dc_context_new: {} {}".format(os_name, db_path))
+        self._dc_context = ffi.gc(
+            ptr,
+            lib.dc_context_unref,
+        )
 
         self._shutdown_event = Event()
         self._event_thread = EventThread(self)

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -83,7 +83,7 @@ class Account(object):
             db_path = db_path.encode("utf8")
 
         ptr = lib.dc_context_new_closed(db_path) if closed else lib.dc_context_new(ffi.NULL, db_path, ffi.NULL)
-        if self._dc_context == ffi.NULL:
+        if ptr == ffi.NULL:
             raise ValueError("Could not dc_context_new: {} {}".format(os_name, db_path))
         self._dc_context = ffi.gc(
             ptr,


### PR DESCRIPTION
Closes #3419