### PR TITLE
Update mime of known file types

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1231,8 +1231,9 @@ pub fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)> {
         "xml" => (Viewtype::File, "application/xml"),
         "xls" => (Viewtype::File, "application/vnd.ms-excel"),
         "zip" => (Viewtype::File, "application/zip"),
-        "heif" => (Viewtype::File, "image/heif"), // supported since Android 10
-        "heic" => (Viewtype::File, "image/heic"), // supported since Android 10
+        "heif" => (Viewtype::File, "image/heif"), // supported since Android 10 / iOS 11
+        "heic" => (Viewtype::File, "image/heic"), // supported since Android 10 / iOS 11
+        "avif" => (Viewtype::File, "image/avif"), // supported since Android 12 / iOS 16
         "txt" => (Viewtype::File, "text/plain"),
         _ => {
             return None;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1186,6 +1186,11 @@ pub fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)> {
         "m4a" => (Viewtype::Audio, "audio/m4a"),
         "mp3" => (Viewtype::Audio, "audio/mpeg"),
         "mp4" => (Viewtype::Video, "video/mp4"),
+        "ppt" => (Viewtype::File, "application/vnd.ms-powerpoint"),
+        "pptx" => (
+            Viewtype::File,
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        ),
         "odp" => (
             Viewtype::File,
             "application/vnd.oasis.opendocument.presentation",
@@ -1198,7 +1203,7 @@ pub fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)> {
         "oga" => (Viewtype::Audio, "audio/ogg"),
         "ogg" => (Viewtype::Audio, "audio/ogg"),
         "ogv" => (Viewtype::File, "video/ogg"),
-        "opus" => (Viewtype::File, "audio/ogg"), // not supported eg. on Android 4
+        "opus" => (Viewtype::Audio, "audio/ogg"), // supported since Android 10
         "otf" => (Viewtype::File, "font/otf"),
         "pdf" => (Viewtype::File, "application/pdf"),
         "png" => (Viewtype::Image, "image/png"),
@@ -1223,8 +1228,12 @@ pub fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)> {
             Viewtype::File,
             "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
         ),
-        "xml" => (Viewtype::File, "application/vnd.ms-excel"),
+        "xml" => (Viewtype::File, "application/xml"),
+        "xls" => (Viewtype::File, "application/vnd.ms-excel"),
         "zip" => (Viewtype::File, "application/zip"),
+        "heif" => (Viewtype::Image, "image/heif"), // supported since Android 10
+        "heic" => (Viewtype::Image, "image/heic"), // supported since Android 10
+        "txt" => (Viewtype::File, "text/plain"),
         _ => {
             return None;
         }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1203,7 +1203,7 @@ pub fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)> {
         "oga" => (Viewtype::Audio, "audio/ogg"),
         "ogg" => (Viewtype::Audio, "audio/ogg"),
         "ogv" => (Viewtype::File, "video/ogg"),
-        "opus" => (Viewtype::Audio, "audio/ogg"), // supported since Android 10
+        "opus" => (Viewtype::File, "audio/ogg"), // supported since Android 10
         "otf" => (Viewtype::File, "font/otf"),
         "pdf" => (Viewtype::File, "application/pdf"),
         "png" => (Viewtype::Image, "image/png"),
@@ -1231,8 +1231,8 @@ pub fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)> {
         "xml" => (Viewtype::File, "application/xml"),
         "xls" => (Viewtype::File, "application/vnd.ms-excel"),
         "zip" => (Viewtype::File, "application/zip"),
-        "heif" => (Viewtype::Image, "image/heif"), // supported since Android 10
-        "heic" => (Viewtype::Image, "image/heic"), // supported since Android 10
+        "heif" => (Viewtype::File, "image/heif"), // supported since Android 10
+        "heic" => (Viewtype::File, "image/heic"), // supported since Android 10
         "txt" => (Viewtype::File, "text/plain"),
         _ => {
             return None;


### PR DESCRIPTION
Most important here were the missing HEIF/HEIC image format, supported a long time in iOS and since Android 10.