### PR TITLE
Downgrade tox to version 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
 
     - name: install tox
       if: ${{ matrix.python }}
-      run: pip install tox
+      run: pip install --upgrade 'tox<4'
 
     - name: build C library
       if: ${{ matrix.python }}


### PR DESCRIPTION
Our CI pipeline currently does not work with tox 4.0.