### PR TITLE
Release 1.103.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## Unreleased
 
 ### Changes
+
+### API-Changes
+
+### Fixes
+
+
+## 1.103.0
+
+### Changes
 - Disable Autocrypt & Authres-checking for mailing lists,
   because they don't work well with mailing lists #3765
 - Refactor: Remove the remaining AsRef<str> #3669

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "deltachat"
-version = "1.102.0"
+version = "1.103.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat-jsonrpc"
-version = "1.102.0"
+version = "1.103.0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat-rpc-server"
-version = "1.102.0"
+version = "1.103.0"
 dependencies = [
  "anyhow",
  "deltachat-jsonrpc",
@@ -985,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "deltachat_ffi"
-version = "1.102.0"
+version = "1.103.0"
 dependencies = [
  "anyhow",
  "deltachat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat"
-version = "1.102.0"
+version = "1.103.0"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2021"
 license = "MPL-2.0"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat_ffi"
-version = "1.102.0"
+version = "1.103.0"
 description = "Deltachat FFI"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"

--- a/deltachat-jsonrpc/Cargo.toml
+++ b/deltachat-jsonrpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat-jsonrpc"
-version = "1.102.0"
+version = "1.103.0"
 description = "DeltaChat JSON-RPC API"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2021"

--- a/deltachat-jsonrpc/typescript/package.json
+++ b/deltachat-jsonrpc/typescript/package.json
@@ -48,5 +48,5 @@
   },
   "type": "module",
   "types": "dist/deltachat.d.ts",
-  "version": "1.102.0"
+  "version": "1.103.0"
 }

--- a/deltachat-rpc-server/Cargo.toml
+++ b/deltachat-rpc-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deltachat-rpc-server"
-version = "1.102.0"
+version = "1.103.0"
 description = "DeltaChat JSON-RPC server"
 authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2021"

--- a/package.json
+++ b/package.json
@@ -60,5 +60,5 @@
     "test:mocha": "mocha -r esm node/test/test.js --growl --reporter=spec --bail --exit"
   },
   "types": "node/dist/index.d.ts",
-  "version": "1.102.0"
+  "version": "1.103.0"
 }


### PR DESCRIPTION
Release with an IMAP timeout fix.

after commit, on master make sure to: 

   git tag -a 1.103.0
   git push origin 1.103.0
   git tag -a py-1.103.0
   git push origin py-1.103.0
