### PR TITLE
use context.get_config_bool() for Config::Bot everywhere

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -525,7 +525,7 @@ async fn add_parts(
         }
 
         // signals wether the current user is a bot
-        let is_bot = context.get_config(Config::Bot).await?.is_some();
+        let is_bot = context.get_config_bool(Config::Bot).await?;
 
         if chat_id.is_none() {
             // try to create a group
@@ -1858,7 +1858,7 @@ async fn create_or_lookup_mailinglist(
             p.to_string()
         });
 
-        let is_bot = context.get_config(Config::Bot).await?.is_some();
+        let is_bot = context.get_config_bool(Config::Bot).await?;
         let blocked = if is_bot {
             Blocked::Not
         } else {


### PR DESCRIPTION
We were already using context.get_config_bool(Config::Bot) in some places, this unifies this.

`get_config(Config::Bot).await?.is_some()` is wrong since it considers `Some("0")` to be `true`, and `set_config_bool(Config::Bot, false)` will set the config to `Some("0")`.

followup for #3831

#skip-changelog