### PR TITLE
python bindings account setup: remove deviation from default config

### DIFF
--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -618,8 +618,6 @@ class Account(object):
             assert addr and password, "you must specify email and password once to configure this database/account"
             self.set_config("addr", addr)
             self.set_config("mail_pw", password)
-            self.set_config("mvbox_move", "0")
-            self.set_config("sentbox_watch", "0")
             self.set_config("bot", "1")
             configtracker = self.configure()
             configtracker.wait_finish()


### PR DESCRIPTION
We noticed that disabling watching the DeltaChat folder is bad for bots which run with mailcow accounts, as mailcow instances by default have a Sieve rule which automatically moves all messages with a Chat-Version header to the DeltaChat folder. This led to lost messages.

There is no reason that these default options are set here, tbh I didn't really think about them before I added them. So let's remove them.

The affected function is so far only used by mailadm, where the bug was originally discovered, and this quickstart echo bot example: https://github.com/deltachat-bot/bot-pages/pull/45 which doesn't care about the default config. So we can still safely remove this without affecting implementations.