### PR TITLE
Remove unused pytest-async plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - If a classical-email-user sends an email to a group and adds new recipients,
   add the new recipients as group members #3781
+- Remove `pytest-async` plugin #3846
 
 ### API-Changes
 

--- a/deltachat-rpc-client/tox.ini
+++ b/deltachat-rpc-client/tox.ini
@@ -13,7 +13,6 @@ passenv =
     DCC_NEW_TMP_EMAIL
 deps =
     pytest
-    pytest-async
     pytest-asyncio
     aiohttp
     aiodns


### PR DESCRIPTION
We use pytest-asyncio instead