### PR TITLE
Do not add an error if the message is encrypted but not signed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### API-Changes
 
 ### Fixes
+- Do not add an error if the message is encrypted but not signed #3860
 
 
 ## 1.104.0

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -391,11 +391,6 @@ impl MimeMessage {
         //         part.error = Some("Seems like DKIM failed, this either is an attack or (more likely) a bug in Authentication-Results checking. Please tell us about this at https://support.delta.chat.".to_string());
         //     }
         // }
-        if encrypted && parser.signatures.is_empty() {
-            for part in parser.parts.iter_mut() {
-                part.error = Some("No valid signature".to_string());
-            }
-        }
 
         if parser.is_mime_modified {
             parser.decoded_data = mail_raw;

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -3075,6 +3075,26 @@ async fn test_thunderbird_autocrypt_unencrypted() -> Result<()> {
     Ok(())
 }
 
+/// Alice receives an encrypted, but unsigned message.
+///
+/// Test that the message is displayed without any errors,
+/// but also without a padlock.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_thunderbird_unsigned() -> Result<()> {
+    let alice = TestContext::new_alice().await;
+    alice.set_config(Config::ShowEmails, Some("2")).await?;
+
+    // Alice receives an unsigned message from Bob.
+    let raw = include_bytes!("../../test-data/message/thunderbird_encrypted_unsigned.eml");
+    receive_imf(&alice, raw, false).await?;
+
+    let msg = alice.get_last_msg().await;
+    assert!(!msg.get_showpadlock());
+    assert!(msg.error().is_none());
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_mua_user_adds_member() -> Result<()> {
     let t = TestContext::new_alice().await;

--- a/test-data/message/thunderbird_encrypted_unsigned.eml
+++ b/test-data/message/thunderbird_encrypted_unsigned.eml
@@ -1,0 +1,44 @@
+Message-ID: <1e87b947-d7be-1ebd-e374-e22ebaa5e00a@example.net>
+Date: Fri, 23 Dec 2022 13:00:00 +0000
+MIME-Version: 1.0
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:102.0) Gecko/20100101
+ Thunderbird/102.6.1
+Content-Language: en-US
+To: Alice <alice@example.org>
+From: Bob <bob@example.net>
+Subject: ...
+Content-Type: multipart/encrypted;
+ protocol="application/pgp-encrypted";
+ boundary="------------LXsQ1GfDj60OyJAdRFaJ9eSx"
+
+This is an OpenPGP/MIME encrypted message (RFC 4880 and 3156)
+--------------LXsQ1GfDj60OyJAdRFaJ9eSx
+Content-Type: application/pgp-encrypted
+Content-Description: PGP/MIME version identification
+
+Version: 1
+
+--------------LXsQ1GfDj60OyJAdRFaJ9eSx
+Content-Type: application/octet-stream; name="encrypted.asc"
+Content-Description: OpenPGP encrypted message
+Content-Disposition: inline; filename="encrypted.asc"
+
+-----BEGIN PGP MESSAGE-----
+
+wV4D5tq63hTeebASAQdAgKVFSZ8p8RyNRongu8xc0qnEl54jbOTjrow1rYHECFUw
+44bDFHvaSjFYMFcFmumYZQ+hFcjaoIEv78Wx6GmEGTFzFcs8mBKUGbRDFeLJebbU
+0sE8AcETwB3nrhR4WvUYlmqt87EAJfigMYX3Cmod0Pz9cFPdE13NIoOotZXEcxHq
+aGefenHJUYF1/FX9iuGRMt/qo41stlSJ6Z575mxUKnHexJVnvoDgFLTwS2dGTNlt
+0VBk7NOeaCmbxm8u4uJ3kt2vPG7ViYsSvHMGdYciIkGMsyHpJPzrOHzyoXZuuea1
+t8QTZym3FhHH9gbTRCnfnIX60G1Qu9hSMRAQandA6J2to9IahmlahFP9XoUin3fK
+ikeCHoNs9kTFFXarU0q99O6byhQqwSehoMhx4BLEFXvMp49jD9LzHUGJmR3Pdcqb
+lBgU9mPYWflfiQ8wj2Awyj94+YR3ovaOuc75LE+JylJ9BLk3axZou2HI6hDCoZJg
+XQkF46JMPV4NArOtPxP1N5/Gvo9TGvH7H4LdMhsI1Wc8Lfiks6UdcGXUblAlEfcN
+rQfywPIH4n+H8cTqk1v2ON3OsD9sFluggWUHEWLP3Eqtr1RO2YQURv+N+pcqvLyq
+kPIP9JQ5rfSMjbRNBmN5RReflomYcq9Dt8iobMWXt2fokiyJueaRwZSst2d/pG6H
+oYqzzxM7DXnxaJvZELGwJ2tGlQPL5JtSZL+jgL+Zd7+Z7czuRLLoVqf0Q6tgQPKE
+s8cpgxVDW0hp5T3ukNvL03SxK+v+dqBPFLd9FYcxMA==
+=Wl0m
+-----END PGP MESSAGE-----
+
+--------------LXsQ1GfDj60OyJAdRFaJ9eSx--


### PR DESCRIPTION
Services like Lacre [1] on Disroot and Inbound Encryption on Posteo [2] offer to encrypt all incoming messages with the provided OpenPGP public key. Resulting messages are encrypted, but not end-to-end encrypted and not signed by the sender, therefore should not have a padlock displayed. However, such encrypted and unsigned message is also not an indication of an error on ongoing attack, so we shoud not report this as a problem to the user.

[1] https://lacre.io/
[2] https://posteo.de/en/help/how-do-i-activate-inbound-encryption-with-my-public-pgp-key

Fixes #3848 