### PR TITLE
Don't parse the message again after detached signatures validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 - Validate signatures in try_decrypt() even if the message isn't encrypted #3859
+- Don't parse the message again after detached signatures validation #3862
 
 ### API-Changes
 


### PR DESCRIPTION
If we move the detached signatures validation code out of try_decrypt(), we don't need to convert an already parsed signed message part to Vec and then parse it back. Also this simplifies the try_decrypt() semantics and return type. It can't make a good coffee anyway.