### PR TITLE
Remove authors field from Cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "deltachat"
 version = "1.104.0"
-authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2021"
 license = "MPL-2.0"
 rust-version = "1.61"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -2,7 +2,6 @@
 name = "deltachat_ffi"
 version = "1.104.0"
 description = "Deltachat FFI"
-authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 readme = "README.md"
 license = "MPL-2.0"

--- a/deltachat-jsonrpc/Cargo.toml
+++ b/deltachat-jsonrpc/Cargo.toml
@@ -2,7 +2,6 @@
 name = "deltachat-jsonrpc"
 version = "1.104.0"
 description = "DeltaChat JSON-RPC API"
-authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2021"
 default-run = "deltachat-jsonrpc-server"
 license = "MPL-2.0"

--- a/deltachat-rpc-server/Cargo.toml
+++ b/deltachat-rpc-server/Cargo.toml
@@ -2,7 +2,6 @@
 name = "deltachat-rpc-server"
 version = "1.104.0"
 description = "DeltaChat JSON-RPC server"
-authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2021"
 readme = "README.md"
 license = "MPL-2.0"

--- a/deltachat_derive/Cargo.toml
+++ b/deltachat_derive/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "deltachat_derive"
 version = "2.0.0"
-authors = ["Delta Chat Developers (ML) <delta@codespeak.net>"]
 edition = "2018"
 license = "MPL-2.0"
 


### PR DESCRIPTION
See Rust RFC 3052 [1]. This field is no longer required, so there is no need to have a filler value here anymore.

[1] <https://rust-lang.github.io/rfcs/3052-optional-authors-field.html>