### PR TITLE
Bump MSRV to 1.63.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,13 +77,13 @@ jobs:
             rust: 1.64.0
             python: false # Python bindings compilation on Windows is not supported.
 
-          # Minimum Supported Rust Version = 1.61.0
+          # Minimum Supported Rust Version = 1.63.0
           #
           # Minimum Supported Python Version = 3.7
           # This is the minimum version for which manylinux Python wheels are
           # built.
           - os: ubuntu-latest
-            rust: 1.61.0
+            rust: 1.63.0
             python: 3.7
     runs-on: ${{ matrix.os }}
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "deltachat"
 version = "1.104.0"
 edition = "2021"
 license = "MPL-2.0"
-rust-version = "1.61"
+rust-version = "1.63"
 
 [profile.dev]
 debug = 0


### PR DESCRIPTION
Bumping MSRV from 1.61.0 to 1.63.0, because `arbitrary` crate requires it and fuzzing crates depend on it, at least by default. We still use 1.64.0 as our default rust toolchain.