### PR TITLE
Do not trim leading spaces from message lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 - Do not add an error if the message is encrypted but not signed #3860
+- Do not strip leading spaces from message lines #3867
 
 
 ## 1.104.0


### PR DESCRIPTION
This is a problem when you want to send some python code over Delta Chat.