### PR TITLE
Move format_flowed to a separate crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 - Validate signatures in try_decrypt() even if the message isn't encrypted #3859
 - Don't parse the message again after detached signatures validation #3862
+- Move format=flowed support to a separate crate #3869
 
 ### API-Changes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,6 +887,7 @@ dependencies = [
  "encoded-words",
  "escaper",
  "fast-socks5",
+ "format-flowed",
  "futures",
  "futures-lite",
  "hex",
@@ -1444,6 +1445,10 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "format-flowed"
+version = "1.0.0"
 
 [[package]]
 name = "futures"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ panic = 'abort'
 
 [dependencies]
 deltachat_derive = { path = "./deltachat_derive" }
+format-flowed = { path = "./format-flowed" }
 
 ansi_term = { version = "0.12.1", optional = true }
 anyhow = "1"
@@ -99,7 +100,8 @@ members = [
   "deltachat-ffi",
   "deltachat_derive",
   "deltachat-jsonrpc",
-  "deltachat-rpc-server"
+  "deltachat-rpc-server",
+  "format-flowed",
 ]
 
 [[example]]

--- a/format-flowed/Cargo.toml
+++ b/format-flowed/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "format-flowed"
+version = "1.0.0"
+description = "format=flowed support"
+edition = "2021"
+license = "MPL-2.0"
+
+keywords = ["email"]
+categories = ["email"]
+
+[dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,6 @@ pub mod imex;
 mod scheduler;
 #[macro_use]
 mod job;
-mod format_flowed;
 pub mod key;
 mod keyring;
 pub mod location;

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -4,6 +4,7 @@ use std::convert::TryInto;
 
 use anyhow::{bail, ensure, Context as _, Result};
 use chrono::TimeZone;
+use format_flowed::{format_flowed, format_flowed_quote};
 use lettre_email::{mime, Address, Header, MimeMultipartType, PartBuilder};
 use tokio::fs;
 
@@ -15,7 +16,6 @@ use crate::contact::Contact;
 use crate::context::{get_version_str, Context};
 use crate::e2ee::EncryptHelper;
 use crate::ephemeral::Timer as EphemeralTimer;
-use crate::format_flowed::{format_flowed, format_flowed_quote};
 use crate::html::new_html_mimepart;
 use crate::location;
 use crate::message::{self, Message, MsgId, Viewtype};

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -9,6 +9,7 @@ use std::str;
 
 use anyhow::{bail, Context as _, Result};
 use deltachat_derive::{FromSql, ToSql};
+use format_flowed::unformat_flowed;
 use lettre_email::mime::{self, Mime};
 use mailparse::{addrparse_header, DispositionType, MailHeader, MailHeaderMap, SingleInfo};
 use once_cell::sync::Lazy;
@@ -24,7 +25,6 @@ use crate::decrypt::{
 };
 use crate::dehtml::dehtml;
 use crate::events::EventType;
-use crate::format_flowed::unformat_flowed;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
 use crate::key::{DcKey, Fingerprint, SignedPublicKey, SignedSecretKey};
 use crate::keyring::Keyring;


### PR DESCRIPTION
This makes it possible to fuzz test the functions
without exposing the module interface in the deltachat core interface.

Also ensure that format_flowed will not grow a dependency on deltachat core types.