### PR TITLE
tweaks to link2xt/jsonrpc-webxdc

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/account.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/account.py
@@ -108,7 +108,7 @@ class Account:
             obj = (await obj.get_snapshot()).address
         return Contact(self, await self._rpc.create_contact(self.id, obj, name))
 
-    async def get_contact_by_id(self, contact_id: int) -> Contact:
+    def get_contact_by_id(self, contact_id: int) -> Contact:
         """Return Contact instance for the given contact ID."""
         return Contact(self, contact_id)
 

--- a/deltachat-rpc-client/src/deltachat_rpc_client/message.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/message.py
@@ -1,5 +1,5 @@
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from ._utils import AttrDict
 from .contact import Contact
@@ -49,10 +49,14 @@ class Message:
         """Mark the message as seen."""
         await self._rpc.markseen_msgs(self.account.id, [self.id])
 
-    async def send_webxdc_status_update(self, update: dict, description: str) -> None:
+    async def send_webxdc_status_update(
+        self, update: Union[dict, str], description: str
+    ) -> None:
         """Send a webxdc status update. This message must be a webxdc."""
+        if not isinstance(update, str):
+            update = json.dumps(update)
         await self._rpc.send_webxdc_status_update(
-            self.account.id, self.id, json.dumps(update), description
+            self.account.id, self.id, update, description
         )
 
     async def get_webxdc_status_updates(self, last_known_serial: int = 0) -> list:

--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -174,7 +174,7 @@ async def test_contact(acfactory) -> None:
     bob_addr = await bob.get_config("addr")
     alice_contact_bob = await alice.create_contact(bob_addr, "Bob")
 
-    assert alice_contact_bob == await alice.get_contact_by_id(alice_contact_bob.id)
+    assert alice_contact_bob == alice.get_contact_by_id(alice_contact_bob.id)
     assert repr(alice_contact_bob)
     await alice_contact_bob.block()
     await alice_contact_bob.unblock()


### PR DESCRIPTION
* also make `get_contact_by_id()` non-async
* accept object already converted to string in `send_webxdc_status_update()` to avoid issues with objects that are not JSON serializable (example `datetime.datetime`)