### PR TITLE
use u32 as id as done elsewhere

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4763,7 +4763,7 @@ char*           dc_contact_get_verifier_addr       (dc_contact_t* contact);
  *    we verified the contact ourself. If it is 0, we don't have verifier information or 
  *    the contact is not verified.
  */
-int            dc_contact_get_verifier_id      (dc_contact_t* contact);
+uint32_t       dc_contact_get_verifier_id      (dc_contact_t* contact);
 
 
 /**

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3983,10 +3983,10 @@ pub unsafe extern "C" fn dc_contact_get_verifier_addr(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_contact_get_verifier_id(contact: *mut dc_contact_t) -> libc::c_int {
+pub unsafe extern "C" fn dc_contact_get_verifier_id(contact: *mut dc_contact_t) -> u32 {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_get_verifier_id()");
-        return 0 as libc::c_int;
+        return 0;
     }
     let ffi_contact = &*contact;
     let ctx = &*ffi_contact.context;
@@ -3995,7 +3995,7 @@ pub unsafe extern "C" fn dc_contact_get_verifier_id(contact: *mut dc_contact_t) 
         .unwrap_or_default()
         .unwrap_or_default();
 
-    contact_id.to_u32() as libc::c_int
+    contact_id.to_u32()
 }
 // dc_lot_t
 


### PR DESCRIPTION
this will avoid some incompatibilities and castingss in UI.

successor of https://github.com/deltachat/deltachat-core-rust/pull/3839

#skip-changelog