### PR TITLE
Fix uncaught exception in node JSON-RPC tests

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -59,6 +59,7 @@ jobs:
           npm run test
         env:
           DCC_NEW_TMP_EMAIL: ${{ secrets.DCC_NEW_TMP_EMAIL }}
+          NODE_OPTIONS: '--force-node-api-uncaught-exceptions-policy=true'
       - name: Run tests on Windows, except lint
         timeout-minutes: 10
         if: runner.os == 'Windows'
@@ -67,3 +68,4 @@ jobs:
           npm run test:mocha
         env:
           DCC_NEW_TMP_EMAIL: ${{ secrets.DCC_NEW_TMP_EMAIL }}
+          NODE_OPTIONS: '--force-node-api-uncaught-exceptions-policy=true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixes
 - Do not add an error if the message is encrypted but not signed #3860
 - Do not strip leading spaces from message lines #3867
+- Fix uncaught exception in JSON-RPC tests #3884
 
 
 ## 1.104.0

--- a/node/test/test.js
+++ b/node/test/test.js
@@ -121,7 +121,7 @@ describe('JSON RPC', function () {
     const promises = {}
     dc.startJsonRpcHandler((msg) => {
       const response = JSON.parse(msg)
-      promises[response.id](response)
+      if (response.hasOwnProperty('id')) promises[response.id](response)
       delete promises[response.id]
     })
     const call = (request) => {


### PR DESCRIPTION
Events don't have an `id`, so promises[response.id] does not exist for them.

This currently prints a DEP0168 [1] deprecation warning, but will likely return an error in the future.

[1] https://nodejs.org/api/all.html#all_deprecations_dep0168-unhandled-exception-in-node-api-callbacks