### PR TITLE
Improve error handling of existing messages fetch and never retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix uncaught exception in JSON-RPC tests #3884
 - Fix STARTTLS connection and add a test for it #3907
 - Trigger reconnection when failing to fetch existing messages #3911
+- Do not retry fetching existing messages after failure, prevents infinite reconnection loop #3913
 
 
 ## 1.104.0

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -141,6 +141,16 @@ async fn inbox_loop(ctx: Context, started: Sender<()>, inbox_handlers: ImapConne
                     match ctx.get_config_bool(Config::FetchedExistingMsgs).await {
                         Ok(fetched_existing_msgs) => {
                             if !fetched_existing_msgs {
+                                // Consider it done even if we fail.
+                                //
+                                // This operation is not critical enough to retry,
+                                // especially if the error is persistent.
+                                if let Err(err) =
+                                    ctx.set_config_bool(Config::FetchedExistingMsgs, true).await
+                                {
+                                    warn!(ctx, "Can't set Config::FetchedExistingMsgs: {:#}", err);
+                                }
+
                                 if let Err(err) = connection.fetch_existing_msgs(&ctx).await {
                                     warn!(ctx, "Failed to fetch existing messages: {:#}", err);
                                     connection.trigger_reconnect(&ctx);


### PR DESCRIPTION
There are at least two user reports that fetching existing messages sometimes results in infinite loop of retrying it. Account is working if set up from the backup, but never starts working if set up from scratch.

This change improves error reporting, but also sets FetchedExistingMsgs before actually trying to do it. This way if the operation fails, connection is reestablished, but fetching existing messages is not retried again over and over.