### PR TITLE
Securejoin: Fix adding and handling Autocrypt-Gossip headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Unreleased
 
+### Fixes
+- Securejoin: Fix adding and handling Autocrypt-Gossip headers #3914
+
 ### API-Changes
 - jsonrpc: add verified-by information to `Contact`-Object
+
 
 ## 1.106.0
 

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5811,7 +5811,7 @@ void dc_event_unref(dc_event_t* event);
  * @param data2 (int) The progress as:
  *     300=vg-/vc-request received, typically shown as "bob@addr joins".
  *     600=vg-/vc-request-with-auth received, vg-member-added/vc-contact-confirm sent, typically shown as "bob@addr verified".
- *     800=vg-member-added-received received, shown as "bob@addr securely joined GROUP", only sent for the verified-group-protocol.
+ *     800=contact added to chat, shown as "bob@addr securely joined GROUP". Only for the verified-group-protocol.
  *     1000=Protocol finished for this contact.
  */
 #define DC_EVENT_SECUREJOIN_INVITER_PROGRESS      2060

--- a/python/tests/test_0_complex_or_slow.py
+++ b/python/tests/test_0_complex_or_slow.py
@@ -521,6 +521,9 @@ def test_see_new_verified_member_after_going_online(acfactory, tmpdir, lp):
     ac1._evtracker.wait_securejoin_inviter_progress(1000)
 
     lp.sec("ac2: sending message")
+    # Message can be sent only after a receipt of "vg-member-added" message. Just wait for
+    # "Member Me (<addr>) added by <addr>." message.
+    ac2._evtracker.wait_next_incoming_message()
     msg_out = chat2.send_text("hello")
 
     lp.sec("ac1: receiving message")

--- a/python/tests/test_0_complex_or_slow.py
+++ b/python/tests/test_0_complex_or_slow.py
@@ -492,3 +492,45 @@ def test_multidevice_sync_seen(acfactory, lp):
     assert ac1_clone_message.is_in_seen
     # Test that the timer is started on the second device after synchronizing the seen status.
     assert "Expires: " in ac1_clone_message.get_message_info()
+
+
+def test_see_new_verified_member_after_going_online(acfactory, tmpdir, lp):
+    """The test for the bug #3836:
+    - Alice has two devices, the second is offline.
+    - Alice creates a verified group and sends a QR invitation to Bob.
+    - Bob joins the group and sends a message there. Alice sees it.
+    - Alice's second devices goes online, but doesn't see Bob in the group.
+    """
+    ac1, ac2 = acfactory.get_online_accounts(2)
+    ac2_addr = ac2.get_config("addr")
+    ac1_offl = acfactory.new_online_configuring_account(cloned_from=ac1)
+    for ac in [ac1, ac1_offl]:
+        ac.set_config("bcc_self", "1")
+    acfactory.bring_accounts_online()
+    dir = tmpdir.mkdir("exportdir")
+    ac1.export_self_keys(dir.strpath)
+    ac1_offl.import_self_keys(dir.strpath)
+    ac1_offl.stop_io()
+
+    lp.sec("ac1: create verified-group QR, ac2 scans and joins")
+    chat = ac1.create_group_chat("hello", verified=True)
+    assert chat.is_protected()
+    qr = chat.get_join_qr()
+    lp.sec("ac2: start QR-code based join-group protocol")
+    chat2 = ac2.qr_join_chat(qr)
+    ac1._evtracker.wait_securejoin_inviter_progress(1000)
+
+    lp.sec("ac2: sending message")
+    msg_out = chat2.send_text("hello")
+
+    lp.sec("ac1: receiving message")
+    msg_in = ac1._evtracker.wait_next_incoming_message()
+    assert msg_in.text == msg_out.text
+    assert msg_in.get_sender_contact().addr == ac2_addr
+
+    lp.sec("ac1_offl: going online, receiving message")
+    ac1_offl.start_io()
+    ac1_offl._evtracker.wait_securejoin_inviter_progress(1000)
+    msg_in = ac1_offl._evtracker.wait_next_incoming_message()
+    assert msg_in.text == msg_out.text
+    assert msg_in.get_sender_contact().addr == ac2_addr

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -88,7 +88,7 @@ def test_export_import_self_keys(acfactory, tmpdir, lp):
         lp.indent(dir.strpath + os.sep + name)
     lp.sec("importing into existing account")
     ac2.import_self_keys(dir.strpath)
-    (key_id2,) = ac2._evtracker.get_info_regex_groups(r".*stored.*KeyId\((.*)\).*", check_error=False)
+    (key_id2,) = ac2._evtracker.get_info_regex_groups(r".*stored.*KeyId\((.*)\).*")
     assert key_id2 == key_id
 
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -283,7 +283,7 @@ pub enum EventType {
     /// @param data2 (int) Progress as:
     ///     300=vg-/vc-request received, typically shown as "bob@addr joins".
     ///     600=vg-/vc-request-with-auth received, vg-member-added/vc-contact-confirm sent, typically shown as "bob@addr verified".
-    ///     800=vg-member-added-received received, shown as "bob@addr securely joined GROUP", only sent for the verified-group-protocol.
+    ///     800=contact added to chat, shown as "bob@addr securely joined GROUP". Only for the verified-group-protocol.
     ///     1000=Protocol finished for this contact.
     SecurejoinInviterProgress {
         contact_id: ContactId,

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -656,7 +656,7 @@ async fn import_self_keys(context: &Context, dir: &Path) -> Result<()> {
             Ok(buf) => {
                 let armored = std::string::String::from_utf8_lossy(&buf);
                 if let Err(err) = set_self_key(context, &armored, set_default, false).await {
-                    error!(context, "set_self_key: {}", err);
+                    info!(context, "set_self_key: {}", err);
                     continue;
                 }
             }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -689,7 +689,9 @@ impl<'a> MimeFactory<'a> {
                 .fold(message, |message, header| message.header(header));
 
             // Add gossip headers in chats with multiple recipients
-            if peerstates.len() > 1 && self.should_do_gossip(context).await? {
+            if (peerstates.len() > 1 || context.get_config_bool(Config::BccSelf).await?)
+                && self.should_do_gossip(context).await?
+            {
                 for peerstate in peerstates.iter().filter_map(|(state, _)| state.as_ref()) {
                     if peerstate.peek_key(min_verified).is_some() {
                         if let Some(header) = peerstate.render_gossip_header(min_verified) {

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -917,6 +917,17 @@ impl<'a> MimeFactory<'a> {
                             "Secure-Join".to_string(),
                             "vg-member-added".to_string(),
                         ));
+                        // FIXME: Old clients require Secure-Join-Fingerprint header. Remove this
+                        // eventually.
+                        let fingerprint = Peerstate::from_addr(context, email_to_add)
+                            .await?
+                            .context("No peerstate found in db")?
+                            .public_key_fingerprint
+                            .context("No public key fingerprint in db for the member to add")?;
+                        headers.protected.push(Header::new(
+                            "Secure-Join-Fingerprint".into(),
+                            fingerprint.hex(),
+                        ));
                     }
                 }
                 SystemMessage::GroupNameChanged => {

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -722,9 +722,11 @@ impl<'a> MimeFactory<'a> {
             ));
 
             if std::env::var(crate::DCC_MIME_DEBUG).is_ok() {
-                info!(context, "mimefactory: outgoing message mime:");
-                let raw_message = message.clone().build().as_string();
-                println!("{}", raw_message);
+                info!(
+                    context,
+                    "mimefactory: unencrypted message mime-body:\n{}",
+                    message.clone().build().as_string(),
+                );
             }
 
             let encrypted = encrypt_helper
@@ -781,6 +783,14 @@ impl<'a> MimeFactory<'a> {
             .unprotected
             .into_iter()
             .fold(outer_message, |message, header| message.header(header));
+
+        if std::env::var(crate::DCC_MIME_DEBUG).is_ok() {
+            info!(
+                context,
+                "mimefactory: outgoing message mime-body:\n{}",
+                outer_message.clone().build().as_string(),
+            );
+        }
 
         let MimeFactory {
             last_added_location_id,

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -244,8 +244,11 @@ impl MimeMessage {
                     mail_raw = raw;
                     let decrypted_mail = mailparse::parse_mail(&mail_raw)?;
                     if std::env::var(crate::DCC_MIME_DEBUG).is_ok() {
-                        info!(context, "decrypted message mime-body:");
-                        println!("{}", String::from_utf8_lossy(&mail_raw));
+                        info!(
+                            context,
+                            "decrypted message mime-body:\n{}",
+                            String::from_utf8_lossy(&mail_raw),
+                        );
                     }
                     (Ok(decrypted_mail), signatures, true)
                 }

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2178,10 +2178,10 @@ async fn check_verified_properties(
                     if let Some(fp) = fp {
                         peerstate.set_verified(
                             PeerstateKeyType::GossipKey,
-                            &fp,
+                            fp,
                             PeerstateVerifiedStatus::BidirectVerified,
                             contact.get_addr().to_owned(),
-                        );
+                        )?;
                         peerstate.save_to_db(&context.sql).await?;
                         is_verified = true;
                     }

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -94,9 +94,12 @@ pub(crate) async fn receive_imf_inner(
 ) -> Result<Option<ReceivedMsg>> {
     info!(context, "Receiving message, seen={}...", seen);
 
-    if std::env::var(crate::DCC_MIME_DEBUG).unwrap_or_default() == "2" {
-        info!(context, "receive_imf: incoming message mime-body:");
-        println!("{}", String::from_utf8_lossy(imf_raw));
+    if std::env::var(crate::DCC_MIME_DEBUG).is_ok() {
+        info!(
+            context,
+            "receive_imf: incoming message mime-body:\n{}",
+            String::from_utf8_lossy(imf_raw),
+        );
     }
 
     let mut mime_parser =

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -455,6 +455,8 @@ pub(crate) async fn handle_securejoin_handshake(
                     }
                     None => bail!("Chat {} not found", &field_grpid),
                 }
+                inviter_progress!(context, contact_id, 800);
+                inviter_progress!(context, contact_id, 1000);
             } else {
                 // Alice -> Bob
                 secure_connection_established(
@@ -503,9 +505,6 @@ pub(crate) async fn handle_securejoin_handshake(
                     return Ok(HandshakeMessage::Ignore);
                 }
                 if join_vg {
-                    // Responsible for showing "$Bob securely joined $group" message
-                    inviter_progress!(context, contact_id, 800);
-                    inviter_progress!(context, contact_id, 1000);
                     let field_grpid = mime_message
                         .get_header(HeaderDef::SecureJoinGroup)
                         .map(|s| s.as_str())
@@ -670,6 +669,12 @@ pub(crate) async fn observe_securejoin_on_other_device(
                 .await?;
                 return Ok(HandshakeMessage::Ignore);
             }
+            if step.as_str() == "vg-member-added" {
+                inviter_progress!(context, contact_id, 800);
+            }
+            if step.as_str() == "vg-member-added" || step.as_str() == "vc-contact-confirm" {
+                inviter_progress!(context, contact_id, 1000);
+            }
             Ok(if step.as_str() == "vg-member-added" {
                 HandshakeMessage::Propagate
             } else {
@@ -768,6 +773,7 @@ mod tests {
     use crate::chatlist::Chatlist;
     use crate::constants::{Chattype, DC_GCM_ADDDAYMARKER};
     use crate::contact::ContactAddress;
+    use crate::contact::VerifiedStatus;
     use crate::peerstate::Peerstate;
     use crate::receive_imf::receive_imf;
     use crate::test_utils::{TestContext, TestContextManager};

--- a/src/securejoin/bobstate.rs
+++ b/src/securejoin/bobstate.rs
@@ -368,7 +368,7 @@ impl BobState {
         }
         mark_peer_as_verified(
             context,
-            self.invite.fingerprint(),
+            self.invite.fingerprint().clone(),
             mime_message.from.addr.to_string(),
         )
         .await?;


### PR DESCRIPTION
I don't like much that actually gossip headers are handled before observe_securejoin_on_other_device() that just takes the peer's current gossip pubkey, because if the first device forgets to add the gossip header, we may proceed with the outdated key, but this isn't a security issue unless the old key is compromised. But looking through all gossip headers again is an excessive work. Maybe it's worth adding some map for processed gossip headers