### PR TITLE
mark all archived read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Buffer IMAP client writes #3888
 - move `DC_CHAT_ID_ARCHIVED_LINK` to the top of chat lists
   and make `dc_get_fresh_msg_cnt()` work for `DC_CHAT_ID_ARCHIVED_LINK` #3918
+- make `dc_marknoticed_chat()` work for `DC_CHAT_ID_ARCHIVED_LINK` #3919
 - Update provider database
 
 ### API-Changes

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -21,7 +21,7 @@ use crate::chat::{self, Chat, ChatId};
 use crate::chatlist::Chatlist;
 use crate::config::Config;
 use crate::constants::Chattype;
-use crate::constants::{DC_GCM_ADDDAYMARKER, DC_MSG_ID_DAYMARKER};
+use crate::constants::{DC_GCL_NO_SPECIALS, DC_GCM_ADDDAYMARKER, DC_MSG_ID_DAYMARKER};
 use crate::contact::{Contact, ContactId, Modifier, Origin};
 use crate::context::Context;
 use crate::events::{Event, EventType, Events};
@@ -502,7 +502,7 @@ impl TestContext {
 
     /// Gets the most recent message over all chats.
     pub async fn get_last_msg(&self) -> Message {
-        let chats = Chatlist::try_load(&self.ctx, 0, None, None)
+        let chats = Chatlist::try_load(&self.ctx, DC_GCL_NO_SPECIALS, None, None)
             .await
             .expect("failed to load chatlist");
         // 0 is correct in the next line (as opposed to `chats.len() - 1`, which would be the last element):


### PR DESCRIPTION
this pr is a successor of #3918:

- fix test_utils
- let marknoticed_chat() work for the pseudo archive-link chat (the idea is to have a button to make all of archive as noticed quickly)
- add tests for the archived-link counters and archive-mark-noticed

as usual, for review, hiding whitespace makes some sense :)