### PR TITLE
jsonrpc: add fresh message count to the archive-link chatlistitem variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### API-Changes
 - jsonrpc: add python API for webxdc updates #3872
+- jsonrpc: add fresh message count to ChatListItemFetchResult::ArchiveLink
 - Add ffi functions to retrieve `verified by` information #3786
 
 ### Fixes


### PR DESCRIPTION
this is a followup to #3918

I went with option "C" from my comment:
https://github.com/deltachat/deltachat-core-rust/pull/3918#issuecomment-1371224339

- Archive link is (still) very different from a normal chat, so most of the options would be empty / not relevant
- avatar path is not needed as desktop renders it differently anyway,
it's not really a chat like saved messages or device messages where it made more sense
for the core to supply the icon, vs. using the svg directly.
- translating the string in the coreas stock-string is more annoying than doing it from the ui, especially when
this special pseudo chat has different rendering anyway so also no need to provide a name property


We could also try the other options, but I think this is the cleaner way for the jsonrpc api. I understand why handling it as normal chatlistitem is easier in the cffi, because there the ui can specify to not fetch/calculate irrelevant information.