### PR TITLE
python: set reasonable timeouts for account requests

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
@@ -12,8 +12,11 @@ from .rpc import Rpc
 async def get_temp_credentials() -> dict:
     url = os.getenv("DCC_NEW_TMP_EMAIL")
     assert url, "Failed to get online account, DCC_NEW_TMP_EMAIL is not set"
+
+    # Replace default 5 minute timeout with a 1 minute timeout.
+    timeout = aiohttp.ClientTimeout(total=60)
     async with aiohttp.ClientSession() as session:
-        async with session.post(url) as response:
+        async with session.post(url, timeout=timeout) as response:
             return json.loads(await response.text())
 
 

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -176,7 +176,7 @@ class TestProcess:
                 try:
                     yield self._configlist[index]
                 except IndexError:
-                    res = requests.post(liveconfig_opt)
+                    res = requests.post(liveconfig_opt, timeout=60)
                     if res.status_code != 200:
                         pytest.fail("newtmpuser count={} code={}: '{}'".format(index, res.status_code, res.text))
                     d = res.json()


### PR DESCRIPTION
`requests` library does not have a timeout at all by default.

#skip-changelog