### PR TITLE
Use SMTP pipelining

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changes
+- Pipeline SMTP commands #3924
+
 ### Fixes
 - Securejoin: Fix adding and handling Autocrypt-Gossip headers #3914
 - fix verifier-by addr was empty string intead of None #3961

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,8 +166,7 @@ dependencies = [
 [[package]]
 name = "async-smtp"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da21e1dd19fbad3e095ad519fb1558ab77fd82e5c4778dca8f9be0464589e1e"
+source = "git+https://github.com/async-email/async-smtp?branch=master#983597125fbb1b0eefd3eb5a21d917af71b2e1c3"
 dependencies = [
  "async-native-tls",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ansi_term = { version = "0.12.1", optional = true }
 anyhow = "1"
 async-imap = { git = "https://github.com/async-email/async-imap", branch = "master", default-features = false, features = ["runtime-tokio"] }
 async-native-tls = { version = "0.4", default-features = false, features = ["runtime-tokio"] }
-async-smtp = { version = "0.5", default-features = false, features = ["smtp-transport", "socks5", "runtime-tokio"] }
+async-smtp = { git = "https://github.com/async-email/async-smtp", branch = "master", default-features = false, features = ["smtp-transport", "socks5", "runtime-tokio"] }
 trust-dns-resolver = "0.22"
 tokio = { version = "1", features = ["fs", "rt-multi-thread", "macros"] }
 tokio-tar = { version = "0.3" } # TODO: integrate tokio into async-tar


### PR DESCRIPTION
This is to test https://github.com/async-email/async-smtp/pull/54

I tested it a bit, pipelining indeed works but I don't see any significant gains from it in 1:1 chats. It should visibly reduce delays in multi-user chats because you can pipeline all the `RCPT TO:` commands at once.