### PR TITLE
add get_chat_list_item_by_id method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 ### API-Changes
 - jsonrpc: add python API for webxdc updates #3872
 - jsonrpc: add fresh message count to ChatListItemFetchResult::ArchiveLink
+- jsonrpc: add `get_chatlist_entry_by_chat` method #3929
+- jsonrpc: second field of chat list entry is now an `Option<u32>`, before it was just `u32` #3929
 - Add ffi functions to retrieve `verified by` information #3786
 
 ### Fixes

--- a/deltachat-jsonrpc/src/api/types/chat_list.rs
+++ b/deltachat-jsonrpc/src/api/types/chat_list.rs
@@ -16,7 +16,7 @@ use typescript_type_def::TypeDef;
 use super::color_int_to_hex_string;
 
 #[derive(Deserialize, Serialize, TypeDef)]
-pub struct ChatListEntry(pub u32, pub u32);
+pub struct ChatListEntry(pub u32, pub Option<u32>);
 
 #[derive(Serialize, TypeDef)]
 #[serde(tag = "type")]
@@ -59,10 +59,7 @@ pub(crate) async fn get_chat_list_item_by_id(
     entry: &ChatListEntry,
 ) -> Result<ChatListItemFetchResult> {
     let chat_id = ChatId::new(entry.0);
-    let last_msgid = match entry.1 {
-        0 => None,
-        _ => Some(MsgId::new(entry.1)),
-    };
+    let last_msgid = entry.1.map(|msg_id| MsgId::new(msg_id));
 
     let fresh_message_counter = chat_id.get_fresh_msg_cnt(ctx).await?;
 

--- a/deltachat-jsonrpc/src/api/types/chat_list.rs
+++ b/deltachat-jsonrpc/src/api/types/chat_list.rs
@@ -59,7 +59,7 @@ pub(crate) async fn get_chat_list_item_by_id(
     entry: &ChatListEntry,
 ) -> Result<ChatListItemFetchResult> {
     let chat_id = ChatId::new(entry.0);
-    let last_msgid = entry.1.map(|msg_id| MsgId::new(msg_id));
+    let last_msgid = entry.1.map(MsgId::new);
 
     let fresh_message_counter = chat_id.get_fresh_msg_cnt(ctx).await?;
 

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -362,6 +362,38 @@ pub async fn get_archived_cnt(context: &Context) -> Result<usize> {
     Ok(count)
 }
 
+/// Returns a single chatlistitem (chatId and messageid), used by desktop to partially update the chatlist on specific events
+pub async fn get_chatlistitem_for_chat(
+    context: &Context,
+    chat_id: ChatId,
+) -> Result<(ChatId, Option<MsgId>)> {
+    // Similar result as normal chatlist, only one item though and:
+    // archived and blocked chats are included
+    context
+        .sql
+        .query_row(
+            "SELECT c.id, m.id
+                FROM chats c
+                LEFT JOIN msgs m
+                    ON c.id=m.chat_id
+                    AND m.id=(
+                            SELECT id
+                                FROM msgs
+                            WHERE chat_id=c.id
+                                AND (hidden=0 OR state=?1)
+                                ORDER BY timestamp DESC, id DESC LIMIT 1)
+                WHERE c.id=?2
+                GROUP BY c.id",
+            paramsv![MessageState::OutDraft, chat_id],
+            |row: &rusqlite::Row| {
+                let chat_id: ChatId = row.get(0)?;
+                let msg_id: Option<MsgId> = row.get(1)?;
+                Ok((chat_id, msg_id))
+            },
+        )
+        .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
- add `get_chat_list_item_by_id` method
- jsonrpc: second field of chat list entry is now an `Option<u32>`, before it was just `u32`

### why?

because desktop currently fetches the chatlist multiple times, even though it just needs the chatlistitem for one chat:

![image](https://user-images.githubusercontent.com/18725968/211124899-c66b6a8e-d15a-4e4d-9173-f9a080e02916.png)


Note: @r10s was worried before (long time ago) that exposing the method to get a single
updated chatlistitem could lead to race conditions, where the chatlist item is newer than 
the chatlist order.

But I don't think this will change anything for desktop besides making it a little faster.
(because currently desktop fetches the whole chatlist
instead of just the entry it needs when an entry updates)

In my subjective testing this helped reducing message replay time (after backup) import on desktop by 13-19%. backup import is a good stress test for this because it calls this code-path often.