### PR TITLE
jsonrpc: remove msgId from chatlistentry (#3071)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+- BREAKING: jsonrpc:
+  - `get_chatlist_items_by_entries` now takes only chatids instead of `ChatListEntries`
+  - `get_chatlist_entries` now returns `Vec<u32>` of chatids instead of `ChatListEntries`
+
+
 ## [1.114.0] - 2023-04-24
 
 ### Changes

--- a/deltachat-jsonrpc/src/api/types/chat.rs
+++ b/deltachat-jsonrpc/src/api/types/chat.rs
@@ -1,6 +1,6 @@
 use std::time::{Duration, SystemTime};
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context as _, Result};
 use deltachat::chat::{self, get_chat_contacts, ChatVisibility};
 use deltachat::chat::{Chat, ChatId};
 use deltachat::constants::Chattype;
@@ -53,7 +53,9 @@ impl FullChat {
             contacts.push(
                 ContactObject::try_from_dc_contact(
                     context,
-                    Contact::load_from_db(context, *contact_id).await?,
+                    Contact::load_from_db(context, *contact_id)
+                        .await
+                        .context("failed to load contact")?,
                 )
                 .await?,
             )
@@ -73,7 +75,8 @@ impl FullChat {
         let was_seen_recently = if chat.get_type() == Chattype::Single {
             match contact_ids.get(0) {
                 Some(contact) => Contact::load_from_db(context, *contact)
-                    .await?
+                    .await
+                    .context("failed to load contact for was_seen_recently")?
                     .was_seen_recently(),
                 None => false,
             }

--- a/deltachat-jsonrpc/src/api/types/chat_list.rs
+++ b/deltachat-jsonrpc/src/api/types/chat_list.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use deltachat::chat::{Chat, ChatId};
 use deltachat::chatlist::get_last_message_for_chat;
 use deltachat::constants::*;
@@ -64,8 +64,10 @@ pub(crate) async fn get_chat_list_item_by_id(
 
     let last_msgid = get_last_message_for_chat(ctx, chat_id).await?;
 
-    let chat = Chat::load_from_db(ctx, chat_id).await?;
-    let summary = Chatlist::get_summary2(ctx, chat_id, last_msgid, Some(&chat)).await?;
+    let chat = Chat::load_from_db(ctx, chat_id).await.context("chat")?;
+    let summary = Chatlist::get_summary2(ctx, chat_id, last_msgid, Some(&chat))
+        .await
+        .context("summary")?;
 
     let summary_text1 = summary.prefix.map_or_else(String::new, |s| s.to_string());
     let summary_text2 = summary.text.to_owned();
@@ -93,7 +95,8 @@ pub(crate) async fn get_chat_list_item_by_id(
         let contact = chat_contacts.get(0);
         let was_seen_recently = match contact {
             Some(contact) => Contact::load_from_db(ctx, *contact)
-                .await?
+                .await
+                .context("contact")?
                 .was_seen_recently(),
             None => false,
         };

--- a/deltachat-jsonrpc/src/api/types/chat_list.rs
+++ b/deltachat-jsonrpc/src/api/types/chat_list.rs
@@ -1,22 +1,17 @@
 use anyhow::Result;
+use deltachat::chat::{Chat, ChatId};
+use deltachat::chatlist::get_last_message_for_chat;
 use deltachat::constants::*;
 use deltachat::contact::{Contact, ContactId};
 use deltachat::{
     chat::{get_chat_contacts, ChatVisibility},
     chatlist::Chatlist,
 };
-use deltachat::{
-    chat::{Chat, ChatId},
-    message::MsgId,
-};
 use num_traits::cast::ToPrimitive;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use typescript_type_def::TypeDef;
 
 use super::color_int_to_hex_string;
-
-#[derive(Deserialize, Serialize, TypeDef)]
-pub struct ChatListEntry(pub u32, pub u32);
 
 #[derive(Serialize, TypeDef)]
 #[serde(tag = "type")]
@@ -56,14 +51,9 @@ pub enum ChatListItemFetchResult {
 
 pub(crate) async fn get_chat_list_item_by_id(
     ctx: &deltachat::context::Context,
-    entry: &ChatListEntry,
+    entry: u32,
 ) -> Result<ChatListItemFetchResult> {
-    let chat_id = ChatId::new(entry.0);
-    let last_msgid = match entry.1 {
-        0 => None,
-        _ => Some(MsgId::new(entry.1)),
-    };
-
+    let chat_id = ChatId::new(entry);
     let fresh_message_counter = chat_id.get_fresh_msg_cnt(ctx).await?;
 
     if chat_id.is_archived_link() {
@@ -71,6 +61,8 @@ pub(crate) async fn get_chat_list_item_by_id(
             fresh_message_counter,
         });
     }
+
+    let last_msgid = get_last_message_for_chat(ctx, chat_id).await?;
 
     let chat = Chat::load_from_db(ctx, chat_id).await?;
     let summary = Chatlist::get_summary2(ctx, chat_id, last_msgid, Some(&chat)).await?;

--- a/deltachat-jsonrpc/typescript/example/example.ts
+++ b/deltachat-jsonrpc/typescript/example/example.ts
@@ -67,7 +67,7 @@ async function run() {
       null,
       null
     );
-    for (const [chatId, _messageId] of chats) {
+    for (const chatId of chats) {
       const chat = await client.rpc.getFullChatById(selectedAccount, chatId);
       write($main, `<h3>${chat.name}</h3>`);
       const messageIds = await client.rpc.getMessageIds(

--- a/deltachat-rpc-client/src/deltachat_rpc_client/account.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/account.py
@@ -177,7 +177,7 @@ class Account:
 
         entries = await self._rpc.get_chatlist_entries(self.id, flags, query, contact and contact.id)
         if not snapshot:
-            return [Chat(self, entry[0]) for entry in entries]
+            return [Chat(self, entry) for entry in entries]
 
         items = await self._rpc.get_chatlist_items_by_entries(self.id, entries)
         chats = []

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -362,6 +362,25 @@ pub async fn get_archived_cnt(context: &Context) -> Result<usize> {
     Ok(count)
 }
 
+/// Gets the last message of a chat, the message that would also be displayed in the ChatList
+/// Used for passing to `deltachat::chatlist::Chatlist::get_summary2`
+pub async fn get_last_message_for_chat(
+    context: &Context,
+    chat_id: ChatId,
+) -> Result<Option<MsgId>> {
+    context
+        .sql
+        .query_get_value(
+            "SELECT id
+                FROM msgs
+                WHERE chat_id=?2
+                AND (hidden=0 OR state=?1)
+                ORDER BY timestamp DESC, id DESC LIMIT 1",
+            (MessageState::OutDraft, chat_id),
+        )
+        .await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -311,13 +311,17 @@ impl Chatlist {
         };
 
         let (lastmsg, lastcontact) = if let Some(lastmsg_id) = lastmsg_id {
-            let lastmsg = Message::load_from_db(context, lastmsg_id).await?;
+            let lastmsg = Message::load_from_db(context, lastmsg_id)
+                .await
+                .context("loading message failed")?;
             if lastmsg.from_id == ContactId::SELF {
                 (Some(lastmsg), None)
             } else {
                 match chat.typ {
                     Chattype::Group | Chattype::Broadcast | Chattype::Mailinglist => {
-                        let lastcontact = Contact::load_from_db(context, lastmsg.from_id).await?;
+                        let lastcontact = Contact::load_from_db(context, lastmsg.from_id)
+                            .await
+                            .context("loading contact failed")?;
                         (Some(lastmsg), Some(lastcontact))
                     }
                     Chattype::Single | Chattype::Undefined => (Some(lastmsg), None),


### PR DESCRIPTION
What?

Remove message id from chatlistentry and chatlistentry now becomes just the chat id, now the last message used by the summary is fetched when loading the chatlistitem via the chatId. This should decrease the likelihood of races when sending a message in desktop because it deletes the draft and sends a new message so a cached draft message id can result in an error blinking up such as this one:
<img width="408" alt="Bildschirmfoto 2023-01-07 um 20 48 27" src="https://user-images.githubusercontent.com/18725968/211171454-f7cd2569-5b12-4f06-b1ac-fa5b8ca5aea1.png">

This makes the code simpler and prevents races due to desktop caching the message id of chatlistEntries.

EDIT: I investigated a bit more about the speed, still somewhat subjective, but this is what I think I understand: scrolling/initial-load is a little bit slower (because it has more sql queries), but updating (tested with backup import) might be a bit faster because less stuff is transferred and requested, but the sql call to get the last message is still there and it's unique (only asking for one message), so if sqlite does caching then it might have been a bit faster before.
But the upside to this change is still that there are:
- fewer **edge cases** (races where draft/msg does not exist anymore but desktop still requests a chatlist item with that message)
- and now there is one central place that we need to watch (all in core, desktop only needs to get the debouncing right)

## Current state of the PR

bugs are solved now, works fine in  https://github.com/deltachat/deltachat-desktop/pull/3071