### PR TITLE
Re-enable DKIM-checks

### DIFF
--- a/src/authres.rs
+++ b/src/authres.rs
@@ -645,7 +645,6 @@ Authentication-Results: dkim=";
             .unwrap();
     }
 
-    #[ignore = "Disallowing keychanges is disabled for now"]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_handle_authres_fails() -> Result<()> {
         let mut tcm = TestContextManager::new();
@@ -823,8 +822,7 @@ Authentication-Results: dkim=";
             .insert_str(0, "Authentication-Results: example.net; dkim=fail\n");
         let rcvd = bob.recv_msg(&sent).await;
 
-        // Disallowing keychanges is disabled for now:
-        // assert!(rcvd.error.unwrap().contains("DKIM failed"));
+        assert!(rcvd.error.unwrap().contains("DKIM failed"));
         // The message info should contain a warning:
         assert!(message::get_msg_info(&bob, rcvd.id)
             .await

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -83,8 +83,7 @@ pub(crate) async fn prepare_decryption(
         from,
         autocrypt_header.as_ref(),
         message_time,
-        // Disallowing keychanges is disabled for now:
-        true, // dkim_results.allow_keychange,
+        dkim_results.allow_keychange,
     )
     .await?;
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -321,8 +321,7 @@ impl MimeMessage {
             if let (Some(peerstate), Ok(mail)) = (&mut decryption_info.peerstate, mail) {
                 if message_time > peerstate.last_seen_autocrypt
                     && mail.ctype.mimetype != "multipart/report"
-                // Disallowing keychanges is disabled for now:
-                // && decryption_info.dkim_results.allow_keychange
+                    && decryption_info.dkim_results.allow_keychange
                 {
                     peerstate.degrade_encryption(message_time);
                 }
@@ -393,12 +392,11 @@ impl MimeMessage {
         parser.heuristically_parse_ndn(context).await;
         parser.parse_headers(context).await?;
 
-        // Disallowing keychanges is disabled for now
-        // if !decryption_info.dkim_results.allow_keychange {
-        //     for part in parser.parts.iter_mut() {
-        //         part.error = Some("Seems like DKIM failed, this either is an attack or (more likely) a bug in Authentication-Results checking. Please tell us about this at https://support.delta.chat.".to_string());
-        //     }
-        // }
+        if !parser.decryption_info.dkim_results.allow_keychange {
+            for part in parser.parts.iter_mut() {
+                part.error = Some("Seems like DKIM failed, this either is an attack or (more likely) a bug in Authentication-Results checking. Please tell us about this at https://support.delta.chat.".to_string());
+            }
+        }
 
         if parser.is_mime_modified {
             parser.decoded_data = mail_raw;


### PR DESCRIPTION
Reverts #3728
Closes #3735
Reopens #3700
This makes https://github.com/deltachat/deltachat-android/issues/2299 a bit worse, because there will be errors on more messsages, and also on incoming messages. This should also be fixed before releasing this.

Now might be a good time, since #3933 was just merged?