### PR TITLE
Print chats when a test failed

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -705,9 +705,12 @@ impl Deref for TestContext {
 impl Drop for TestContext {
     fn drop(&mut self) {
         task::block_in_place(move || {
-            Handle::current().block_on(async move {
-                self.print_chats().await;
-            });
+            if let Ok(handle) = Handle::try_current() {
+                // Print the chats if runtime still exists.
+                handle.block_on(async move {
+                    self.print_chats().await;
+                });
+            }
         });
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1089,4 +1089,12 @@ mod tests {
         bob.ctx.emit_event(EventType::Info("there".into()));
         // panic!("Both fail");
     }
+
+    /// Checks that dropping the `TestContext` after the runtime does not panic,
+    /// e.g. that `TestContext::drop` does not assume the runtime still exists.
+    #[test]
+    fn test_new_test_context() {
+        let runtime = tokio::runtime::Runtime::new().expect("unable to create tokio runtime");
+        runtime.block_on(TestContext::new());
+    }
 }


### PR DESCRIPTION
E.g.
```
========== Chats of bob: ==========
Single#Chat#10: alice@example.org [alice@example.org]
--------------------------------------------------------------------------------
Msg#10:  (Contact#Contact#10): hellooo [FRESH]
Msg#11:  (Contact#Contact#10): hellooo without mailing list [FRESH]
--------------------------------------------------------------------------------

========== Chats of alice: ==========
Single#Chat#10: bob@example.net [bob@example.net]
--------------------------------------------------------------------------------
Msg#10: Me (Contact#Contact#Self): hellooo  √
Msg#11: Me (Contact#Contact#Self): hellooo without mailing list  √
--------------------------------------------------------------------------------
```

I found this very useful sometimes, so, let's try to re-introduce it (it was removed in #3449)

#skip-changelog since it's only for debugging