### PR TITLE
fix: only send contact changed event for recently seen if it is relevant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### API-Changes
 
 ### Fixes
-
+- fix: only send contact changed event for recently seen if it is relevant (not too old to matter) #3938
 
 ## 1.105.0
 

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1416,6 +1416,7 @@ pub(crate) async fn update_last_seen(
         )
         .await?
         > 0
+        && timestamp > time() - SEEN_RECENTLY_SECONDS
     {
         context.interrupt_recently_seen(contact_id, timestamp).await;
     }


### PR DESCRIPTION
(no events for contacts that are already offline again)

This dramatically speeds up replay after backup import on desktop.


~~seems like this doesn't work....~~ ~~probably was my unfinished desktop pr instead, this pr looks fine~~ edit: works as expected, was just using a broken desktop pr