### PR TITLE
Return Option from Contact::add_or_lookup()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Fixes
 - fix: only send contact changed event for recently seen if it is relevant (not too old to matter) #3938
 - Immediately save `accounts.toml` if it was modified by a migration from absolute paths to relative paths #3943
+- Do not treat invalid email addresses as an exception #3942
+
 
 ## 1.105.0
 

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -942,6 +942,20 @@ def test_dont_show_emails(acfactory, lp):
     ac1.direct_imap.append(
         "Spam",
         """
+        From: delta<address: inbox@nhroy.com>
+        Subject: subj
+        To: {}
+        Message-ID: <spam.message99@junk.org>
+        Content-Type: text/plain; charset=utf-8
+
+        Unknown & malformed message in Spam
+    """.format(
+            ac1.get_config("configured_addr")
+        ),
+    )
+    ac1.direct_imap.append(
+        "Spam",
+        """
         From: alice@example.org
         Subject: subj
         To: {}

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4693,7 +4693,9 @@ mod tests {
         assert!(!shall_attach_selfavatar(&t, chat_id).await?);
 
         let (contact_id, _) =
-            Contact::add_or_lookup(&t, "", "foo@bar.org", Origin::IncomingUnknownTo).await?;
+            Contact::add_or_lookup(&t, "", "foo@bar.org", Origin::IncomingUnknownTo)
+                .await?
+                .unwrap();
         add_contact_to_chat(&t, chat_id, contact_id).await?;
         assert!(!shall_attach_selfavatar(&t, chat_id).await?);
         t.set_config(Config::Selfavatar, None).await?; // setting to None also forces re-sending
@@ -4940,7 +4942,9 @@ mod tests {
         bob.set_config(Config::ShowEmails, Some("2")).await?;
 
         let (contact_id, _) =
-            Contact::add_or_lookup(&alice, "", "bob@example.net", Origin::ManuallyCreated).await?;
+            Contact::add_or_lookup(&alice, "", "bob@example.net", Origin::ManuallyCreated)
+                .await?
+                .unwrap();
         let alice_chat_id = create_group_chat(&alice, ProtectionStatus::Unprotected, "grp").await?;
         let alice_chat = Chat::load_from_db(&alice, alice_chat_id).await?;
 
@@ -5651,7 +5655,9 @@ mod tests {
     async fn test_create_for_contact_with_blocked() -> Result<()> {
         let t = TestContext::new().await;
         let (contact_id, _) =
-            Contact::add_or_lookup(&t, "", "foo@bar.org", Origin::ManuallyCreated).await?;
+            Contact::add_or_lookup(&t, "", "foo@bar.org", Origin::ManuallyCreated)
+                .await?
+                .unwrap();
 
         // create a blocked chat
         let chat_id_orig =

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1737,7 +1737,19 @@ async fn should_move_out_of_spam(
         };
         // No chat found.
         let (from_id, blocked_contact, _origin) =
-            from_field_to_contact_id(context, &from, true).await?;
+            match from_field_to_contact_id(context, &from, true)
+                .await
+                .context("from_field_to_contact_id")?
+            {
+                Some(res) => res,
+                None => {
+                    warn!(
+                        context,
+                        "Contact with From address {:?} cannot exist, not moving out of spam", from
+                    );
+                    return Ok(false);
+                }
+            };
         if blocked_contact {
             // Contact is blocked, leave the message in spam.
             return Ok(false);
@@ -2027,7 +2039,10 @@ pub(crate) async fn prefetch_should_download(
         None => return Ok(false),
     };
     let (_from_id, blocked_contact, origin) =
-        from_field_to_contact_id(context, &from, true).await?;
+        match from_field_to_contact_id(context, &from, true).await? {
+            Some(res) => res,
+            None => return Ok(false),
+        };
     // prevent_rename=true as this might be a mailing list message and in this case it would be bad if we rename the contact.
     // (prevent_rename is the last argument of from_field_to_contact_id())
 
@@ -2347,14 +2362,14 @@ async fn add_all_recipients_as_contacts(
         .await
         .with_context(|| format!("could not select {}", mailbox))?;
 
-    let contacts = imap
+    let recipients = imap
         .get_all_recipients(context)
         .await
         .context("could not get recipients")?;
 
     let mut any_modified = false;
-    for contact in contacts {
-        let display_name_normalized = contact
+    for recipient in recipients {
+        let display_name_normalized = recipient
             .display_name
             .as_ref()
             .map(|s| normalize_name(s))
@@ -2363,17 +2378,20 @@ async fn add_all_recipients_as_contacts(
         match Contact::add_or_lookup(
             context,
             &display_name_normalized,
-            &contact.addr,
+            &recipient.addr,
             Origin::OutgoingTo,
         )
-        .await
+        .await?
         {
-            Ok((_, modified)) => {
+            Some((_, modified)) => {
                 if modified != Modifier::None {
                     any_modified = true;
                 }
             }
-            Err(e) => warn!(context, "Could not add recipient: {}", e),
+            None => warn!(
+                context,
+                "Could not add contact for recipient with address {:?}", recipient.addr
+            ),
         }
     }
     if any_modified {

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1821,6 +1821,7 @@ mod tests {
             Contact::add_or_lookup(&t, "Dave", "dave@example.com", Origin::ManuallyCreated)
                 .await
                 .unwrap()
+                .unwrap()
                 .0;
 
         let chat_id = ChatId::create_for_contact(&t, contact_id).await.unwrap();

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -542,14 +542,17 @@ impl Peerstate {
                 if (chat.typ == Chattype::Group && chat.is_protected())
                     || chat.typ == Chattype::Broadcast
                 {
-                    chat::remove_from_chat_contacts_table(context, *chat_id, contact_id).await?;
-
-                    let (new_contact_id, _) =
+                    if let Some((new_contact_id, _)) =
                         Contact::add_or_lookup(context, "", new_addr, Origin::IncomingUnknownFrom)
+                            .await?
+                    {
+                        chat::remove_from_chat_contacts_table(context, *chat_id, contact_id)
                             .await?;
-                    chat::add_to_chat_contacts_table(context, *chat_id, &[new_contact_id]).await?;
+                        chat::add_to_chat_contacts_table(context, *chat_id, &[new_contact_id])
+                            .await?;
 
-                    context.emit_event(EventType::ChatModified(*chat_id));
+                        context.emit_event(EventType::ChatModified(*chat_id));
+                    }
                 }
             }
 

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -368,6 +368,7 @@ Can we chat at 1pm pacific, today?"
 
         let bob_id = Contact::add_or_lookup(&alice, "", "bob@example.net", Origin::ManuallyCreated)
             .await?
+            .unwrap()
             .0;
         let bob_reaction = reactions.get(bob_id);
         assert!(bob_reaction.is_empty()); // Bob has not reacted to message yet.

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -429,6 +429,7 @@ async fn test_escaped_recipients() {
         Contact::add_or_lookup(&t, "Carl", "carl@host.tld", Origin::IncomingUnknownFrom)
             .await
             .unwrap()
+            .unwrap()
             .0;
 
     receive_imf(
@@ -470,6 +471,7 @@ async fn test_cc_to_contact() {
     let carl_contact_id =
         Contact::add_or_lookup(&t, "garabage", "carl@host.tld", Origin::IncomingUnknownFrom)
             .await
+            .unwrap()
             .unwrap()
             .0;
 
@@ -2058,6 +2060,7 @@ async fn test_duplicate_message() -> Result<()> {
         Origin::IncomingUnknownFrom,
     )
     .await?
+    .unwrap()
     .0;
 
     let first_message = b"Received: from [127.0.0.1]
@@ -2111,6 +2114,7 @@ async fn test_ignore_footer_status_from_mailinglist() -> Result<()> {
     t.set_config(Config::ShowEmails, Some("2")).await?;
     let bob_id = Contact::add_or_lookup(&t, "", "bob@example.net", Origin::IncomingUnknownCc)
         .await?
+        .unwrap()
         .0;
     let bob = Contact::load_from_db(&t, bob_id).await?;
     assert_eq!(bob.get_status(), "");
@@ -2529,7 +2533,8 @@ Second thread."#;
         "fiona@example.net",
         Origin::IncomingUnknownTo,
     )
-    .await?;
+    .await?
+    .unwrap();
 
     chat::add_contact_to_chat(&alice, alice_first_msg.chat_id, alice_fiona_contact_id).await?;
     let alice_first_invite = alice.pop_sent_msg().await;

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -1006,7 +1006,8 @@ mod tests {
             "bob@example.net",
             Origin::ManuallyCreated,
         )
-        .await?;
+        .await?
+        .unwrap();
         let contact_bob = Contact::load_from_db(&alice.ctx, contact_bob_id).await?;
         assert_eq!(
             contact_bob.is_verified(&alice.ctx).await?,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -529,7 +529,11 @@ impl TestContext {
         let (contact_id, modified) =
             Contact::add_or_lookup(self, &name, &addr, Origin::MailinglistAddress)
                 .await
-                .unwrap();
+                .expect("add_or_lookup")
+                .expect(&format!(
+                    "contact with address {:?} cannot be created",
+                    &addr
+                ));
         match modified {
             Modifier::None => (),
             Modifier::Modified => warn!(&self.ctx, "Contact {} modified by TestContext", &addr),


### PR DESCRIPTION
This allows to distinguish exceptions,
such as database errors, from invalid user input.
For example, if the From: field of the message
does not look like an email address, the mail
should be ignored. But if there is a database
failure while writing a new contact for the address, this error should be bubbled up.

Fixes #3939 