### PR TITLE
Save modified .toml if absolute paths were replaced with relative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 - fix: only send contact changed event for recently seen if it is relevant (not too old to matter) #3938
+- Immediately save `accounts.toml` if it was modified by a migration from absolute paths to relative paths #3943
 
 ## 1.105.0
 

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -367,13 +367,20 @@ impl Config {
 
         // Previous versions of the core stored absolute paths in account config.
         // Convert them to relative paths.
+        let mut modified = false;
         for account in &mut inner.accounts {
             if let Ok(new_dir) = account.dir.strip_prefix(dir) {
                 account.dir = new_dir.to_path_buf();
+                modified = true;
             }
         }
 
-        Ok(Config { file, inner })
+        let config = Self { file, inner };
+        if modified {
+            config.sync().await?;
+        }
+
+        Ok(config)
     }
 
     /// Loads all accounts defined in the configuration file.


### PR DESCRIPTION
Previously this required adding or removing an account.

Fixes #3936