### PR TITLE
add verified-by api to jsonrpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### API-Changes
+- jsonrpc: add verified-by information to `Contact`-Object
+
 ## 1.106.0
 
 ### Changes

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3975,13 +3975,10 @@ pub unsafe extern "C" fn dc_contact_get_verifier_addr(
     }
     let ffi_contact = &*contact;
     let ctx = &*ffi_contact.context;
-    block_on(Contact::get_verifier_addr(
-        ctx,
-        &ffi_contact.contact.get_id(),
-    ))
-    .log_err(ctx, "failed to get verifier for contact")
-    .unwrap_or_default()
-    .strdup()
+    block_on(ffi_contact.contact.get_verifier_addr(ctx))
+        .log_err(ctx, "failed to get verifier for contact")
+        .unwrap_or_default()
+        .strdup()
 }
 
 #[no_mangle]
@@ -3992,12 +3989,12 @@ pub unsafe extern "C" fn dc_contact_get_verifier_id(contact: *mut dc_contact_t) 
     }
     let ffi_contact = &*contact;
     let ctx = &*ffi_contact.context;
-    let contact_id = block_on(Contact::get_verifier_id(ctx, &ffi_contact.contact.get_id()))
+    let verifier_contact_id = block_on(ffi_contact.contact.get_verifier_id(ctx))
         .log_err(ctx, "failed to get verifier")
         .unwrap_or_default()
         .unwrap_or_default();
 
-    contact_id.to_u32()
+    verifier_contact_id.to_u32()
 }
 // dc_lot_t
 

--- a/deltachat-jsonrpc/src/api/types/contact.rs
+++ b/deltachat-jsonrpc/src/api/types/contact.rs
@@ -20,6 +20,10 @@ pub struct ContactObject {
     name_and_addr: String,
     is_blocked: bool,
     is_verified: bool,
+    /// the address that verified this contact
+    verifier_addr: Option<String>,
+    /// the id of the contact that verified this contact
+    verifier_id: Option<u32>,
     /// the contact's last seen timestamp
     last_seen: i64,
     was_seen_recently: bool,
@@ -36,6 +40,18 @@ impl ContactObject {
         };
         let is_verified = contact.is_verified(context).await? == VerifiedStatus::BidirectVerified;
 
+        let (verifier_addr, verifier_id) = if is_verified {
+            (
+                contact.get_verifier_addr(context).await?,
+                contact
+                    .get_verifier_id(context)
+                    .await?
+                    .map(|contact_id| contact_id.to_u32()),
+            )
+        } else {
+            (None, None)
+        };
+
         Ok(ContactObject {
             address: contact.get_addr().to_owned(),
             color: color_int_to_hex_string(contact.get_color()),
@@ -48,6 +64,8 @@ impl ContactObject {
             name_and_addr: contact.get_name_n_addr(),
             is_blocked: contact.is_blocked(),
             is_verified,
+            verifier_addr,
+            verifier_id,
             last_seen: contact.last_seen(),
             was_seen_recently: contact.was_seen_recently(),
         })

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1154,24 +1154,16 @@ impl Contact {
         Ok(VerifiedStatus::Unverified)
     }
 
-    /// Returns the address that verified the given contact.
-    pub async fn get_verifier_addr(
-        context: &Context,
-        contact_id: &ContactId,
-    ) -> Result<Option<String>> {
-        let contact = Contact::load_from_db(context, *contact_id).await?;
-
-        Ok(Peerstate::from_addr(context, contact.get_addr())
+    /// Returns the address that verified the contact.
+    pub async fn get_verifier_addr(&self, context: &Context) -> Result<Option<String>> {
+        Ok(Peerstate::from_addr(context, self.get_addr())
             .await?
             .and_then(|peerstate| peerstate.get_verifier().map(|addr| addr.to_owned())))
     }
 
-    /// Returns the ContactId that verified the given contact.
-    pub async fn get_verifier_id(
-        context: &Context,
-        contact_id: &ContactId,
-    ) -> Result<Option<ContactId>> {
-        let verifier_addr = Contact::get_verifier_addr(context, contact_id).await?;
+    /// Returns the ContactId that verified the contact.
+    pub async fn get_verifier_id(&self, context: &Context) -> Result<Option<ContactId>> {
+        let verifier_addr = self.get_verifier_addr(context).await?;
         if let Some(addr) = verifier_addr {
             Ok(Contact::lookup_id_by_addr(context, &addr, Origin::AddressBook).await?)
         } else {


### PR DESCRIPTION
also refactor it so that it is not a static method anymore
(would have resulted in two load-Contact-from-db-calls in jsonrpc)

looks like this was forgotten in #3839