### PR TITLE
ci: disable fail-fast

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
   build_and_test:
     name: Build and test
     strategy:
+      fail-fast: false
       matrix:
         include:
           # Currently used Rust version.


### PR DESCRIPTION
This setting is true by default and causes
Windows build to cancel when Linux fails
due to flaky test and vice versa.
Cancelled test then has to be restarted
from scratch even though it was not going
to fail.