### PR TITLE
remove comma from unit in message-details

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1180,7 +1180,7 @@ pub async fn get_msg_info(context: &Context, msg_id: MsgId) -> Result<String> {
 
     if let Some(path) = msg.get_file(context) {
         let bytes = get_filebytes(context, &path).await?;
-        ret += &format!("\nFile: {}, {}, bytes\n", path.display(), bytes);
+        ret += &format!("\nFile: {}, {} bytes\n", path.display(), bytes);
     }
 
     if msg.viewtype != Viewtype::Text {


### PR DESCRIPTION
it shoud read "filename.ext, 123 bytes" and not "filename.ext, 123, bytes"

#skip-changelog