### PR TITLE
fix verifier-by addr was empty string instead of None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 - Securejoin: Fix adding and handling Autocrypt-Gossip headers #3914
+- fix verifier-by addr was empty string intead of None
 
 ### API-Changes
 - jsonrpc: add verified-by information to `Contact`-Object

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -223,7 +223,10 @@ impl Peerstate {
                         .transpose()
                         .unwrap_or_default(),
                     fingerprint_changed: false,
-                    verifier: row.get("verifier")?,
+                    verifier: {
+                        let verifier: Option<String> = row.get("verifier")?;
+                        verifier.filter(|verifier| !verifier.is_empty())
+                    },
                 };
 
                 Ok(res)


### PR DESCRIPTION
this was making `Contact::lookup_id_by_addr` fail inside of `get_verifier_id`.