### PR TITLE
configure: log SOCKS5 configuration for IMAP like we do for SMTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Emit DC_EVENT_MSGS_CHANGED for DC_CHAT_ID_ARCHIVED_LINK when the number of archived chats with
   unread messages increases #3959
 - Fix Peerstate comparison #3962
+- Log SOCKS5 configuration for IMAP like already done for SMTP #3964
 
 ### API-Changes
 - jsonrpc: add verified-by information to `Contact`-Object

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -565,13 +565,18 @@ async fn try_imap_one_param(
     provider_strict_tls: bool,
 ) -> Result<Imap, ConfigurationError> {
     let inf = format!(
-        "imap: {}@{}:{} security={} certificate_checks={} oauth2={}",
+        "imap: {}@{}:{} security={} certificate_checks={} oauth2={} socks5_config={}",
         param.user,
         param.server,
         param.port,
         param.security,
         param.certificate_checks,
-        param.oauth2
+        param.oauth2,
+        if let Some(socks5_config) = socks5_config {
+            socks5_config.to_string()
+        } else {
+            "None".to_string()
+        }
     );
     info!(context, "Trying: {}", inf);
 


### PR DESCRIPTION
Related to #3963 