### PR TITLE
Terminate recently seen loop if cannot receive interrupts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix Peerstate comparison #3962
 - Log SOCKS5 configuration for IMAP like already done for SMTP #3964
 - Fix SOCKS5 usage for IMAP #3965
+- Exit from recently seen loop on interrupt channel errors to avoid busy looping #3966
 
 ### API-Changes
 - jsonrpc: add verified-by information to `Contact`-Object

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1612,6 +1612,9 @@ impl RecentlySeenLoop {
                             context,
                             "Error receiving an interruption in recently seen loop: {}", err
                         );
+                        // Maybe the sender side is closed.
+                        // Terminate the loop to avoid looping indefinitely.
+                        return;
                     }
                     Ok(Ok(RecentlySeenInterrupt {
                         contact_id,


### PR DESCRIPTION
It seems .abort() does not work on the recently seen loop in some cases, e.g. if it is busy looping in a separate thread.

In my case after account reconfiguration recently seen loop kept running and issuing warnings about closed interrupt channel.

Exit from recently seen loop on errors to avoid using 100% CPU in such cases.