### PR TITLE
Delete messages to the Trash folder for Gmail by default (#3957)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Fixes
 - Start SQL transactions with IMMEDIATE behaviour rather than default DEFERRED one. #4063
+- Fix a problem with Gmail where (auto-)deleted messages would get archived instead of deleted.
+  Move them to the Trash folder for Gmail which auto-deletes trashed messages in 30 days #3972
 
 ### API-Changes
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -249,7 +249,7 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
                                         }
                                     }
                                 },
-                                strict_tls: Some(provider.strict_tls),
+                                strict_tls: Some(provider.opt.strict_tls),
                             })
                             .collect();
 
@@ -338,7 +338,7 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
         .collect();
     let provider_strict_tls = param
         .provider
-        .map_or(socks5_config.is_some(), |provider| provider.strict_tls);
+        .map_or(socks5_config.is_some(), |provider| provider.opt.strict_tls);
 
     let smtp_config_task = task::spawn(async move {
         let mut smtp_configured = false;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -201,7 +201,7 @@ pub const BALANCED_IMAGE_SIZE: u32 = 1280;
 pub const WORSE_IMAGE_SIZE: u32 = 640;
 
 // this value can be increased if the folder configuration is changed and must be redone on next program start
-pub(crate) const DC_FOLDERS_CONFIGURED_VERSION: i32 = 3;
+pub(crate) const DC_FOLDERS_CONFIGURED_VERSION: i32 = 4;
 
 #[cfg(test)]
 mod tests {

--- a/src/context.rs
+++ b/src/context.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime};
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{bail, ensure, Context as _, Result};
 use async_channel::{self as channel, Receiver, Sender};
 use ratelimit::Ratelimit;
 use tokio::sync::{Mutex, RwLock};
@@ -623,6 +623,10 @@ impl Context {
             .get_config(Config::ConfiguredMvboxFolder)
             .await?
             .unwrap_or_else(|| "<unset>".to_string());
+        let configured_trash_folder = self
+            .get_config(Config::ConfiguredTrashFolder)
+            .await?
+            .unwrap_or_else(|| "<unset>".to_string());
 
         let mut res = get_info();
 
@@ -689,6 +693,7 @@ impl Context {
         res.insert("configured_inbox_folder", configured_inbox_folder);
         res.insert("configured_sentbox_folder", configured_sentbox_folder);
         res.insert("configured_mvbox_folder", configured_mvbox_folder);
+        res.insert("configured_trash_folder", configured_trash_folder);
         res.insert("mdns_enabled", mdns_enabled.to_string());
         res.insert("e2ee_enabled", e2ee_enabled.to_string());
         res.insert(
@@ -721,6 +726,12 @@ impl Context {
             self.get_config_int(Config::DeleteServerAfter)
                 .await?
                 .to_string(),
+        );
+        res.insert(
+            "delete_to_trash",
+            self.get_config(Config::DeleteToTrash)
+                .await?
+                .unwrap_or_else(|| "<unset>".to_string()),
         );
         res.insert(
             "last_housekeeping",
@@ -885,6 +896,33 @@ impl Context {
     pub async fn is_mvbox(&self, folder_name: &str) -> Result<bool> {
         let mvbox = self.get_config(Config::ConfiguredMvboxFolder).await?;
         Ok(mvbox.as_deref() == Some(folder_name))
+    }
+
+    /// Returns true if given folder name is the name of the trash folder.
+    pub async fn is_trash(&self, folder_name: &str) -> Result<bool> {
+        let trash = self.get_config(Config::ConfiguredTrashFolder).await?;
+        Ok(trash.as_deref() == Some(folder_name))
+    }
+
+    pub(crate) async fn should_delete_to_trash(&self) -> Result<bool> {
+        if let Some(v) = self.get_config_bool_opt(Config::DeleteToTrash).await? {
+            return Ok(v);
+        }
+        if let Some(provider) = self.get_configured_provider().await? {
+            return Ok(provider.opt.delete_to_trash);
+        }
+        Ok(false)
+    }
+
+    /// Returns `target` for deleted messages as per `imap` table. Empty string means "delete w/o
+    /// moving to trash".
+    pub(crate) async fn get_delete_msgs_target(&self) -> Result<String> {
+        if !self.should_delete_to_trash().await? {
+            return Ok("".into());
+        }
+        self.get_config(Config::ConfiguredTrashFolder)
+            .await?
+            .context("No configured trash folder")
     }
 
     pub(crate) fn derive_blobdir(dbfile: &Path) -> PathBuf {

--- a/src/download.rs
+++ b/src/download.rs
@@ -138,7 +138,7 @@ impl Job {
             context
                 .sql
                 .query_row_optional(
-                    "SELECT uid, folder FROM imap WHERE rfc724_mid=? AND target!=''",
+                    "SELECT uid, folder FROM imap WHERE rfc724_mid=? AND target=folder",
                     paramsv![msg.rfc724_mid],
                     |row| {
                         let server_uid: u32 = row.get(0)?;

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -274,7 +274,7 @@ impl Imap {
             param
                 .provider
                 .map_or(param.socks5_config.is_some(), |provider| {
-                    provider.strict_tls
+                    provider.opt.strict_tls
                 }),
             idle_interrupt_receiver,
         )?;

--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -7,7 +7,7 @@ use futures_lite::FutureExt;
 
 use super::session::Session;
 use super::Imap;
-use crate::imap::client::IMAP_TIMEOUT;
+use crate::imap::{client::IMAP_TIMEOUT, FolderMeaning};
 use crate::{context::Context, scheduler::InterruptInfo};
 
 const IDLE_TIMEOUT: Duration = Duration::from_secs(23 * 60);
@@ -113,6 +113,7 @@ impl Imap {
         &mut self,
         context: &Context,
         watch_folder: Option<String>,
+        folder_meaning: FolderMeaning,
     ) -> InterruptInfo {
         // Idle using polling. This is also needed if we're not yet configured -
         // in this case, we're waiting for a configure job (and an interrupt).
@@ -173,7 +174,7 @@ impl Imap {
                     // will have already fetched the messages so perform_*_fetch
                     // will not find any new.
                     match self
-                        .fetch_new_messages(context, &watch_folder, false, false)
+                        .fetch_new_messages(context, &watch_folder, folder_meaning, false)
                         .await
                     {
                         Ok(res) => {

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, time::Instant};
 use anyhow::{Context as _, Result};
 use futures::stream::StreamExt;
 
-use super::{get_folder_meaning, get_folder_meaning_by_name};
+use super::{get_folder_meaning_by_attrs, get_folder_meaning_by_name};
 use crate::config::Config;
 use crate::imap::Imap;
 use crate::log::LogExt;
@@ -33,7 +33,7 @@ impl Imap {
         let mut folder_configs = BTreeMap::new();
 
         for folder in folders {
-            let folder_meaning = get_folder_meaning(&folder);
+            let folder_meaning = get_folder_meaning_by_attrs(folder.attributes());
             if folder_meaning == FolderMeaning::Virtual {
                 // Gmail has virtual folders that should be skipped. For example,
                 // emails appear in the inbox and under "All Mail" as soon as it is
@@ -53,21 +53,22 @@ impl Imap {
                     .or_insert_with(|| folder.name().to_string());
             }
 
-            let is_drafts = folder_meaning == FolderMeaning::Drafts
-                || (folder_meaning == FolderMeaning::Unknown
-                    && folder_name_meaning == FolderMeaning::Drafts);
-            let is_spam_folder = folder_meaning == FolderMeaning::Spam
-                || (folder_meaning == FolderMeaning::Unknown
-                    && folder_name_meaning == FolderMeaning::Spam);
+            let folder_meaning = match folder_meaning {
+                FolderMeaning::Unknown => folder_name_meaning,
+                _ => folder_meaning,
+            };
 
             // Don't scan folders that are watched anyway
-            if !watched_folders.contains(&folder.name().to_string()) && !is_drafts {
+            if !watched_folders.contains(&folder.name().to_string())
+                && folder_meaning != FolderMeaning::Drafts
+                && folder_meaning != FolderMeaning::Trash
+            {
                 let session = self.session.as_mut().context("no session")?;
                 // Drain leftover unsolicited EXISTS messages
                 session.server_sent_unsolicited_exists(context)?;
 
                 loop {
-                    self.fetch_move_delete(context, folder.name(), is_spam_folder)
+                    self.fetch_move_delete(context, folder.name(), folder_meaning)
                         .await
                         .ok_or_log_msg(context, "Can't fetch new msgs in scanned folder");
 
@@ -80,15 +81,15 @@ impl Imap {
             }
         }
 
-        // Set the `ConfiguredSentboxFolder` or set it to `None` if the folder was deleted.
-        context
-            .set_config(
-                Config::ConfiguredSentboxFolder,
-                folder_configs
-                    .get(&Config::ConfiguredSentboxFolder)
-                    .map(|s| s.as_str()),
-            )
-            .await?;
+        // Set configs for necessary folders. Or reset if the folder was deleted.
+        for conf in [
+            Config::ConfiguredSentboxFolder,
+            Config::ConfiguredTrashFolder,
+        ] {
+            context
+                .set_config(conf, folder_configs.get(&conf).map(|s| s.as_str()))
+                .await?;
+        }
 
         last_scan.replace(Instant::now());
         Ok(true)

--- a/src/job.rs
+++ b/src/job.rs
@@ -12,7 +12,7 @@ use deltachat_derive::{FromSql, ToSql};
 use rand::{thread_rng, Rng};
 
 use crate::context::Context;
-use crate::imap::Imap;
+use crate::imap::{get_folder_meaning, FolderMeaning, Imap};
 use crate::param::Params;
 use crate::scheduler::InterruptInfo;
 use crate::tools::time;
@@ -172,8 +172,12 @@ impl Job {
         let mut any_failed = false;
 
         for folder in all_folders {
+            let folder_meaning = get_folder_meaning(&folder);
+            if folder_meaning == FolderMeaning::Virtual {
+                continue;
+            }
             if let Err(e) = imap
-                .resync_folder_uids(context, folder.name().to_string())
+                .resync_folder_uids(context, folder.name(), folder_meaning)
                 .await
             {
                 warn!(context, "{:#}", e);

--- a/src/message.rs
+++ b/src/message.rs
@@ -1386,11 +1386,12 @@ pub async fn delete_msgs(context: &Context, msg_ids: &[MsgId]) -> Result<()> {
             context.emit_event(EventType::WebxdcInstanceDeleted { msg_id: *msg_id });
         }
 
+        let target = context.get_delete_msgs_target().await?;
         context
             .sql
             .execute(
-                "UPDATE imap SET target='' WHERE rfc724_mid=?",
-                paramsv![msg.rfc724_mid],
+                "UPDATE imap SET target=? WHERE rfc724_mid=?",
+                paramsv![target, msg.rfc724_mid],
             )
             .await?;
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -129,13 +129,6 @@ pub struct Provider {
     /// Default configuration values to set when provider is configured.
     pub config_defaults: Option<Vec<ConfigDefault>>,
 
-    /// True if provider is known to use use proper,
-    /// not self-signed certificates.
-    pub strict_tls: bool,
-
-    /// Maximum number of recipients the provider allows to send a single email to.
-    pub max_smtp_rcpt_to: Option<u16>,
-
     /// Type of OAuth 2 authorization if provider supports it.
     pub oauth2_authorizer: Option<Oauth2Authorizer>,
 
@@ -144,10 +137,27 @@ pub struct Provider {
 }
 
 /// Provider options with good defaults.
-#[derive(Debug, Default, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct ProviderOptions {
+    /// True if provider is known to use use proper,
+    /// not self-signed certificates.
+    pub strict_tls: bool,
+
+    /// Maximum number of recipients the provider allows to send a single email to.
+    pub max_smtp_rcpt_to: Option<u16>,
+
     /// Move messages to the Trash folder instead of marking them "\Deleted".
     pub delete_to_trash: bool,
+}
+
+impl Default for ProviderOptions {
+    fn default() -> Self {
+        Self {
+            strict_tls: true,
+            max_smtp_rcpt_to: None,
+            delete_to_trash: false,
+        }
+    }
 }
 
 /// Get resolver to query MX records.

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -138,6 +138,16 @@ pub struct Provider {
 
     /// Type of OAuth 2 authorization if provider supports it.
     pub oauth2_authorizer: Option<Oauth2Authorizer>,
+
+    /// Options with good defaults.
+    pub opt: ProviderOptions,
+}
+
+/// Provider options with good defaults.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ProviderOptions {
+    /// Move messages to the Trash folder instead of marking them "\Deleted".
+    pub delete_to_trash: bool,
 }
 
 /// Get resolver to query MX records.

--- a/src/provider/data.rs
+++ b/src/provider/data.rs
@@ -35,8 +35,6 @@ static P_163: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -65,8 +63,6 @@ static P_AKTIVIX_ORG: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -84,8 +80,6 @@ static P_AOL: Lazy<Provider> = Lazy::new(|| {
         Server { protocol: Smtp, socket: Ssl, hostname: "smtp.aol.com", port: 465, username_pattern: Email },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 }
@@ -115,8 +109,6 @@ static P_ARCOR_DE: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -145,8 +137,6 @@ static P_AUTISTICI_ORG: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -175,8 +165,6 @@ static P_BLINDZELN_ORG: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -205,8 +193,6 @@ static P_BLUEWIN_CH: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -235,8 +221,6 @@ static P_BUZON_UY: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -265,8 +249,6 @@ static P_CHELLO_AT: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -280,8 +262,6 @@ static P_COMCAST: Lazy<Provider> = Lazy::new(|| Provider {
     overview_page: "https://providers.delta.chat/comcast",
     server: vec![],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -295,8 +275,6 @@ static P_DISMAIL_DE: Lazy<Provider> = Lazy::new(|| Provider {
     overview_page: "https://providers.delta.chat/dismail-de",
     server: vec![],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -325,8 +303,6 @@ static P_DISROOT: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -355,8 +331,6 @@ static P_E_EMAIL: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -370,8 +344,6 @@ static P_ESPIV_NET: Lazy<Provider> = Lazy::new(|| Provider {
     overview_page: "https://providers.delta.chat/espiv-net",
     server: vec![],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -389,8 +361,6 @@ static P_EXAMPLE_COM: Lazy<Provider> = Lazy::new(|| {
         Server { protocol: Smtp, socket: Starttls, hostname: "smtp.example.com", port: 1337, username_pattern: Email },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 }
@@ -421,8 +391,6 @@ static P_FASTMAIL: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -438,8 +406,6 @@ static P_FIREMAIL_DE: Lazy<Provider> = Lazy::new(|| {
     server: vec![
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 }
@@ -467,8 +433,6 @@ static P_FIVE_CHAT: Lazy<Provider> = Lazy::new(|| Provider {
             value: "0",
         },
     ]),
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -486,8 +450,6 @@ static P_FREENET_DE: Lazy<Provider> = Lazy::new(|| {
         Server { protocol: Smtp, socket: Starttls, hostname: "mx.freenet.de", port: 587, username_pattern: Email },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 }
@@ -506,11 +468,10 @@ static P_GMAIL: Lazy<Provider> = Lazy::new(|| {
         Server { protocol: Smtp, socket: Ssl, hostname: "smtp.gmail.com", port: 465, username_pattern: Email },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: Some(Oauth2Authorizer::Gmail),
     opt: ProviderOptions {
         delete_to_trash: true,
+        ..Default::default()
     },
 }
 });
@@ -546,8 +507,6 @@ static P_GMX_NET: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -574,10 +533,11 @@ static P_HERMES_RADIO: Lazy<Provider> = Lazy::new(|| Provider {
             value: "2",
         },
     ]),
-    strict_tls: false,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
-    opt: Default::default(),
+    opt: ProviderOptions {
+        strict_tls: false,
+        ..Default::default()
+    },
 });
 
 // hey.com.md: hey.com
@@ -591,8 +551,6 @@ static P_HEY_COM: Lazy<Provider> = Lazy::new(|| {
     server: vec![
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 }
@@ -607,8 +565,6 @@ static P_I_UA: Lazy<Provider> = Lazy::new(|| Provider {
     overview_page: "https://providers.delta.chat/i-ua",
     server: vec![],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -622,8 +578,6 @@ static P_I3_NET: Lazy<Provider> = Lazy::new(|| Provider {
     overview_page: "https://providers.delta.chat/i3-net",
     server: vec![],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -652,8 +606,6 @@ static P_ICLOUD: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -682,10 +634,11 @@ static P_INFOMANIAK_COM: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: Some(10),
     oauth2_authorizer: None,
-    opt: Default::default(),
+    opt: ProviderOptions {
+        max_smtp_rcpt_to: Some(10),
+        ..Default::default()
+    },
 });
 
 // kolst.com.md: kolst.com
@@ -697,8 +650,6 @@ static P_KOLST_COM: Lazy<Provider> = Lazy::new(|| Provider {
     overview_page: "https://providers.delta.chat/kolst-com",
     server: vec![],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -712,8 +663,6 @@ static P_KONTENT_COM: Lazy<Provider> = Lazy::new(|| Provider {
     overview_page: "https://providers.delta.chat/kontent-com",
     server: vec![],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -742,8 +691,6 @@ static P_MAIL_DE: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -761,8 +708,6 @@ static P_MAIL_RU: Lazy<Provider> = Lazy::new(|| {
         Server { protocol: Smtp, socket: Ssl, hostname: "smtp.mail.ru", port: 465, username_pattern: Email },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 }
@@ -792,8 +737,6 @@ static P_MAIL2TOR: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -822,8 +765,6 @@ static P_MAILBOX_ORG: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -852,8 +793,6 @@ static P_MAILO_COM: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -907,10 +846,12 @@ static P_NAUTA_CU: Lazy<Provider> = Lazy::new(|| Provider {
             value: "0",
         },
     ]),
-    strict_tls: false,
-    max_smtp_rcpt_to: Some(20),
     oauth2_authorizer: None,
-    opt: Default::default(),
+    opt: ProviderOptions {
+        strict_tls: false,
+        max_smtp_rcpt_to: Some(20),
+        ..Default::default()
+    },
 });
 
 // naver.md: naver.com
@@ -937,8 +878,6 @@ static P_NAVER: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -967,8 +906,6 @@ static P_NUBO_COOP: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -997,8 +934,6 @@ static P_OUTLOOK_COM: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1027,8 +962,6 @@ static P_OUVATON_COOP: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1057,8 +990,6 @@ static P_POSTEO: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1074,8 +1005,6 @@ static P_PROTONMAIL: Lazy<Provider> = Lazy::new(|| {
     server: vec![
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 }
@@ -1094,8 +1023,6 @@ static P_QQ: Lazy<Provider> = Lazy::new(|| {
         Server { protocol: Smtp, socket: Ssl, hostname: "smtp.qq.com", port: 465, username_pattern: Email },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 }
@@ -1125,8 +1052,6 @@ static P_RISEUP_NET: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1140,8 +1065,6 @@ static P_ROGERS_COM: Lazy<Provider> = Lazy::new(|| Provider {
     overview_page: "https://providers.delta.chat/rogers-com",
     server: vec![],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1170,8 +1093,6 @@ static P_SYSTEMAUSFALL_ORG: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1200,8 +1121,6 @@ static P_SYSTEMLI_ORG: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1219,8 +1138,6 @@ static P_T_ONLINE: Lazy<Provider> = Lazy::new(|| {
         Server { protocol: Smtp, socket: Ssl, hostname: "securesmtp.t-online.de", port: 465, username_pattern: Email },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 }
@@ -1270,8 +1187,6 @@ static P_TESTRUN: Lazy<Provider> = Lazy::new(|| Provider {
             value: "0",
         },
     ]),
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1300,8 +1215,6 @@ static P_TISCALI_IT: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1317,8 +1230,6 @@ static P_TUTANOTA: Lazy<Provider> = Lazy::new(|| {
     server: vec![
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 }
@@ -1333,8 +1244,6 @@ static P_UKR_NET: Lazy<Provider> = Lazy::new(|| Provider {
     overview_page: "https://providers.delta.chat/ukr-net",
     server: vec![],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1363,8 +1272,6 @@ static P_UNDERNET_UY: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1378,8 +1285,6 @@ static P_VFEMAIL: Lazy<Provider> = Lazy::new(|| Provider {
     overview_page: "https://providers.delta.chat/vfemail",
     server: vec![],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1408,8 +1313,6 @@ static P_VIVALDI: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1438,8 +1341,6 @@ static P_VODAFONE_DE: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1458,8 +1359,6 @@ static P_WEB_DE: Lazy<Provider> = Lazy::new(|| {
         Server { protocol: Smtp, socket: Starttls, hostname: "smtp.web.de", port: 587, username_pattern: Emaillocalpart },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 }
@@ -1478,8 +1377,6 @@ static P_YAHOO: Lazy<Provider> = Lazy::new(|| {
         Server { protocol: Smtp, socket: Ssl, hostname: "smtp.mail.yahoo.com", port: 465, username_pattern: Email },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 }
@@ -1509,8 +1406,6 @@ static P_YANDEX_RU: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: Some(Oauth2Authorizer::Yandex),
     opt: Default::default(),
 });
@@ -1530,8 +1425,6 @@ static P_YGGMAIL: Lazy<Provider> = Lazy::new(|| {
     config_defaults: Some(vec![
         ConfigDefault { key: Config::MvboxMove, value: "0" },
     ]),
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 }
@@ -1561,8 +1454,6 @@ static P_ZIGGO_NL: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });
@@ -1591,8 +1482,6 @@ static P_ZOHO: Lazy<Provider> = Lazy::new(|| Provider {
         },
     ],
     config_defaults: None,
-    strict_tls: true,
-    max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
     opt: Default::default(),
 });

--- a/src/provider/data.rs
+++ b/src/provider/data.rs
@@ -7,7 +7,9 @@ use once_cell::sync::Lazy;
 use crate::provider::Protocol::*;
 use crate::provider::Socket::*;
 use crate::provider::UsernamePattern::*;
-use crate::provider::{Config, ConfigDefault, Oauth2Authorizer, Provider, Server, Status};
+use crate::provider::{
+    Config, ConfigDefault, Oauth2Authorizer, Provider, ProviderOptions, Server, Status,
+};
 
 // 163.md: 163.com
 static P_163: Lazy<Provider> = Lazy::new(|| Provider {
@@ -36,6 +38,7 @@ static P_163: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // aktivix.org.md: aktivix.org
@@ -65,6 +68,7 @@ static P_AKTIVIX_ORG: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // aol.md: aol.com
@@ -83,6 +87,7 @@ static P_AOL: Lazy<Provider> = Lazy::new(|| {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 }
 });
 
@@ -113,6 +118,7 @@ static P_ARCOR_DE: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // autistici.org.md: autistici.org
@@ -142,6 +148,7 @@ static P_AUTISTICI_ORG: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // blindzeln.org.md: delta.blinzeln.de, delta.blindzeln.org
@@ -171,6 +178,7 @@ static P_BLINDZELN_ORG: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // bluewin.ch.md: bluewin.ch
@@ -200,6 +208,7 @@ static P_BLUEWIN_CH: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // buzon.uy.md: buzon.uy
@@ -229,6 +238,7 @@ static P_BUZON_UY: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // chello.at.md: chello.at
@@ -258,6 +268,7 @@ static P_CHELLO_AT: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // comcast.md: xfinity.com, comcast.net
@@ -272,6 +283,7 @@ static P_COMCAST: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // dismail.de.md: dismail.de
@@ -286,6 +298,7 @@ static P_DISMAIL_DE: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // disroot.md: disroot.org
@@ -315,6 +328,7 @@ static P_DISROOT: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // e.email.md: e.email
@@ -344,6 +358,7 @@ static P_E_EMAIL: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // espiv.net.md: espiv.net
@@ -358,6 +373,7 @@ static P_ESPIV_NET: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // example.com.md: example.com, example.org, example.net
@@ -376,6 +392,7 @@ static P_EXAMPLE_COM: Lazy<Provider> = Lazy::new(|| {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 }
 });
 
@@ -407,6 +424,7 @@ static P_FASTMAIL: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // firemail.de.md: firemail.at, firemail.de
@@ -423,6 +441,7 @@ static P_FIREMAIL_DE: Lazy<Provider> = Lazy::new(|| {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 }
 });
 
@@ -451,6 +470,7 @@ static P_FIVE_CHAT: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // freenet.de.md: freenet.de
@@ -469,6 +489,7 @@ static P_FREENET_DE: Lazy<Provider> = Lazy::new(|| {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 }
 });
 
@@ -488,6 +509,9 @@ static P_GMAIL: Lazy<Provider> = Lazy::new(|| {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: Some(Oauth2Authorizer::Gmail),
+    opt: ProviderOptions {
+        delete_to_trash: true,
+    },
 }
 });
 
@@ -525,6 +549,7 @@ static P_GMX_NET: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // hermes.radio.md: ac.hermes.radio, ac1.hermes.radio, ac2.hermes.radio, ac3.hermes.radio, ac4.hermes.radio, ac5.hermes.radio, ac6.hermes.radio, ac7.hermes.radio, ac8.hermes.radio, ac9.hermes.radio, ac10.hermes.radio, ac11.hermes.radio, ac12.hermes.radio, ac13.hermes.radio, ac14.hermes.radio, ac15.hermes.radio, ka.hermes.radio, ka1.hermes.radio, ka2.hermes.radio, ka3.hermes.radio, ka4.hermes.radio, ka5.hermes.radio, ka6.hermes.radio, ka7.hermes.radio, ka8.hermes.radio, ka9.hermes.radio, ka10.hermes.radio, ka11.hermes.radio, ka12.hermes.radio, ka13.hermes.radio, ka14.hermes.radio, ka15.hermes.radio, ec.hermes.radio, ec1.hermes.radio, ec2.hermes.radio, ec3.hermes.radio, ec4.hermes.radio, ec5.hermes.radio, ec6.hermes.radio, ec7.hermes.radio, ec8.hermes.radio, ec9.hermes.radio, ec10.hermes.radio, ec11.hermes.radio, ec12.hermes.radio, ec13.hermes.radio, ec14.hermes.radio, ec15.hermes.radio, hermes.radio
@@ -552,6 +577,7 @@ static P_HERMES_RADIO: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: false,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // hey.com.md: hey.com
@@ -568,6 +594,7 @@ static P_HEY_COM: Lazy<Provider> = Lazy::new(|| {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 }
 });
 
@@ -583,6 +610,7 @@ static P_I_UA: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // i3.net.md: i3.net
@@ -597,6 +625,7 @@ static P_I3_NET: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // icloud.md: icloud.com, me.com, mac.com
@@ -626,6 +655,7 @@ static P_ICLOUD: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // infomaniak.com.md: ik.me
@@ -655,6 +685,7 @@ static P_INFOMANIAK_COM: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: Some(10),
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // kolst.com.md: kolst.com
@@ -669,6 +700,7 @@ static P_KOLST_COM: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // kontent.com.md: kontent.com
@@ -683,6 +715,7 @@ static P_KONTENT_COM: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // mail.de.md: mail.de
@@ -712,6 +745,7 @@ static P_MAIL_DE: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // mail.ru.md: mail.ru, inbox.ru, internet.ru, bk.ru, list.ru
@@ -730,6 +764,7 @@ static P_MAIL_RU: Lazy<Provider> = Lazy::new(|| {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 }
 });
 
@@ -760,6 +795,7 @@ static P_MAIL2TOR: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // mailbox.org.md: mailbox.org, secure.mailbox.org
@@ -789,6 +825,7 @@ static P_MAILBOX_ORG: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // mailo.com.md: mailo.com
@@ -818,6 +855,7 @@ static P_MAILO_COM: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // nauta.cu.md: nauta.cu
@@ -872,6 +910,7 @@ static P_NAUTA_CU: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: false,
     max_smtp_rcpt_to: Some(20),
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // naver.md: naver.com
@@ -901,6 +940,7 @@ static P_NAVER: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // nubo.coop.md: nubo.coop
@@ -930,6 +970,7 @@ static P_NUBO_COOP: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // outlook.com.md: hotmail.com, outlook.com, office365.com, outlook.com.tr, live.com, outlook.de
@@ -959,6 +1000,7 @@ static P_OUTLOOK_COM: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // ouvaton.coop.md: ouvaton.org
@@ -988,6 +1030,7 @@ static P_OUVATON_COOP: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // posteo.md: posteo.de, posteo.af, posteo.at, posteo.be, posteo.ca, posteo.ch, posteo.cl, posteo.co, posteo.co.uk, posteo.com.br, posteo.cr, posteo.cz, posteo.dk, posteo.ee, posteo.es, posteo.eu, posteo.fi, posteo.gl, posteo.gr, posteo.hn, posteo.hr, posteo.hu, posteo.ie, posteo.in, posteo.is, posteo.it, posteo.jp, posteo.la, posteo.li, posteo.lt, posteo.lu, posteo.me, posteo.mx, posteo.my, posteo.net, posteo.nl, posteo.no, posteo.nz, posteo.org, posteo.pe, posteo.pl, posteo.pm, posteo.pt, posteo.ro, posteo.ru, posteo.se, posteo.sg, posteo.si, posteo.tn, posteo.uk, posteo.us
@@ -1017,6 +1060,7 @@ static P_POSTEO: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // protonmail.md: protonmail.com, protonmail.ch, pm.me
@@ -1033,6 +1077,7 @@ static P_PROTONMAIL: Lazy<Provider> = Lazy::new(|| {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 }
 });
 
@@ -1052,6 +1097,7 @@ static P_QQ: Lazy<Provider> = Lazy::new(|| {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 }
 });
 
@@ -1082,6 +1128,7 @@ static P_RISEUP_NET: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // rogers.com.md: rogers.com
@@ -1096,6 +1143,7 @@ static P_ROGERS_COM: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // systemausfall.org.md: systemausfall.org, solidaris.me
@@ -1125,6 +1173,7 @@ static P_SYSTEMAUSFALL_ORG: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // systemli.org.md: systemli.org
@@ -1154,6 +1203,7 @@ static P_SYSTEMLI_ORG: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // t-online.md: t-online.de, magenta.de
@@ -1172,6 +1222,7 @@ static P_T_ONLINE: Lazy<Provider> = Lazy::new(|| {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 }
 });
 
@@ -1222,6 +1273,7 @@ static P_TESTRUN: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // tiscali.it.md: tiscali.it
@@ -1251,6 +1303,7 @@ static P_TISCALI_IT: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // tutanota.md: tutanota.com, tutanota.de, tutamail.com, tuta.io, keemail.me
@@ -1267,6 +1320,7 @@ static P_TUTANOTA: Lazy<Provider> = Lazy::new(|| {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 }
 });
 
@@ -1282,6 +1336,7 @@ static P_UKR_NET: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // undernet.uy.md: undernet.uy
@@ -1311,6 +1366,7 @@ static P_UNDERNET_UY: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // vfemail.md: vfemail.net
@@ -1325,6 +1381,7 @@ static P_VFEMAIL: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // vivaldi.md: vivaldi.net
@@ -1354,6 +1411,7 @@ static P_VIVALDI: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // vodafone.de.md: vodafone.de, vodafonemail.de
@@ -1383,6 +1441,7 @@ static P_VODAFONE_DE: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // web.de.md: web.de, email.de, flirt.ms, hallo.ms, kuss.ms, love.ms, magic.ms, singles.ms, cool.ms, kanzler.ms, okay.ms, party.ms, pop.ms, stars.ms, techno.ms, clever.ms, deutschland.ms, genial.ms, ich.ms, online.ms, smart.ms, wichtig.ms, action.ms, fussball.ms, joker.ms, planet.ms, power.ms
@@ -1402,6 +1461,7 @@ static P_WEB_DE: Lazy<Provider> = Lazy::new(|| {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 }
 });
 
@@ -1421,6 +1481,7 @@ static P_YAHOO: Lazy<Provider> = Lazy::new(|| {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 }
 });
 
@@ -1451,6 +1512,7 @@ static P_YANDEX_RU: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: Some(Oauth2Authorizer::Yandex),
+    opt: Default::default(),
 });
 
 // yggmail.md: yggmail
@@ -1471,6 +1533,7 @@ static P_YGGMAIL: Lazy<Provider> = Lazy::new(|| {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 }
 });
 
@@ -1501,6 +1564,7 @@ static P_ZIGGO_NL: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 // zoho.md: zohomail.eu, zohomail.com, zoho.com
@@ -1530,6 +1594,7 @@ static P_ZOHO: Lazy<Provider> = Lazy::new(|| Provider {
     strict_tls: true,
     max_smtp_rcpt_to: None,
     oauth2_authorizer: None,
+    opt: Default::default(),
 });
 
 pub(crate) static PROVIDER_DATA: Lazy<HashMap<&'static str, &'static Provider>> = Lazy::new(|| {

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -342,11 +342,12 @@ pub(crate) async fn receive_imf_inner(
         if received_msg.needs_delete_job
             || (delete_server_after == Some(0) && is_partial_download.is_none())
         {
+            let target = context.get_delete_msgs_target().await?;
             context
                 .sql
                 .execute(
-                    "UPDATE imap SET target='' WHERE rfc724_mid=?",
-                    paramsv![rfc724_mid],
+                    "UPDATE imap SET target=? WHERE rfc724_mid=?",
+                    paramsv![target, rfc724_mid],
                 )
                 .await?;
         } else if !mime_parser.mdn_reports.is_empty() && mime_parser.has_chat_version() {

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -101,8 +101,9 @@ impl Smtp {
             &lp.smtp,
             &lp.socks5_config,
             &lp.addr,
-            lp.provider
-                .map_or(lp.socks5_config.is_some(), |provider| provider.strict_tls),
+            lp.provider.map_or(lp.socks5_config.is_some(), |provider| {
+                provider.opt.strict_tls
+            }),
         )
         .await
     }

--- a/src/smtp/send.rs
+++ b/src/smtp/send.rs
@@ -47,7 +47,7 @@ impl Smtp {
         let chunk_size = context
             .get_configured_provider()
             .await?
-            .and_then(|provider| provider.max_smtp_rcpt_to)
+            .and_then(|provider| provider.opt.max_smtp_rcpt_to)
             .map_or(DEFAULT_MAX_SMTP_RCPT_TO, usize::from);
 
         for recipients_chunk in recipients.chunks(chunk_size) {


### PR DESCRIPTION
Gmail archives messages marked as `\Deleted` by default if those messages aren't in the Trash. But
if move them to the Trash instead, they will be auto-deleted in 30 days.

Fixes #3957