### PR TITLE
Do not pass Result as a function argument

### DIFF
--- a/src/debug_logging.rs
+++ b/src/debug_logging.rs
@@ -70,7 +70,7 @@ pub async fn maybe_set_logging_xdc(
         context,
         msg.get_viewtype(),
         chat_id,
-        msg.param.get_path(Param::File, context),
+        msg.param.get_path(Param::File, context).unwrap_or_default(),
         msg.get_id(),
     )
     .await?;
@@ -83,11 +83,11 @@ pub async fn maybe_set_logging_xdc_inner(
     context: &Context,
     viewtype: Viewtype,
     chat_id: ChatId,
-    file: anyhow::Result<Option<PathBuf>>,
+    file: Option<PathBuf>,
     msg_id: MsgId,
 ) -> anyhow::Result<()> {
     if viewtype == Viewtype::Webxdc {
-        if let Ok(Some(file)) = file {
+        if let Some(file) = file {
             if let Some(file_name) = file.file_name().and_then(|name| name.to_str()) {
                 if file_name.starts_with("debug_logging")
                     && file_name.ends_with(".xdc")

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1237,7 +1237,9 @@ SET rfc724_mid=excluded.rfc724_mid, chat_id=excluded.chat_id,
             context,
             part.typ,
             chat_id,
-            part.param.get_path(Param::File, context),
+            part.param
+                .get_path(Param::File, context)
+                .unwrap_or_default(),
             *msg_id,
         )
         .await?;


### PR DESCRIPTION
#skip-changelog

Follow-up to #3958

I also filed an issue for clippy at https://github.com/rust-lang/rust-clippy/issues/10227, passing Result around is like passing an exception around in C++ or Python, possible but non-idiomatic IMO.