### PR TITLE
Redo SMTP connection code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 ## Changes
+- Use read/write timeouts instead of per-command timeouts for SMTP #3985
+- Cache DNS results for SMTP connections #3985
 
 ## Fixes
 - Fix Securejoin for multiple devices on a joining side #3982
@@ -23,7 +25,7 @@
 
 ### Changes
 - Pipeline SMTP commands #3924
-- Cache DNS results #3970
+- Cache DNS results for IMAP connections #3970
 
 ### Fixes
 - Securejoin: Fix adding and handling Autocrypt-Gossip headers #3914

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,21 +165,18 @@ dependencies = [
 
 [[package]]
 name = "async-smtp"
-version = "0.6.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ade89127f9e0d44f9e83cf574d499060005cd45b7dc76be89c0167487fe8edd"
+checksum = "7384febcabdd07a498c9f4fbaa7e488ff4eb60d0ade14b47b09ec44b8f645301"
 dependencies = [
- "async-native-tls",
- "async-trait",
+ "anyhow",
  "base64 0.13.1",
  "bufstream",
- "fast-socks5",
  "futures",
  "hostname",
  "log",
  "nom 7.1.1",
  "pin-project",
- "pin-utils",
  "thiserror",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ ansi_term = { version = "0.12.1", optional = true }
 anyhow = "1"
 async-imap = { git = "https://github.com/async-email/async-imap", branch = "master", default-features = false, features = ["runtime-tokio"] }
 async-native-tls = { version = "0.4", default-features = false, features = ["runtime-tokio"] }
-async-smtp = { version = "0.6", default-features = false, features = ["smtp-transport", "socks5", "runtime-tokio"] }
+async-smtp = { version = "0.8", default-features = false, features = ["runtime-tokio"] }
 trust-dns-resolver = "0.22"
 tokio = { version = "1", features = ["fs", "rt-multi-thread", "macros"] }
 tokio-tar = { version = "0.3" } # TODO: integrate tokio into async-tar
@@ -157,7 +157,6 @@ internals = []
 repl = ["internals", "rustyline", "log", "pretty_env_logger", "ansi_term", "dirs"]
 vendored = [
   "async-native-tls/vendored",
-  "async-smtp/native-tls-vendored",
   "rusqlite/bundled-sqlcipher-vendored-openssl",
   "reqwest/native-tls-vendored"
 ]

--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -47,6 +47,7 @@ async def test_configure_starttls(acfactory) -> None:
 
     # Use STARTTLS
     await account.set_config("mail_security", "2")
+    await account.set_config("send_security", "2")
     await account.configure()
     assert await account.is_configured()
 

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -4,7 +4,6 @@ use std::fmt;
 
 use anyhow::{ensure, Result};
 use async_native_tls::Certificate;
-pub use async_smtp::ServerAddress;
 use once_cell::sync::Lazy;
 
 use crate::constants::{DC_LP_AUTH_FLAGS, DC_LP_AUTH_NORMAL, DC_LP_AUTH_OAUTH2};

--- a/src/socks.rs
+++ b/src/socks.rs
@@ -5,7 +5,6 @@ use std::pin::Pin;
 use std::time::Duration;
 
 use anyhow::Result;
-pub use async_smtp::ServerAddress;
 use fast_socks5::client::{Config, Socks5Stream};
 use fast_socks5::util::target_addr::ToTargetAddr;
 use fast_socks5::AuthenticationMethod;
@@ -86,14 +85,6 @@ impl Socks5Config {
             .await?;
 
         Ok(socks_stream)
-    }
-
-    pub fn to_async_smtp_socks5_config(&self) -> async_smtp::smtp::Socks5Config {
-        async_smtp::smtp::Socks5Config {
-            host: self.host.clone(),
-            port: self.port,
-            user_password: self.user_password.clone(),
-        }
     }
 }
 


### PR DESCRIPTION
This builds on top of #3983 and depends on large async-smtp refactoring removing connection establishment from the library: https://github.com/async-email/async-smtp/pull/57 New async-smtp works on top of user provided async streams.

Network connections, including TCP, TLS, STARTTLS, SOCKS5 are now handled by the delta chat core itself. This allows to share the same TCP connection code for all SMTP and IMAP connections, use DNS cache stored in the database and proper read/write timeouts instead of per-command and per-message timeouts.