### PR TITLE
Always optimize dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,12 @@ opt-level = 1
 [profile.test]
 opt-level = 0
 
+# Always optimize dependencies.
+# This does not apply to crates in the workspace.
+# <https://doc.rust-lang.org/cargo/reference/profiles.html#overrides>
+[profile.dev.package."*"]
+opt-level = 3
+
 [profile.release]
 lto = true
 panic = 'abort'


### PR DESCRIPTION
They are only built once, but the time of
`cargo nextest run` is reduced by around 40% as a result.