### PR TITLE
Remove the nightly PGP feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,4 +155,3 @@ vendored = [
   "rusqlite/bundled-sqlcipher-vendored-openssl",
   "reqwest/native-tls-vendored"
 ]
-nightly = ["pgp/nightly"]

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -29,6 +29,5 @@ once_cell = "1.17.0"
 [features]
 default = ["vendored"]
 vendored = ["deltachat/vendored"]
-nightly = ["deltachat/nightly"]
 jsonrpc = ["deltachat-jsonrpc"]
 


### PR DESCRIPTION
This was to test pgp early on, but that's not deltachat's business.
If needed the PGP project can always do this with patching.