### PR TITLE
Remove bitflags from get_chat_msgs() interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   Account.`get_message_by_id` may return `None` in this case.
 
 ## API-Changes
+- Remove bitflags from `get_chat_msgs()` interface #4022
+  C interface is not changed.
+  Rust and JSON-RPC API have `flags` integer argument
+  replaced with two boolean flags `info_only` and `add_daymarker`.
 
 
 ## 1.107.1

--- a/benches/get_chat_msgs.rs
+++ b/benches/get_chat_msgs.rs
@@ -14,7 +14,7 @@ async fn get_chat_msgs_benchmark(dbfile: &Path, chats: &[ChatId]) {
         .unwrap();
 
     for c in chats.iter().take(10) {
-        black_box(chat::get_chat_msgs(&context, *c, 0).await.ok());
+        black_box(chat::get_chat_msgs(&context, *c).await.ok());
     }
 }
 

--- a/deltachat-jsonrpc/typescript/example/example.ts
+++ b/deltachat-jsonrpc/typescript/example/example.ts
@@ -76,7 +76,8 @@ async function run() {
       const messageIds = await client.rpc.getMessageIds(
         selectedAccount,
         chatId,
-        0
+        false,
+        false
       );
       const messages = await client.rpc.getMessages(
         selectedAccount,

--- a/deltachat-jsonrpc/typescript/test/online.ts
+++ b/deltachat-jsonrpc/typescript/test/online.ts
@@ -97,7 +97,8 @@ describe("online tests", function () {
     const messageList = await dc.rpc.getMessageIds(
       accountId2,
       chatIdOnAccountB,
-      0
+      false,
+      false
     );
 
     expect(messageList).have.length(1);
@@ -133,7 +134,8 @@ describe("online tests", function () {
     const messageList = await dc.rpc.getMessageIds(
       accountId2,
       chatIdOnAccountB,
-      0
+      false,
+      false
     );
     const message = await dc.rpc.getMessage(
       accountId2,
@@ -150,7 +152,7 @@ describe("online tests", function () {
     await eventPromise2;
 
     const messageId = (
-      await dc.rpc.getMessageIds(accountId1, chatId, 0)
+      await dc.rpc.getMessageIds(accountId1, chatId, false, false)
     ).reverse()[0];
     const message2 = await dc.rpc.getMessage(accountId1, messageId);
     expect(message2.text).equal("super secret message");

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -648,8 +648,15 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             let sel_chat = sel_chat.as_ref().unwrap();
 
             let time_start = std::time::SystemTime::now();
-            let msglist =
-                chat::get_chat_msgs(&context, sel_chat.get_id(), DC_GCM_ADDDAYMARKER).await?;
+            let msglist = chat::get_chat_msgs_ex(
+                &context,
+                sel_chat.get_id(),
+                chat::MessageListOptions {
+                    info_only: false,
+                    add_daymarker: true,
+                },
+            )
+            .await?;
             let time_needed = time_start.elapsed().unwrap_or_default();
 
             let msglist: Vec<MsgId> = msglist

--- a/deltachat-rpc-client/src/deltachat_rpc_client/chat.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/chat.py
@@ -174,9 +174,9 @@ class Chat:
         snapshot["message"] = Message(self.account, snapshot.id)
         return snapshot
 
-    async def get_messages(self, flags: int = 0) -> List[Message]:
+    async def get_messages(self, info_only: bool = False, add_daymarker: bool = False) -> List[Message]:
         """get the list of messages in this chat."""
-        msgs = await self._rpc.get_message_ids(self.account.id, self.id, flags)
+        msgs = await self._rpc.get_message_ids(self.account.id, self.id, info_only, add_daymarker)
         return [Message(self.account, msg_id) for msg_id in msgs]
 
     async def get_fresh_message_count(self) -> int:

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -19,7 +19,7 @@ use crate::color::str_to_color;
 use crate::config::Config;
 use crate::constants::{
     Blocked, Chattype, DC_CHAT_ID_ALLDONE_HINT, DC_CHAT_ID_ARCHIVED_LINK, DC_CHAT_ID_LAST_SPECIAL,
-    DC_CHAT_ID_TRASH, DC_GCM_ADDDAYMARKER, DC_GCM_INFO_ONLY, DC_RESEND_USER_AVATAR_DAYS,
+    DC_CHAT_ID_TRASH, DC_RESEND_USER_AVATAR_DAYS,
 };
 use crate::contact::{Contact, ContactId, Origin, VerifiedStatus};
 use crate::context::Context;
@@ -2376,12 +2376,40 @@ pub async fn send_videochat_invitation(context: &Context, chat_id: ChatId) -> Re
     send_msg(context, chat_id, &mut msg).await
 }
 
-pub async fn get_chat_msgs(
+/// Chat message list request options.
+#[derive(Debug)]
+pub struct MessageListOptions {
+    /// Return only info messages.
+    pub info_only: bool,
+
+    /// Add day markers before each date regarding the local timezone.
+    pub add_daymarker: bool,
+}
+
+/// Returns all messages belonging to the chat.
+pub async fn get_chat_msgs(context: &Context, chat_id: ChatId) -> Result<Vec<ChatItem>> {
+    get_chat_msgs_ex(
+        context,
+        chat_id,
+        MessageListOptions {
+            info_only: false,
+            add_daymarker: false,
+        },
+    )
+    .await
+}
+
+/// Returns messages belonging to the chat according to the given options.
+pub async fn get_chat_msgs_ex(
     context: &Context,
     chat_id: ChatId,
-    flags: u32,
+    options: MessageListOptions,
 ) -> Result<Vec<ChatItem>> {
-    let process_row = if (flags & DC_GCM_INFO_ONLY) != 0 {
+    let MessageListOptions {
+        info_only,
+        add_daymarker,
+    } = options;
+    let process_row = if info_only {
         |row: &rusqlite::Row| {
             // is_info logic taken from Message.is_info()
             let params = row.get::<_, String>("param")?;
@@ -2431,7 +2459,7 @@ pub async fn get_chat_msgs(
         let cnv_to_local = gm2local_offset();
 
         for (ts, curr_id) in sorted_rows {
-            if (flags & DC_GCM_ADDDAYMARKER) != 0 {
+            if add_daymarker {
                 let curr_local_timestamp = ts + cnv_to_local;
                 let curr_day = curr_local_timestamp / 86400;
                 if curr_day != last_day {
@@ -2446,7 +2474,7 @@ pub async fn get_chat_msgs(
         Ok(ret)
     };
 
-    let items = if (flags & DC_GCM_INFO_ONLY) != 0 {
+    let items = if info_only {
         context
             .sql
             .query_map(
@@ -4942,7 +4970,7 @@ mod tests {
         assert!(chat.is_protected());
         assert!(chat.is_unpromoted());
 
-        let msgs = get_chat_msgs(&t, chat_id, 0).await?;
+        let msgs = get_chat_msgs(&t, chat_id).await?;
         assert_eq!(msgs.len(), 1);
 
         let msg = t.get_last_msg_in(chat_id).await;
@@ -4971,7 +4999,7 @@ mod tests {
         assert!(!chat.is_protected());
         assert!(!chat.is_unpromoted());
 
-        let msgs = get_chat_msgs(&t, chat_id, 0).await?;
+        let msgs = get_chat_msgs(&t, chat_id).await?;
         assert_eq!(msgs.len(), 3);
 
         // enable protection on promoted chat, the info-message is sent via send_msg() this time
@@ -5069,7 +5097,7 @@ mod tests {
         add_contact_to_chat(&alice, alice_chat_id, contact_id).await?;
         assert_eq!(get_chat_contacts(&alice, alice_chat_id).await?.len(), 2);
         send_text_msg(&alice, alice_chat_id, "hi!".to_string()).await?;
-        assert_eq!(get_chat_msgs(&alice, alice_chat_id, 0).await?.len(), 1);
+        assert_eq!(get_chat_msgs(&alice, alice_chat_id).await?.len(), 1);
 
         // Alice has an SMTP-server replacing the `Message-ID:`-header (as done eg. by outlook.com).
         let sent_msg = alice.pop_sent_msg().await;
@@ -5102,7 +5130,7 @@ mod tests {
         let msg = alice.get_last_msg().await;
         assert_eq!(msg.chat_id, alice_chat_id);
         assert_eq!(msg.text, Some("ho!".to_string()));
-        assert_eq!(get_chat_msgs(&alice, alice_chat_id, 0).await?.len(), 2);
+        assert_eq!(get_chat_msgs(&alice, alice_chat_id).await?.len(), 2);
         Ok(())
     }
 
@@ -5130,7 +5158,7 @@ mod tests {
         assert_eq!(chat.id.get_fresh_msg_cnt(&t).await?, 1);
         assert_eq!(t.get_fresh_msgs().await?.len(), 1);
 
-        let msgs = get_chat_msgs(&t, chat.id, 0).await?;
+        let msgs = get_chat_msgs(&t, chat.id).await?;
         assert_eq!(msgs.len(), 1);
         let msg_id = match msgs.first().unwrap() {
             ChatItem::Message { msg_id } => *msg_id,
@@ -5180,7 +5208,7 @@ mod tests {
             .is_contact_request());
         assert_eq!(chat_id.get_msg_cnt(&t).await?, 1);
         assert_eq!(chat_id.get_fresh_msg_cnt(&t).await?, 1);
-        let msgs = get_chat_msgs(&t, chat_id, 0).await?;
+        let msgs = get_chat_msgs(&t, chat_id).await?;
         assert_eq!(msgs.len(), 1);
         let msg_id = match msgs.first().unwrap() {
             ChatItem::Message { msg_id } => *msg_id,
@@ -5268,7 +5296,7 @@ mod tests {
         let chat_id = msg.chat_id;
         assert_eq!(chat_id.get_fresh_msg_cnt(&alice).await?, 1);
 
-        let msgs = get_chat_msgs(&alice, chat_id, 0).await?;
+        let msgs = get_chat_msgs(&alice, chat_id).await?;
         assert_eq!(msgs.len(), 1);
 
         // Alice disables receiving classic emails.
@@ -5280,7 +5308,7 @@ mod tests {
         // Already received classic email should still be in the chat.
         assert_eq!(chat_id.get_fresh_msg_cnt(&alice).await?, 1);
 
-        let msgs = get_chat_msgs(&alice, chat_id, 0).await?;
+        let msgs = get_chat_msgs(&alice, chat_id).await?;
         assert_eq!(msgs.len(), 1);
 
         Ok(())
@@ -5427,7 +5455,7 @@ mod tests {
         assert!(msg1.get_text().unwrap().contains("bob@example.net"));
 
         let chat_id2 = ChatId::create_for_contact(&t, bob_id).await?;
-        assert_eq!(get_chat_msgs(&t, chat_id2, 0).await?.len(), 0);
+        assert_eq!(get_chat_msgs(&t, chat_id2).await?.len(), 0);
         forward_msgs(&t, &[msg1.id], chat_id2).await?;
         let msg2 = t.get_last_msg_in(chat_id2).await;
         assert!(!msg2.is_info()); // forwarded info-messages lose their info-state
@@ -5596,15 +5624,15 @@ mod tests {
         let msg = bob.recv_msg(&sent1).await;
         assert_eq!(msg.get_text().unwrap(), "alice->bob");
         assert_eq!(get_chat_contacts(&bob, msg.chat_id).await?.len(), 2);
-        assert_eq!(get_chat_msgs(&bob, msg.chat_id, 0).await?.len(), 1);
+        assert_eq!(get_chat_msgs(&bob, msg.chat_id).await?.len(), 1);
         bob.recv_msg(&sent2).await;
         assert_eq!(get_chat_contacts(&bob, msg.chat_id).await?.len(), 3);
-        assert_eq!(get_chat_msgs(&bob, msg.chat_id, 0).await?.len(), 2);
+        assert_eq!(get_chat_msgs(&bob, msg.chat_id).await?.len(), 2);
         let received = bob.recv_msg_opt(&sent3).await;
         // No message should actually be added since we already know this message:
         assert!(received.is_none());
         assert_eq!(get_chat_contacts(&bob, msg.chat_id).await?.len(), 3);
-        assert_eq!(get_chat_msgs(&bob, msg.chat_id, 0).await?.len(), 2);
+        assert_eq!(get_chat_msgs(&bob, msg.chat_id).await?.len(), 2);
 
         // Claire does not receive the first message, however, due to resending, she has a similar view as Alice and Bob
         let claire = TestContext::new().await;
@@ -5613,7 +5641,7 @@ mod tests {
         let msg = claire.recv_msg(&sent3).await;
         assert_eq!(msg.get_text().unwrap(), "alice->bob");
         assert_eq!(get_chat_contacts(&claire, msg.chat_id).await?.len(), 3);
-        assert_eq!(get_chat_msgs(&claire, msg.chat_id, 0).await?.len(), 2);
+        assert_eq!(get_chat_msgs(&claire, msg.chat_id).await?.len(), 2);
         let msg_from = Contact::get_by_id(&claire, msg.get_from_id()).await?;
         assert_eq!(msg_from.get_addr(), "alice@example.org");
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -112,9 +112,6 @@ pub const DC_GCL_NO_SPECIALS: usize = 0x02;
 pub const DC_GCL_ADD_ALLDONE_HINT: usize = 0x04;
 pub const DC_GCL_FOR_FORWARDING: usize = 0x08;
 
-pub const DC_GCM_ADDDAYMARKER: u32 = 0x01;
-pub const DC_GCM_INFO_ONLY: u32 = 0x02;
-
 pub const DC_GCL_VERIFIED_ONLY: u32 = 0x01;
 pub const DC_GCL_ADD_SELF: u32 = 0x02;
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -978,20 +978,20 @@ mod tests {
         assert_eq!(t.get_fresh_msgs().await.unwrap().len(), 0);
 
         receive_msg(&t, &bob).await;
-        assert_eq!(get_chat_msgs(&t, bob.id, 0).await.unwrap().len(), 1);
+        assert_eq!(get_chat_msgs(&t, bob.id).await.unwrap().len(), 1);
         assert_eq!(bob.id.get_fresh_msg_cnt(&t).await.unwrap(), 1);
         assert_eq!(t.get_fresh_msgs().await.unwrap().len(), 1);
 
         receive_msg(&t, &claire).await;
         receive_msg(&t, &claire).await;
-        assert_eq!(get_chat_msgs(&t, claire.id, 0).await.unwrap().len(), 2);
+        assert_eq!(get_chat_msgs(&t, claire.id).await.unwrap().len(), 2);
         assert_eq!(claire.id.get_fresh_msg_cnt(&t).await.unwrap(), 2);
         assert_eq!(t.get_fresh_msgs().await.unwrap().len(), 3);
 
         receive_msg(&t, &dave).await;
         receive_msg(&t, &dave).await;
         receive_msg(&t, &dave).await;
-        assert_eq!(get_chat_msgs(&t, dave.id, 0).await.unwrap().len(), 3);
+        assert_eq!(get_chat_msgs(&t, dave.id).await.unwrap().len(), 3);
         assert_eq!(dave.id.get_fresh_msg_cnt(&t).await.unwrap(), 3);
         assert_eq!(t.get_fresh_msgs().await.unwrap().len(), 6);
 
@@ -1006,7 +1006,7 @@ mod tests {
         receive_msg(&t, &bob).await;
         receive_msg(&t, &claire).await;
         receive_msg(&t, &dave).await;
-        assert_eq!(get_chat_msgs(&t, claire.id, 0).await.unwrap().len(), 3);
+        assert_eq!(get_chat_msgs(&t, claire.id).await.unwrap().len(), 3);
         assert_eq!(claire.id.get_fresh_msg_cnt(&t).await.unwrap(), 3);
         assert_eq!(t.get_fresh_msgs().await.unwrap().len(), 6); // muted claire is not counted
 
@@ -1023,7 +1023,7 @@ mod tests {
         let t = TestContext::new_alice().await;
         let bob = t.create_chat_with_contact("", "bob@g.it").await;
         receive_msg(&t, &bob).await;
-        assert_eq!(get_chat_msgs(&t, bob.id, 0).await.unwrap().len(), 1);
+        assert_eq!(get_chat_msgs(&t, bob.id).await.unwrap().len(), 1);
 
         // chat is unmuted by default, here and in the following assert(),
         // we check mainly that the SQL-statements in is_muted() and get_fresh_msgs()

--- a/src/download.rs
+++ b/src/download.rs
@@ -450,7 +450,7 @@ mod tests {
         .await?;
         let msg = bob.get_last_msg().await;
         let chat_id = msg.chat_id;
-        assert_eq!(get_chat_msgs(&bob, chat_id, 0).await?.len(), 1);
+        assert_eq!(get_chat_msgs(&bob, chat_id).await?.len(), 1);
         assert_eq!(msg.download_state(), DownloadState::Available);
 
         // downloading the status update afterwards expands to nothing and moves the placeholder to trash-chat
@@ -464,7 +464,7 @@ mod tests {
             false,
         )
         .await?;
-        assert_eq!(get_chat_msgs(&bob, chat_id, 0).await?.len(), 0);
+        assert_eq!(get_chat_msgs(&bob, chat_id).await?.len(), 0);
         assert!(Message::load_from_db(&bob, msg.id)
             .await?
             .chat_id
@@ -517,13 +517,13 @@ mod tests {
         .await?;
         let msg = bob.get_last_msg().await;
         let chat_id = msg.chat_id;
-        assert_eq!(get_chat_msgs(&bob, chat_id, 0).await?.len(), 1);
+        assert_eq!(get_chat_msgs(&bob, chat_id).await?.len(), 1);
         assert_eq!(msg.download_state(), DownloadState::Available);
 
         // downloading the mdn afterwards expands to nothing and deletes the placeholder directly
         // (usually mdn are too small for not being downloaded directly)
         receive_imf_inner(&bob, "bar@example.org", raw, false, None, false).await?;
-        assert_eq!(get_chat_msgs(&bob, chat_id, 0).await?.len(), 0);
+        assert_eq!(get_chat_msgs(&bob, chat_id).await?.len(), 0);
         assert!(Message::load_from_db(&bob, msg.id)
             .await?
             .chat_id

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -1080,7 +1080,7 @@ mod tests {
     }
 
     async fn check_msg_is_deleted(t: &TestContext, chat: &Chat, msg_id: MsgId) {
-        let chat_items = chat::get_chat_msgs(t, chat.id, 0).await.unwrap();
+        let chat_items = chat::get_chat_msgs(t, chat.id).await.unwrap();
         // Check that the chat is empty except for possibly info messages:
         for item in &chat_items {
             if let ChatItem::Message { msg_id } = item {

--- a/src/message.rs
+++ b/src/message.rs
@@ -2144,7 +2144,7 @@ mod tests {
             .unwrap();
 
         let mut has_image = false;
-        let chatitems = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
+        let chatitems = chat::get_chat_msgs(&t, device_chat_id).await.unwrap();
         for chatitem in chatitems {
             if let ChatItem::Message { msg_id } = chatitem {
                 if let Ok(msg) = Message::load_from_db(&t, msg_id).await {
@@ -2288,7 +2288,7 @@ mod tests {
         assert_eq!(msg1.chat_id, msg2.chat_id);
         let chats = Chatlist::try_load(&bob, 0, None, None).await?;
         assert_eq!(chats.len(), 1);
-        let msgs = chat::get_chat_msgs(&bob, bob_chat_id, 0).await?;
+        let msgs = chat::get_chat_msgs(&bob, bob_chat_id).await?;
         assert_eq!(msgs.len(), 2);
         assert_eq!(bob.get_fresh_msgs().await?.len(), 0);
 
@@ -2299,7 +2299,7 @@ mod tests {
         let bob_chat = Chat::load_from_db(&bob, bob_chat_id).await?;
         assert_eq!(bob_chat.blocked, Blocked::Request);
 
-        let msgs = chat::get_chat_msgs(&bob, bob_chat_id, 0).await?;
+        let msgs = chat::get_chat_msgs(&bob, bob_chat_id).await?;
         assert_eq!(msgs.len(), 2);
         bob_chat_id.accept(&bob).await.unwrap();
 

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -443,24 +443,24 @@ Content-Disposition: reaction\n\
         let chat_alice = alice.create_chat(&bob).await;
         let alice_msg = alice.send_text(chat_alice.id, "Hi!").await;
         let bob_msg = bob.recv_msg(&alice_msg).await;
-        assert_eq!(get_chat_msgs(&alice, chat_alice.id, 0).await?.len(), 1);
-        assert_eq!(get_chat_msgs(&bob, bob_msg.chat_id, 0).await?.len(), 1);
+        assert_eq!(get_chat_msgs(&alice, chat_alice.id).await?.len(), 1);
+        assert_eq!(get_chat_msgs(&bob, bob_msg.chat_id).await?.len(), 1);
 
         let alice_msg2 = alice.send_text(chat_alice.id, "Hi again!").await;
         bob.recv_msg(&alice_msg2).await;
-        assert_eq!(get_chat_msgs(&alice, chat_alice.id, 0).await?.len(), 2);
-        assert_eq!(get_chat_msgs(&bob, bob_msg.chat_id, 0).await?.len(), 2);
+        assert_eq!(get_chat_msgs(&alice, chat_alice.id).await?.len(), 2);
+        assert_eq!(get_chat_msgs(&bob, bob_msg.chat_id).await?.len(), 2);
 
         bob_msg.chat_id.accept(&bob).await?;
 
         send_reaction(&bob, bob_msg.id, "👍").await.unwrap();
         expect_reactions_changed_event(&bob, bob_msg.chat_id, bob_msg.id, ContactId::SELF).await?;
-        assert_eq!(get_chat_msgs(&bob, bob_msg.chat_id, 0).await?.len(), 2);
+        assert_eq!(get_chat_msgs(&bob, bob_msg.chat_id).await?.len(), 2);
 
         let bob_reaction_msg = bob.pop_sent_msg().await;
         let alice_reaction_msg = alice.recv_msg_opt(&bob_reaction_msg).await.unwrap();
         assert_eq!(alice_reaction_msg.chat_id, DC_CHAT_ID_TRASH);
-        assert_eq!(get_chat_msgs(&alice, chat_alice.id, 0).await?.len(), 2);
+        assert_eq!(get_chat_msgs(&alice, chat_alice.id).await?.len(), 2);
 
         let reactions = get_msg_reactions(&alice, alice_msg.sender_msg_id).await?;
         assert_eq!(reactions.to_string(), "👍1");

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -779,7 +779,7 @@ mod tests {
     use crate::chat;
     use crate::chat::ProtectionStatus;
     use crate::chatlist::Chatlist;
-    use crate::constants::{Chattype, DC_GCM_ADDDAYMARKER};
+    use crate::constants::Chattype;
     use crate::contact::ContactAddress;
     use crate::contact::VerifiedStatus;
     use crate::peerstate::Peerstate;
@@ -922,7 +922,7 @@ mod tests {
         // Check Alice got the verified message in her 1:1 chat.
         {
             let chat = alice.create_chat(&bob).await;
-            let msg_id = chat::get_chat_msgs(&alice.ctx, chat.get_id(), DC_GCM_ADDDAYMARKER)
+            let msg_id = chat::get_chat_msgs(&alice.ctx, chat.get_id())
                 .await
                 .unwrap()
                 .into_iter()
@@ -971,7 +971,7 @@ mod tests {
         // Check Bob got the verified message in his 1:1 chat.
         {
             let chat = bob.create_chat(&alice).await;
-            let msg_id = chat::get_chat_msgs(&bob.ctx, chat.get_id(), DC_GCM_ADDDAYMARKER)
+            let msg_id = chat::get_chat_msgs(&bob.ctx, chat.get_id())
                 .await
                 .unwrap()
                 .into_iter()
@@ -1281,7 +1281,7 @@ mod tests {
                 Blocked::Yes,
                 "Alice's 1:1 chat with Bob is not hidden"
             );
-            let msg_id = chat::get_chat_msgs(&alice.ctx, alice_chatid, DC_GCM_ADDDAYMARKER)
+            let msg_id = chat::get_chat_msgs(&alice.ctx, alice_chatid)
                 .await
                 .unwrap()
                 .into_iter()
@@ -1326,17 +1326,14 @@ mod tests {
                 Blocked::Yes,
                 "Bob's 1:1 chat with Alice is not hidden"
             );
-            for item in chat::get_chat_msgs(&bob.ctx, bob_chatid, DC_GCM_ADDDAYMARKER)
-                .await
-                .unwrap()
-            {
+            for item in chat::get_chat_msgs(&bob.ctx, bob_chatid).await.unwrap() {
                 if let chat::ChatItem::Message { msg_id } = item {
                     let msg = Message::load_from_db(&bob.ctx, msg_id).await.unwrap();
                     let text = msg.get_text().unwrap();
                     println!("msg {msg_id} text: {text}");
                 }
             }
-            let mut msg_iter = chat::get_chat_msgs(&bob.ctx, bob_chatid, DC_GCM_ADDDAYMARKER)
+            let mut msg_iter = chat::get_chat_msgs(&bob.ctx, bob_chatid)
                 .await
                 .unwrap()
                 .into_iter();

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -1449,16 +1449,10 @@ mod tests {
         };
 
         // delete self-talk first; this adds a message to device-chat about how self-talk can be restored
-        let device_chat_msgs_before = chat::get_chat_msgs(&t, device_chat_id, 0)
-            .await
-            .unwrap()
-            .len();
+        let device_chat_msgs_before = chat::get_chat_msgs(&t, device_chat_id).await.unwrap().len();
         self_talk_id.delete(&t).await.ok();
         assert_eq!(
-            chat::get_chat_msgs(&t, device_chat_id, 0)
-                .await
-                .unwrap()
-                .len(),
+            chat::get_chat_msgs(&t, device_chat_id).await.unwrap().len(),
             device_chat_msgs_before + 1
         );
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -476,7 +476,7 @@ mod tests {
         let chat = Chat::load_from_db(&alice, chat_id).await?;
         assert!(chat.is_self_talk());
         assert_eq!(Chatlist::try_load(&alice, 0, None, None).await?.len(), 1);
-        let msgs = chat::get_chat_msgs(&alice, chat_id, 0).await?;
+        let msgs = chat::get_chat_msgs(&alice, chat_id).await?;
         assert_eq!(msgs.len(), 0);
 
         // let alice's other device receive and execute the sync message,

--- a/src/tests/aeap.rs
+++ b/src/tests/aeap.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 
 use crate::chat;
 use crate::chat::ChatId;
-use crate::constants;
 use crate::contact;
 use crate::contact::Contact;
 use crate::contact::ContactId;
@@ -345,9 +344,16 @@ async fn mark_as_verified(this: &TestContext, other: &TestContext) {
 }
 
 async fn get_last_info_msg(t: &TestContext, chat_id: ChatId) -> Option<Message> {
-    let msgs = chat::get_chat_msgs(&t.ctx, chat_id, constants::DC_GCM_INFO_ONLY)
-        .await
-        .unwrap();
+    let msgs = chat::get_chat_msgs_ex(
+        &t.ctx,
+        chat_id,
+        chat::MessageListOptions {
+            info_only: true,
+            add_daymarker: false,
+        },
+    )
+    .await
+    .unwrap();
     let msg_id = if let chat::ChatItem::Message { msg_id } = msgs.last()? {
         msg_id
     } else {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -1180,7 +1180,7 @@ DKIM Results: Passed=true, Works=true, Allow_Keychange=true";
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         let device_chat_id = chats.get_chat_id(0).unwrap();
-        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
+        let msgs = chat::get_chat_msgs(&t, device_chat_id).await.unwrap();
         assert_eq!(msgs.len(), 1);
 
         // the message should be added only once a day - test that an hour later and nearly a day later
@@ -1190,7 +1190,7 @@ DKIM Results: Passed=true, Works=true, Allow_Keychange=true";
             get_provider_update_timestamp(),
         )
         .await;
-        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
+        let msgs = chat::get_chat_msgs(&t, device_chat_id).await.unwrap();
         assert_eq!(msgs.len(), 1);
 
         maybe_warn_on_bad_time(
@@ -1199,7 +1199,7 @@ DKIM Results: Passed=true, Works=true, Allow_Keychange=true";
             get_provider_update_timestamp(),
         )
         .await;
-        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
+        let msgs = chat::get_chat_msgs(&t, device_chat_id).await.unwrap();
         assert_eq!(msgs.len(), 1);
 
         // next day, there should be another device message
@@ -1212,7 +1212,7 @@ DKIM Results: Passed=true, Works=true, Allow_Keychange=true";
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         assert_eq!(device_chat_id, chats.get_chat_id(0).unwrap());
-        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
+        let msgs = chat::get_chat_msgs(&t, device_chat_id).await.unwrap();
         assert_eq!(msgs.len(), 2);
     }
 
@@ -1242,7 +1242,7 @@ DKIM Results: Passed=true, Works=true, Allow_Keychange=true";
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         let device_chat_id = chats.get_chat_id(0).unwrap();
-        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
+        let msgs = chat::get_chat_msgs(&t, device_chat_id).await.unwrap();
         assert_eq!(msgs.len(), 1);
 
         // do not repeat the warning every day ...
@@ -1262,7 +1262,7 @@ DKIM Results: Passed=true, Works=true, Allow_Keychange=true";
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         let device_chat_id = chats.get_chat_id(0).unwrap();
-        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
+        let msgs = chat::get_chat_msgs(&t, device_chat_id).await.unwrap();
         let test_len = msgs.len();
         assert!(test_len == 1 || test_len == 2);
 
@@ -1277,7 +1277,7 @@ DKIM Results: Passed=true, Works=true, Allow_Keychange=true";
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
         assert_eq!(chats.len(), 1);
         let device_chat_id = chats.get_chat_id(0).unwrap();
-        let msgs = chat::get_chat_msgs(&t, device_chat_id, 0).await.unwrap();
+        let msgs = chat::get_chat_msgs(&t, device_chat_id).await.unwrap();
         assert_eq!(msgs.len(), test_len + 1);
     }
 


### PR DESCRIPTION
get_chat_msgs() function is split into new get_chat_msgs() without flags and get_chat_msgs_ex() which accepts booleans instead of bitflags.

FFI call dc_get_chat_msgs() is still using bitflags for compatibility.

JSON-RPC calls get_message_ids() and get_message_list_items() accept booleans instead of bitflags now.