### PR TITLE
Add scripts/clippy.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             override: true
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@v2
-      - run: cargo clippy --workspace --tests --examples --benches -- -D warnings
+      - run: scripts/clippy.sh
 
   docs:
     name: Rust doc comments

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,6 +6,8 @@ and an own build machine.
 
 ## Description of scripts 
 
+- `clippy.sh` runs `cargo clippy` for all Rust code in the project.
+
 - `../.github/workflows` contains jobs run by GitHub Actions.
 
 - `remote_tests_python.sh` rsyncs to a build machine and runs

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Run clippy for all Rust code in the project.
+cargo clippy --workspace --tests --examples --benches -- -D warnings


### PR DESCRIPTION
The script makes it easier to manually check REPL and benchmark code with clippy without the need to copy-paste all the flags.