### PR TITLE
python: save references to asyncio tasks to avoid GC

### DIFF
--- a/deltachat-rpc-client/examples/echobot_advanced.py
+++ b/deltachat-rpc-client/examples/echobot_advanced.py
@@ -64,7 +64,8 @@ async def main():
 
         bot = Bot(account, hooks)
         if not await bot.is_configured():
-            asyncio.create_task(bot.configure(email=sys.argv[1], password=sys.argv[2]))
+            # Save a reference to avoid garbage collection of the task.
+            _configure_task = asyncio.create_task(bot.configure(email=sys.argv[1], password=sys.argv[2]))
         await bot.run_forever()
 
 

--- a/deltachat-rpc-client/src/deltachat_rpc_client/_utils.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/_utils.py
@@ -104,7 +104,8 @@ async def _run_cli(
         if not await client.is_configured():
             assert args.email, "Account is not configured and email must be provided"
             assert args.password, "Account is not configured and password must be provided"
-            asyncio.create_task(client.configure(email=args.email, password=args.password))
+            # Save a reference to avoid garbage collection of the task.
+            _configure_task = asyncio.create_task(client.configure(email=args.email, password=args.password))
         await client.run_forever()
 
 


### PR DESCRIPTION
Otherwise the task may be garbage collected
and cancelled.

See <https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task> for reference.