### PR TITLE
Remove unused ConfiguredE2EEEnabled key

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -213,7 +213,6 @@ pub enum Config {
     /// Whether OAuth 2 is used with configured provider.
     ConfiguredServerFlags,
     ConfiguredSendSecurity,
-    ConfiguredE2EEEnabled,
     ConfiguredInboxFolder,
     ConfiguredMvboxFolder,
     ConfiguredSentboxFolder,


### PR DESCRIPTION
`e2ee_enabled` is always used without `configured_` prefix.

#skip-changelog