### PR TITLE
jsonrpc: `get_messages` now returns a map with `MessageLoadResult` instead of failing completely if one of the requested messages could not be loaded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 ### Fixes
 
 ### API-Changes
+
 - Remove `MimeMessage::from_bytes()` public interface. #4033
+- BREAKING Types: jsonrpc: `get_messages` now returns a map with `MessageLoadResult` instead of failing completely if one of the requested messages could not be loaded.
 
 
 ## 1.108.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### API-Changes
 
 - Remove `MimeMessage::from_bytes()` public interface. #4033
-- BREAKING Types: jsonrpc: `get_messages` now returns a map with `MessageLoadResult` instead of failing completely if one of the requested messages could not be loaded.
+- BREAKING Types: jsonrpc: `get_messages` now returns a map with `MessageLoadResult` instead of failing completely if one of the requested messages could not be loaded. #4038
 
 
 ## 1.108.0

--- a/deltachat-jsonrpc/src/api/mod.rs
+++ b/deltachat-jsonrpc/src/api/mod.rs
@@ -461,7 +461,7 @@ impl CommandApi {
                     Ok(res) => res,
                     Err(err) => ChatListItemFetchResult::Error {
                         id: entry.0,
-                        error: format!("{err:?}"),
+                        error: format!("{err:#}"),
                     },
                 },
             );
@@ -943,7 +943,7 @@ impl CommandApi {
 
     /// get multiple messages in one call,
     /// if loading one message fails the error is stored in the result object in it's place.
-    /// 
+    ///
     /// this is the batch variant of [get_message]
     async fn get_messages(
         &self,
@@ -957,9 +957,9 @@ impl CommandApi {
             messages.insert(
                 message_id,
                 match message_result {
-                    Ok(message) => MessageLoadResult::Message (message ),
+                    Ok(message) => MessageLoadResult::Message(message),
                     Err(error) => MessageLoadResult::LoadingError {
-                        error: format!("{error:?}"),
+                        error: format!("{error:#}"),
                     },
                 },
             );

--- a/deltachat-jsonrpc/src/api/mod.rs
+++ b/deltachat-jsonrpc/src/api/mod.rs
@@ -45,6 +45,7 @@ use types::message::MessageObject;
 use types::provider_info::ProviderInfo;
 use types::webxdc::WebxdcMessageInfo;
 
+use self::types::message::MessageLoadResult;
 use self::types::{
     chat::{BasicChat, JSONRPCChatVisibility, MuteDuration},
     location::JsonrpcLocation,
@@ -940,17 +941,27 @@ impl CommandApi {
         MsgId::new(message_id).get_html(&ctx).await
     }
 
+    /// get multiple messages in one call,
+    /// if loading one message fails the error is stored in the result object in it's place.
+    /// 
+    /// this is the batch variant of [get_message]
     async fn get_messages(
         &self,
         account_id: u32,
         message_ids: Vec<u32>,
-    ) -> Result<HashMap<u32, MessageObject>> {
+    ) -> Result<HashMap<u32, MessageLoadResult>> {
         let ctx = self.get_context(account_id).await?;
-        let mut messages: HashMap<u32, MessageObject> = HashMap::new();
+        let mut messages: HashMap<u32, MessageLoadResult> = HashMap::new();
         for message_id in message_ids {
+            let message_result = MessageObject::from_message_id(&ctx, message_id).await;
             messages.insert(
                 message_id,
-                MessageObject::from_message_id(&ctx, message_id).await?,
+                match message_result {
+                    Ok(message) => MessageLoadResult::Message (message ),
+                    Err(error) => MessageLoadResult::LoadingError {
+                        error: format!("{error:?}"),
+                    },
+                },
             );
         }
         Ok(messages)

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -20,6 +20,13 @@ use super::reactions::JSONRPCReactions;
 use super::webxdc::WebxdcMessageInfo;
 
 #[derive(Serialize, TypeDef)]
+#[serde(rename_all = "camelCase", tag = "variant")]
+pub enum MessageLoadResult {
+    Message(MessageObject),
+    LoadingError { error: String },
+}
+
+#[derive(Serialize, TypeDef)]
 #[serde(rename = "Message", rename_all = "camelCase")]
 pub struct MessageObject {
     id: u32,

--- a/deltachat-jsonrpc/typescript/example/example.ts
+++ b/deltachat-jsonrpc/typescript/example/example.ts
@@ -68,10 +68,7 @@ async function run() {
       null
     );
     for (const [chatId, _messageId] of chats) {
-      const chat = await client.rpc.getFullChatById(
-        selectedAccount,
-        chatId
-      );
+      const chat = await client.rpc.getFullChatById(selectedAccount, chatId);
       write($main, `<h3>${chat.name}</h3>`);
       const messageIds = await client.rpc.getMessageIds(
         selectedAccount,
@@ -84,7 +81,9 @@ async function run() {
         messageIds
       );
       for (const [_messageId, message] of Object.entries(messages)) {
-        write($main, `<p>${message.text}</p>`);
+        if (message.variant === "message")
+          write($main, `<p>${message.text}</p>`);
+        else write($main, `<p>loading error: ${message.error}</p>`);
       }
     }
   }


### PR DESCRIPTION
fixes #3980

`get_messages` now returns an `MessageLoadResult` enum similar to `ChatListItemFetchResult`.

The new returned type looks like this:
```ts
getMessages(accountId: T.U32, messageIds: (T.U32)[]): Promise<Record<T.U32,T.MessageLoadResult>>

export type MessageLoadResult =
  | ({ variant: "message" } & Message)
  | ({ variant: "loadingError" } & { error: string });
```

This pr implements solution B from #3980, look there fro slightly more info.