### PR TITLE
sql: use semaphore to limit access to the connection pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - deltachat-rpc-server: do not block stdin while processing the request. #4041
   deltachat-rpc-server now reads the next request as soon as previous request handler is spawned.
 - enable `auto_vacuum` on all SQL connections #2955
+- use semaphore for connection pool #4061
 
 ### API-Changes
 

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -338,7 +338,7 @@ impl Sql {
     pub(crate) async fn get_conn(&self) -> Result<PooledConnection> {
         let lock = self.pool.read().await;
         let pool = lock.as_ref().context("no SQL connection")?;
-        let conn = pool.get().await;
+        let conn = pool.get().await?;
 
         Ok(conn)
     }


### PR DESCRIPTION
This ensures that if multiple connections are returned to the pool at the same time, waiters get them in the order they were placed in the queue.