### PR TITLE
JSON-RPC: Add CommonJS build

### DIFF
--- a/deltachat-jsonrpc/typescript/package.json
+++ b/deltachat-jsonrpc/typescript/package.json
@@ -14,7 +14,7 @@
     "c8": "^7.10.0",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
-    "esbuild": "^0.14.11",
+    "esbuild": "^0.17.9",
     "http-server": "^14.1.1",
     "mocha": "^9.1.1",
     "node-fetch": "^2.6.1",
@@ -24,13 +24,20 @@
     "typescript": "^4.5.5",
     "ws": "^8.5.0"
   },
+  "exports": {
+    ".": {
+      "require": "./dist/deltachat.cjs",
+      "import": "./dist/deltachat.js"
+    }
+  },
   "license": "MPL-2.0",
   "main": "dist/deltachat.js",
   "name": "@deltachat/jsonrpc-client",
   "scripts": {
-    "build": "run-s generate-bindings extract-constants build:tsc build:bundle",
+    "build": "run-s generate-bindings extract-constants build:tsc build:bundle build:cjs",
     "build:bundle": "esbuild --format=esm --bundle dist/deltachat.js --outfile=dist/deltachat.bundle.js",
     "build:tsc": "tsc",
+    "build:cjs": "esbuild --format=cjs --bundle --packages=external dist/deltachat.js --outfile=dist/deltachat.cjs",
     "docs": "typedoc --out docs deltachat.ts",
     "example": "run-s build example:build example:start",
     "example:build": "esbuild --bundle dist/example/example.js --outfile=dist/example.bundle.js",


### PR DESCRIPTION
@Simon-Laux needs a CommonJS build of deltachat-jsonrpc. This adds this. It should just work in recent versions of Node.js as it uses the `"exports" ` key in `package.json`.

Depends on https://github.com/deltachat/yerpc/pull/36