### PR TITLE
Correctly clear database cache after import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Start SQL transactions with IMMEDIATE behaviour rather than default DEFERRED one. #4063
 - Fix a problem with Gmail where (auto-)deleted messages would get archived instead of deleted.
   Move them to the Trash folder for Gmail which auto-deletes trashed messages in 30 days #3972
+- Clear config cache after backup import. This bug sometimes resulted in the import to seemingly work at first. #4067
 
 ### API-Changes
 

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -427,8 +427,6 @@ async fn import_backup(
         context.get_dbfile().display()
     );
 
-    context.sql.config_cache.write().await.clear();
-
     let mut archive = Archive::new(backup_file);
 
     let mut entries = archive.entries()?;

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -785,7 +785,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use ::pgp::armor::BlockType;
+    use tokio::task;
 
     use super::*;
     use crate::pgp::{split_armored_data, HEADER_AUTOCRYPT, HEADER_SETUPCODE};
@@ -929,6 +932,46 @@ mod tests {
             context2.get_config(Config::Addr).await?,
             Some("alice@example.org".to_string())
         );
+
+        Ok(())
+    }
+
+    /// This is a regression test for
+    /// https://github.com/deltachat/deltachat-android/issues/2263
+    /// where the config cache wasn't reset properly after a backup.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_import_backup_reset_config_cache() -> Result<()> {
+        let backup_dir = tempfile::tempdir()?;
+        let context1 = TestContext::new_alice().await;
+        let context2 = TestContext::new().await;
+        assert!(!context2.is_configured().await?);
+
+        // export from context1
+        imex(&context1, ImexMode::ExportBackup, backup_dir.path(), None).await?;
+
+        // import to context2
+        let backup = has_backup(&context2, backup_dir.path()).await?;
+        let context2_cloned = context2.clone();
+        let handle = task::spawn(async move {
+            imex(
+                &context2_cloned,
+                ImexMode::ImportBackup,
+                backup.as_ref(),
+                None,
+            )
+            .await
+            .unwrap();
+        });
+
+        while !handle.is_finished() {
+            // The database is still unconfigured;
+            // fill the config cache with the old value.
+            context2.is_configured().await.ok();
+            tokio::time::sleep(Duration::from_micros(1)).await;
+        }
+
+        // Assert that the config cache has the new value now.
+        assert!(context2.is_configured().await?);
 
         Ok(())
     }


### PR DESCRIPTION
Fix https://github.com/deltachat/deltachat-android/issues/2263.

The problem was:
- Import started
- The config cache was cleared[^1]
- The user turned off and on the screen -> `is_configured()` was called by the UI -> the result `false` was correctly loaded from the database -> it was put into the config cache
- Import finished
- ConversationListActivity (that's the main activity with the chats) was started
- It called is_configured() -> the result `false` was loaded from the config cache.
- It starts the WelcomeActivity again because it thinks that we're not configured yet.

The fix is: Clear the config cache right after the import finished.

What I'm unsure about: Should I remove [^1] (the line where the config cache was cleared before this PR already)?
Pro: It's not necessary anymore and doing things like this "to be sure" can hide regressions
Contra: Removing it _might_ introduce some other bug we don't think about, and it doesn't hurt to clear the config cache there, too, to be sure.

[^1]: https://github.com/deltachat/deltachat-core-rust/blob/d44156748f9828eb30cdeba49351b0fba33c5cc2/src/imex.rs#L430