### PR TITLE
python: replace pkg_resources with importlib.metadata

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "deltachat"
 description = "Python bindings for the Delta Chat Core library using CFFI against the Rust-implemented libdeltachat"
 readme = "README.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "holger krekel, Floris Bruynooghe, Bjoern Petersen and contributors" },
 ]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "deltachat"
 description = "Python bindings for the Delta Chat Core library using CFFI against the Rust-implemented libdeltachat"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.7"
 authors = [
     { name = "holger krekel, Floris Bruynooghe, Bjoern Petersen and contributors" },
 ]
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
     "cffi>=1.0.0",
     "imap-tools",
+    "importlib_metadata;python_version<'3.8'",
     "pluggy",
     "requests",
 ]

--- a/python/src/deltachat/__init__.py
+++ b/python/src/deltachat/__init__.py
@@ -1,6 +1,9 @@
 import sys
 
-from importlib.metadata import PackageNotFoundError, version
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError, version
 
 from . import capi, events, hookspec  # noqa
 from .account import Account, get_core_info  # noqa

--- a/python/src/deltachat/__init__.py
+++ b/python/src/deltachat/__init__.py
@@ -1,6 +1,6 @@
 import sys
 
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, version
 
 from . import capi, events, hookspec  # noqa
 from .account import Account, get_core_info  # noqa
@@ -11,8 +11,8 @@ from .hookspec import account_hookimpl, global_hookimpl  # noqa
 from .message import Message  # noqa
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     # package is not installed
     __version__ = "0.0.0.dev0-unknown"
 

--- a/python/src/deltachat/__init__.py
+++ b/python/src/deltachat/__init__.py
@@ -1,8 +1,8 @@
 import sys
 
-try:
+if sys.version_info >= (3, 8):
     from importlib.metadata import PackageNotFoundError, version
-except ImportError:
+else:
     from importlib_metadata import PackageNotFoundError, version
 
 from . import capi, events, hookspec  # noqa


### PR DESCRIPTION
Use of `pkg_resources` is discouraged in favor of `importlib.resources`, `importlib.metadata`, and their backports. See https://setuptools.pypa.io/en/latest/pkg_resources.html.