### PR TITLE
mention speedup of #4065 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Changes
 - use transaction in `Contact::add_or_lookup()` #4059
 - Organize the connection pool as a stack rather than a queue to ensure that
-  connection page cache is reused more often. #4065
+  connection page cache is reused more often.
+  This speeds up tests by 28%, real usage will have lower speedup. #4065
 - Use transaction in `update_blocked_mailinglist_contacts`. #4058
 - Remove `Sql.get_conn()` interface in favor of `.call()` and `.transaction()`. #4055
 


### PR DESCRIPTION
the speedup of #4065 is larger than measured first

running `cargo test`, first we thought there is only a slight speedup from 13.5 seconds to 12.5 seconds on a m1pro.

however, there is one test that does 11 seconds of sleep() (test_modify_chat_disordered) as this test is not run very first, this slows down things overall.

skipping this test,
speedup is from 13.5 seconds to 9.5 seconds -
28% faster - and this is something we should mention in the changelog :)

(this pr does not remove or change the slow test.
i think, due to the number of cores, this is not needed until someone has a machine where the other tests run in 2 seconds or so)