### PR TITLE
Re-disable DKIM-checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Use transaction in `update_blocked_mailinglist_contacts`. #4058
 - Remove `Sql.get_conn()` interface in favor of `.call()` and `.transaction()`. #4055
 - Updated provider database.
+- Disable DKIM-Checks again #4076
 
 ### Fixes
 - Start SQL transactions with IMMEDIATE behaviour rather than default DEFERRED one. #4063

--- a/src/authres.rs
+++ b/src/authres.rs
@@ -644,6 +644,7 @@ Authentication-Results: dkim=";
             .unwrap();
     }
 
+    #[ignore = "Disallowing keychanges is disabled for now"]
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_handle_authres_fails() -> Result<()> {
         let mut tcm = TestContextManager::new();
@@ -821,7 +822,8 @@ Authentication-Results: dkim=";
             .insert_str(0, "Authentication-Results: example.net; dkim=fail\n");
         let rcvd = bob.recv_msg(&sent).await;
 
-        assert!(rcvd.error.unwrap().contains("DKIM failed"));
+        // Disallowing keychanges is disabled for now:
+        // assert!(rcvd.error.unwrap().contains("DKIM failed"));
         // The message info should contain a warning:
         assert!(message::get_msg_info(&bob, rcvd.id)
             .await

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -99,7 +99,8 @@ pub(crate) async fn prepare_decryption(
         from,
         autocrypt_header.as_ref(),
         message_time,
-        dkim_results.allow_keychange,
+        // Disallowing keychanges is disabled for now:
+        true, // dkim_results.allow_keychange,
     )
     .await?;
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -342,7 +342,8 @@ impl MimeMessage {
             if let (Some(peerstate), Ok(mail)) = (&mut decryption_info.peerstate, mail) {
                 if message_time > peerstate.last_seen_autocrypt
                     && mail.ctype.mimetype != "multipart/report"
-                    && decryption_info.dkim_results.allow_keychange
+                // Disallowing keychanges is disabled for now:
+                // && decryption_info.dkim_results.allow_keychange
                 {
                     peerstate.degrade_encryption(message_time);
                 }
@@ -413,11 +414,12 @@ impl MimeMessage {
         parser.heuristically_parse_ndn(context).await;
         parser.parse_headers(context).await?;
 
-        if !parser.decryption_info.dkim_results.allow_keychange {
-            for part in parser.parts.iter_mut() {
-                part.error = Some("Seems like DKIM failed, this either is an attack or (more likely) a bug in Authentication-Results checking. Please tell us about this at https://support.delta.chat.".to_string());
-            }
-        }
+        // Disallowing keychanges is disabled for now
+        // if !decryption_info.dkim_results.allow_keychange {
+        //     for part in parser.parts.iter_mut() {
+        //         part.error = Some("Seems like DKIM failed, this either is an attack or (more likely) a bug in Authentication-Results checking. Please tell us about this at https://support.delta.chat.".to_string());
+        //     }
+        // }
 
         if parser.is_mime_modified {
             parser.decoded_data = mail_raw;


### PR DESCRIPTION
Reverts deltachat/deltachat-core-rust#3935 because apparently that makes things easier for releasing again
Reopens #3735
Closes #3700

DKIM checks still are not reliable enough (esp. deltachat.de randomly not signing a message).

Path forward:
- Only if we get a message with a peerstate change AND wrong DKIM, we show a warning symbol. We need to think carefully about the error message that's shown when clicking on it. Mabye sth. like `Failed to check if this message was actually sent by Bob. If you want to be sure, ask back if Bob actually sent it.`
- We don't disallow keychanges since this only makes sense if we want to fully enable AEAP, which is questionable considering the state of DKIM-checks in the wild.
- Maybe later: If we get a well-signed message with wrong DKIM, reset DKIM expectations

