### PR TITLE
python: replace pkg_resources with importlib.metadata

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
     "cffi>=1.0.0",
     "imap-tools",
+    "importlib_metadata;python_version<'3.8'",
     "pluggy",
     "requests",
 ]

--- a/python/src/deltachat/__init__.py
+++ b/python/src/deltachat/__init__.py
@@ -1,6 +1,9 @@
 import sys
 
-from pkg_resources import DistributionNotFound, get_distribution
+if sys.version_info >= (3, 8):
+    from importlib.metadata import PackageNotFoundError, version
+else:
+    from importlib_metadata import PackageNotFoundError, version
 
 from . import capi, events, hookspec  # noqa
 from .account import Account, get_core_info  # noqa
@@ -11,8 +14,8 @@ from .hookspec import account_hookimpl, global_hookimpl  # noqa
 from .message import Message  # noqa
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
+    __version__ = version(__name__)
+except PackageNotFoundError:
     # package is not installed
     __version__ = "0.0.0.dev0-unknown"
 


### PR DESCRIPTION
Use of `pkg_resources` is discouraged in favor of `importlib.resources`, `importlib.metadata`, and their backports.

closes #4069 