### PR TITLE
mimeparser: wrap try_decrypt() into block_in_place()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Make smeared timestamp generation non-async. #4075
 
 ### Fixes
+- Do not block async task executor while decrypting the messages. #4079
 
 ### API-Changes
 


### PR DESCRIPTION
try_decrypt() is a CPU-bound task.
When called from async function,
it should be wrapped in tokio::task::spawn_blocking(). Using tokio::task::spawn_blocking() is difficult here because of &mail, &private_keyring and &public_keyring borrows, so we should at least use tokio::task::block_in_place() to avoid blocking the executor.