### PR TITLE
Update timestamps in parameters with transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix a problem with Gmail where (auto-)deleted messages would get archived instead of deleted.
   Move them to the Trash folder for Gmail which auto-deletes trashed messages in 30 days #3972
 - Clear config cache after backup import. This bug sometimes resulted in the import to seemingly work at first. #4067
+- Update timestamps in `param` columns with transactions. #4083
 
 ### API-Changes
 


### PR DESCRIPTION
This avoids accidentally reverting the changes
to the `param` column done by another thread.