### PR TITLE
Switch to "vX.Y.Z" tagging scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Remove `Sql.get_conn()` interface in favor of `.call()` and `.transaction()`. #4055
 - Updated provider database.
 - Disable DKIM-Checks again #4076
+- Switch from "X.Y.Z" and "py-X.Y.Z" to "vX.Y.Z" tags. #4089
 
 ### Fixes
 - Start SQL transactions with IMMEDIATE behaviour rather than default DEFERRED one. #4063

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -44,8 +44,8 @@ deltachat = [
 
 [tool.setuptools_scm]
 root = ".."
-tag_regex = '^(?P<prefix>py-)?(?P<version>[^\+]+)(?P<suffix>.*)?$'
-git_describe_command = "git describe --dirty --tags --long --match py-*.*"
+tag_regex = '^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$'
+git_describe_command = "git describe --dirty --tags --long --match v*.*"
 
 [tool.black]
 line-length = 120

--- a/scripts/concourse/docs_wheels.yml
+++ b/scripts/concourse/docs_wheels.yml
@@ -12,7 +12,7 @@ resources:
   source:
     branch: master
     uri: https://github.com/deltachat/deltachat-core-rust.git
-    tag_filter: "py-*"
+    tag_filter: "v*"
 
 jobs:
 - name: doxygen

--- a/scripts/set_core_version.py
+++ b/scripts/set_core_version.py
@@ -115,10 +115,8 @@ def main():
 
     print("after commit, on master make sure to: ")
     print("")
-    print(f"   git tag -a {newversion}")
-    print(f"   git push origin {newversion}")
-    print(f"   git tag -a py-{newversion}")
-    print(f"   git push origin py-{newversion}")
+    print(f"   git tag -a v{newversion}")
+    print(f"   git push origin v{newversion}")
     print("")
 
 


### PR DESCRIPTION
Previously we used tags like "1.109.0" and "py-1.109.0". Since Python bindings are always released
at the same time as the core,
it is easier to use a single tag for them.

"v" prefix is added to make matching by "v*" easier in CI and scripts.