### PR TITLE
make slowest test faster

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4090,7 +4090,6 @@ mod tests {
         send_text_msg(&alice, alice_chat_id, "populate".to_string()).await?;
 
         add_contact_to_chat(&alice, alice_chat_id, bob_id).await?;
-        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
         let add1 = alice.pop_sent_msg().await;
 
         add_contact_to_chat(&alice, alice_chat_id, claire_id).await?;
@@ -4109,29 +4108,18 @@ mod tests {
 
         remove_contact_from_chat(&alice, alice_chat_id, daisy_id).await?;
         let remove2 = alice.pop_sent_msg().await;
-        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
 
         assert_eq!(get_chat_contacts(&alice, alice_chat_id).await?.len(), 2);
 
         // Bob receives the add and deletion messages out of order
         let bob = TestContext::new_bob().await;
         bob.recv_msg(&add1).await;
-        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
-
         bob.recv_msg(&add3).await;
-        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
-
         let bob_chat_id = bob.recv_msg(&add2).await.chat_id;
-        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
-
         assert_eq!(get_chat_contacts(&bob, bob_chat_id).await?.len(), 4);
 
         bob.recv_msg(&remove2).await;
-        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
-
         bob.recv_msg(&remove1).await;
-        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
-
         assert_eq!(get_chat_contacts(&bob, bob_chat_id).await?.len(), 2);
 
         Ok(())


### PR DESCRIPTION
the slowest test was `test_modify_chat_disordered`; due to several sleep(), it lasts at least 11 seconds.

however, many of the sleep() are not needed and were added just to get things done that time.

this pr removes 7 superfluous sleeps,
making the test finish in about 3 seconds,
so that this test is no longer the bottleneck when running `cargo test` on fast machines.
(this is not only useful to safe some seconds -
but also to notice degradations as of
https://github.com/deltachat/deltachat-core-rust/issues/4051#issuecomment-1436995166 )

#skip-changelog