### PR TITLE
add countermitm and openpgp4fpr to "standard used"

### DIFF
--- a/standards.md
+++ b/standards.md
@@ -17,6 +17,8 @@ Seen status synchronization      | IMAP CONDSTORE extension ([RFC 7162][])
 Client/server identification     | IMAP ID extension ([RFC 2971][])
 Authorization                    | OAuth2 ([RFC 6749][])
 End-to-end encryption            | [Autocrypt Level 1][], OpenPGP ([RFC 4880][]), Security Multiparts for MIME ([RFC 1847][]) and [“Mixed Up” Encryption repairing](https://tools.ietf.org/id/draft-dkg-openpgp-pgpmime-message-mangling-00.html)
+Detect/prevent active attacks    | [countermitm][] protocols
+Compare public keys              | [openpgp4fpr][] URI Scheme
 Header encryption                | [Protected Headers for Cryptographic E-mail](https://datatracker.ietf.org/doc/draft-autocrypt-lamps-protected-headers/)
 Configuration assistance         | [Autoconfigure](https://web.archive.org/web/20210402044801/https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration) and [Autodiscover][]
 Messenger functions              | [Chat-over-Email](https://github.com/deltachat/deltachat-core-rust/blob/master/spec.md#chat-mail-specification)
@@ -27,6 +29,8 @@ Return receipts                  | Message Disposition Notification (MDN, [RFC 8
 Locations                        | KML ([Open Geospatial Consortium](http://www.opengeospatial.org/standards/kml/), [Google Dev](https://developers.google.com/kml/))
 
 [Autocrypt Level 1]: https://autocrypt.org/level1.html
+[countermitm]: https://countermitm.readthedocs.io/en/latest/
+[openpgp4fpr]: https://metacode.biz/openpgp/openpgp4fpr
 [Autodiscover]: https://learn.microsoft.com/en-us/exchange/autodiscover-service-for-exchange-2013
 [XEP-0392]: https://xmpp.org/extensions/xep-0392.html
 [RFC 1847]: https://tools.ietf.org/html/rfc1847


### PR DESCRIPTION
noticed that this is missing
while working on https://github.com/deltachat/invite