### PR TITLE
ci: Make sure clippy script checks everything

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1,4 +1,4 @@
-#![warn(unused, clippy::all, clippy::missing_docs_in_private_items)]
+#![warn(unused, clippy::all)]
 #![allow(
     non_camel_case_types,
     non_snake_case,

--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 # Run clippy for all Rust code in the project.
-cargo clippy --workspace --tests --examples --benches -- -D warnings
+cargo clippy --workspace --all-targets -- -D warnings


### PR DESCRIPTION
Also disable missing_docs_in_private_items as this is like 300+ errors
currently.

#skip-changelog