### PR TITLE
Optimize release builds and dependencies for size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,12 @@ opt-level = 0
 # This does not apply to crates in the workspace.
 # <https://doc.rust-lang.org/cargo/reference/profiles.html#overrides>
 [profile.dev.package."*"]
-opt-level = 3
+opt-level = "z"
 
 [profile.release]
 lto = true
 panic = 'abort'
+opt-level = "z"
 
 [dependencies]
 deltachat_derive = { path = "./deltachat_derive" }


### PR DESCRIPTION
We have decided not to enable it previously because of Windows CI failures: https://github.com/deltachat/deltachat-core-rust/pull/1087

Let's see if it works now.