### PR TITLE
Compress `mime_headers` column with HTML emails stored in database (#4077)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 ### Changes
 - Add support for `--version` argument to `deltachat-rpc-server`. #4224
   It can be used to check the installed version without starting the server.
+- Compress `mime_headers` column with HTML emails stored in database
 
 ### Fixes
 - deltachat-rpc-client: fix bug in `Chat.send_message()`: invalid `MessageData` field `quotedMsg` instead of `quotedMsgId`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +495,27 @@ checksum = "e412e2cd0f2b2d93e02543ceae7917b3c70331573df19ee046bcbc35e45e87d7"
 dependencies = [
  "byteorder",
  "cipher",
+]
+
+[[package]]
+name = "brotli"
+version = "3.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1126,6 +1162,7 @@ dependencies = [
  "backtrace",
  "base64 0.21.0",
  "bitflags",
+ "brotli",
  "chrono",
  "criterion",
  "deltachat_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ async_zip = { version = "0.0.11", default-features = false, features = ["deflate
 backtrace = "0.3"
 base64 = "0.21"
 bitflags = "1.3"
+brotli = "3.3"
 chrono = { version = "0.4", default-features=false, features = ["clock", "std"] }
 email = { git = "https://github.com/deltachat/rust-email", branch = "master" }
 encoded-words = { git = "https://github.com/async-email/encoded-words", branch = "master" }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -35,8 +35,9 @@ use crate::scheduler::InterruptInfo;
 use crate::smtp::send_msg_to_smtp;
 use crate::stock_str;
 use crate::tools::{
-    create_id, create_outgoing_rfc724_mid, create_smeared_timestamp, create_smeared_timestamps,
-    get_abs_path, gm2local_offset, improve_single_line_input, time, IsNoneOrEmpty,
+    buf_compress, create_id, create_outgoing_rfc724_mid, create_smeared_timestamp,
+    create_smeared_timestamps, get_abs_path, gm2local_offset, improve_single_line_input, time,
+    IsNoneOrEmpty,
 };
 use crate::webxdc::WEBXDC_SUFFIX;
 use crate::{location, sql};
@@ -1580,7 +1581,12 @@ impl Chat {
             } else {
                 msg.param.get(Param::SendHtml).map(|s| s.to_string())
             };
-            html.map(|html| new_html_mimepart(html).build().as_string())
+            match html {
+                Some(html) => Some(tokio::task::block_in_place(move || {
+                    buf_compress(new_html_mimepart(html).build().as_string().as_bytes())
+                })?),
+                None => None,
+            }
         } else {
             None
         };
@@ -1594,7 +1600,8 @@ impl Chat {
                      SET rfc724_mid=?, chat_id=?, from_id=?, to_id=?, timestamp=?, type=?,
                          state=?, txt=?, subject=?, param=?,
                          hidden=?, mime_in_reply_to=?, mime_references=?, mime_modified=?,
-                         mime_headers=?, location_id=?, ephemeral_timer=?, ephemeral_timestamp=?
+                         mime_headers=?, mime_compressed=1, location_id=?, ephemeral_timer=?,
+                         ephemeral_timestamp=?
                      WHERE id=?;",
                     paramsv![
                         new_rfc724_mid,
@@ -1640,10 +1647,11 @@ impl Chat {
                         mime_references,
                         mime_modified,
                         mime_headers,
+                        mime_compressed,
                         location_id,
                         ephemeral_timer,
                         ephemeral_timestamp)
-                        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);",
+                        VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,1,?,?,?);",
                     paramsv![
                         new_rfc724_mid,
                         self.id,


### PR DESCRIPTION
It compresses for me HTML emails more than twice (10468 -> 4988 bytes f.e.), but for some reason in my db they take 0% of total disk usage, so, @link2xt, better measure how it helps to u. But currently i use the max. compression level (11), it's too slow and takes much time when upgrading a db. So, for ur db u probably need to reduce it, maybe even to 6.

UPD: Forgot to do `vacuum` on my db. Remeasured -- it reduces my db in 1.797 times.