### PR TITLE
Do not prepare the message explicitly in the test context

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -599,7 +599,6 @@ impl TestContext {
     /// [`TestContext::recv_msg`] with the returned [`SentMessage`] if it wants to receive
     /// the message.
     pub async fn send_msg(&self, chat_id: ChatId, msg: &mut Message) -> SentMessage<'_> {
-        chat::prepare_msg(self, chat_id, msg).await.unwrap();
         let msg_id = chat::send_msg(self, chat_id, msg).await.unwrap();
         let res = self.pop_sent_msg().await;
         assert_eq!(


### PR DESCRIPTION
Explicit `prepare_msg` corresponding to `dc_prepare_msg` is intended only for the case where the message is prepared before the file is ready. It is not indented for calling right before send_msg and requires that file path in the blobdir.

With explicit `prepare_msg` removed
all the tests still pass but there is no requirement that the file is put into blobdir beforehand.

#skip-changelog