### PR TITLE
Drop unused columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Run `cargo-deny` in CI. #4101
 - Check provider database with CI. #4099 
 - Switch to DEFERRED transactions #4100
+- Drop unused SQL columns #4141
 
 ### Fixes
 - Do not block async task executor while decrypting the messages. #4079

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -690,6 +690,17 @@ CREATE INDEX smtp_messageid ON imap(rfc724_mid);
         }
         sql.set_db_version(98).await?;
     }
+    if dbversion < 99 {
+        sql.execute_migration(
+            "ALTER TABLE msgs DROP COLUMN server_folder;
+             ALTER TABLE msgs DROP COLUMN server_uid;
+             ALTER TABLE msgs DROP COLUMN move_state;
+             ALTER TABLE chats DROP COLUMN draft_timestamp;
+             ALTER TABLE chats DROP COLUMN draft_txt",
+            99,
+        )
+        .await?;
+    }
 
     let new_version = sql
         .get_raw_config_int(VERSION_CFG)


### PR DESCRIPTION
We are currently using libsqlite3-sys 0.25.2,
corresponding to SQLcipher 4.5.2
and SQLite 3.39.2.

SQLite supports ALTER TABLE DROP COLUMN since version 3.35.0, and it has received critical database corruption bugfixes in 3.35.5. There have been no fixes to it between SQLite 3.36.0 and 3.41.0, so it appears stable now.