### PR TITLE
restore original Doxygen contrasts

### DIFF
--- a/deltachat-ffi/Doxyfile.css
+++ b/deltachat-ffi/Doxyfile.css
@@ -1,11 +1,11 @@
 
 :root {
-	--accent: hsl(0 0% 70%);
+	--accent: hsl(0 0% 85%);
 }
 
 @media (prefers-color-scheme: dark) {
 	:root {
-		--accent: hsl(0 0% 30%);
+		--accent: hsl(0 0% 25%);
 	}
 }
 


### PR DESCRIPTION
the contrast was decreased at
https://github.com/deltachat/deltachat-core-rust/pull/4136 , there were also suggestions to fix it there,
but it was probably just forgotten :)

this pr increases the contrast
between code background and code font again to the level it was before
and also to what similar themes are doing.

before/after:

<img width="340" alt="Screenshot 2023-03-11 at 13 57 01" src="https://user-images.githubusercontent.com/9800740/224486106-be07879e-efd6-4b58-a3cf-fa7620431e37.png"> <img width="340" alt="Screenshot 2023-03-11 at 13 58 24" src="https://user-images.githubusercontent.com/9800740/224486108-a568f893-49e6-438c-950b-f4aabdf3f595.png">
