### PR TITLE
Upgrade async-smtp to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,13 +177,12 @@ dependencies = [
 
 [[package]]
 name = "async-smtp"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7384febcabdd07a498c9f4fbaa7e488ff4eb60d0ade14b47b09ec44b8f645301"
+checksum = "8709c0d4432be428a88a06746689a9cb543e8e27ef7f61ca4d0455003a3d8c5b"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
- "bufstream",
  "futures",
  "hostname",
  "log",
@@ -400,12 +399,6 @@ dependencies = [
  "memchr",
  "safemem",
 ]
-
-[[package]]
-name = "bufstream"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e38929add23cdf8a366df9b0e088953150724bcbe5fc330b0d8eb3b328eec8"
 
 [[package]]
 name = "bumpalo"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ anyhow = "1"
 async-channel = "1.8.0"
 async-imap = { git = "https://github.com/async-email/async-imap", branch = "master", default-features = false, features = ["runtime-tokio"] }
 async-native-tls = { version = "0.5", default-features = false, features = ["runtime-tokio"] }
-async-smtp = { version = "0.8", default-features = false, features = ["runtime-tokio"] }
+async-smtp = { version = "0.9", default-features = false, features = ["runtime-tokio"] }
 async_zip = { version = "0.0.9", default-features = false, features = ["deflate"] }
 backtrace = "0.3"
 base64 = "0.21"


### PR DESCRIPTION
async-smtp does not implement read buffering anymore and expects library user to implement it.

To implement read buffer, we wrap streams into BufStream instead of BufWriter.

#skip-changelog