### PR TITLE
allow generated html being rendered in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 - Drop unused SQL columns #4141
 - "full message view" not needed because of footers that go to contact status #4151
+- Pick up system's light/dark mode in generated message HTML #4150
 
 
 ## 1.111.0

--- a/src/html.rs
+++ b/src/html.rs
@@ -292,7 +292,10 @@ mod tests {
         assert_eq!(
             parser.html,
             r##"<!DOCTYPE html>
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="color-scheme" content="light dark" />
+</head><body>
 This message does not have Content-Type nor Subject.<br/>
 <br/>
 </body></html>
@@ -308,7 +311,10 @@ This message does not have Content-Type nor Subject.<br/>
         assert_eq!(
             parser.html,
             r##"<!DOCTYPE html>
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="color-scheme" content="light dark" />
+</head><body>
 message with a non-UTF-8 encoding: äöüßÄÖÜ<br/>
 <br/>
 </body></html>
@@ -325,7 +331,10 @@ message with a non-UTF-8 encoding: äöüßÄÖÜ<br/>
         assert_eq!(
             parser.html,
             r##"<!DOCTYPE html>
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="color-scheme" content="light dark" />
+</head><body>
 This line ends with a space and will be merged with the next one due to format=flowed.<br/>
 <br/>
 This line does not end with a space<br/>
@@ -344,7 +353,10 @@ and will be wrapped as usual.<br/>
         assert_eq!(
             parser.html,
             r##"<!DOCTYPE html>
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="color-scheme" content="light dark" />
+</head><body>
 mime-modified should not be set set as there is no html and no special stuff;<br/>
 although not being a delta-message.<br/>
 test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x27; :)<br/>

--- a/src/plaintext.rs
+++ b/src/plaintext.rs
@@ -34,8 +34,13 @@ impl PlainText {
 
         let lines = split_lines(&self.text);
 
-        let mut ret =
-            "<!DOCTYPE html>\n<html><head><meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" /></head><body>\n".to_string();
+        let mut ret = r#"<!DOCTYPE html>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="color-scheme" content="light dark" />
+</head><body>
+"#
+        .to_string();
 
         for line in lines {
             let is_quote = line.starts_with('>');
@@ -118,7 +123,10 @@ http://link-at-start-of-line.org
         assert_eq!(
             html,
             r##"<!DOCTYPE html>
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="color-scheme" content="light dark" />
+</head><body>
 line 1<br/>
 line 2<br/>
 line with <a href="https://link-mid-of-line.org">https://link-mid-of-line.org</a> and <a href="http://link-end-of-line.com/file?foo=bar%20">http://link-end-of-line.com/file?foo=bar%20</a><br/>
@@ -140,7 +148,10 @@ line with <a href="https://link-mid-of-line.org">https://link-mid-of-line.org</a
         assert_eq!(
             html,
             r#"<!DOCTYPE html>
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="color-scheme" content="light dark" />
+</head><body>
 line with &lt;<a href="http://encapsulated.link/?foo=_bar">http://encapsulated.link/?foo=_bar</a>&gt; here!<br/>
 </body></html>
 "#
@@ -158,7 +169,10 @@ line with &lt;<a href="http://encapsulated.link/?foo=_bar">http://encapsulated.l
         assert_eq!(
             html,
             r#"<!DOCTYPE html>
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="color-scheme" content="light dark" />
+</head><body>
 line with nohttp://no.link here<br/>
 </body></html>
 "#
@@ -176,7 +190,10 @@ line with nohttp://no.link here<br/>
         assert_eq!(
             html,
             r#"<!DOCTYPE html>
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="color-scheme" content="light dark" />
+</head><body>
 just an address: <a href="mailto:foo@bar.org">foo@bar.org</a> <a href="mailto:another@one.de">another@one.de</a><br/>
 </body></html>
 "#
@@ -194,7 +211,10 @@ just an address: <a href="mailto:foo@bar.org">foo@bar.org</a> <a href="mailto:an
         assert_eq!(
             html,
             r#"<!DOCTYPE html>
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="color-scheme" content="light dark" />
+</head><body>
 line still line<br/>
 <em>&gt;quote </em><br/>
 <em>&gt;still quote</em><br/>
@@ -215,7 +235,10 @@ line still line<br/>
         assert_eq!(
             html,
             r#"<!DOCTYPE html>
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="color-scheme" content="light dark" />
+</head><body>
 linestill line<br/>
 <em>&gt;quote </em><br/>
 <em>&gt;still quote</em><br/>
@@ -236,7 +259,10 @@ linestill line<br/>
         assert_eq!(
             html,
             r#"<!DOCTYPE html>
-<html><head><meta http-equiv="Content-Type" content="text/html; charset=utf-8" /></head><body>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="color-scheme" content="light dark" />
+</head><body>
 line <br/>
 still line<br/>
 <em>&gt;quote </em><br/>


### PR DESCRIPTION
`<meta name="color-scheme" content="light dark" />` is a hint to the browsers that the page can be rendered in light as well as in dark mode and that the browser can apply corresponding defaults.

as we do not add css colors on our own,
this is sufficient for letting generated html messasge being rendered in dark mode.

cmp. https://drafts.csswg.org/css-color-adjust/#color-scheme-prop

closes #4146

cc @WofWca (i cannot mark you for review)