### PR TITLE
"full message view" not needed because of footers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changes
 - Drop unused SQL columns #4141
+- "full message view" not needed because of footers that go to contact status #4151
 
 
 ## 1.111.0

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -2085,9 +2085,11 @@ Original signature",
         false,
     )
     .await?;
-    let one2one_chat_id = t.get_last_msg().await.chat_id;
+    let msg = t.get_last_msg().await;
+    let one2one_chat_id = msg.chat_id;
     let bob = Contact::load_from_db(&t, bob_id).await?;
     assert_eq!(bob.get_status(), "Original signature");
+    assert!(!msg.has_html());
 
     receive_imf(
         &t,


### PR DESCRIPTION
standard footers meanwhile go to the "contact status", so they are no longer a reason to trigger "full message view".

this was already discussed when the HTML view was introduced at #2125 however, forgotten to change when the "contact status" was added at #2218

this pr will result in a cleaner chat view
with less "Show Full Message..." buttons
and will also save some storage
(in fact, i came over that when reviewing #4129 )