### PR TITLE
Delete expired messages using multiple SQL requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   background process spawned by `dc_configure()` or `dc_imex()`
   or `dc_jsonrpc_instance_t` is unreferenced
   during handling the JSON-RPC request. #4153
+- Delete expired messages using multiple SQL requests. #4158
 
 
 ## 1.111.0


### PR DESCRIPTION
With existing approach of constructing
the SQL query dynamically I get errors like this:
   ephemeral.rs:575: update failed: too many SQL variables: Error code 1: SQL error or missing database

In my case it is trying to delete 143658 messages. This is the result of importing a Desktop backup
and enabling device auto-deletion on the phone.
Current SQLite limit is 32766 variables
as stated in <https://www.sqlite.org/limits.html>.