### PR TITLE
Show unobfuscated file-names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - "full message view" not needed because of footers that go to contact status #4151
 - Pick up system's light/dark mode in generated message HTML #4150
 - Support non-persistent configuration with DELTACHAT_* env
+- Improve obfuscation behaviour for known files #4159
 
 ### Fixes
 - Fix segmentation fault if `dc_context_unref()` is called during

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -216,7 +216,7 @@ impl<'a> BlobObject<'a> {
     }
 
     pub fn as_original_name(&self) -> Option<&str> {
-        self.original_name.as_ref().map(|x| &**x)
+        self.original_name.as_deref()
     }
 
     pub fn set_original_name(&mut self, name: String) {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -6078,34 +6078,4 @@ mod tests {
 
         Ok(())
     }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_blob_renaming() -> Result<()> {
-        let alice = TestContext::new_alice().await;
-        let bob = TestContext::new_bob().await;
-        let chat_id = create_group_chat(&alice, ProtectionStatus::Unprotected, "Group").await?;
-        add_contact_to_chat(
-            &alice,
-            chat_id,
-            Contact::create(&alice, "bob", "bob@example.net").await?,
-        )
-        .await?;
-
-        let mut msg = Message::new(Viewtype::File);
-        msg.set_file("./test-data/webxdc/chess.xdc", None);
-
-        let file_send = alice.send_msg(chat_id, &mut msg).await;
-        let msg = bob.recv_msg(&file_send).await;
-        info!(bob, "{:#?}, {:?}", msg.param, msg.viewtype);
-
-        let mut msg = Message::new(Viewtype::File);
-        msg.set_file("./test-data/webxdc/chess.xdc", None);
-
-        let file_send = alice.send_msg(chat_id, &mut msg).await;
-        let msg = bob.recv_msg(&file_send).await;
-        info!(bob, "{:#?}, {:?}", msg.param, msg.viewtype);
-
-
-        Ok(())
-    }
 }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -6092,23 +6092,19 @@ mod tests {
         .await?;
 
         let mut msg = Message::new(Viewtype::File);
-        msg.set_file("./test-data/image/avatar64x64.png", None);
-        info!(alice, "{:#?}, {:?}", msg.param, msg.viewtype);
+        msg.set_file("./test-data/webxdc/chess.xdc", None);
 
-        send_msg(&alice, chat_id, &mut msg).await?;
-        let msg = bob.recv_msg(&alice.pop_sent_msg().await).await;
-
+        let file_send = alice.send_msg(chat_id, &mut msg).await;
+        let msg = bob.recv_msg(&file_send).await;
         info!(bob, "{:#?}, {:?}", msg.param, msg.viewtype);
-        //bob_chat_id.accept(&bob).await?;
 
         let mut msg = Message::new(Viewtype::File);
-        msg.set_file("./test-data/image/avatar64x64.png", None);
-        info!(alice, "{:#?}, {:?}", msg.param, msg.viewtype);
+        msg.set_file("./test-data/webxdc/chess.xdc", None);
 
-        send_msg(&alice, chat_id, &mut msg).await?;
-        let msg = bob.recv_msg(&alice.pop_sent_msg().await).await;
-
+        let file_send = alice.send_msg(chat_id, &mut msg).await;
+        let msg = bob.recv_msg(&file_send).await;
         info!(bob, "{:#?}, {:?}", msg.param, msg.viewtype);
+
 
         Ok(())
     }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1383,11 +1383,16 @@ async fn build_body_file(
     msg: &Message,
     base_name: &str,
 ) -> Result<(PartBuilder, String)> {
-    let blob = msg
+    let mut blob = msg
         .param
         .get_blob(Param::File, context, true)
         .await?
         .context("msg has no filename")?;
+
+    if let Some(name) = msg.param.get(Param::OriginalName) {
+        blob.set_original_name(name.to_string());
+    };
+
     let suffix = blob.suffix().unwrap_or("dat");
 
     // Get file name to use for sending.  For privacy purposes, we do

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1246,6 +1246,9 @@ impl MimeMessage {
         part.mimetype = Some(mime_type);
         part.bytes = decoded_data.len();
         part.param.set(Param::File, blob.as_name());
+        if let Some(name) = blob.as_original_name() {
+            part.param.set(Param::OriginalName, name);
+        }
         part.param.set(Param::MimeType, raw_mime);
         part.is_related = is_related;
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -21,6 +21,9 @@ pub enum Param {
     /// For messages and jobs
     File = b'f',
 
+    /// For messages
+    OriginalName = b'#',
+
     /// For messages: This name should be shown instead of contact.get_display_name()
     /// (used if this is a mailinglist
     /// or explicitly set using set_override_sender_name(), eg. by bots)
@@ -335,7 +338,7 @@ impl Params {
     /// Gets the parameter and returns a [BlobObject] for it.
     ///
     /// This parses the parameter value as a [ParamsFile] and than
-    /// tries to return a [BlobObject] for that file.  If the file is
+    /// tries to return a [BlobObject] for that file. If the file is
     /// not yet a valid blob, one will be created by copying the file
     /// only if `create` is set to `true`, otherwise an error is
     /// returned.
@@ -344,7 +347,6 @@ impl Params {
     /// created without copying if the path already refers to a valid
     /// blob.  If so a [BlobObject] will be returned regardless of the
     /// `create` argument.
-    #[allow(clippy::needless_lifetimes)]
     pub async fn get_blob<'a>(
         &self,
         key: Param,

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -432,7 +432,7 @@ async fn smtp_loop(ctx: Context, started: Sender<()>, smtp_handlers: SmtpConnect
                 if !duration_until_can_send.is_zero() {
                     info!(
                         ctx,
-                        "smtp got rate limited, waiting for {} until can send again",
+                        "smtp got rate limited, waiting for {} until resend",
                         duration_to_str(duration_until_can_send)
                     );
                     tokio::time::timeout(duration_until_can_send, async {


### PR DESCRIPTION
This PR implements the approach from #3817. 
It stores the original filename in a Param field and when sending out a file which has been obfuscated, it uses the original filename. This way there should only be one level of obfuscation on each device. 

fixes #3817
