### PR TITLE
sql: expect zero-column results from `PRAGMA incremental_vacuum`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   or `dc_jsonrpc_instance_t` is unreferenced
   during handling the JSON-RPC request. #4153
 - Delete expired messages using multiple SQL requests. #4158
+- Do not emit "Failed to run incremental vacuum" warnings on success. #4160
 
 
 ## 1.111.0


### PR DESCRIPTION
The fact that `PRAGMA incremental_vacuum` may return a zero-column SQLITE_ROW result is documented in `sqlite3_data_count()` documentation: <https://www.sqlite.org/c3ref/data_count.html>

Previously successful auto_vacuum worked,
but resulted in a "Failed to run incremental vacuum" log.

Fixes #3515