### PR TITLE
Increase Minimum Supported Rust Version to 1.64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,13 @@ jobs:
             rust: 1.68.0
             python: false # Python bindings compilation on Windows is not supported.
 
-          # Minimum Supported Rust Version = 1.63.0
+          # Minimum Supported Rust Version = 1.64.0
           #
           # Minimum Supported Python Version = 3.7
           # This is the minimum version for which manylinux Python wheels are
           # built.
           - os: ubuntu-latest
-            rust: 1.63.0
+            rust: 1.64.0
             python: 3.7
     runs-on: ${{ matrix.os }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Pick up system's light/dark mode in generated message HTML #4150
 - Support non-persistent configuration with DELTACHAT_* env
 - Print deltachat-repl errors with causes. #4166
+- Increase MSRV to 1.64. #4167
 
 ### Fixes
 - Fix segmentation fault if `dc_context_unref()` is called during

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "deltachat"
 version = "1.111.0"
 edition = "2021"
 license = "MPL-2.0"
-rust-version = "1.63"
+rust-version = "1.64"
 
 [profile.dev]
 debug = 0


### PR DESCRIPTION
It is required for clap_lex v0.3.2
and async_zip 0.0.11.
