### PR TITLE
feat: Pause IO for BackupProvider

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2644,10 +2644,6 @@ void dc_str_unref (char* str);
 /**
  * Creates an object for sending a backup to another device.
  *
- * Before calling this function IO must be stopped using dc_accounts_stop_io()
- * or dc_stop_io() so that no changes to the blobs or database are happening.
- * IO should only be restarted once dc_backup_provider_wait() has returned.
- *
  * The backup is sent to through a peer-to-peer channel which is bootstrapped
  * by a QR-code.  The backup contains the entire state of the account
  * including credentials.  This can be used to setup a new device.
@@ -2708,9 +2704,7 @@ char* dc_backup_provider_get_qr_svg (const dc_backup_provider_t* backup_provider
 /**
  * Waits for the sending to finish.
  *
- * This is a blocking call and should only be called once.  Once this function
- * returns IO can be started again using dc_accounts_start_io() or
- * dc_start_io().
+ * This is a blocking call and should only be called once.
  *
  * @memberof dc_backup_provider_t
  * @param backup_provider The backup provider object as created by

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -91,7 +91,7 @@ pub async fn imex(
     let cancel = context.alloc_ongoing().await?;
 
     let res = {
-        let mut guard = context.scheduler.pause(context).await;
+        let mut guard = context.scheduler.pause(context.clone()).await;
         let res = imex_inner(context, what, path, passphrase)
             .race(async {
                 cancel.recv().await.ok();


### PR DESCRIPTION
This makes the BackupProvider automatically invoke pause-io while it
is needed.

It needed to make the guard independent from the Context lifetime to
make this work.  Which is a bit sad.

Closes #4176

#skip-changelog