### PR TITLE
Make sure set_last_error is called for .log_err()

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -4178,7 +4178,9 @@ pub unsafe extern "C" fn dc_backup_provider_get_qr(
         return "".strdup();
     }
     let ffi_provider = &*provider;
+    let ctx = &*ffi_provider.context;
     deltachat::qr::format_backup(&ffi_provider.provider.qr())
+        .log_err(ctx, "BackupProvider get_qr failed")
         .unwrap_or_default()
         .strdup()
 }
@@ -4195,6 +4197,7 @@ pub unsafe extern "C" fn dc_backup_provider_get_qr_svg(
     let ctx = &*ffi_provider.context;
     let provider = &ffi_provider.provider;
     block_on(generate_backup_qr(ctx, &provider.qr()))
+        .log_err(ctx, "BackupProvider get_qr_svg failed")
         .unwrap_or_default()
         .strdup()
 }
@@ -4209,7 +4212,7 @@ pub unsafe extern "C" fn dc_backup_provider_wait(provider: *mut dc_backup_provid
     let ctx = &*ffi_provider.context;
     let provider = &mut ffi_provider.provider;
     block_on(provider)
-        .log_err(ctx, "Failed to join provider")
+        .log_err(ctx, "Failed to await BackupProvider")
         .ok();
 }
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -147,6 +147,7 @@ impl<T, E: std::fmt::Display> LogExt<T, E> for Result<T, E> {
             );
             // We can't use the warn!() macro here as the file!() and line!() macros
             // don't work with #[track_caller]
+            context.set_last_error(&full);
             context.emit_event(crate::EventType::Warning(full));
         };
         self


### PR DESCRIPTION
We have a common .log_err() trait method which is very prevalent and
useful in the FFI bindings.  However this was not hooked up with the
set_last_error/get_last_error mechanism, which the error! macro was
hooked up with.

This hooks correctly hooks up the two and makes sure to log all errors
around backup provider/retrieval.

Closes #4186, #4178