### PR TITLE
smtp: disable buffering while running STARTTLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Delete expired messages using multiple SQL requests. #4158
 - Do not emit "Failed to run incremental vacuum" warnings on success. #4160
 - Ability to send backup over network and QR code to setup second device #4007
+- Disable buffering during STARTTLS setup. #4190
 
 ## [1.111.0] - 2023-03-05
 

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -143,7 +143,7 @@ impl Smtp {
         // Run STARTTLS command and convert the client back into a stream.
         let client = smtp::SmtpClient::new().smtp_utf8(true);
         let transport = SmtpTransport::new(client, BufStream::new(socks5_stream)).await?;
-        let tcp_stream = transport.starttls().await?;
+        let tcp_stream = transport.starttls().await?.into_inner();
         let tls_stream = wrap_tls(strict_tls, hostname, tcp_stream)
             .await
             .context("STARTTLS upgrade failed")?;
@@ -199,7 +199,7 @@ impl Smtp {
         // Run STARTTLS command and convert the client back into a stream.
         let client = smtp::SmtpClient::new().smtp_utf8(true);
         let transport = SmtpTransport::new(client, BufStream::new(tcp_stream)).await?;
-        let tcp_stream = transport.starttls().await?;
+        let tcp_stream = transport.starttls().await?.into_inner();
         let tls_stream = wrap_tls(strict_tls, hostname, tcp_stream)
             .await
             .context("STARTTLS upgrade failed")?;


### PR DESCRIPTION
Otherwise TLS setup fails on macOS and iOS with `errSSLClosedAbort`.
(<https://developer.apple.com/documentation/security/errsslclosedabort>)

Fixes #4190 and #4197.