### PR TITLE
ref(jsonrpc): Do not explicitly stop IO for provider

### DIFF
--- a/deltachat-jsonrpc/src/api/mod.rs
+++ b/deltachat-jsonrpc/src/api/mod.rs
@@ -1361,7 +1361,6 @@ impl CommandApi {
     /// Returns once a remote device has retrieved the backup.
     async fn provide_backup(&self, account_id: u32) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
-        ctx.stop_io().await;
         let provider = match imex::BackupProvider::prepare(&ctx).await {
             Ok(provider) => provider,
             Err(err) => {
@@ -1369,9 +1368,7 @@ impl CommandApi {
                 return Err(err);
             }
         };
-        let res = provider.await;
-        ctx.start_io().await;
-        res
+        provider.await
     }
 
     /// Returns the text of the QR code for the running [`CommandApi::provide_backup`].


### PR DESCRIPTION
Since #4182 (35f50a89655c36f1b94cf864f862dbc43b42579a) we no longer
need to stop IO explicitly, so let's not do that as it makes things
simpler to understand.

#skip-changelog