### PR TITLE
python: fail fast on the tests

### DIFF
--- a/deltachat-rpc-client/tox.ini
+++ b/deltachat-rpc-client/tox.ini
@@ -6,7 +6,7 @@ envlist =
 
 [testenv]
 commands =
-    pytest {posargs}
+    pytest --exitfirst {posargs}
 setenv =
 # Avoid stack overflow when Rust core is built without optimizations.
     RUST_MIN_STACK=8388608

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -8,7 +8,7 @@ envlist =
 
 [testenv]
 commands = 
-    pytest -n6 --extra-info -v -rsXx --ignored --strict-tls {posargs: tests examples}
+    pytest -n6 --exitfirst --extra-info -v -rsXx --ignored --strict-tls {posargs: tests examples}
     pip wheel . -w {toxworkdir}/wheelhouse --no-deps
 setenv =
 # Avoid stack overflow when Rust core is built without optimizations.


### PR DESCRIPTION
Do not waste CI time running the rest of the tests if CI is not going to be green anyway.

#skip-changelog