### PR TITLE
deps(iroh): switch back to iroh main branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,7 +2427,7 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 [[package]]
 name = "iroh"
 version = "0.3.0"
-source = "git+https://github.com/n0-computer/iroh?branch=flub/ticket-multiple-addrs#aacd1d84e11b218e55e9622c4500973224904fe9"
+source = "git+https://github.com/n0-computer/iroh?branch=main#9ac4cf6e770879c8b2ec0dc6666fe531469e68e3"
 dependencies = [
  "abao",
  "anyhow",
@@ -2465,6 +2465,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
+ "walkdir",
  "webpki",
  "x509-parser",
  "zeroize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ hex = "0.4.0"
 humansize = "2"
 image = { version = "0.24.5", default-features=false, features = ["gif", "jpeg", "ico", "png", "pnm", "webp", "bmp"] }
 # iroh = { version = "0.3.0", default-features = false }
-iroh = { git = 'https://github.com/n0-computer/iroh', branch = "flub/ticket-multiple-addrs" }
+iroh = { git = 'https://github.com/n0-computer/iroh', branch = "main" }
 kamadak-exif = "0.5"
 lettre_email = { git = "https://github.com/deltachat/lettre", branch = "master" }
 libc = "0.2"


### PR DESCRIPTION
The relevant changes are now in the main branch again.  And the main branch is a bit better to depend on.

#skip-changelog