### PR TITLE
Reintroduce pytest-rerunfailures

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -8,7 +8,7 @@ envlist =
 
 [testenv]
 commands = 
-    pytest -n6 --extra-info -v -rsXx --ignored --strict-tls {posargs: tests examples}
+    pytest -n6 --extra-info --reruns 2 --reruns-delay 5 -v -rsXx --ignored --strict-tls {posargs: tests examples}
     pip wheel . -w {toxworkdir}/wheelhouse --no-deps
 setenv =
 # Avoid stack overflow when Rust core is built without optimizations.
@@ -21,6 +21,7 @@ passenv =
     RUSTC_WRAPPER
 deps = 
     pytest
+    pytest-rerunfailures
     pytest-timeout
     pytest-xdist
     pdbpp


### PR DESCRIPTION
Tests on GitHub Actions are very flaky recently.