### PR TITLE
fix(dc_receive_backup): Spawn needs a 'static lifetime

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -4233,6 +4233,21 @@ pub unsafe extern "C" fn dc_backup_provider_unref(provider: *mut dc_backup_provi
     drop(Box::from_raw(provider));
 }
 
+fn receive_backup(ctx: Context, qr_text: String) -> libc::c_int {
+    let qr = match block_on(qr::check_qr(&ctx, &qr_text)).log_err(&ctx, "Invalid QR code") {
+        Ok(qr) => qr,
+        Err(_) => return 0,
+    };
+    spawn(async move {
+        let ctx = ctx;
+        imex::get_backup(&ctx, qr)
+            .await
+            .log_err(&ctx, "Get backup failed")
+            .ok();
+    });
+    1
+}
+
 #[no_mangle]
 pub unsafe extern "C" fn dc_receive_backup(
     context: *mut dc_context_t,
@@ -4244,19 +4259,7 @@ pub unsafe extern "C" fn dc_receive_backup(
     }
     let ctx = &*context;
     let qr_text = to_string_lossy(qr);
-    let qr = match block_on(qr::check_qr(ctx, &qr_text)).log_err(ctx, "Invalid QR code") {
-        Ok(qr) => qr,
-        Err(_) => return 0,
-    };
-    let ctx = ctx.clone();
-    spawn(async move {
-        let ctx = ctx;
-        imex::get_backup(&ctx, qr)
-            .await
-            .log_err(&ctx, "Get backup failed")
-            .ok();
-    });
-    1
+    receive_backup(ctx.clone(), qr_text)
 }
 
 trait ResultExt<T, E> {


### PR DESCRIPTION
Otherwise it is possible for the context that is used in the spawn to
be unreferenced.  Really this should be caught by the borrow checker
that ensures we only spawn things with a 'static lifetime, but we're
handling raw pointers so it doesn't.

Closes: #4204