### PR TITLE
ref(ffi): dc_receive_backup should block

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -4233,21 +4233,6 @@ pub unsafe extern "C" fn dc_backup_provider_unref(provider: *mut dc_backup_provi
     drop(Box::from_raw(provider));
 }
 
-fn receive_backup(ctx: Context, qr_text: String) -> libc::c_int {
-    let qr = match block_on(qr::check_qr(&ctx, &qr_text)).log_err(&ctx, "Invalid QR code") {
-        Ok(qr) => qr,
-        Err(_) => return 0,
-    };
-    spawn(async move {
-        let ctx = ctx;
-        imex::get_backup(&ctx, qr)
-            .await
-            .log_err(&ctx, "Get backup failed")
-            .ok();
-    });
-    1
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn dc_receive_backup(
     context: *mut dc_context_t,
@@ -4259,7 +4244,22 @@ pub unsafe extern "C" fn dc_receive_backup(
     }
     let ctx = &*context;
     let qr_text = to_string_lossy(qr);
-    receive_backup(ctx.clone(), qr_text)
+    let qr = match block_on(qr::check_qr(ctx, &qr_text))
+        .log_err(ctx, "Invalid QR code")
+        .context("Invalid QR code")
+        .set_last_error(ctx)
+    {
+        Ok(qr) => qr,
+        Err(_) => return 0,
+    };
+    match block_on(imex::get_backup(ctx, qr))
+        .log_err(ctx, "Get backup failed")
+        .context("Get backup failed")
+        .set_last_error(ctx)
+    {
+        Ok(_) => 1,
+        Err(_) => 0,
+    }
 }
 
 trait ResultExt<T, E> {


### PR DESCRIPTION
The documentation says this blocks.  This should block because it also
means the error reporting is more accurate by calling set_last_error
just before returning.

#skip-changelog since this makes it behave as is documented