### PR TITLE
Add scripts/deny.sh

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,6 +8,8 @@ and an own build machine.
 
 - `clippy.sh` runs `cargo clippy` for all Rust code in the project.
 
+- `deny.sh` runs `cargo deny` for all Rust code in the project.
+
 - `../.github/workflows` contains jobs run by GitHub Actions.
 
 - `remote_tests_python.sh` rsyncs to a build machine and runs

--- a/scripts/deny.sh
+++ b/scripts/deny.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+cargo deny --workspace --all-features check -D warnings


### PR DESCRIPTION
This can be used to manually run `cargo deny`
without specifying all the parameters manually.

Similar to existing scripts/clippy.sh