### PR TITLE
Do not use IDLE in test_fetch_existing_msgs_group_and_single

### DIFF
--- a/python/tests/test_0_complex_or_slow.py
+++ b/python/tests/test_0_complex_or_slow.py
@@ -271,12 +271,12 @@ def test_fetch_existing_msgs_group_and_single(acfactory, lp):
     ac1._evtracker.wait_next_incoming_message()
 
     lp.sec("send out message with bcc to ourselves")
-    with ac1.direct_imap.idle() as idle1:
-        ac1.set_config("bcc_self", "1")
-        ac1_ac2_chat = ac1.create_chat(ac2)
-        ac1_ac2_chat.send_text("outgoing, encrypted direct message, creating a chat")
-        # wait until the bcc_self message arrives
-        assert idle1.wait_for_seen()
+    ac1.set_config("bcc_self", "1")
+    ac1_ac2_chat = ac1.create_chat(ac2)
+    ac1_ac2_chat.send_text("outgoing, encrypted direct message, creating a chat")
+
+    # wait until the bcc_self message arrives
+    ac1._evtracker.get_info_contains("Marked messages [0-9]+ in folder INBOX as seen.")
 
     lp.sec("Clone online account and let it fetch the existing messages")
     ac1_clone = acfactory.new_online_configuring_account(cloned_from=ac1)


### PR DESCRIPTION
Makes the test less flaky,
as Dovecot sometimes sends only the EXISTS response, but not the FETCH response for flags.

Part of #4212.

#skip-changelog