### PR TITLE
receive_imf: Mark special messages as seen (#3054)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 - deltachat-rpc-client: fix bug in `Chat.send_message()`: invalid `MessageData` field `quotedMsg` instead of `quotedMsgId`
+- receive_imf: Mark special messages as seen. Exactly: delivery reports, webxdc status updates.
 
 
 ## [1.112.0] - 2023-03-23

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -319,6 +319,9 @@ def test_webxdc_message(acfactory, data, lp):
     assert msg2.text == "message1"
     assert msg2.is_webxdc()
     assert msg2.filename
+    ac2._evtracker.get_info_contains("Marked messages [0-9]+ in folder INBOX as seen.")
+    ac2.direct_imap.select_folder("Inbox")
+    assert len(list(ac2.direct_imap.conn.fetch(AND(seen=True)))) == 1
 
 
 def test_mvbox_sentbox_threads(acfactory, lp):

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -534,6 +534,7 @@ async fn add_parts(
         if chat_id.is_none() && mime_parser.delivery_report.is_some() {
             chat_id = Some(DC_CHAT_ID_TRASH);
             info!(context, "Message is a DSN (TRASH).",);
+            markseen_on_imap_table(context, rfc724_mid).await.ok();
         }
 
         if chat_id.is_none() {
@@ -868,6 +869,7 @@ async fn add_parts(
             if part.typ == Viewtype::Text && part.msg.is_empty() {
                 chat_id = Some(DC_CHAT_ID_TRASH);
                 info!(context, "Message is a status update only (TRASH).");
+                markseen_on_imap_table(context, rfc724_mid).await.ok();
             }
         }
     }


### PR DESCRIPTION
Exactly: delivery reports, webxdc status updates.