### PR TITLE
deltachat-rpc-client: configure setuptools_scm

### DIFF
--- a/deltachat-rpc-client/pyproject.toml
+++ b/deltachat-rpc-client/pyproject.toml
@@ -21,6 +21,9 @@ deltachat_rpc_client = [
 [project.entry-points.pytest11]
 "deltachat_rpc_client.pytestplugin" = "deltachat_rpc_client.pytestplugin"
 
+[tool.setuptools_scm]
+root = ".."
+
 [tool.black]
 line-length = 120
 


### PR DESCRIPTION
This makes `python -m build` produce wheels with a version other than 0.0.0.