### PR TITLE
check against null in dc_backup_provider_unref()

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -4230,6 +4230,10 @@ pub unsafe extern "C" fn dc_backup_provider_wait(provider: *mut dc_backup_provid
 
 #[no_mangle]
 pub unsafe extern "C" fn dc_backup_provider_unref(provider: *mut dc_backup_provider_t) {
+    if provider.is_null() {
+        eprintln!("ignoring careless call to dc_backup_provider_unref()");
+        return;
+    }
     drop(Box::from_raw(provider));
 }
 


### PR DESCRIPTION
this is what we're doing in most comparable unref() functions.

came over this when checking crashes on "quick abort during prepare" on android, cmp. https://github.com/deltachat/deltachat-android/pull/2514/commits/e42918daf0193f244725d777fe096ee2ff28e324 - android checks against null now on its own, but i think, it should be here as well.

https://github.com/deltachat/deltachat-android/pull/2514/commits/e42918daf0193f244725d777fe096ee2ff28e324 fixes some reproducible crashes as "always crash on abort during prepare", but there still seems more complicated cases, also desktop has some reports iirc

related: #4179, #4192

#skip-changelog