### PR TITLE
ref(logging): Remove message from LogExt::log_err

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -156,7 +156,9 @@ async fn on_configure_completed(
                     Some(stock_str::aeap_explanation_and_link(context, &old_addr, &new_addr).await);
                 chat::add_device_msg(context, None, Some(&mut msg))
                     .await
-                    .ok_or_log_msg(context, "Cannot add AEAP explanation");
+                    .context("Cannot add AEAP explanation")
+                    .log_err(context)
+                    .ok();
             }
         }
     }

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -691,7 +691,8 @@ async fn add_parts(
             } else if allow_creation {
                 if let Ok(chat) = ChatIdBlocked::get_for_contact(context, from_id, create_blocked)
                     .await
-                    .log_err(context, "Failed to get (new) chat for contact")
+                    .context("Failed to get (new) chat for contact")
+                    .log_err(context)
                 {
                     chat_id = Some(chat.id);
                     chat_id_blocked = chat.blocked;
@@ -843,7 +844,8 @@ async fn add_parts(
             // maybe an Autocrypt Setup Message
             if let Ok(chat) = ChatIdBlocked::get_for_contact(context, ContactId::SELF, Blocked::Not)
                 .await
-                .log_err(context, "Failed to get (new) chat for contact")
+                .context("Failed to get (new) chat for contact")
+                .log_err(context)
             {
                 chat_id = Some(chat.id);
                 chat_id_blocked = chat.blocked;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -757,7 +757,9 @@ pub async fn housekeeping(context: &Context) -> Result<()> {
             (),
         )
         .await
-        .ok_or_log_msg(context, "failed to remove old MDNs");
+        .context("failed to remove old MDNs")
+        .log_err(context)
+        .ok();
 
     info!(context, "Housekeeping done.");
     Ok(())


### PR DESCRIPTION
This removes the message that needed to be supplied to LogExt::log_err
calls.  This was from a time before we adopted anyhow and now we are
better off using anyhow::Context::context for the message: it is more
consistent, composes better and is less custom.

The benefit of the composition can be seen in the FFI calls which need
to both log the error as well as return it to the caller via
the set_last_error mechanism.

It also removes the LogExt::ok_or_log_msg funcion for the same reason,
the message is obsoleted by anyhow's context.

#skip-changelog