### PR TITLE
Build zig-rpc-server for i686

### DIFF
--- a/.github/workflows/deltachat-rpc-server.yml
+++ b/.github/workflows/deltachat-rpc-server.yml
@@ -15,7 +15,7 @@ jobs:
   # Build a version statically linked against musl libc
   # to avoid problems with glibc version incompatibility.
   build_linux:
-    name: Cross-compile deltachat-rpc-server for x86_64, aarch64 and armv7 Linux
+    name: Cross-compile deltachat-rpc-server for x86_64, i686, aarch64 and armv7 Linux
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -28,6 +28,13 @@ jobs:
         with:
           name: deltachat-rpc-server-x86_64
           path: target/x86_64-unknown-linux-musl/release/deltachat-rpc-server
+          if-no-files-found: error
+
+      - name: Upload i686 binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: deltachat-rpc-server-i686
+          path: target/i686-unknown-linux-musl/release/deltachat-rpc-server
           if-no-files-found: error
 
       - name: Upload aarch64 binary
@@ -90,7 +97,7 @@ jobs:
       - name: Compose dist/ directory
         run: |
           mkdir dist
-          for x in x86_64 aarch64 armv7 win32.exe win64.exe; do
+          for x in x86_64 i686 aarch64 armv7 win32.exe win64.exe; do
             mv "deltachat-rpc-server-$x"/* "dist/deltachat-rpc-server-$x"
           done
 

--- a/scripts/zig-cc
+++ b/scripts/zig-cc
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+import subprocess
+import sys
+import os
+
+
+def flag_filter(flag: str) -> bool:
+    if flag == "-lc":
+        return False
+    if flag == "-Wl,-melf_i386":
+        return False
+    if "self-contained" in flag and "crt" in flag:
+        return False
+    return True
+
+
+def main():
+    args = [flag for flag in sys.argv[1:] if flag_filter(flag)]
+    zig_target = os.environ["ZIG_TARGET"]
+    zig_cpu = os.environ.get("ZIG_CPU")
+    if zig_cpu:
+        zig_cpu_args = ["-mcpu=" + zig_cpu]
+        args = [x for x in args if not x.startswith("-march")]
+    else:
+        zig_cpu_args = []
+
+    subprocess.run(
+        ["zig", "cc", "-target", zig_target, *zig_cpu_args, *args], check=True
+    )
+
+
+main()

--- a/scripts/zig-rpc-server.sh
+++ b/scripts/zig-rpc-server.sh
@@ -1,11 +1,14 @@
 #!/bin/sh
 #
-# Build statically linked deltachat-rpc-server using cargo-zigbuild.
+# Build statically linked deltachat-rpc-server using zig.
 
 set -x
 set -e
 
 unset RUSTFLAGS
+
+# Pin Rust version to avoid uncontrolled changes in the compiler and linker flags.
+export RUSTUP_TOOLCHAIN=1.68.1
 
 ZIG_VERSION=0.11.0-dev.2213+515e1c93e
 
@@ -15,9 +18,35 @@ wget "https://ziglang.org/builds/zig-linux-x86_64-$ZIG_VERSION.tar.xz"
 tar xf "zig-linux-x86_64-$ZIG_VERSION.tar.xz"
 export PATH="$PWD/zig-linux-x86_64-$ZIG_VERSION:$PATH"
 
-cargo install cargo-zigbuild
+rustup target add i686-unknown-linux-musl
+CC="$PWD/scripts/zig-cc" \
+TARGET_CC="$PWD/scripts/zig-cc" \
+CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_LINKER="$PWD/scripts/zig-cc" \
+LD="$PWD/scripts/zig-cc" \
+ZIG_TARGET="x86-linux-musl" \
+cargo build --release --target i686-unknown-linux-musl -p deltachat-rpc-server --features vendored
 
-for TARGET in x86_64-unknown-linux-musl aarch64-unknown-linux-musl armv7-unknown-linux-musleabihf; do
-	rustup target add "$TARGET"
-	cargo zigbuild --release --target "$TARGET" -p deltachat-rpc-server --features vendored
-done
+rustup target add armv7-unknown-linux-musleabihf
+CC="$PWD/scripts/zig-cc" \
+TARGET_CC="$PWD/scripts/zig-cc" \
+CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER="$PWD/scripts/zig-cc" \
+LD="$PWD/scripts/zig-cc" \
+ZIG_TARGET="arm-linux-musleabihf" \
+ZIG_CPU="generic+v7a+vfp3-d32+thumb2-neon" \
+cargo build --release --target armv7-unknown-linux-musleabihf -p deltachat-rpc-server --features vendored
+
+rustup target add x86_64-unknown-linux-musl
+CC="$PWD/scripts/zig-cc" \
+TARGET_CC="$PWD/scripts/zig-cc" \
+CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="$PWD/scripts/zig-cc" \
+LD="$PWD/scripts/zig-cc" \
+ZIG_TARGET="x86_64-linux-musl" \
+cargo build --release --target x86_64-unknown-linux-musl -p deltachat-rpc-server --features vendored
+
+rustup target add aarch64-unknown-linux-musl
+CC="$PWD/scripts/zig-cc" \
+TARGET_CC="$PWD/scripts/zig-cc" \
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="$PWD/scripts/zig-cc" \
+LD="$PWD/scripts/zig-cc" \
+ZIG_TARGET="aarch64-linux-musl" \
+cargo build --release --target aarch64-unknown-linux-musl -p deltachat-rpc-server --features vendored


### PR DESCRIPTION
cargo-zigbuild is replaced with a simple zig-cc wrapper. cargo-zigbuild still tries to use i386-linux-musl triple, while in zig 0.11 x86-linux-musl should be used [1].

This also gives us more control over compilation flags used and prevents changes due to cargo-zigbuild upgrades, as its version was not pinned.

[1] Merged PR "all: rename i386 to x86 "
    <https://github.com/ziglang/zig/pull/13101>