### PR TITLE
fix(imex): Clone provider in dc_backup_provider_wait()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changes
 - Update iroh, remove `default-net` from `[patch.crates-io]` section.
-
+- Fix crash when dc_backup_provider_t is unrefed while dc_backup_provider_wait() is still using it.  #4244
 
 ## [1.112.1] - 2023-03-27
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -4221,10 +4221,17 @@ pub unsafe extern "C" fn dc_backup_provider_wait(provider: *mut dc_backup_provid
     let ffi_provider = &mut *provider;
     let ctx = &*ffi_provider.context;
     let provider = &mut ffi_provider.provider;
+    backup_provider_wait(ctx.clone(), provider.clone());
+}
+
+// Because this is a long-running operation make sure we own the Context and BackupProvider.
+// This stops a FFI user from deallocating it by calling unref on the object while we are
+// using it.
+fn backup_provider_wait(context: Context, provider: BackupProvider) {
     block_on(provider)
-        .log_err(ctx, "Failed to await BackupProvider")
+        .log_err(&context, "Failed to await BackupProvider")
         .context("Failed to await BackupProvider")
-        .set_last_error(ctx)
+        .set_last_error(&context)
         .ok();
 }
 

--- a/src/imex/transfer.rs
+++ b/src/imex/transfer.rs
@@ -27,6 +27,7 @@ use std::net::Ipv4Addr;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::Poll;
 
 use anyhow::{anyhow, bail, ensure, format_err, Context as _, Result};
@@ -78,7 +79,7 @@ pub struct BackupProvider {
     /// The ticket to retrieve the backup collection.
     ticket: Ticket,
     /// Guard to cancel the provider on drop.
-    _drop_guard: tokio_util::sync::DropGuard,
+    _drop_guard: Arc<tokio_util::sync::DropGuard>,
 }
 
 impl BackupProvider {
@@ -151,7 +152,7 @@ impl BackupProvider {
         Ok(Self {
             handle,
             ticket,
-            _drop_guard: drop_token.drop_guard(),
+            _drop_guard: Arc::new(drop_token.drop_guard()),
         })
     }
 


### PR DESCRIPTION
This is a long running process and there has been at least one crash in this function.  By owning both the context and the provider when waiting we can avoid them being deallocated while we are still using them.

To make the BackupProvider clonable this transforms all the errors from it into Strings.  These are clonable and how we report most our errors anyway.  The Future impl of BackupProvider then turns this into an anyhow::Error so all other code can keep using anyhow as usual.

This will likely resolve the crash reported at https://github.com/deltachat/deltachat-core-rust/issues/4179#issuecomment-1485138810  It won't fix #4242  itself though, that's done by https://github.com/deltachat/deltachat-core-rust/pull/4242, I think the comment reports a different bug.