### PR TITLE
fix(imex): transfer::get_backup must always free ongoing process

### DIFF
--- a/src/imex/transfer.rs
+++ b/src/imex/transfer.rs
@@ -392,12 +392,10 @@ pub async fn get_backup(context: &Context, qr: Qr) -> Result<()> {
     let cancel_token = context.alloc_ongoing().await?;
     let res = tokio::select! {
         biased;
-        res = get_backup_inner(context, qr) => {
-            context.free_ongoing().await;
-            res
-        }
+        res = get_backup_inner(context, qr) => res,
         _ = cancel_token.recv() => Err(format_err!("cancelled")),
     };
+    context.free_ongoing().await;
     res
 }
 


### PR DESCRIPTION
When the ongoing process is cancelled it is still the responsibility
of whoever took out the ongoing process to free it.  This code was
only freeing the ongoing process when completed normally but not when
cancelled.