### PR TITLE
ref(logging): remove LogExt::log_or_ok

### DIFF
--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -563,7 +563,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             context.maybe_network().await;
         }
         "housekeeping" => {
-            sql::housekeeping(&context).await.ok_or_log(&context);
+            sql::housekeeping(&context).await.log_err(&context).ok();
         }
         "listchats" | "listarchived" | "chats" => {
             let listflags = if arg0 == "listarchived" {

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -92,7 +92,7 @@ impl<'a> BlobObject<'a> {
                     if attempt >= MAX_ATTEMPT {
                         return Err(err).context("failed to create file");
                     } else if attempt == 1 && !dir.exists() {
-                        fs::create_dir_all(dir).await.ok_or_log(context);
+                        fs::create_dir_all(dir).await.log_err(context).ok();
                     } else {
                         name = format!("{}-{}{}", stem, rand::random::<u32>(), ext);
                     }

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -575,7 +575,8 @@ pub(crate) async fn ephemeral_loop(context: &Context, interrupt_receiver: Receiv
 
         delete_expired_messages(context, time())
             .await
-            .ok_or_log(context);
+            .log_err(context)
+            .ok();
     }
 }
 

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -759,7 +759,7 @@ async fn export_database(context: &Context, dest: &Path, passphrase: String) -> 
         .with_context(|| format!("path {} is not valid unicode", dest.display()))?;
 
     context.sql.set_raw_config_int("backup_time", now).await?;
-    sql::housekeeping(context).await.ok_or_log(context);
+    sql::housekeeping(context).await.log_err(context).ok();
     context
         .sql
         .call_write(|conn| {

--- a/src/log.rs
+++ b/src/log.rs
@@ -65,9 +65,6 @@ pub trait LogExt<T, E>
 where
     Self: std::marker::Sized,
 {
-    #[track_caller]
-    fn log_err_inner(self, context: &Context) -> Result<T, E>;
-
     /// Emits a warning if the receiver contains an Err value.
     ///
     /// Thanks to the [track_caller](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html#track_caller)
@@ -76,36 +73,15 @@ where
     /// Unfortunately, the track_caller feature does not work on async functions (as of Rust 1.50).
     /// Once it is, you can add `#[track_caller]` to helper functions that use one of the log helpers here
     /// so that the location of the caller can be seen in the log. (this won't work with the macros,
-    /// like warn!(), since the file!() and line!() macros don't work with track_caller)  
+    /// like warn!(), since the file!() and line!() macros don't work with track_caller)
     /// See <https://github.com/rust-lang/rust/issues/78840> for progress on this.
     #[track_caller]
-    fn log_err(self, context: &Context) -> Result<T, E> {
-        self.log_err_inner(context)
-    }
-
-    /// Emits a warning if the receiver contains an Err value and returns an [`Option<T>`].
-    ///
-    /// Example:
-    /// ```text
-    /// if let Err(e) = do_something() {
-    ///     warn!(context, "{:#}", e);
-    /// }
-    /// ```
-    /// is equivalent to:
-    /// ```text
-    /// do_something().ok_or_log(context);
-    /// ```
-    ///
-    /// For a note on the `track_caller` feature, see the doc comment on `log_err()`.
-    #[track_caller]
-    fn ok_or_log(self, context: &Context) -> Option<T> {
-        self.log_err_inner(context).ok()
-    }
+    fn log_err(self, context: &Context) -> Result<T, E>;
 }
 
 impl<T, E: std::fmt::Display> LogExt<T, E> for Result<T, E> {
     #[track_caller]
-    fn log_err_inner(self, context: &Context) -> Result<T, E> {
+    fn log_err(self, context: &Context) -> Result<T, E> {
         if let Err(e) = &self {
             let location = std::panic::Location::caller();
 

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -337,7 +337,7 @@ impl Context {
             let mut folder_added = false;
 
             if let Some(config) = folder.to_config().filter(|c| watched_folders.contains(c)) {
-                let f = self.get_config(config).await.ok_or_log(self).flatten();
+                let f = self.get_config(config).await.log_err(self).ok().flatten();
 
                 if let Some(foldername) = f {
                     let detailed = &state.get_detailed().await;


### PR DESCRIPTION
This further reduces the cognitive overload of having many ways to do
something.  The same is very easily done using composition.  Followup
from 82ace72527648ef2dc32e08cf177880732394565 or #4235.

#skip-changelog