### PR TITLE
ref(scheduler): Make InnerSchedulerState an enum

### DIFF
--- a/src/imex.rs
+++ b/src/imex.rs
@@ -91,7 +91,7 @@ pub async fn imex(
     let cancel = context.alloc_ongoing().await?;
 
     let res = {
-        let _guard = context.scheduler.pause(context.clone()).await;
+        let _guard = context.scheduler.pause(context.clone()).await?;
         imex_inner(context, what, path, passphrase)
             .race(async {
                 cancel.recv().await.ok();

--- a/src/imex/transfer.rs
+++ b/src/imex/transfer.rs
@@ -92,7 +92,7 @@ impl BackupProvider {
 
         // Acquire global "ongoing" mutex.
         let cancel_token = context.alloc_ongoing().await?;
-        let paused_guard = context.scheduler.pause(context.clone()).await;
+        let paused_guard = context.scheduler.pause(context.clone()).await?;
         let context_dir = context
             .get_blobdir()
             .parent()
@@ -371,7 +371,7 @@ pub async fn get_backup(context: &Context, qr: Qr) -> Result<()> {
         !context.is_configured().await?,
         "Cannot import backups to accounts in use."
     );
-    let _guard = context.scheduler.pause(context.clone()).await;
+    let _guard = context.scheduler.pause(context.clone()).await?;
 
     // Acquire global "ongoing" mutex.
     let cancel_token = context.alloc_ongoing().await?;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -151,7 +151,7 @@ impl SchedulerState {
                     ref started,
                     ref mut pause_guards_count,
                 } => {
-                    *pause_guards_count -= 1;
+                    *pause_guards_count = pause_guards_count.saturating_sub(1);
                     if *pause_guards_count == 0 {
                         match *started {
                             true => SchedulerState::do_start(inner, context.clone()).await,


### PR DESCRIPTION
This is more verbose, but makes reasoning about things easier.

Followup from #4246.

#skip-changelog