### PR TITLE
Remove upper limit on the attachment size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Changes
+- Remove upper limit on the attachment size. #4253
 
 ### Fixes
 


### PR DESCRIPTION
Recommended file size is used for recoding media.
For the upper size, we rely on the provider to tell us back if the message cannot be delivered to some recipients. This allows to send large files, such as APKs,
when using providers that don't have such strict limits.