### PR TITLE
ref(sql): Do not warn if BLOBS_BACKUP_NAME does not exist

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -897,12 +897,14 @@ pub async fn remove_unused_files(context: &Context) -> Result<()> {
                 }
             }
             Err(err) => {
-                warn!(
-                    context,
-                    "Housekeeping: Cannot read dir {}: {:#}.",
-                    p.display(),
-                    err
-                );
+                if !p.ends_with(BLOBS_BACKUP_NAME) {
+                    warn!(
+                        context,
+                        "Housekeeping: Cannot read dir {}: {:#}.",
+                        p.display(),
+                        err
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
It is perfectly normal for this directory to not exist.

#skip-changelog