### PR TITLE
Rewrite it in Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,17 +78,9 @@ jobs:
             rust: nightly
             python: false # Python bindings compilation on Windows is not supported.
           - os: macos-latest
-            rust: 1.68.0
+            rust: nightly
             python: 3.9
 
-          # Minimum Supported Rust Version = 1.65.0
-          #
-          # Minimum Supported Python Version = 3.7
-          # This is the minimum version for which manylinux Python wheels are
-          # built.
-          - os: ubuntu-latest
-            rust: 1.65.0
-            python: 3.7
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master
@@ -100,6 +92,11 @@ jobs:
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@v2
 
+      - name: Install python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+
       - name: Check
         run: cargo check --workspace --bins --examples --tests --benches
 
@@ -108,12 +105,6 @@ jobs:
 
       - name: Test cargo vendor
         run: cargo vendor
-
-      - name: Install python
-        if: ${{ matrix.python }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python }}
 
       - name: Install tox
         if: ${{ matrix.python }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     name: Rustfmt and Clippy
     runs-on: ubuntu-latest
     env:
-      RUSTUP_TOOLCHAIN: 1.68.0
+      RUSTUP_TOOLCHAIN: nightly
     steps:
       - uses: actions/checkout@v3
       - name: Install rustfmt and clippy
@@ -72,10 +72,10 @@ jobs:
         include:
           # Currently used Rust version.
           - os: ubuntu-latest
-            rust: 1.68.0
+            rust: nightly
             python: 3.9
           - os: windows-latest
-            rust: 1.68.0
+            rust: nightly
             python: false # Python bindings compilation on Windows is not supported.
           - os: macos-latest
             rust: 1.68.0

--- a/.github/workflows/jsonrpc.yml
+++ b/.github/workflows/jsonrpc.yml
@@ -38,7 +38,7 @@ jobs:
       - name: make sure websocket server version still builds
         run: |
           cd deltachat-jsonrpc
-          cargo build --bin deltachat-jsonrpc-server --features webserver
+          cargo +nightly build --bin deltachat-jsonrpc-server --features webserver
       - name: Run linter
         run: |
           cd deltachat-jsonrpc/typescript

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Increase MSRV to 1.65.0. #4236
 - Remove upper limit on the attachment size. #4253
 - Update rPGP to 0.10.1. #4236
+- Rewrite it in Python
 
 ### Fixes
 - Fix python bindings README documentation on installing the bindings from source.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
@@ -1176,6 +1176,7 @@ dependencies = [
  "hex",
  "humansize",
  "image",
+ "inline-python",
  "iroh",
  "kamadak-exif",
  "lettre_email",
@@ -2481,6 +2482,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "inline-python"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "211fb7fb668ad51bc03eb45ace2d6b677af6777137abf2ae5fcd1d1136d8950d"
+dependencies = [
+ "inline-python-macros",
+ "pyo3",
+]
+
+[[package]]
+name = "inline-python-macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c11adf3d765e0528063fde8c10e3a3e3e2a75bdeafd3c0a6841a8f72b37944c"
+dependencies = [
+ "libc",
+ "proc-macro2",
+ "pyo3",
+ "quote",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2800,6 +2823,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "memoffset"
@@ -3610,6 +3642,40 @@ dependencies = [
  "rand_xorshift",
  "regex-syntax",
  "unarray",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+ "parking_lot",
+ "pyo3-build-config",
+ "pyo3-ffi",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28fcd1e73f06ec85bf3280c48c67e731d8290ad3d730f8be9dc07946923005c8"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.17.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
 ]
 
 [[package]]
@@ -4672,6 +4738,12 @@ name = "tagger"
 version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aaa6f5d645d1dae4cd0286e9f8bf15b75a31656348e5e106eb1a940abd34b63"
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,8 @@ toml = "0.7"
 trust-dns-resolver = "0.22"
 url = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
+inline-python = "0.10.0"
+
 
 [dev-dependencies]
 ansi_term = "0.12.0"
@@ -152,8 +154,4 @@ harness = false
 [features]
 default = ["vendored"]
 internals = []
-vendored = [
-  "async-native-tls/vendored",
-  "rusqlite/bundled-sqlcipher-vendored-openssl",
-  "reqwest/native-tls-vendored"
-]
+vendored = ["async-native-tls/vendored", "rusqlite/bundled-sqlcipher-vendored-openssl", "reqwest/native-tls-vendored"]


### PR DESCRIPTION
This PR starts rewriting DC Core in Python. For now, I rewrote extract_address_from_receive_header(), which is quite a fundamental function (when I had a semantical error in the Python code, 56 tests failed).

Python is more readable, more concise, and more future-proof than the relatively young Rust.

This should be thought of as a "port" instead of a "rewrite" because we would not start from scratch; instead we will translate Rust to Python, incrementally, module by module, in the span of one release. We'll use [inline_python](https://lib.rs/crates/inline-python) so the Rust and Python bits can talk to each other until Rust is gone, and tests keep passing at every commit.

`inline_python` needs nightly rust, so, test this with `cargo +nightly test`. I'm not sure if I managed to correctly configure the CI in the first try.