### PR TITLE
show some text instead of nothing on empty quota list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixes
 - Fix python bindings README documentation on installing the bindings from source.
+- Show a warning if quota list is empty #4261
 
 ## [1.112.4] - 2023-03-31
 

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -396,64 +396,72 @@ impl Context {
         if let Some(quota) = &*quota {
             match &quota.recent {
                 Ok(quota) => {
-                    let roots_cnt = quota.len();
-                    for (root_name, resources) in quota {
-                        use async_imap::types::QuotaResourceName::*;
-                        for resource in resources {
-                            ret += "<li>";
+                    if quota.len() > 0 {
+                        for (root_name, resources) in quota {
+                            use async_imap::types::QuotaResourceName::*;
+                            for resource in resources {
+                                ret += "<li>";
 
-                            // root name is empty eg. for gmail and redundant eg. for riseup.
-                            // therefore, use it only if there are really several roots.
-                            if roots_cnt > 1 && !root_name.is_empty() {
-                                ret +=
-                                    &format!("<b>{}:</b> ", &*escaper::encode_minimal(root_name));
-                            } else {
-                                info!(self, "connectivity: root name hidden: \"{}\"", root_name);
+                                // root name is empty eg. for gmail and redundant eg. for riseup.
+                                // therefore, use it only if there are really several roots.
+                                if quota.len() > 1 && !root_name.is_empty() {
+                                    ret += &format!(
+                                        "<b>{}:</b> ",
+                                        &*escaper::encode_minimal(root_name)
+                                    );
+                                } else {
+                                    info!(
+                                        self,
+                                        "connectivity: root name hidden: \"{}\"", root_name
+                                    );
+                                }
+
+                                let messages = stock_str::messages(self).await;
+                                let part_of_total_used = stock_str::part_of_total_used(
+                                    self,
+                                    &resource.usage.to_string(),
+                                    &resource.limit.to_string(),
+                                )
+                                .await;
+                                ret += &match &resource.name {
+                                    Atom(resource_name) => {
+                                        format!(
+                                            "<b>{}:</b> {}",
+                                            &*escaper::encode_minimal(resource_name),
+                                            part_of_total_used
+                                        )
+                                    }
+                                    Message => {
+                                        format!("<b>{part_of_total_used}:</b> {messages}")
+                                    }
+                                    Storage => {
+                                        // do not use a special title needed for "Storage":
+                                        // - it is usually shown directly under the "Storage" headline
+                                        // - by the units "1 MB of 10 MB used" there is some difference to eg. "Messages: 1 of 10 used"
+                                        // - the string is not longer than the other strings that way (minus title, plus units) -
+                                        //   additional linebreaks on small displays are unlikely therefore
+                                        // - most times, this is the only item anyway
+                                        let usage = &format_size(resource.usage * 1024, BINARY);
+                                        let limit = &format_size(resource.limit * 1024, BINARY);
+                                        stock_str::part_of_total_used(self, usage, limit).await
+                                    }
+                                };
+
+                                let percent = resource.get_usage_percentage();
+                                let color = if percent >= QUOTA_ERROR_THRESHOLD_PERCENTAGE {
+                                    "red"
+                                } else if percent >= QUOTA_WARN_THRESHOLD_PERCENTAGE {
+                                    "yellow"
+                                } else {
+                                    "green"
+                                };
+                                ret += &format!("<div class=\"bar\"><div class=\"progress {color}\" style=\"width: {percent}%\">{percent}%</div></div>");
+
+                                ret += "</li>";
                             }
-
-                            let messages = stock_str::messages(self).await;
-                            let part_of_total_used = stock_str::part_of_total_used(
-                                self,
-                                &resource.usage.to_string(),
-                                &resource.limit.to_string(),
-                            )
-                            .await;
-                            ret += &match &resource.name {
-                                Atom(resource_name) => {
-                                    format!(
-                                        "<b>{}:</b> {}",
-                                        &*escaper::encode_minimal(resource_name),
-                                        part_of_total_used
-                                    )
-                                }
-                                Message => {
-                                    format!("<b>{part_of_total_used}:</b> {messages}")
-                                }
-                                Storage => {
-                                    // do not use a special title needed for "Storage":
-                                    // - it is usually shown directly under the "Storage" headline
-                                    // - by the units "1 MB of 10 MB used" there is some difference to eg. "Messages: 1 of 10 used"
-                                    // - the string is not longer than the other strings that way (minus title, plus units) -
-                                    //   additional linebreaks on small displays are unlikely therefore
-                                    // - most times, this is the only item anyway
-                                    let usage = &format_size(resource.usage * 1024, BINARY);
-                                    let limit = &format_size(resource.limit * 1024, BINARY);
-                                    stock_str::part_of_total_used(self, usage, limit).await
-                                }
-                            };
-
-                            let percent = resource.get_usage_percentage();
-                            let color = if percent >= QUOTA_ERROR_THRESHOLD_PERCENTAGE {
-                                "red"
-                            } else if percent >= QUOTA_WARN_THRESHOLD_PERCENTAGE {
-                                "yellow"
-                            } else {
-                                "green"
-                            };
-                            ret += &format!("<div class=\"bar\"><div class=\"progress {color}\" style=\"width: {percent}%\">{percent}%</div></div>");
-
-                            ret += "</li>";
                         }
+                    } else {
+                        ret += format!("<li>Warning: {domain} claims to support quota but gives no information</li>").as_str();
                     }
                 }
                 Err(e) => {

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -396,7 +396,7 @@ impl Context {
         if let Some(quota) = &*quota {
             match &quota.recent {
                 Ok(quota) => {
-                    if quota.len() > 0 {
+                    if !quota.is_empty() {
                         for (root_name, resources) in quota {
                             use async_imap::types::QuotaResourceName::*;
                             for resource in resources {


### PR DESCRIPTION
(best reviewed with whitespace disabled)

some providers say that they support QUOTA in the IMAP CAPABILITY, but return an empty list without any quota information then.

in our "Connectivity", this looks a bit of an error.

i have not seen this error often - only for testrun.org - if it is usual, we could also just say "not supported" (as we do in case QUOTA is not returned).
a translations seems not to be needed for now,
it seems unusual, and all other errors are not translated as well.

@missytake maybe this can also be fixed on testrun?

before/after (gxc8z at testrun):

<img width=270 src=https://user-images.githubusercontent.com/9800740/229295679-9f6f9de1-97f0-4159-96da-716356d8fbb2.PNG> <img width= 270 src=https://user-images.githubusercontent.com/9800740/229295672-4fae3d90-9621-44d1-9436-d6d14ece6086.PNG>

this is how it looks if quota is really supported (tunis4 at testrun):

<img width= 270 src=https://user-images.githubusercontent.com/9800740/229295678-9039876b-e85c-4de2-b28a-a616009bf0d2.PNG> 
