### PR TITLE
ci: split CI into more parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run clippy
         run: scripts/clippy.sh
       - name: Check
-        run: cargo check --workspace --bins --examples --tests --benches
+        run: cargo check --workspace --all-targets --all-features
 
   cargo_deny:
     name: cargo deny


### PR DESCRIPTION
With this, all the builds happen in parallel in 3-6 minutes,
and then python tests run for 8-9 minutes.

Before, it was 6-17 minutes for compilation,
then 19-31 minutes for python tests.
Compilation of the library and test binary was not parallelized,
and then python tests included async python tests
and deltachat-rpc-server binary compilation.

Now, deltachat-rpc-server compilation,
Rust testing and async python tests are separate jobs.