### PR TITLE
fix(imex): Transfer large collection of blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,9 +2325,9 @@ checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "iroh"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c019223f5af15f978ff44ae02b8b83d21d53df4c42d4475aa80670819c3ecdce"
+checksum = "e4fb9858c8cd3dd924a5da5bc511363845a9bcfdfac066bb2ef8454eb6111546"
 dependencies = [
  "abao",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ futures-lite = "1.12.0"
 hex = "0.4.0"
 humansize = "2"
 image = { version = "0.24.5", default-features=false, features = ["gif", "jpeg", "ico", "png", "pnm", "webp", "bmp"] }
-iroh = { version = "0.4.0", default-features = false }
+iroh = { version = "0.4.1", default-features = false }
 kamadak-exif = "0.5"
 lettre_email = { git = "https://github.com/deltachat/lettre", branch = "master" }
 libc = "0.2"


### PR DESCRIPTION
There was a bug in iroh when transferring a large collection of blobs,
not the entire collection index was transferred due to buffer issues.