### PR TITLE
add a device message when backup transfer ends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 1.112.6 - unreleased
 
+### Changes
+
+- Add a device message after backup transfer #4301
+
 ### Fixed
 
 - Updated `iroh` from 0.4.0 to 0.4.1 to fix transfer of large accounts with many blob files.

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -7069,6 +7069,11 @@ void dc_event_unref(dc_event_t* event);
 /// `%1$s` will be replaced by name and address of the account.
 #define DC_STR_BACKUP_TRANSFER_QR 162
 
+/// "Account transferred to your second device."
+///
+/// Used as a device message after a successful backup transfer.
+#define DC_STR_BACKUP_TRANSFER_MSG_BODY 163
+
 /**
  * @}
  */

--- a/src/imex/transfer.rs
+++ b/src/imex/transfer.rs
@@ -47,9 +47,11 @@ use tokio_stream::wrappers::ReadDirStream;
 use tokio_util::sync::CancellationToken;
 
 use crate::blob::BlobDirContents;
-use crate::chat::delete_and_reset_all_device_msgs;
+use crate::chat::{add_device_msg, delete_and_reset_all_device_msgs};
 use crate::context::Context;
+use crate::message::{Message, Viewtype};
 use crate::qr::Qr;
+use crate::stock_str::backup_transfer_msg_body;
 use crate::{e2ee, EventType};
 
 use super::{export_database, DBFILE_BACKUP_NAME};
@@ -270,7 +272,12 @@ impl BackupProvider {
             }
         };
         match &res {
-            Ok(_) => context.emit_event(SendProgress::Completed.into()),
+            Ok(_) => {
+                context.emit_event(SendProgress::Completed.into());
+                let mut msg = Message::new(Viewtype::Text);
+                msg.text = Some(backup_transfer_msg_body(context).await);
+                add_device_msg(context, None, Some(&mut msg)).await?;
+            }
             Err(err) => {
                 error!(context, "Backup transfer failure: {err:#}");
                 context.emit_event(SendProgress::Failed.into())

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -407,6 +407,9 @@ pub enum StockMessage {
 
     #[strum(props(fallback = "Scan to set up second device for %1$s"))]
     BackupTransferQr = 162,
+
+    #[strum(props(fallback = "ℹ️ Account transferred to your second device."))]
+    BackupTransferMsgBody = 163,
 }
 
 impl StockMessage {
@@ -1259,6 +1262,10 @@ pub(crate) async fn backup_transfer_qr(context: &Context) -> Result<String> {
     Ok(translated(context, StockMessage::BackupTransferQr)
         .await
         .replace1(&full_name))
+}
+
+pub(crate) async fn backup_transfer_msg_body(context: &Context) -> String {
+    translated(context, StockMessage::BackupTransferMsgBody).await
 }
 
 impl Context {


### PR DESCRIPTION
that way, UI can just close the transfer dialog, so that, at the end, both devices end in the chatlist.
    
we can also use  this for troubleshooting - if the device message is not present, transfer did not succeed completely.
    
(a separate device message may be nice in that case - but that is another effort, same for making the device message reappear after deletion or after some time)
