### PR TITLE
New API to wait for messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@
   Also terminate on ctrl-c.
 - Refactorings #4317
 - Add JSON-RPC API `can_send()`.
+- New `dc_get_next_msgs()` and `dc_wait_next_msgs()` C APIs.
+  New `get_next_msgs()` and `wait_next_msgs()` JSON-RPC API.
+  These APIs can be used by bots to get all unprocessed messages
+  in the order of their arrival and wait for them without relying on events.
+- Async Python API `get_fresh_messages_in_arrival_order()` is deprecated
+  in favor of `get_next_msgs()` and `wait_next_msgs()`.
+- New Python bindings API `Account.wait_next_incoming_message()`.
+- New Python bindings APIs `Message.is_from_self()` and `Message.is_from_device()`.
 
 ### Fixes
 - Fix python bindings README documentation on installing the bindings from source.

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1281,6 +1281,50 @@ pub unsafe extern "C" fn dc_get_fresh_msgs(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_get_next_msgs(context: *mut dc_context_t) -> *mut dc_array::dc_array_t {
+    if context.is_null() {
+        eprintln!("ignoring careless call to dc_get_next_msgs()");
+        return ptr::null_mut();
+    }
+    let ctx = &*context;
+
+    let msg_ids = block_on(ctx.get_next_msgs())
+        .context("failed to get next messages")
+        .log_err(ctx)
+        .unwrap_or_default();
+    let arr = dc_array_t::from(
+        msg_ids
+            .iter()
+            .map(|msg_id| msg_id.to_u32())
+            .collect::<Vec<u32>>(),
+    );
+    Box::into_raw(Box::new(arr))
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dc_wait_next_msgs(
+    context: *mut dc_context_t,
+) -> *mut dc_array::dc_array_t {
+    if context.is_null() {
+        eprintln!("ignoring careless call to dc_wait_next_msgs()");
+        return ptr::null_mut();
+    }
+    let ctx = &*context;
+
+    let msg_ids = block_on(ctx.wait_next_msgs())
+        .context("failed to wait for next messages")
+        .log_err(ctx)
+        .unwrap_or_default();
+    let arr = dc_array_t::from(
+        msg_ids
+            .iter()
+            .map(|msg_id| msg_id.to_u32())
+            .collect::<Vec<u32>>(),
+    );
+    Box::into_raw(Box::new(arr))
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_marknoticed_chat(context: *mut dc_context_t, chat_id: u32) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_marknoticed_chat()");

--- a/deltachat-rpc-client/examples/echobot_no_hooks.py
+++ b/deltachat-rpc-client/examples/echobot_no_hooks.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import sys
 
-from deltachat_rpc_client import DeltaChat, EventType, Rpc
+from deltachat_rpc_client import DeltaChat, EventType, Rpc, SpecialContactId
 
 
 async def main():
@@ -30,9 +30,9 @@ async def main():
             await deltachat.start_io()
 
         async def process_messages():
-            for message in await account.get_fresh_messages_in_arrival_order():
+            for message in await account.get_next_messages():
                 snapshot = await message.get_snapshot()
-                if not snapshot.is_bot and not snapshot.is_info:
+                if snapshot.from_id != SpecialContactId.SELF and not snapshot.is_bot and not snapshot.is_info:
                     await snapshot.chat.send_text(snapshot.text)
                 await snapshot.message.mark_seen()
 

--- a/deltachat-rpc-client/src/deltachat_rpc_client/__init__.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/__init__.py
@@ -3,7 +3,7 @@ from ._utils import AttrDict, run_bot_cli, run_client_cli
 from .account import Account
 from .chat import Chat
 from .client import Bot, Client
-from .const import EventType
+from .const import EventType, SpecialContactId
 from .contact import Contact
 from .deltachat import DeltaChat
 from .message import Message
@@ -19,6 +19,7 @@ __all__ = [
     "DeltaChat",
     "EventType",
     "Message",
+    "SpecialContactId",
     "Rpc",
     "run_bot_cli",
     "run_client_cli",

--- a/deltachat-rpc-client/src/deltachat_rpc_client/account.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/account.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from warnings import warn
 
 from ._utils import AttrDict
 from .chat import Chat
@@ -239,7 +240,22 @@ class Account:
         fresh_msg_ids = await self._rpc.get_fresh_msgs(self.id)
         return [Message(self, msg_id) for msg_id in fresh_msg_ids]
 
+    async def get_next_messages(self) -> List[Message]:
+        """Return a list of next messages."""
+        next_msg_ids = await self._rpc.get_next_msgs(self.id)
+        return [Message(self, msg_id) for msg_id in next_msg_ids]
+
+    async def wait_next_messages(self) -> List[Message]:
+        """Wait for new messages and return a list of them."""
+        next_msg_ids = await self._rpc.wait_next_msgs(self.id)
+        return [Message(self, msg_id) for msg_id in next_msg_ids]
+
     async def get_fresh_messages_in_arrival_order(self) -> List[Message]:
         """Return fresh messages list sorted in the order of their arrival, with ascending IDs."""
+        warn(
+            "get_fresh_messages_in_arrival_order is deprecated, use get_next_messages instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         fresh_msg_ids = sorted(await self._rpc.get_fresh_msgs(self.id))
         return [Message(self, msg_id) for msg_id in fresh_msg_ids]

--- a/deltachat-rpc-client/src/deltachat_rpc_client/client.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/client.py
@@ -20,7 +20,7 @@ from ._utils import (
     parse_system_image_changed,
     parse_system_title_changed,
 )
-from .const import COMMAND_PREFIX, EventType, SystemMessageType
+from .const import COMMAND_PREFIX, EventType, SpecialContactId, SystemMessageType
 from .events import (
     EventFilter,
     GroupImageChanged,
@@ -189,9 +189,10 @@ class Client:
 
     async def _process_messages(self) -> None:
         if self._should_process_messages:
-            for message in await self.account.get_fresh_messages_in_arrival_order():
+            for message in await self.account.get_next_messages():
                 snapshot = await message.get_snapshot()
-                await self._on_new_msg(snapshot)
+                if snapshot.from_id not in [SpecialContactId.SELF, SpecialContactId.DEVICE]:
+                    await self._on_new_msg(snapshot)
                 if snapshot.is_info and snapshot.system_message_type != SystemMessageType.WEBXDC_INFO_MESSAGE:
                     await self._handle_info_msg(snapshot)
                 await snapshot.message.mark_seen()

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -344,6 +344,16 @@ class Message:
         contact_id = lib.dc_msg_get_from_id(self._dc_msg)
         return Contact(self.account, contact_id)
 
+    def is_from_self(self):
+        """Return true if the message is sent by self."""
+        contact_id = lib.dc_msg_get_from_id(self._dc_msg)
+        return contact_id == const.DC_CONTACT_ID_SELF
+
+    def is_from_device(self):
+        """Return true if the message is sent by the device."""
+        contact_id = lib.dc_msg_get_from_id(self._dc_msg)
+        return contact_id == const.DC_CONTACT_ID_DEVICE
+
     #
     # Message State query methods
     #

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -44,21 +44,21 @@ def test_configure_generate_key(acfactory, lp):
     lp.sec("ac1: send unencrypted message to ac2")
     chat.send_text("message1")
     lp.sec("ac2: waiting for message from ac1")
-    msg_in = ac2._evtracker.wait_next_incoming_message()
+    msg_in = ac2.wait_next_incoming_message()
     assert msg_in.text == "message1"
     assert not msg_in.is_encrypted()
 
     lp.sec("ac2: send encrypted message to ac1")
     msg_in.chat.send_text("message2")
     lp.sec("ac1: waiting for message from ac2")
-    msg2_in = ac1._evtracker.wait_next_incoming_message()
+    msg2_in = ac1.wait_next_incoming_message()
     assert msg2_in.text == "message2"
     assert msg2_in.is_encrypted()
 
     lp.sec("ac1: send encrypted message to ac2")
     msg2_in.chat.send_text("message3")
     lp.sec("ac2: waiting for message from ac1")
-    msg3_in = ac2._evtracker.wait_next_incoming_message()
+    msg3_in = ac2.wait_next_incoming_message()
     assert msg3_in.text == "message3"
     assert msg3_in.is_encrypted()
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1666,6 +1666,7 @@ impl Chat {
                     ],
                 )
                 .await?;
+            context.new_msgs_notify.notify_one();
             msg.id = MsgId::new(u32::try_from(raw_id)?);
 
             maybe_set_logging_xdc(context, msg, self.id).await?;
@@ -3628,6 +3629,7 @@ pub async fn add_device_msg_with_importance(
                 ),
             )
             .await?;
+        context.new_msgs_notify.notify_one();
 
         msg_id = MsgId::new(u32::try_from(row_id)?);
         if !msg.hidden {
@@ -3741,6 +3743,7 @@ pub(crate) async fn add_info_msg_with_cmd(
             parent.map(|msg|msg.rfc724_mid.clone()).unwrap_or_default()
         )
     ).await?;
+    context.new_msgs_notify.notify_one();
 
     let msg_id = MsgId::new(row_id.try_into()?);
     context.emit_msgs_changed(chat_id, msg_id);

--- a/src/config.rs
+++ b/src/config.rs
@@ -308,6 +308,9 @@ pub enum Config {
     /// This value is used internally to remember the MsgId of the logging xdc
     #[strum(props(default = "0"))]
     DebugLogging,
+
+    /// Last message processed by the bot.
+    LastMsgId,
 }
 
 impl Context {
@@ -355,6 +358,11 @@ impl Context {
 
     /// Returns 32-bit signed integer configuration value for the given key.
     pub async fn get_config_int(&self, key: Config) -> Result<i32> {
+        Ok(self.get_config_parsed(key).await?.unwrap_or_default())
+    }
+
+    /// Returns 32-bit unsigned integer configuration value for the given key.
+    pub async fn get_config_u32(&self, key: Config) -> Result<u32> {
         Ok(self.get_config_parsed(key).await?.unwrap_or_default())
     }
 
@@ -456,6 +464,12 @@ impl Context {
                 self.sql.set_raw_config(key.as_ref(), value).await?;
             }
         }
+        Ok(())
+    }
+
+    /// Set the given config to an unsigned 32-bit integer value.
+    pub async fn set_config_u32(&self, key: Config, value: u32) -> Result<()> {
+        self.set_config(key, Some(&value.to_string())).await?;
         Ok(())
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant, SystemTime};
 use anyhow::{bail, ensure, Context as _, Result};
 use async_channel::{self as channel, Receiver, Sender};
 use ratelimit::Ratelimit;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{Mutex, Notify, RwLock};
 use tokio::task;
 
 use crate::chat::{get_chat_cnt, ChatId};
@@ -218,6 +218,11 @@ pub struct InnerContext {
     /// IMAP UID resync request.
     pub(crate) resync_request: AtomicBool,
 
+    /// Notify about new messages.
+    ///
+    /// This causes [`Context::wait_next_msgs`] to wake up.
+    pub(crate) new_msgs_notify: Notify,
+
     /// Server ID response if ID capability is supported
     /// and the server returned non-NIL on the inbox connection.
     /// <https://datatracker.ietf.org/doc/html/rfc2971>
@@ -363,6 +368,11 @@ impl Context {
             blobdir.display()
         );
 
+        let new_msgs_notify = Notify::new();
+        // Notify once immediately to allow processing old messages
+        // without starting I/O.
+        new_msgs_notify.notify_one();
+
         let inner = InnerContext {
             id,
             blobdir,
@@ -379,6 +389,7 @@ impl Context {
             quota: RwLock::new(None),
             quota_update_request: AtomicBool::new(false),
             resync_request: AtomicBool::new(false),
+            new_msgs_notify,
             server_id: RwLock::new(None),
             creation_time: std::time::SystemTime::now(),
             last_full_folder_scan: Mutex::new(None),
@@ -767,6 +778,10 @@ impl Context {
             "debug_logging",
             self.get_config_int(Config::DebugLogging).await?.to_string(),
         );
+        res.insert(
+            "last_msg_id",
+            self.get_config_int(Config::LastMsgId).await?.to_string(),
+        );
 
         let elapsed = self.creation_time.elapsed();
         res.insert("uptime", duration_to_str(elapsed.unwrap_or_default()));
@@ -810,6 +825,66 @@ impl Context {
                 },
             )
             .await?;
+        Ok(list)
+    }
+
+    /// Returns a list of messages with database ID higher than requested.
+    ///
+    /// Blocked contacts and chats are excluded,
+    /// but self-sent messages and contact requests are included in the results.
+    pub async fn get_next_msgs(&self) -> Result<Vec<MsgId>> {
+        let last_msg_id = match self.get_config(Config::LastMsgId).await? {
+            Some(s) => MsgId::new(s.parse()?),
+            None => MsgId::new_unset(),
+        };
+
+        let list = self
+            .sql
+            .query_map(
+                "SELECT m.id
+                     FROM msgs m
+                     LEFT JOIN contacts ct
+                            ON m.from_id=ct.id
+                     LEFT JOIN chats c
+                            ON m.chat_id=c.id
+                     WHERE m.id>?
+                       AND m.hidden=0
+                       AND m.chat_id>9
+                       AND ct.blocked=0
+                       AND c.blocked!=1
+                     ORDER BY m.id ASC",
+                (
+                    last_msg_id.to_u32(), // Explicitly convert to u32 because 0 is allowed.
+                ),
+                |row| {
+                    let msg_id: MsgId = row.get(0)?;
+                    Ok(msg_id)
+                },
+                |rows| {
+                    let mut list = Vec::new();
+                    for row in rows {
+                        list.push(row?);
+                    }
+                    Ok(list)
+                },
+            )
+            .await?;
+        Ok(list)
+    }
+
+    /// Returns a list of messages with database ID higher than last marked as seen.
+    ///
+    /// This function is supposed to be used by bot to request messages
+    /// that are not processed yet.
+    ///
+    /// Waits for notification and returns a result.
+    /// Note that the result may be empty if the message is deleted
+    /// shortly after notification or notification is manually triggered
+    /// to interrupt waiting.
+    /// Notification may be manually triggered by calling [`Self::stop_io`].
+    pub async fn wait_next_msgs(&self) -> Result<Vec<MsgId>> {
+        self.new_msgs_notify.notified().await;
+        let list = self.get_next_msgs().await?;
         Ok(list)
     }
 
@@ -1441,6 +1516,40 @@ mod tests {
 
         // Another ongoing process can be allocated now.
         let _receiver = context.alloc_ongoing().await?;
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_get_next_msgs() -> Result<()> {
+        let alice = TestContext::new_alice().await;
+        let bob = TestContext::new_bob().await;
+
+        let alice_chat = alice.create_chat(&bob).await;
+
+        assert!(alice.get_next_msgs().await?.is_empty());
+        assert!(bob.get_next_msgs().await?.is_empty());
+
+        let sent_msg = alice.send_text(alice_chat.id, "Hi Bob").await;
+        let received_msg = bob.recv_msg(&sent_msg).await;
+
+        let bob_next_msg_ids = bob.get_next_msgs().await?;
+        assert_eq!(bob_next_msg_ids.len(), 1);
+        assert_eq!(bob_next_msg_ids.get(0), Some(&received_msg.id));
+
+        bob.set_config_u32(Config::LastMsgId, received_msg.id.to_u32())
+            .await?;
+        assert!(bob.get_next_msgs().await?.is_empty());
+
+        // Next messages include self-sent messages.
+        let alice_next_msg_ids = alice.get_next_msgs().await?;
+        assert_eq!(alice_next_msg_ids.len(), 1);
+        assert_eq!(alice_next_msg_ids.get(0), Some(&sent_msg.sender_msg_id));
+
+        alice
+            .set_config_u32(Config::LastMsgId, sent_msg.sender_msg_id.to_u32())
+            .await?;
+        assert!(alice.get_next_msgs().await?.is_empty());
 
         Ok(())
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1468,6 +1468,12 @@ pub async fn markseen_msgs(context: &Context, msg_ids: Vec<MsgId>) -> Result<()>
         return Ok(());
     }
 
+    let old_last_msg_id = MsgId::new(context.get_config_u32(Config::LastMsgId).await?);
+    let last_msg_id = msg_ids.iter().fold(&old_last_msg_id, std::cmp::max);
+    context
+        .set_config_u32(Config::LastMsgId, last_msg_id.to_u32())
+        .await?;
+
     let msgs = context
         .sql
         .query_map(

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -363,6 +363,7 @@ pub(crate) async fn receive_imf_inner(
             chat_id.emit_msg_event(context, *msg_id, incoming && fresh);
         }
     }
+    context.new_msgs_notify.notify_one();
 
     mime_parser
         .handle_reports(context, from_id, sent_timestamp, &mime_parser.parts)


### PR DESCRIPTION
This patch adds new C APIs
dc_get_next_msgs() and dc_wait_next_msgs(),
and their JSON-RPC counterparts
get_next_msgs() and wait_next_msgs().
New configuration "last_msg_id"
tracks the last message ID processed by the bot.
get_next_msgs() returns message IDs above
the "last_msg_id".
wait_next_msgs() waits for new message notification
and calls get_next_msgs().
wait_next_msgs() can be used to build
a separate message processing loop
independent of the event loop.

Async Python API get_fresh_messages_in_arrival_order()
is deprecated in favor of get_next_messages().

Introduced Python APIs:
- Account.wait_next_incoming_message()
- Message.is_from_self()
- Message.is_from_device()

Introduced Rust APIs:
- Context.set_config_u32()
- Context.get_config_u32()