### PR TITLE
Debug logging refactoring

### DIFF
--- a/src/debug_logging.rs
+++ b/src/debug_logging.rs
@@ -134,7 +134,7 @@ pub(crate) async fn set_debug_logging_xdc(ctx: &Context, id: Option<MsgId>) -> a
                 )
                 .await?;
             {
-                let debug_logging = &mut *ctx.debug_logging.write().await;
+                let debug_logging = &mut *ctx.debug_logging.write().expect("RwLock is poisoned");
                 match debug_logging {
                     // Switch logging xdc
                     Some(debug_logging) => debug_logging.msg_id = msg_id,
@@ -162,7 +162,7 @@ pub(crate) async fn set_debug_logging_xdc(ctx: &Context, id: Option<MsgId>) -> a
             ctx.sql
                 .set_raw_config(Config::DebugLogging.as_ref(), None)
                 .await?;
-            *ctx.debug_logging.write().await = None;
+            *ctx.debug_logging.write().expect("RwLock is poisoned") = None;
             info!(ctx, "removing logging webxdc");
         }
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1425,7 +1425,7 @@ pub async fn delete_msgs(context: &Context, msg_ids: &[MsgId]) -> Result<()> {
         let logging_xdc_id = context
             .debug_logging
             .read()
-            .await
+            .expect("RwLock is poisoned")
             .as_ref()
             .map(|dl| dl.msg_id);
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -105,7 +105,12 @@ impl SchedulerState {
         // to allow for clean shutdown.
         context.new_msgs_notify.notify_one();
 
-        if let Some(debug_logging) = context.debug_logging.read().await.as_ref() {
+        if let Some(debug_logging) = context
+            .debug_logging
+            .read()
+            .expect("RwLock is poisoned")
+            .as_ref()
+        {
             debug_logging.loop_handle.abort();
         }
         let prev_state = std::mem::replace(&mut *inner, new_state);

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -2466,9 +2466,9 @@ sth_for_the = "future""#
             include_bytes!("../test-data/webxdc/minimal.xdc"),
         )
         .await?;
-        assert!(alice.debug_logging.read().await.is_none());
+        assert!(alice.debug_logging.read().unwrap().is_none());
         send_msg(&alice, chat_id, &mut instance).await?;
-        assert!(alice.debug_logging.read().await.is_some());
+        assert!(alice.debug_logging.read().unwrap().is_some());
 
         alice.emit_event(EventType::Info("hi".to_string()));
         alice


### PR DESCRIPTION
Move DebugLogging into debug logging module.
Remove Context.send_log_event().
Use blocking_read() instead of try_read() to
get read lock on debug_logging() in synchronous code.
Do not try to log events while holding a lock
on DebugLogging.

#skip-changelog