### PR TITLE
Update to released async-imap 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Updated `async-imap` to v0.8.0 to fix erroneous EOF detection in long IMAP responses.
+
 ## [1.112.6] - 2023-04-04
 
 ### Changes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,12 +189,12 @@ dependencies = [
 
 [[package]]
 name = "async-imap"
-version = "0.6.0"
-source = "git+https://github.com/async-email/async-imap?branch=master#90270474a5a494669e7c63c13471d189afdc98ae"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d11e163a705d0c809dfc886eee95df5117c758539c940c0fe9aa3aa4da5388ce"
 dependencies = [
  "async-channel",
- "async-native-tls 0.4.0",
- "base64 0.13.1",
+ "base64 0.21.0",
  "byte-pool",
  "chrono",
  "futures",
@@ -216,18 +216,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
 dependencies = [
  "event-listener",
-]
-
-[[package]]
-name = "async-native-tls"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d57d4cec3c647232e1094dc013546c0b33ce785d8aeb251e1f20dfaf8a9a13fe"
-dependencies = [
- "native-tls",
- "thiserror",
- "tokio",
- "url",
 ]
 
 [[package]]
@@ -494,9 +482,9 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-pool"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c7230ddbb427b1094d477d821a99f3f54d36333178eeb806e279bcdcecf0ca"
+checksum = "c2f1b21189f50b5625efa6227cf45e9d4cfdc2e73582df2b879e9689e78a7158"
 dependencies = [
  "crossbeam-queue",
  "stable_deref_trait",
@@ -1067,7 +1055,7 @@ dependencies = [
  "anyhow",
  "async-channel",
  "async-imap",
- "async-native-tls 0.5.0",
+ "async-native-tls",
  "async-smtp",
  "async_zip",
  "backtrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ ratelimit = { path = "./deltachat-ratelimit" }
 
 anyhow = "1"
 async-channel = "1.8.0"
-async-imap = { git = "https://github.com/async-email/async-imap", branch = "master", default-features = false, features = ["runtime-tokio"] }
+async-imap = { version = "0.8.0", default-features = false, features = ["runtime-tokio"] }
 async-native-tls = { version = "0.5", default-features = false, features = ["runtime-tokio"] }
 async-smtp = { version = "0.9", default-features = false, features = ["runtime-tokio"] }
 async_zip = { version = "0.0.11", default-features = false, features = ["deflate", "fs"] }


### PR DESCRIPTION
It fixes important bug in `ensure_capacity()` that sometimes resulted in erroneous detection of EOF in IMAP response.

This is for merging into the stable branch which is currently at roughly 0.6.0 (https://github.com/async-email/async-imap/commit/90270474a5a494669e7c63c13471d189afdc98ae) without even the workaround from v0.7.0.