### PR TITLE
Do not use println! in JSON-RPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+- JSON-RPC: do not print to stdout on failure to find an account.
+
+
 ## [1.113.0] - 2023-04-18
 
 ### Added

--- a/deltachat-jsonrpc/src/api/mod.rs
+++ b/deltachat-jsonrpc/src/api/mod.rs
@@ -205,8 +205,6 @@ impl CommandApi {
             let context_option = self.accounts.read().await.get_account(id);
             if let Some(ctx) = context_option {
                 accounts.push(Account::from_context(&ctx, id).await?)
-            } else {
-                println!("account with id {id} doesn't exist anymore");
             }
         }
         Ok(accounts)


### PR DESCRIPTION
This may break the output of deltachat-rpc-server