### PR TITLE
build(rust): Increase MSRV to 1.68

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,13 +78,13 @@ jobs:
           - os: macos-latest
             rust: 1.68.2
 
-          # Minimum Supported Rust Version = 1.65.0
+          # Minimum Supported Rust Version = 1.68.0
           #
           # Minimum Supported Python Version = 3.7
           # This is the minimum version for which manylinux Python wheels are
           # built.
           - os: ubuntu-latest
-            rust: 1.65.0
+            rust: 1.68.0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - BREAKING: jsonrpc:
   - `get_chatlist_items_by_entries` now takes only chatids instead of `ChatListEntries`
   - `get_chatlist_entries` now returns `Vec<u32>` of chatids instead of `ChatListEntries`
-
+- Increase MSRV to 1.68. #4375
 
 ## [1.114.0] - 2023-04-24
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "deltachat"
 version = "1.114.0"
 edition = "2021"
 license = "MPL-2.0"
-rust-version = "1.65"
+rust-version = "1.68"
 
 [profile.dev]
 debug = 0


### PR DESCRIPTION
iOS is now on 1.69 and Android on 1.68, so bump the msrv.