### PR TITLE
scripts/deny.sh: update package cache before running `cargo deny`

### DIFF
--- a/scripts/deny.sh
+++ b/scripts/deny.sh
@@ -1,2 +1,6 @@
 #!/bin/sh
+
+# Update package cache without changing the lockfile.
+cargo update --dry-run
+
 cargo deny --workspace --all-features check -D warnings


### PR DESCRIPTION
Otherwise it is impossible to detect yanked versions.