### PR TITLE
Make the bots automatically accept group chat contact requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - BREAKING: jsonrpc:
   - `get_chatlist_items_by_entries` now takes only chatids instead of `ChatListEntries`
   - `get_chatlist_entries` now returns `Vec<u32>` of chatids instead of `ChatListEntries`
+### Fixes
+- Make the bots automatically accept group chat contact requests. #4377
 
 
 ## [1.114.0] - 2023-04-24

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -557,7 +557,13 @@ async fn add_parts(
                 blocked: Blocked::Request,
             }) if is_bot => Blocked::Not,
             Some(ChatIdBlocked { id: _, blocked }) => blocked,
-            None => Blocked::Request,
+            None => {
+                if is_bot {
+                    Blocked::Not
+                } else {
+                    Blocked::Request
+                }
+            }
         };
 
         if chat_id.is_none() {

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -2981,6 +2981,17 @@ async fn test_auto_accept_for_bots() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_auto_accept_group_for_bots() -> Result<()> {
+    let t = TestContext::new_alice().await;
+    t.set_config(Config::Bot, Some("1")).await.unwrap();
+    receive_imf(&t, GRP_MAIL, false).await?;
+    let msg = t.get_last_msg().await;
+    let chat = chat::Chat::load_from_db(&t, msg.chat_id).await?;
+    assert!(!chat.is_contact_request());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_no_private_reply_to_blocked_account() -> Result<()> {
     let mut tcm = TestContextManager::new();
     let alice = tcm.alice().await;


### PR DESCRIPTION
This fixes a bug likely introduced in #4316 