### PR TITLE
fix: fetch at most 100 existing messages even if EXISTS was not received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - JSON-RPC: add API to get reactions outside the message snapshot
 ### Fixes
 - Make the bots automatically accept group chat contact requests. #4377
+- Fetch at most 100 existing messages even if EXISTS was not received. #4383
 
 
 ## [1.114.0] - 2023-04-24

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1324,8 +1324,8 @@ impl Imap {
         // Fetch last DC_FETCH_EXISTING_MSGS_COUNT (100) messages.
         // Sequence numbers are sequential. If there are 1000 messages in the inbox,
         // we can fetch the sequence numbers 900-1000 and get the last 100 messages.
-        let first = cmp::max(1, exists - DC_FETCH_EXISTING_MSGS_COUNT);
-        let set = format!("{first}:*");
+        let first = cmp::max(1, exists - DC_FETCH_EXISTING_MSGS_COUNT + 1);
+        let set = format!("{first}:{exists}");
         let mut list = session
             .fetch(&set, PREFETCH_FLAGS)
             .await


### PR DESCRIPTION
According to RFC 3501, EXISTS must always be sent in response to SELECT. But if the server does not send it for some reason, async-imap uses the default value, so we will essentially fetch `1:*` and downloading all messages may take a long time.

Fixes #4382 