### PR TITLE
feat: add dc_jsonrpc_blocking_call()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "yerpc",
 ]
 
 [[package]]
@@ -5754,9 +5755,9 @@ dependencies = [
 
 [[package]]
 name = "yerpc"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a0257f42e6bdc187f37074723b6094da3502cee21ae517b3c54d2c37d506e7"
+checksum = "b2c26a804eaa30c1ff1a296dc6dd1a7d7c622750dafcd0d6b2ed5e3c5c3beb22"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = "1"
 thiserror = "1"
 rand = "0.8"
 once_cell = "1.17.0"
+yerpc = { version = "0.4.4", features = ["anyhow_expose"] }
 
 [features]
 default = ["vendored"]

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5721,6 +5721,18 @@ void dc_jsonrpc_request(dc_jsonrpc_instance_t* jsonrpc_instance, const char* req
 char* dc_jsonrpc_next_response(dc_jsonrpc_instance_t* jsonrpc_instance);
 
 /**
+ * Make a JSON-RPC call and return a response.
+ *
+ * @memberof dc_jsonrpc_instance_t
+ * @param jsonrpc_instance jsonrpc instance as returned from dc_jsonrpc_init().
+ * @param method JSON-RPC method name, e.g. `check_email_validity`.
+ * @param params JSON-RPC method parameters, e.g. `["alice@example.org"]`.
+ * @return JSON-RPC response as string, must be freed using dc_str_unref() after usage.
+ *     On error, NULL is returned.
+ */
+char* dc_jsonrpc_blocking_call(dc_jsonrpc_instance_t* jsonrpc_instance, const char *method, const char *params);
+
+/**
  * @class dc_event_emitter_t
  *
  * Opaque object that is used to get events from a single context.

--- a/deltachat-jsonrpc/Cargo.toml
+++ b/deltachat-jsonrpc/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4"
 async-channel = { version = "1.8.0" }
 futures = { version = "0.3.28" }
 serde_json = "1.0.96"
-yerpc = { version = "0.4.3", features = ["anyhow_expose"] }
+yerpc = { version = "0.4.4", features = ["anyhow_expose"] }
 typescript-type-def = { version = "0.5.5", features = ["json_value"] }
 tokio = { version = "1.28.0" }
 sanitize-filename = "0.4"


### PR DESCRIPTION
Closes #4385

Result is returned as is, errors are returned as NULL. Another option would be to emulate [JSON-RPC responses](https://www.jsonrpc.org/specification#response_object) and return either `{"result": ...}` or `{"error": ...}` if we want to handle the errors.