### PR TITLE
fix: recreate `smtp` table with AUTOINCREMENT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Make the bots automatically accept group chat contact requests. #4377
 - Fetch at most 100 existing messages even if EXISTS was not received. #4383
 - jsonrpc: typescript client: fix types of events in event emitter
+- Recreate `smtp` table with AUTOINCREMENT `id`. #4390
 - delete `smtp` rows when message sending is cancelled #4391
 
 


### PR DESCRIPTION
This ensures the rows cannot be confused accidentally when referred by row_id.