### PR TITLE
test: Add golden tests infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1193,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "pgp",
+ "pretty_assertions",
  "pretty_env_logger",
  "proptest",
  "qrcodegen",
@@ -1399,6 +1410,12 @@ checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
 dependencies = [
  "cipher",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -3202,6 +3219,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "output_vt100"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628223faebab4e3e40667ee0b2336d34a5b960ff60ea743ddfdbcf7770bcfb66"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3544,6 +3570,18 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a25e9bcb20aa780fd0bb16b72403a9064d6b3f22f026946029acb941a50af755"
+dependencies = [
+ "ctor",
+ "diff",
+ "output_vt100",
+ "yansi",
+]
 
 [[package]]
 name = "pretty_env_logger"
@@ -5743,6 +5781,12 @@ checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ proptest = { version = "1", default-features = false, features = ["std"] }
 tempfile = "3"
 testdir = "0.7.3"
 tokio = { version = "1", features = ["parking_lot", "rt-multi-thread", "macros"] }
+pretty_assertions = "1.3.0"
 
 [workspace]
 members = [

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -627,7 +627,7 @@ impl TestContext {
         res
     }
 
-    #[allow(clippy::unused)]
+    #[allow(unused)]
     pub async fn golden_test_chat(&self, chat_id: ChatId, filename: &str) {
         let filename = Path::new("test-data/golden/").join(filename);
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::ops::{Deref, DerefMut};
 use std::panic;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -628,7 +629,7 @@ impl TestContext {
 
     #[allow(clippy::unused)]
     pub async fn golden_test_chat(&self, chat_id: ChatId, filename: &str) {
-        let filename = "test-data/golden/".to_owned() + filename;
+        let filename = Path::new("test-data/golden/").join(filename);
 
         let actual = self.display_chat(chat_id).await;
 
@@ -637,7 +638,9 @@ impl TestContext {
         let expected = fs::read(&filename).await.unwrap_or_default();
         let expected = String::from_utf8(expected).unwrap();
         if (std::env::var("UPDATE_GOLDEN_TESTS") == Ok("1".to_string())) && actual != expected {
-            fs::write(&filename, &actual).await.expect(&filename);
+            fs::write(&filename, &actual)
+                .await
+                .unwrap_or_else(|e| panic!("Error writing {filename:?}: {e}"));
         } else {
             assert_eq!(
                 actual, expected,


### PR DESCRIPTION
Add `golden_test_chat`, which takes a chat_id and a golden file that describes how the chat should look.

If e.g. the chat should be verified, but isn't, the test output looks like this: (the nice diff is thanks to `pretty_assertions`)

![Screenshot_2023-05-10_17-46-14](https://github.com/deltachat/deltachat-core-rust/assets/18012815/b6c3fe77-7057-4635-bce9-93363a91faf5)

Using `UPDATE_GOLDEN_TESTS=1 cargo test`, you can update the golden tests.

This is in preparation for #4315; I wanted to pull out some changes to not make that PR huge. See 343c072af for a test that actually uses it.