### PR TITLE
api to get read receipts by contacts for a message

### DIFF
--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -536,3 +536,10 @@ pub struct MessageData {
     pub override_sender_name: Option<String>,
     pub quoted_message_id: Option<u32>,
 }
+
+#[derive(Serialize, TypeDef)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageReadReceipt {
+    pub contact_id: u32,
+    pub timestamp: i64,
+}


### PR DESCRIPTION

feat: api: `get_msg_read_receipts` - get the contacts that send read receipts for a message
api: jsonrpc: new `MessageReadReceipt` type and `get_message_read_receipts` jsonrpc method


Basically an api to get the info who read a message when, that is currently only accessible as 
part of the message info text.
