### PR TITLE
fix: Don't put a double dot at the end of error messages

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2084,7 +2084,7 @@ async fn check_verified_properties(
 ) -> Result<()> {
     let contact = Contact::load_from_db(context, from_id).await?;
 
-    ensure!(mimeparser.was_encrypted(), "This message is not encrypted.");
+    ensure!(mimeparser.was_encrypted(), "This message is not encrypted");
 
     if mimeparser.get_header(HeaderDef::ChatVerified).is_none() {
         // we do not fail here currently, this would exclude (a) non-deltas
@@ -2117,7 +2117,7 @@ async fn check_verified_properties(
         if let Some(peerstate) = peerstate {
             ensure!(
                 peerstate.has_verified_key(&mimeparser.signatures),
-                "The message was sent with non-verified encryption."
+                "The message was sent with non-verified encryption"
             );
         }
     }


### PR DESCRIPTION
The callers of `check_verified_properties` also add a dot, which lead to messages like `Verification problem: This message is not encrypted..`