### PR TITLE
api!: make dc_jsonrpc_blocking_call accept JSON-RPC request

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5755,12 +5755,11 @@ char* dc_jsonrpc_next_response(dc_jsonrpc_instance_t* jsonrpc_instance);
  *
  * @memberof dc_jsonrpc_instance_t
  * @param jsonrpc_instance jsonrpc instance as returned from dc_jsonrpc_init().
- * @param method JSON-RPC method name, e.g. `check_email_validity`.
- * @param params JSON-RPC method parameters, e.g. `["alice@example.org"]`.
+ * @param input JSON-RPC request.
  * @return JSON-RPC response as string, must be freed using dc_str_unref() after usage.
- *     On error, NULL is returned.
+ *     If there is no response, NULL is returned.
  */
-char* dc_jsonrpc_blocking_call(dc_jsonrpc_instance_t* jsonrpc_instance, const char *method, const char *params);
+char* dc_jsonrpc_blocking_call(dc_jsonrpc_instance_t* jsonrpc_instance, const char *input);
 
 /**
  * @class dc_event_emitter_t

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -5010,7 +5010,7 @@ pub unsafe extern "C" fn dc_accounts_get_event_emitter(
 #[cfg(feature = "jsonrpc")]
 mod jsonrpc {
     use deltachat_jsonrpc::api::CommandApi;
-    use deltachat_jsonrpc::yerpc::{OutReceiver, RpcClient, RpcServer, RpcSession};
+    use deltachat_jsonrpc::yerpc::{OutReceiver, RpcClient, RpcSession};
 
     use super::*;
 
@@ -5086,25 +5086,24 @@ mod jsonrpc {
     #[no_mangle]
     pub unsafe extern "C" fn dc_jsonrpc_blocking_call(
         jsonrpc_instance: *mut dc_jsonrpc_instance_t,
-        method: *const libc::c_char,
-        params: *const libc::c_char,
+        input: *const libc::c_char,
     ) -> *mut libc::c_char {
         if jsonrpc_instance.is_null() {
             eprintln!("ignoring careless call to dc_jsonrpc_blocking_call()");
             return ptr::null_mut();
         }
         let api = &*jsonrpc_instance;
-        let method = to_string_lossy(method);
-        let params = to_string_lossy(params);
-        let params: Option<yerpc::Params> = match serde_json::from_str(&params) {
-            Ok(params) => Some(params),
-            Err(_) => None,
-        };
-        let params = params.map(yerpc::Params::into_value).unwrap_or_default();
-        let res = block_on(api.handle.server().handle_request(method, params));
+        let input = to_string_lossy(input);
+        let res = block_on(api.handle.process_incoming(&input));
         match res {
-            Ok(res) => res.to_string().strdup(),
-            Err(_) => ptr::null_mut(),
+            Some(message) => {
+                if let Ok(message) = serde_json::to_string(&message) {
+                    message.strdup()
+                } else {
+                    ptr::null_mut()
+                }
+            }
+            None => ptr::null_mut(),
         }
     }
 }

--- a/python/tests/test_4_lowlevel.py
+++ b/python/tests/test_4_lowlevel.py
@@ -1,3 +1,4 @@
+import json
 from queue import Queue
 
 import deltachat as dc
@@ -226,10 +227,26 @@ def test_jsonrpc_blocking_call(tmp_path):
         lib.dc_accounts_unref,
     )
     jsonrpc = ffi.gc(lib.dc_jsonrpc_init(accounts), lib.dc_jsonrpc_unref)
-    res = from_optional_dc_charpointer(
-        lib.dc_jsonrpc_blocking_call(jsonrpc, b"check_email_validity", b'["alice@example.org"]'),
+    res = json.loads(
+        from_optional_dc_charpointer(
+            lib.dc_jsonrpc_blocking_call(
+                jsonrpc,
+                json.dumps(
+                    {"jsonrpc": "2.0", "method": "check_email_validity", "params": ["alice@example.org"], "id": "123"},
+                ).encode("utf-8"),
+            ),
+        ),
     )
-    assert res == "true"
+    assert res == {"jsonrpc": "2.0", "id": "123", "result": True}
 
-    res = from_optional_dc_charpointer(lib.dc_jsonrpc_blocking_call(jsonrpc, b"check_email_validity", b'["alice"]'))
-    assert res == "false"
+    res = json.loads(
+        from_optional_dc_charpointer(
+            lib.dc_jsonrpc_blocking_call(
+                jsonrpc,
+                json.dumps(
+                    {"jsonrpc": "2.0", "method": "check_email_validity", "params": ["alice"], "id": "456"},
+                ).encode("utf-8"),
+            ),
+        ),
+    )
+    assert res == {"jsonrpc": "2.0", "id": "456", "result": False}


### PR DESCRIPTION
Builds on top of https://github.com/deltachat/deltachat-core-rust/pull/4389

Depends on https://github.com/deltachat/yerpc/pull/50

This API allows to process the error and display or log it.