### PR TITLE
ci: require Python 3.8 for deltachat-rpc-client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,11 +233,12 @@ jobs:
           - os: macos-latest
             python: pypy3.9
 
-          # Minimum Supported Python Version = 3.7
-          # This is the minimum version for which manylinux Python wheels are
-          # built. Test it with minimum supported Rust version.
+          # Minimum Supported Python Version = 3.8
+          #
+          # Python 3.7 has at least one known bug related to starting subprocesses
+          # in asyncio programs: <https://bugs.python.org/issue35621>
           - os: ubuntu-latest
-            python: 3.7
+            python: 3.8
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
With Python 3.7 asynchronous tests randomly fail
with "RuntimeError: Event loop is closed" during shutdown. Backtrace of the error includes `SafeChildWatcher` calls.

Python 3.8 has replaced `SafeChildWatcher`
with a new `ThreadedChildWatcher` by default [1]
as a bugfix for
"asyncio.create_subprocess_exec() only works with main event loop" bug [2].

Python 3.7 scheduled end of life is 2023-06-27
according to <https://devguide.python.org/versions/>.

[1] https://github.com/python/cpython/pull/14344
[2] https://bugs.python.org/issue35621