### PR TITLE
fix: disable `fetch_existing_msgs` setting by default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -145,7 +145,7 @@ pub enum Config {
     /// If set to "1", on the first time `start_io()` is called after configuring,
     /// the newest existing messages are fetched.
     /// Existing recipients are added to the contact database regardless of this setting.
-    #[strum(props(default = "1"))]
+    #[strum(props(default = "0"))]
     FetchExistingMsgs,
 
     /// If set to "1", then existing messages are considered to be already fetched.


### PR DESCRIPTION
This caused too many problems after switching the default setting for `show_emails` from DC_SHOW_EMAILS_OFF to DC_SHOW_EMAILS_ALL in <https://github.com/deltachat/deltachat-core-rust/pull/4019>

There is a topic <https://support.delta.chat/t/setting-no-chats-only-for-show-classic-e-mails-showing-classic-emails/2481> on the forum with multiple requests to revert this setting due to old emails being downloaded.

Note that this does not disable fetching existing contacts.