### PR TITLE
build: use 1 codegen-units for release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ opt-level = "z"
 lto = true
 panic = 'abort'
 opt-level = "z"
+codegen-units = 1
 
 [patch.crates-io]
 quinn-udp = { git = "https://github.com/quinn-rs/quinn", branch="main" }


### PR DESCRIPTION
According to my measurements
this reduced libdeltachat.so size
by 3.3 MB, from 25.17 to 21.84 MB.