### PR TITLE
refactor: do not treat messages without headers as a special case

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -776,10 +776,6 @@ impl MimeMessage {
         self.headers.contains_key("chat-version")
     }
 
-    pub(crate) fn has_headers(&self) -> bool {
-        !self.headers.is_empty()
-    }
-
     pub(crate) fn get_subject(&self) -> Option<String> {
         self.get_header(HeaderDef::Subject)
             .filter(|s| !s.is_empty())

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -138,12 +138,6 @@ pub(crate) async fn receive_imf_inner(
         Ok(mime_parser) => mime_parser,
     };
 
-    // we can not add even an empty record if we have no info whatsoever
-    if !mime_parser.has_headers() {
-        warn!(context, "receive_imf: no headers found.");
-        return Ok(None);
-    }
-
     info!(context, "Received message has Message-Id: {rfc724_mid}");
 
     // check, if the mail is already in our database.


### PR DESCRIPTION
This check was introduced in #993.