### PR TITLE
test: add `make-python-testenv.sh` script

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,6 +18,10 @@ and an own build machine.
 - `remote_tests_rust.sh` rsyncs to the build machine and runs
   `run-rust-test.sh` remotely on the build machine. 
 
+- `make-python-testenv.sh` creates or updates local python test development environment.
+  Reusing the same environment is faster than running `run-python-test.sh` which always
+  recreates environment from scratch and runs additional lints.
+
 - `run-doxygen.sh` generates C-docs which are then uploaded to https://c.delta.chat/
 
 - `run_all.sh` builds Python wheels

--- a/scripts/make-python-testenv.sh
+++ b/scripts/make-python-testenv.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Script to create or update a python development environment.
+# It rebuilds the core and bindings as needed.
+#
+# After running the script, you can either
+# run `pytest` directly with `env/bin/pytest python/`
+# or activate the environment with `. env/bin/activacte`
+# and run `pytest` from there.
+set -euo pipefail
+
+export DCC_RS_TARGET=debug
+export DCC_RS_DEV="$PWD"
+cargo build -p deltachat_ffi --features jsonrpc
+
+if test -d env; then
+	env/bin/pip install -e python --force-reinstall
+else
+	tox -e py --devenv env
+	env/bin/pip install --upgrade pip
+fi


### PR DESCRIPTION
This scripts makes it easy to (re)create python testing environment.