### PR TITLE
feat: add scripts/zig-ffi.sh

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,6 +28,8 @@ and an own build machine.
 
 - `zig-rpc-server.sh` compiles binaries of `deltachat-rpc-server` using Zig toolchain statically linked against musl libc.
 
+- `zig-ffi.sh` compiles C libraries into LLVM bitcode using Zig toolchain with musl libc.
+
 - `android-rpc-server.sh` compiles binaries of `deltachat-rpc-server` using Android NDK.
 
 ## Triggering runs on the build machine locally (fast!)

--- a/scripts/zig-ffi.sh
+++ b/scripts/zig-ffi.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# Build FFI library using zig.
+
+set -x
+set -e
+
+export RUSTFLAGS="-Clinker-plugin-lto"
+export CFLAGS="-fno-unwind-tables -fno-exceptions -fno-asynchronous-unwind-tables -fomit-frame-pointer"
+
+build() {
+	cargo build --release --target $1 -p deltachat_ffi --features vendored
+}
+
+CC="$PWD/scripts/zig-cc" \
+TARGET_CC="$PWD/scripts/zig-cc" \
+CARGO_TARGET_I686_UNKNOWN_LINUX_MUSL_LINKER="$PWD/scripts/zig-cc" \
+LD="$PWD/scripts/zig-cc" \
+ZIG_TARGET="x86-linux-musl" \
+build i686-unknown-linux-musl
+
+CC="$PWD/scripts/zig-cc" \
+TARGET_CC="$PWD/scripts/zig-cc" \
+CARGO_TARGET_ARMV7_UNKNOWN_LINUX_MUSLEABIHF_LINKER="$PWD/scripts/zig-cc" \
+LD="$PWD/scripts/zig-cc" \
+ZIG_TARGET="arm-linux-musleabihf" \
+ZIG_CPU="generic+v7a+vfp3-d32+thumb2-neon" \
+build armv7-unknown-linux-musleabihf
+
+CC="$PWD/scripts/zig-cc" \
+TARGET_CC="$PWD/scripts/zig-cc" \
+CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="$PWD/scripts/zig-cc" \
+LD="$PWD/scripts/zig-cc" \
+ZIG_TARGET="x86_64-linux-musl" \
+build x86_64-unknown-linux-musl
+
+CC="$PWD/scripts/zig-cc" \
+TARGET_CC="$PWD/scripts/zig-cc" \
+CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="$PWD/scripts/zig-cc" \
+LD="$PWD/scripts/zig-cc" \
+ZIG_TARGET="aarch64-linux-musl" \
+build aarch64-unknown-linux-musl


### PR DESCRIPTION
This script can be used to compile the libraries
used in the Android application without the NDK.