### PR TITLE
api!: make Message.text non-optional

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3308,7 +3308,7 @@ pub unsafe extern "C" fn dc_msg_get_text(msg: *mut dc_msg_t) -> *mut libc::c_cha
         return "".strdup();
     }
     let ffi_msg = &*msg;
-    ffi_msg.message.get_text().unwrap_or_default().strdup()
+    ffi_msg.message.get_text().strdup()
 }
 
 #[no_mangle]
@@ -3693,7 +3693,7 @@ pub unsafe extern "C" fn dc_msg_set_text(msg: *mut dc_msg_t, text: *const libc::
         return;
     }
     let ffi_msg = &mut *msg;
-    ffi_msg.message.set_text(to_opt_string_lossy(text))
+    ffi_msg.message.set_text(to_string_lossy(text))
 }
 
 #[no_mangle]

--- a/deltachat-jsonrpc/src/api/mod.rs
+++ b/deltachat-jsonrpc/src/api/mod.rs
@@ -901,7 +901,7 @@ impl CommandApi {
     ) -> Result<u32> {
         let ctx = self.get_context(account_id).await?;
         let mut msg = Message::new(Viewtype::Text);
-        msg.set_text(Some(text));
+        msg.set_text(text);
         let message_id =
             deltachat::chat::add_device_msg(&ctx, Some(&label), Some(&mut msg)).await?;
         Ok(message_id.to_u32())
@@ -1767,9 +1767,7 @@ impl CommandApi {
         } else {
             Viewtype::Text
         });
-        if data.text.is_some() {
-            message.set_text(data.text);
-        }
+        message.set_text(data.text.unwrap_or_default());
         if data.html.is_some() {
             message.set_html(data.html);
         }
@@ -1950,7 +1948,7 @@ impl CommandApi {
         let ctx = self.get_context(account_id).await?;
 
         let mut msg = Message::new(Viewtype::Text);
-        msg.set_text(Some(text));
+        msg.set_text(text);
 
         let message_id = deltachat::chat::send_msg(&ctx, ChatId::new(chat_id), &mut msg).await?;
         Ok(message_id.to_u32())
@@ -1973,9 +1971,7 @@ impl CommandApi {
         } else {
             Viewtype::Text
         });
-        if text.is_some() {
-            message.set_text(text);
-        }
+        message.set_text(text.unwrap_or_default());
         if let Some(file) = file {
             message.set_file(file, None);
         }
@@ -2019,9 +2015,7 @@ impl CommandApi {
         } else {
             Viewtype::Text
         });
-        if text.is_some() {
-            draft.set_text(text);
-        }
+        draft.set_text(text.unwrap_or_default());
         if let Some(file) = file {
             draft.set_file(file, None);
         }

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -180,7 +180,7 @@ impl MessageObject {
             from_id: message.get_from_id().to_u32(),
             quote,
             parent_id,
-            text: message.get_text(),
+            text: Some(message.get_text()).filter(|s| !s.is_empty()),
             has_location: message.has_location(),
             has_html: message.has_html(),
             view_type: message.get_viewtype().into(),
@@ -500,7 +500,7 @@ impl MessageSearchResult {
             is_chat_protected: chat.is_protected(),
             is_chat_contact_request: chat.is_contact_request(),
             is_chat_archived: chat.get_visibility() == ChatVisibility::Archived,
-            message: message.get_text().unwrap_or_default(),
+            message: message.get_text(),
             timestamp: message.get_timestamp(),
         })
     }

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -199,7 +199,7 @@ async fn log_msg(context: &Context, prefix: impl AsRef<str>, msg: &Message) {
         if msg.has_location() { "📍" } else { "" },
         &contact_name,
         contact_id,
-        msgtext.unwrap_or_default(),
+        msgtext,
         if msg.has_html() { "[HAS-HTML]️" } else { "" },
         if msg.get_from_id() == ContactId::SELF {
             ""
@@ -912,9 +912,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                 Viewtype::File
             });
             msg.set_file(arg1, None);
-            if !arg2.is_empty() {
-                msg.set_text(Some(arg2.to_string()));
-            }
+            msg.set_text(arg2.to_string());
             chat::send_msg(&context, sel_chat.as_ref().unwrap().get_id(), &mut msg).await?;
         }
         "sendhtml" => {
@@ -926,11 +924,11 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
 
             let mut msg = Message::new(Viewtype::Text);
             msg.set_html(Some(html.to_string()));
-            msg.set_text(Some(if arg2.is_empty() {
+            msg.set_text(if arg2.is_empty() {
                 path.file_name().unwrap().to_string_lossy().to_string()
             } else {
                 arg2.to_string()
-            }));
+            });
             chat::send_msg(&context, sel_chat.as_ref().unwrap().get_id(), &mut msg).await?;
         }
         "sendsyncmsg" => match context.send_sync_msg().await? {
@@ -979,7 +977,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
 
             if !arg1.is_empty() {
                 let mut draft = Message::new(Viewtype::Text);
-                draft.set_text(Some(arg1.to_string()));
+                draft.set_text(arg1.to_string());
                 sel_chat
                     .as_ref()
                     .unwrap()
@@ -1003,7 +1001,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                 "Please specify text to add as device message."
             );
             let mut msg = Message::new(Viewtype::Text);
-            msg.set_text(Some(arg1.to_string()));
+            msg.set_text(arg1.to_string());
             chat::add_device_msg(&context, None, Some(&mut msg)).await?;
         }
         "listmedia" => {

--- a/src/authres.rs
+++ b/src/authres.rs
@@ -705,7 +705,7 @@ Authentication-Results: dkim=";
         let received = tcm
             .try_send_recv(&alice, &bob2, "My credit card number is 1234")
             .await;
-        assert!(!received.text.as_ref().unwrap().contains("1234"));
+        assert!(!received.text.contains("1234"));
         assert!(received.error.is_some());
 
         tcm.section("Turns out bob2 wasn't an attacker at all, Bob just has a new phone and DKIM just stopped working.");
@@ -786,7 +786,7 @@ Authentication-Results: dkim=";
             .insert_str(0, "List-Post: <mailto:deltachat-community.example.net>\n");
         let rcvd = alice.recv_msg(&sent).await;
         assert!(!rcvd.get_showpadlock());
-        assert_eq!(&rcvd.text.unwrap(), "hellooo in the mailinglist again");
+        assert_eq!(&rcvd.text, "hellooo in the mailinglist again");
 
         Ok(())
     }

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -424,7 +424,7 @@ mod tests {
         // 2s here.
         for chat_id in &[chat_id1, chat_id3, chat_id2] {
             let mut msg = Message::new(Viewtype::Text);
-            msg.set_text(Some("hello".to_string()));
+            msg.set_text("hello".to_string());
             chat_id.set_draft(&t, Some(&mut msg)).await.unwrap();
         }
 
@@ -636,7 +636,7 @@ mod tests {
             .unwrap();
 
         let mut msg = Message::new(Viewtype::Text);
-        msg.set_text(Some("foo:\nbar \r\n test".to_string()));
+        msg.set_text("foo:\nbar \r\n test".to_string());
         chat_id1.set_draft(&t, Some(&mut msg)).await.unwrap();
 
         let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -146,7 +146,7 @@ async fn on_configure_completed(
 
         if !provider.after_login_hint.is_empty() {
             let mut msg = Message::new(Viewtype::Text);
-            msg.text = Some(provider.after_login_hint.to_string());
+            msg.text = provider.after_login_hint.to_string();
             if chat::add_device_msg(context, Some("core-provider-info"), Some(&mut msg))
                 .await
                 .is_err()
@@ -161,7 +161,7 @@ async fn on_configure_completed(
             if !addr_cmp(&new_addr, &old_addr) {
                 let mut msg = Message::new(Viewtype::Text);
                 msg.text =
-                    Some(stock_str::aeap_explanation_and_link(context, &old_addr, &new_addr).await);
+                    stock_str::aeap_explanation_and_link(context, &old_addr, &new_addr).await;
                 chat::add_device_msg(context, None, Some(&mut msg))
                     .await
                     .context("Cannot add AEAP explanation")

--- a/src/context.rs
+++ b/src/context.rs
@@ -1304,11 +1304,11 @@ mod tests {
 
         // Add messages to chat with Bob.
         let mut msg1 = Message::new(Viewtype::Text);
-        msg1.set_text(Some("foobar".to_string()));
+        msg1.set_text("foobar".to_string());
         send_msg(&alice, chat.id, &mut msg1).await?;
 
         let mut msg2 = Message::new(Viewtype::Text);
-        msg2.set_text(Some("barbaz".to_string()));
+        msg2.set_text("barbaz".to_string());
         send_msg(&alice, chat.id, &mut msg2).await?;
 
         // Global search with a part of text finds the message.
@@ -1404,7 +1404,7 @@ mod tests {
 
         // Add 999 messages
         let mut msg = Message::new(Viewtype::Text);
-        msg.set_text(Some("foobar".to_string()));
+        msg.set_text("foobar".to_string());
         for _ in 0..999 {
             send_msg(&alice, chat.id, &mut msg).await?;
         }

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -399,7 +399,7 @@ mod tests {
         let bob = TestContext::new_bob().await;
         receive_imf(&bob, attachment_mime, false).await?;
         let msg = bob.get_last_msg().await;
-        assert_eq!(msg.text.as_deref(), Some("Hello from Thunderbird!"));
+        assert_eq!(msg.text, "Hello from Thunderbird!");
 
         Ok(())
     }

--- a/src/download.rs
+++ b/src/download.rs
@@ -308,7 +308,7 @@ mod tests {
         let chat = t.create_chat_with_contact("Bob", "bob@example.org").await;
 
         let mut msg = Message::new(Viewtype::Text);
-        msg.set_text(Some("Hi Bob".to_owned()));
+        msg.set_text("Hi Bob".to_owned());
         let msg_id = send_msg(&t, chat.id, &mut msg).await?;
         let msg = Message::load_from_db(&t, msg_id).await?;
         assert_eq!(msg.download_state(), DownloadState::Done);
@@ -355,7 +355,6 @@ mod tests {
         assert_eq!(msg.get_subject(), "foo");
         assert!(msg
             .get_text()
-            .unwrap()
             .contains(&stock_str::partial_download_msg_body(&t, 100000).await));
 
         receive_imf_inner(
@@ -370,7 +369,7 @@ mod tests {
         let msg = t.get_last_msg().await;
         assert_eq!(msg.download_state(), DownloadState::Done);
         assert_eq!(msg.get_subject(), "foo");
-        assert_eq!(msg.get_text(), Some("100k text...".to_string()));
+        assert_eq!(msg.get_text(), "100k text...");
 
         Ok(())
     }

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -219,7 +219,7 @@ impl ChatId {
 
         if self.is_promoted(context).await? {
             let mut msg = Message::new(Viewtype::Text);
-            msg.text = Some(stock_ephemeral_timer_changed(context, timer, ContactId::SELF).await);
+            msg.text = stock_ephemeral_timer_changed(context, timer, ContactId::SELF).await;
             msg.param.set_cmd(SystemMessage::EphemeralTimerChanged);
             if let Err(err) = send_msg(context, self, &mut msg).await {
                 error!(
@@ -1062,7 +1062,7 @@ mod tests {
         delete_expired_messages(t, not_deleted_at).await?;
 
         let loaded = Message::load_from_db(t, msg_id).await?;
-        assert_eq!(loaded.text.unwrap(), "Message text");
+        assert_eq!(loaded.text, "Message text");
         assert_eq!(loaded.chat_id, chat.id);
 
         assert!(next_expiration < deleted_at);
@@ -1082,7 +1082,7 @@ mod tests {
             .await;
 
         let loaded = Message::load_from_db(t, msg_id).await?;
-        assert_eq!(loaded.text.unwrap(), "");
+        assert_eq!(loaded.text, "");
         assert_eq!(loaded.chat_id, DC_CHAT_ID_TRASH);
 
         // Check that the msg was deleted locally.
@@ -1105,7 +1105,7 @@ mod tests {
         if let Ok(msg) = Message::load_from_db(t, msg_id).await {
             assert_eq!(msg.from_id, ContactId::UNDEFINED);
             assert_eq!(msg.to_id, ContactId::UNDEFINED);
-            assert!(msg.text.is_none_or_empty(), "{:?}", msg.text);
+            assert_eq!(msg.text, "");
             let rawtxt: Option<String> = t
                 .sql
                 .query_get_value("SELECT txt_raw FROM msgs WHERE id=?;", (msg_id,))

--- a/src/html.rs
+++ b/src/html.rs
@@ -456,7 +456,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         assert_ne!(msg.get_from_id(), ContactId::SELF);
         assert_eq!(msg.is_dc_message, MessengerMessage::No);
         assert!(!msg.is_forwarded());
-        assert!(msg.get_text().unwrap().contains("this is plain"));
+        assert!(msg.get_text().contains("this is plain"));
         assert!(msg.has_html());
         let html = msg.get_id().get_html(&alice).await.unwrap().unwrap();
         assert!(html.contains("this is <b>html</b>"));
@@ -470,7 +470,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         assert_eq!(msg.get_from_id(), ContactId::SELF);
         assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
         assert!(msg.is_forwarded());
-        assert!(msg.get_text().unwrap().contains("this is plain"));
+        assert!(msg.get_text().contains("this is plain"));
         assert!(msg.has_html());
         let html = msg.get_id().get_html(&alice).await.unwrap().unwrap();
         assert!(html.contains("this is <b>html</b>"));
@@ -483,7 +483,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         assert_ne!(msg.get_from_id(), ContactId::SELF);
         assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
         assert!(msg.is_forwarded());
-        assert!(msg.get_text().unwrap().contains("this is plain"));
+        assert!(msg.get_text().contains("this is plain"));
         assert!(msg.has_html());
         let html = msg.get_id().get_html(&bob).await.unwrap().unwrap();
         assert!(html.contains("this is <b>html</b>"));
@@ -526,7 +526,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
         assert!(msg.get_showpadlock());
         assert!(msg.is_forwarded());
-        assert!(msg.get_text().unwrap().contains("this is plain"));
+        assert!(msg.get_text().contains("this is plain"));
         assert!(msg.has_html());
         let html = msg.get_id().get_html(&alice).await.unwrap().unwrap();
         assert!(html.contains("this is <b>html</b>"));
@@ -540,14 +540,14 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         // alice sends a message with html-part to bob
         let chat_id = alice.create_chat(&bob).await.id;
         let mut msg = Message::new(Viewtype::Text);
-        msg.set_text(Some("plain text".to_string()));
+        msg.set_text("plain text".to_string());
         msg.set_html(Some("<b>html</b> text".to_string()));
         assert!(msg.mime_modified);
         chat::send_msg(&alice, chat_id, &mut msg).await.unwrap();
 
         // check the message is written correctly to alice's db
         let msg = alice.get_last_msg_in(chat_id).await;
-        assert_eq!(msg.get_text(), Some("plain text".to_string()));
+        assert_eq!(msg.get_text(), "plain text");
         assert!(!msg.is_forwarded());
         assert!(msg.mime_modified);
         let html = msg.get_id().get_html(&alice).await.unwrap().unwrap();
@@ -557,7 +557,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         let chat_id = bob.create_chat(&alice).await.id;
         let msg = bob.recv_msg(&alice.pop_sent_msg().await).await;
         assert_eq!(msg.chat_id, chat_id);
-        assert_eq!(msg.get_text(), Some("plain text".to_string()));
+        assert_eq!(msg.get_text(), "plain text");
         assert!(!msg.is_forwarded());
         assert!(msg.mime_modified);
         let html = msg.get_id().get_html(&bob).await.unwrap().unwrap();
@@ -575,7 +575,7 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
         .await?;
         let msg = t.get_last_msg().await;
         assert_eq!(msg.viewtype, Viewtype::Text);
-        assert!(msg.text.as_ref().unwrap().contains("foo bar ä ö ü ß"));
+        assert!(msg.text.contains("foo bar ä ö ü ß"));
         assert!(msg.has_html());
         let html = msg.get_id().get_html(&t).await?.unwrap();
         println!("{html}");

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -412,7 +412,7 @@ impl Imap {
                     drop(lock);
 
                     let mut msg = Message::new(Viewtype::Text);
-                    msg.text = Some(message.clone());
+                    msg.text = message.clone();
                     if let Err(e) =
                         chat::add_device_msg_with_importance(context, None, Some(&mut msg), true)
                             .await

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -253,12 +253,10 @@ async fn maybe_add_bcc_self_device_msg(context: &Context) -> Result<()> {
     if !context.sql.get_raw_config_bool("bcc_self").await? {
         let mut msg = Message::new(Viewtype::Text);
         // TODO: define this as a stockstring once the wording is settled.
-        msg.text = Some(
-            "It seems you are using multiple devices with Delta Chat. Great!\n\n\
+        msg.text = "It seems you are using multiple devices with Delta Chat. Great!\n\n\
              If you also want to synchronize outgoing messages across all devices, \
              go to \"Settings → Advanced\" and enable \"Send Copy to Self\"."
-                .to_string(),
-        );
+            .to_string();
         chat::add_device_msg(context, Some("bcc-self-hint"), Some(&mut msg)).await?;
     }
     Ok(())
@@ -1030,10 +1028,7 @@ mod tests {
         // not synchronized yet.
         let sent = alice2.send_text(msg.chat_id, "Test").await;
         alice.recv_msg(&sent).await;
-        assert_ne!(
-            alice.get_last_msg().await.get_text(),
-            Some("Test".to_string())
-        );
+        assert_ne!(alice.get_last_msg().await.get_text(), "Test");
 
         // Transfer the key.
         continue_key_transfer(&alice2, msg.id, &setup_code).await?;
@@ -1041,10 +1036,7 @@ mod tests {
         // Alice sends a message to self from the new device.
         let sent = alice2.send_text(msg.chat_id, "Test").await;
         alice.recv_msg(&sent).await;
-        assert_eq!(
-            alice.get_last_msg().await.get_text(),
-            Some("Test".to_string())
-        );
+        assert_eq!(alice.get_last_msg().await.get_text(), "Test");
 
         Ok(())
     }

--- a/src/imex/transfer.rs
+++ b/src/imex/transfer.rs
@@ -275,7 +275,7 @@ impl BackupProvider {
             Ok(_) => {
                 context.emit_event(SendProgress::Completed.into());
                 let mut msg = Message::new(Viewtype::Text);
-                msg.text = Some(backup_transfer_msg_body(context).await);
+                msg.text = backup_transfer_msg_body(context).await;
                 add_device_msg(context, None, Some(&mut msg)).await?;
             }
             Err(err) => {
@@ -611,7 +611,7 @@ mod tests {
         // Write a message in the self chat
         let self_chat = ctx0.get_self_chat().await;
         let mut msg = Message::new(Viewtype::Text);
-        msg.set_text(Some("hi there".to_string()));
+        msg.set_text("hi there".to_string());
         send_msg(&ctx0, self_chat.id, &mut msg).await.unwrap();
 
         // Send an attachment in the self chat
@@ -643,7 +643,7 @@ mod tests {
             _ => panic!("wrong chat item"),
         };
         let msg = Message::load_from_db(&ctx1, *msgid).await.unwrap();
-        let text = msg.get_text().unwrap();
+        let text = msg.get_text();
         assert_eq!(text, "hi there");
         let msgid = match msgs.get(1).unwrap() {
             ChatItem::Message { msg_id } => msg_id,

--- a/src/location.rs
+++ b/src/location.rs
@@ -280,7 +280,7 @@ pub async fn send_locations_to_chat(
         .await?;
     if 0 != seconds && !is_sending_locations_before {
         let mut msg = Message::new(Viewtype::Text);
-        msg.text = Some(stock_str::msg_location_enabled(context).await);
+        msg.text = stock_str::msg_location_enabled(context).await;
         msg.param.set_cmd(SystemMessage::LocationStreamingEnabled);
         chat::send_msg(context, chat_id, &mut msg)
             .await
@@ -885,7 +885,7 @@ Text message."#,
         )
         .await?;
         let received_msg = alice.get_last_msg().await;
-        assert_eq!(received_msg.text.unwrap(), "Text message.");
+        assert_eq!(received_msg.text, "Text message.");
 
         receive_imf(
             &alice,

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1138,14 +1138,10 @@ impl<'a> MimeFactory<'a> {
         } else {
             None
         };
-        let final_text = {
-            if let Some(ref text) = placeholdertext {
-                text
-            } else if let Some(ref text) = self.msg.text {
-                text
-            } else {
-                ""
-            }
+        let final_text = if let Some(ref text) = placeholdertext {
+            text
+        } else {
+            &self.msg.text
         };
 
         let mut quoted_text = self
@@ -1792,7 +1788,7 @@ mod tests {
             quote: Option<&Message>,
         ) -> Result<String> {
             let mut new_msg = Message::new(Viewtype::Text);
-            new_msg.set_text(Some("Hi".to_string()));
+            new_msg.set_text("Hi".to_string());
             if let Some(q) = quote {
                 new_msg.set_quote(t, Some(q)).await?;
             }
@@ -1879,7 +1875,7 @@ mod tests {
         let chat_id = ChatId::create_for_contact(&t, contact_id).await.unwrap();
 
         let mut new_msg = Message::new(Viewtype::Text);
-        new_msg.set_text(Some("Hi".to_string()));
+        new_msg.set_text("Hi".to_string());
         new_msg.chat_id = chat_id;
         chat::prepare_msg(&t, chat_id, &mut new_msg).await.unwrap();
 
@@ -1987,7 +1983,7 @@ mod tests {
         chat_id.accept(context).await.unwrap();
 
         let mut new_msg = Message::new(Viewtype::Text);
-        new_msg.set_text(Some("Hi".to_string()));
+        new_msg.set_text("Hi".to_string());
         new_msg.chat_id = chat_id;
         chat::prepare_msg(context, chat_id, &mut new_msg)
             .await
@@ -2105,7 +2101,7 @@ mod tests {
         // send message to bob: that should get multipart/mixed because of the avatar moved to inner header;
         // make sure, `Subject:` stays in the outer header (imf header)
         let mut msg = Message::new(Viewtype::Text);
-        msg.set_text(Some("this is the text!".to_string()));
+        msg.set_text("this is the text!".to_string());
 
         let sent_msg = t.send_msg(chat.id, &mut msg).await;
         let mut payload = sent_msg.payload().splitn(3, "\r\n\r\n");
@@ -2165,7 +2161,7 @@ mod tests {
         // send message to bob: that should get multipart/mixed because of the avatar moved to inner header;
         // make sure, `Subject:` stays in the outer header (imf header)
         let mut msg = Message::new(Viewtype::Text);
-        msg.set_text(Some("this is the text!".to_string()));
+        msg.set_text("this is the text!".to_string());
 
         let sent_msg = t.send_msg(chat.id, &mut msg).await;
         let mut payload = sent_msg.payload().splitn(4, "\r\n\r\n");
@@ -2277,7 +2273,7 @@ mod tests {
         // send message to bob: that should get multipart/mixed because of the avatar moved to inner header;
         // make sure, `Subject:` stays in the outer header (imf header)
         let mut msg = Message::new(Viewtype::Text);
-        msg.set_text(Some("this is the text!".to_string()));
+        msg.set_text("this is the text!".to_string());
 
         let sent_msg = t.send_msg(chat.id, &mut msg).await;
         let payload = sent_msg.payload();

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -3221,10 +3221,7 @@ On 2020-10-25, Bob wrote:
         let msg_id = chats.get_msg_id(0).unwrap().unwrap();
         let msg = Message::load_from_db(&t.ctx, msg_id).await.unwrap();
 
-        assert_eq!(
-            msg.text.as_ref().unwrap(),
-            "subj with important info – body text"
-        );
+        assert_eq!(msg.text, "subj with important info – body text");
         assert_eq!(msg.viewtype, Viewtype::Image);
         assert_eq!(msg.error(), None);
         assert_eq!(msg.is_dc_message, MessengerMessage::No);
@@ -3393,9 +3390,9 @@ Some reply
         receive_imf(&t, raw, false).await?;
 
         let msg = t.get_last_msg().await;
-        assert_eq!(msg.get_text().unwrap(), "Some reply");
+        assert_eq!(msg.get_text(), "Some reply");
         let quoted_message = msg.quoted_message(&t).await?.unwrap();
-        assert_eq!(quoted_message.get_text().unwrap(), "Some quote.");
+        assert_eq!(quoted_message.get_text(), "Some quote.");
 
         Ok(())
     }

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -156,7 +156,7 @@ impl Context {
                         self.set_config(Config::QuotaExceeding, Some(&highest.to_string()))
                             .await?;
                         let mut msg = Message::new(Viewtype::Text);
-                        msg.text = Some(stock_str::quota_exceeding(self, highest).await);
+                        msg.text = stock_str::quota_exceeding(self, highest).await;
                         add_device_msg_with_importance(self, None, Some(&mut msg), true).await?;
                     } else if highest <= QUOTA_ALLCLEAR_PERCENTAGE {
                         self.set_config(Config::QuotaExceeding, None).await?;

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -214,7 +214,7 @@ pub async fn send_reaction(context: &Context, msg_id: MsgId, reaction: &str) -> 
 
     let reaction: Reaction = reaction.into();
     let mut reaction_msg = Message::new(Viewtype::Text);
-    reaction_msg.text = Some(reaction.as_str().to_string());
+    reaction_msg.text = reaction.as_str().to_string();
     reaction_msg.set_reaction();
     reaction_msg.in_reply_to = Some(msg.rfc724_mid);
     reaction_msg.hidden = true;

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -250,7 +250,7 @@ async fn test_read_receipt_and_unarchive() -> Result<()> {
     .await?;
     let msg = get_chat_msg(&t, group_id, 0, 1).await;
     assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
-    assert_eq!(msg.text.unwrap(), "hello");
+    assert_eq!(msg.text, "hello");
     assert_eq!(msg.state, MessageState::OutDelivered);
     let group = Chat::load_from_db(&t, group_id).await?;
     assert!(group.get_visibility() == ChatVisibility::Normal);
@@ -415,7 +415,7 @@ async fn test_escaped_from() {
     );
     let msg = get_chat_msg(&t, chat_id, 0, 1).await;
     assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
-    assert_eq!(msg.text.unwrap(), "hello");
+    assert_eq!(msg.text, "hello");
     assert_eq!(msg.param.get_int(Param::WantsMdn).unwrap(), 1);
 }
 
@@ -461,7 +461,7 @@ async fn test_escaped_recipients() {
         .await
         .unwrap();
     assert_eq!(msg.is_dc_message, MessengerMessage::Yes);
-    assert_eq!(msg.text.unwrap(), "hello");
+    assert_eq!(msg.text, "hello");
     assert_eq!(msg.param.get_int(Param::WantsMdn).unwrap(), 1);
 }
 
@@ -713,7 +713,7 @@ async fn test_parse_ndn_group_msg() -> Result<()> {
 
     assert_eq!(
         last_msg.text,
-        Some(stock_str::failed_sending_to(&t, "assidhfaaspocwaeofi@gmail.com").await,)
+        stock_str::failed_sending_to(&t, "assidhfaaspocwaeofi@gmail.com").await
     );
     assert_eq!(last_msg.from_id, ContactId::INFO);
     Ok(())
@@ -734,7 +734,7 @@ async fn load_imf_email(context: &Context, imf_raw: &[u8]) -> Message {
 async fn test_html_only_mail() {
     let t = TestContext::new_alice().await;
     let msg = load_imf_email(&t, include_bytes!("../../test-data/message/wrong-html.eml")).await;
-    assert_eq!(msg.text.unwrap(), "Guten Abend,\n\nLots of text\n\ntext with Umlaut ä...\n\nMfG\n\n--------------------------------------\n\n[Camping ](https://example.com/)\n\nsomeaddress\n\nsometown");
+    assert_eq!(msg.text, "Guten Abend,\n\nLots of text\n\ntext with Umlaut ä...\n\nMfG\n\n--------------------------------------\n\n[Camping ](https://example.com/)\n\nsomeaddress\n\nsometown");
 }
 
 static GH_MAILINGLIST: &[u8] =
@@ -1158,10 +1158,7 @@ async fn test_dhl_mailing_list() -> Result<()> {
     .await
     .unwrap();
     let msg = t.get_last_msg().await;
-    assert_eq!(
-        msg.text,
-        Some("Ihr Paket ist in der Packstation 123 – bla bla".to_string())
-    );
+    assert_eq!(msg.text, "Ihr Paket ist in der Packstation 123 – bla bla");
     assert!(msg.has_html());
     let chat = Chat::load_from_db(&t, msg.chat_id).await.unwrap();
     assert_eq!(chat.typ, Chattype::Mailinglist);
@@ -1186,10 +1183,7 @@ async fn test_dpd_mailing_list() -> Result<()> {
     .await
     .unwrap();
     let msg = t.get_last_msg().await;
-    assert_eq!(
-        msg.text,
-        Some("Bald ist Ihr DPD Paket da – bla bla".to_string())
-    );
+    assert_eq!(msg.text, "Bald ist Ihr DPD Paket da – bla bla");
     assert!(msg.has_html());
     let chat = Chat::load_from_db(&t, msg.chat_id).await.unwrap();
     assert_eq!(chat.typ, Chattype::Mailinglist);
@@ -1294,10 +1288,7 @@ async fn test_mailing_list_with_mimepart_footer() {
     .await
     .unwrap();
     let msg = t.get_last_msg().await;
-    assert_eq!(
-        msg.text,
-        Some("[Intern] important stuff – Hi mr ... [text part]".to_string())
-    );
+    assert_eq!(msg.text, "[Intern] important stuff – Hi mr ... [text part]");
     assert!(msg.has_html());
     let chat = Chat::load_from_db(&t, msg.chat_id).await.unwrap();
     assert_eq!(get_chat_msgs(&t, msg.chat_id).await.unwrap().len(), 1);
@@ -1320,7 +1311,7 @@ async fn test_mailing_list_with_mimepart_footer_signed() {
     .unwrap();
     let msg = t.get_last_msg().await;
     assert_eq!(get_chat_msgs(&t, msg.chat_id).await.unwrap().len(), 1);
-    let text = msg.text.clone().unwrap();
+    let text = msg.text.clone();
     assert!(text.contains("content text"));
     assert!(!text.contains("footer text"));
     assert!(msg.has_html());
@@ -1384,7 +1375,7 @@ async fn test_mailing_list_chat_message() {
     .await
     .unwrap();
     let msg = t.get_last_msg().await;
-    assert_eq!(msg.text, Some("hello, this is a test 👋\n\n_______________________________________________\nTest1 mailing list -- test1@example.net\nTo unsubscribe send an email to test1-leave@example.net".to_string()));
+    assert_eq!(msg.text, "hello, this is a test 👋\n\n_______________________________________________\nTest1 mailing list -- test1@example.net\nTo unsubscribe send an email to test1-leave@example.net".to_string());
     assert!(!msg.has_html());
     let chat = Chat::load_from_db(&t, msg.chat_id).await.unwrap();
     assert_eq!(chat.typ, Chattype::Mailinglist);
@@ -1464,7 +1455,7 @@ async fn test_pdf_filename_simple() {
     )
     .await;
     assert_eq!(msg.viewtype, Viewtype::File);
-    assert_eq!(msg.text.unwrap(), "mail body");
+    assert_eq!(msg.text, "mail body");
     assert_eq!(msg.param.get(Param::File).unwrap(), "$BLOBDIR/simple.pdf");
 }
 
@@ -1478,7 +1469,7 @@ async fn test_pdf_filename_continuation() {
     )
     .await;
     assert_eq!(msg.viewtype, Viewtype::File);
-    assert_eq!(msg.text.unwrap(), "mail body");
+    assert_eq!(msg.text, "mail body");
     assert_eq!(
         msg.param.get(Param::File).unwrap(),
         "$BLOBDIR/test pdf äöüß.pdf"
@@ -1557,7 +1548,7 @@ async fn test_in_reply_to() {
     .unwrap();
 
     let msg = t.get_last_msg().await;
-    assert_eq!(msg.get_text().unwrap(), "reply foo");
+    assert_eq!(msg.get_text(), "reply foo");
 
     // Load the first message from the same chat.
     let msgs = chat::get_chat_msgs(&t, msg.chat_id).await.unwrap();
@@ -1568,7 +1559,7 @@ async fn test_in_reply_to() {
     };
 
     let reply_msg = Message::load_from_db(&t, *msg_id).await.unwrap();
-    assert_eq!(reply_msg.get_text().unwrap(), "hello foo");
+    assert_eq!(reply_msg.get_text(), "hello foo");
 
     // Check that reply got into the same chat as the original message.
     assert_eq!(msg.chat_id, reply_msg.chat_id);
@@ -1626,7 +1617,7 @@ async fn test_in_reply_to_two_member_group() {
     let msg = t.get_last_msg().await;
     let chat = Chat::load_from_db(&t, msg.chat_id).await.unwrap();
     assert_eq!(chat.typ, Chattype::Group);
-    assert_eq!(msg.get_text().unwrap(), "classic reply");
+    assert_eq!(msg.get_text(), "classic reply");
 
     // Receive a Delta Chat reply from Alice.
     // It is assigned to group chat, because it has a group ID.
@@ -1652,7 +1643,7 @@ async fn test_in_reply_to_two_member_group() {
     let msg = t.get_last_msg().await;
     let chat = Chat::load_from_db(&t, msg.chat_id).await.unwrap();
     assert_eq!(chat.typ, Chattype::Group);
-    assert_eq!(msg.get_text().unwrap(), "chat reply");
+    assert_eq!(msg.get_text(), "chat reply");
 
     // Receive a private Delta Chat reply from Alice.
     // It is assigned to 1:1 chat, because it has no group ID,
@@ -1679,7 +1670,7 @@ async fn test_in_reply_to_two_member_group() {
     let msg = t.get_last_msg().await;
     let chat = Chat::load_from_db(&t, msg.chat_id).await.unwrap();
     assert_eq!(chat.typ, Chattype::Single);
-    assert_eq!(msg.get_text().unwrap(), "private reply");
+    assert_eq!(msg.get_text(), "private reply");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1690,7 +1681,7 @@ async fn test_save_mime_headers_off() -> anyhow::Result<()> {
     chat::send_text_msg(&alice, chat_alice.id, "hi!".to_string()).await?;
 
     let msg = bob.recv_msg(&alice.pop_sent_msg().await).await;
-    assert_eq!(msg.get_text(), Some("hi!".to_string()));
+    assert_eq!(msg.get_text(), "hi!");
     assert!(!msg.get_showpadlock());
     let mime = message::get_mime_headers(&bob, msg.id).await?;
     assert!(mime.is_empty());
@@ -1709,7 +1700,7 @@ async fn test_save_mime_headers_on() -> anyhow::Result<()> {
     chat::send_text_msg(&alice, chat_alice.id, "hi!".to_string()).await?;
 
     let msg = bob.recv_msg(&alice.pop_sent_msg().await).await;
-    assert_eq!(msg.get_text(), Some("hi!".to_string()));
+    assert_eq!(msg.get_text(), "hi!");
     assert!(!msg.get_showpadlock());
     let mime = message::get_mime_headers(&bob, msg.id).await?;
     let mime_str = String::from_utf8_lossy(&mime);
@@ -1720,7 +1711,7 @@ async fn test_save_mime_headers_on() -> anyhow::Result<()> {
     let chat_bob = bob.create_chat(&alice).await;
     chat::send_text_msg(&bob, chat_bob.id, "ho!".to_string()).await?;
     let msg = alice.recv_msg(&bob.pop_sent_msg().await).await;
-    assert_eq!(msg.get_text(), Some("ho!".to_string()));
+    assert_eq!(msg.get_text(), "ho!");
     assert!(msg.get_showpadlock());
     let mime = message::get_mime_headers(&alice, msg.id).await?;
     let mime_str = String::from_utf8_lossy(&mime);
@@ -1780,7 +1771,7 @@ async fn create_test_alias(chat_request: bool, group_request: bool) -> (TestCont
 
     let msg = alice.get_last_msg().await;
     assert_eq!(msg.get_subject(), "i have a question");
-    assert!(msg.get_text().unwrap().contains("hi support!"));
+    assert!(msg.get_text().contains("hi support!"));
     let chat = Chat::load_from_db(&alice, msg.chat_id).await.unwrap();
     assert_eq!(chat.typ, Chattype::Group);
     assert_eq!(get_chat_msgs(&alice, chat.id).await.unwrap().len(), 1);
@@ -1805,7 +1796,7 @@ async fn create_test_alias(chat_request: bool, group_request: bool) -> (TestCont
     let msg = Message::load_from_db(&claire, msg_id).await.unwrap();
     msg.chat_id.accept(&claire).await.unwrap();
     assert_eq!(msg.get_subject(), "i have a question");
-    assert!(msg.get_text().unwrap().contains("hi support!"));
+    assert!(msg.get_text().contains("hi support!"));
     let chat = Chat::load_from_db(&claire, msg.chat_id).await.unwrap();
     if group_request {
         assert_eq!(chat.typ, Chattype::Group);
@@ -1826,7 +1817,7 @@ async fn check_alias_reply(reply: &[u8], chat_request: bool, group_request: bool
     receive_imf(&alice, reply, false).await.unwrap();
     let answer = alice.get_last_msg().await;
     assert_eq!(answer.get_subject(), "Re: i have a question");
-    assert!(answer.get_text().unwrap().contains("the version is 1.0"));
+    assert!(answer.get_text().contains("the version is 1.0"));
     assert_eq!(answer.chat_id, request.chat_id);
     let chat_contacts = get_chat_contacts(&alice, answer.chat_id)
         .await
@@ -1849,7 +1840,7 @@ async fn check_alias_reply(reply: &[u8], chat_request: bool, group_request: bool
     receive_imf(&claire, reply, false).await.unwrap();
     let answer = claire.get_last_msg().await;
     assert_eq!(answer.get_subject(), "Re: i have a question");
-    assert!(answer.get_text().unwrap().contains("the version is 1.0"));
+    assert!(answer.get_text().contains("the version is 1.0"));
     assert_eq!(answer.chat_id, request.chat_id);
     assert_eq!(
         answer.get_override_sender_name().unwrap(),
@@ -1921,7 +1912,7 @@ async fn test_dont_assign_to_trash_by_parent() {
     chat_id.accept(&t).await.unwrap();
     let msg = get_chat_msg(&t, chat_id, 0, 1).await; // Make sure that the message is actually in the chat
     assert!(!msg.chat_id.is_special());
-    assert_eq!(msg.text.unwrap(), "Hi – hello");
+    assert_eq!(msg.text, "Hi – hello");
 
     println!("\n========= Delete the message ==========");
     msg.id.trash(&t).await.unwrap();
@@ -1945,7 +1936,7 @@ async fn test_dont_assign_to_trash_by_parent() {
     .unwrap();
     let msg = t.get_last_msg().await;
     assert!(!msg.chat_id.is_special()); // Esp. check that the chat_id is not TRASH
-    assert_eq!(msg.text.unwrap(), "Reply");
+    assert_eq!(msg.text, "Reply");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1996,7 +1987,7 @@ Message content",
 
     // Outgoing email should create a chat.
     let msg = alice.get_last_msg().await;
-    assert_eq!(msg.get_text().unwrap(), "Subj – Message content");
+    assert_eq!(msg.get_text(), "Subj – Message content");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -2243,7 +2234,7 @@ Message-ID: <Gr.eJ_llQIXf0K.buxmrnMmG0Y@gmx.de>"
 
         let group_msg = t.get_last_msg().await;
         assert_eq!(
-            group_msg.text.unwrap(),
+            group_msg.text,
             if *outgoing_is_classical {
                 "single reply-to – Hello, I\'ve just created the group \"single reply-to\" for us."
             } else {
@@ -2283,7 +2274,7 @@ Private reply"#,
         .unwrap();
 
         let private_msg = t.get_last_msg().await;
-        assert_eq!(private_msg.text.unwrap(), "Private reply");
+        assert_eq!(private_msg.text, "Private reply");
         let private_chat = Chat::load_from_db(&t, private_msg.chat_id).await.unwrap();
         assert_eq!(private_chat.typ, Chattype::Single);
         assert_ne!(private_msg.chat_id, group_msg.chat_id);
@@ -2332,7 +2323,7 @@ Message-ID: <Gr.iy1KCE2y65_.mH2TM52miv9@testrun.org>"
         .unwrap();
         let group_msg = t.get_last_msg().await;
         assert_eq!(
-            group_msg.text.unwrap(),
+            group_msg.text,
             if *outgoing_is_classical {
                 "single reply-to – Hello, I\'ve just created the group \"single reply-to\" for us."
             } else {
@@ -2378,7 +2369,7 @@ Sent with my Delta Chat Messenger: https://delta.chat
         .unwrap();
 
         let private_msg = t.get_last_msg().await;
-        assert_eq!(private_msg.text.unwrap(), "Private reply");
+        assert_eq!(private_msg.text, "Private reply");
         let private_chat = Chat::load_from_db(&t, private_msg.chat_id).await.unwrap();
         assert_eq!(private_chat.typ, Chattype::Single);
         assert_ne!(private_msg.chat_id, group_msg.chat_id);
@@ -2420,7 +2411,7 @@ Message-ID: <Gr.eJ_llQIXf0K.buxmrnMmG0Y@gmx.de>"
 
         let group_msg = t.get_last_msg().await;
         assert_eq!(
-            group_msg.text.unwrap(),
+            group_msg.text,
             if *outgoing_is_classical {
                 "single reply-to – Hello, I\'ve just created the group \"single reply-to\" for us."
             } else {
@@ -2457,7 +2448,7 @@ Outgoing reply to all"#,
         .unwrap();
 
         let reply = t.get_last_msg().await;
-        assert_eq!(reply.text.unwrap(), "Out subj – Outgoing reply to all");
+        assert_eq!(reply.text, "Out subj – Outgoing reply to all");
         let reply_chat = Chat::load_from_db(&t, reply.chat_id).await.unwrap();
         assert_eq!(reply_chat.typ, Chattype::Group);
         assert_eq!(reply.chat_id, group_msg.chat_id);
@@ -2480,7 +2471,7 @@ Reply to all"#,
         .unwrap();
 
         let reply = t.get_last_msg().await;
-        assert_eq!(reply.text.unwrap(), "In subj – Reply to all");
+        assert_eq!(reply.text, "In subj – Reply to all");
         let reply_chat = Chat::load_from_db(&t, reply.chat_id).await.unwrap();
         assert_eq!(reply_chat.typ, Chattype::Group);
         assert_eq!(reply.chat_id, group_msg.chat_id);
@@ -2766,7 +2757,7 @@ Hi, I created a group"#,
     .await?;
     let msg_out = t.get_last_msg().await;
     assert_eq!(msg_out.from_id, ContactId::SELF);
-    assert_eq!(msg_out.text.unwrap(), "Hi, I created a group");
+    assert_eq!(msg_out.text, "Hi, I created a group");
     assert_eq!(msg_out.in_reply_to, None);
 
     // Bob replies from a different address
@@ -2790,7 +2781,7 @@ Reply from different address
     .await?;
     let msg_in = t.get_last_msg().await;
     assert_eq!(msg_in.to_id, ContactId::SELF);
-    assert_eq!(msg_in.text.unwrap(), "Reply from different address");
+    assert_eq!(msg_in.text, "Reply from different address");
     assert_eq!(
         msg_in.in_reply_to.unwrap(),
         "Gr.qetqsutor7a.Aresxresy-4@deltachat.de"
@@ -2868,22 +2859,22 @@ async fn test_accept_outgoing() -> Result<()> {
     alice1.recv_msg(&sent).await;
     alice2.recv_msg(&sent).await;
     let alice1_msg = bob2.recv_msg(&sent).await;
-    assert_eq!(alice1_msg.text.unwrap(), "Hello!");
+    assert_eq!(alice1_msg.text, "Hello!");
     let alice1_chat = chat::Chat::load_from_db(&alice1, alice1_msg.chat_id).await?;
     assert!(alice1_chat.is_contact_request());
 
     let alice2_msg = alice2.get_last_msg().await;
-    assert_eq!(alice2_msg.text.unwrap(), "Hello!");
+    assert_eq!(alice2_msg.text, "Hello!");
     let alice2_chat = chat::Chat::load_from_db(&alice2, alice2_msg.chat_id).await?;
     assert!(alice2_chat.is_contact_request());
 
     let bob1_msg = bob1.get_last_msg().await;
-    assert_eq!(bob1_msg.text.unwrap(), "Hello!");
+    assert_eq!(bob1_msg.text, "Hello!");
     let bob1_chat = chat::Chat::load_from_db(&bob1, bob1_msg.chat_id).await?;
     assert!(!bob1_chat.is_contact_request());
 
     let bob2_msg = bob2.get_last_msg().await;
-    assert_eq!(bob2_msg.text.unwrap(), "Hello!");
+    assert_eq!(bob2_msg.text, "Hello!");
     let bob2_chat = chat::Chat::load_from_db(&bob2, bob2_msg.chat_id).await?;
     assert!(!bob2_chat.is_contact_request());
 
@@ -2929,7 +2920,7 @@ async fn test_outgoing_private_reply_multidevice() -> Result<()> {
     assert_eq!(received.from_id, alice1_bob_contact.id);
     assert_eq!(received.to_id, ContactId::SELF);
     assert!(!received.hidden);
-    assert_eq!(received.text, Some("Hello all!".to_string()));
+    assert_eq!(received.text, "Hello all!");
     assert_eq!(received.in_reply_to, None);
     assert_eq!(received.chat_blocked, Blocked::Request);
 
@@ -2939,7 +2930,7 @@ async fn test_outgoing_private_reply_multidevice() -> Result<()> {
     assert_eq!(received_group.can_send(&alice1).await?, false); // Can't send because it's Blocked::Request
 
     let mut msg_out = Message::new(Viewtype::Text);
-    msg_out.set_text(Some("Private reply".to_string()));
+    msg_out.set_text("Private reply".to_string());
 
     assert_eq!(received_group.blocked, Blocked::Request);
     msg_out.set_quote(&alice1, Some(&received)).await?;
@@ -2957,10 +2948,10 @@ async fn test_outgoing_private_reply_multidevice() -> Result<()> {
     assert_eq!(received.from_id, ContactId::SELF);
     assert_eq!(received.to_id, alice2_bob_contact.id);
     assert!(!received.hidden);
-    assert_eq!(received.text, Some("Private reply".to_string()));
+    assert_eq!(received.text, "Private reply");
     assert_eq!(
         received.parent(&alice2).await?.unwrap().text,
-        Some("Hello all!".to_string())
+        "Hello all!".to_string()
     );
     assert_eq!(received.chat_blocked, Blocked::Not);
 
@@ -3021,13 +3012,13 @@ async fn test_no_private_reply_to_blocked_account() -> Result<()> {
 
     // =============== Alice replies private to Bob ==============
     let received = alice.get_last_msg().await;
-    assert_eq!(received.text, Some("Hello all!".to_string()));
+    assert_eq!(received.text, "Hello all!");
 
     let received_group = Chat::load_from_db(&alice, received.chat_id).await?;
     assert_eq!(received_group.typ, Chattype::Group);
 
     let mut msg_out = Message::new(Viewtype::Text);
-    msg_out.set_text(Some("Private reply".to_string()));
+    msg_out.set_text("Private reply".to_string());
     msg_out.set_quote(&alice, Some(&received)).await?;
 
     let alice_bob_chat = alice.create_chat(&bob).await;
@@ -3043,7 +3034,7 @@ async fn test_no_private_reply_to_blocked_account() -> Result<()> {
     // since only chat is a group, no new open chat has been created
     assert_eq!(chat.typ, Chattype::Group);
     let received = bob.get_last_msg().await;
-    assert_eq!(received.text, Some("Hello all!".to_string()));
+    assert_eq!(received.text, "Hello all!");
 
     // =============== Bob unblocks Alice ================
     // test if the blocked chat is restored correctly
@@ -3054,7 +3045,7 @@ async fn test_no_private_reply_to_blocked_account() -> Result<()> {
     let chat = Chat::load_from_db(&bob, chat_id).await.unwrap();
     assert_eq!(chat.typ, Chattype::Single);
     let received = bob.get_last_msg().await;
-    assert_eq!(received.text, Some("Private reply".to_string()));
+    assert_eq!(received.text, "Private reply");
 
     Ok(())
 }

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -178,7 +178,7 @@ async fn send_alice_handshake_msg(
 ) -> Result<()> {
     let mut msg = Message {
         viewtype: Viewtype::Text,
-        text: Some(format!("Secure-Join: {step}")),
+        text: format!("Secure-Join: {step}"),
         hidden: true,
         ..Default::default()
     };
@@ -933,8 +933,7 @@ mod tests {
                 .expect("No messages in Alice's 1:1 chat");
             let msg = Message::load_from_db(&alice.ctx, msg_id).await.unwrap();
             assert!(msg.is_info());
-            let text = msg.get_text().unwrap();
-            assert!(text.contains("bob@example.net verified"));
+            assert!(msg.get_text().contains("bob@example.net verified"));
         }
 
         // Check Alice sent the right message to Bob.
@@ -982,8 +981,7 @@ mod tests {
                 .expect("No messages in Bob's 1:1 chat");
             let msg = Message::load_from_db(&bob.ctx, msg_id).await.unwrap();
             assert!(msg.is_info());
-            let text = msg.get_text().unwrap();
-            assert!(text.contains("alice@example.org verified"));
+            assert!(msg.get_text().contains("alice@example.org verified"));
         }
 
         // Check Bob sent the final message
@@ -1292,8 +1290,7 @@ mod tests {
                 .expect("No messages in Alice's group chat");
             let msg = Message::load_from_db(&alice.ctx, msg_id).await.unwrap();
             assert!(msg.is_info());
-            let text = msg.get_text().unwrap();
-            assert!(text.contains("bob@example.net verified"));
+            assert!(msg.get_text().contains("bob@example.net verified"));
         }
 
         // Bob should not yet have Alice verified
@@ -1328,7 +1325,7 @@ mod tests {
             for item in chat::get_chat_msgs(&bob.ctx, bob_chatid).await.unwrap() {
                 if let chat::ChatItem::Message { msg_id } = item {
                     let msg = Message::load_from_db(&bob.ctx, msg_id).await.unwrap();
-                    let text = msg.get_text().unwrap();
+                    let text = msg.get_text();
                     println!("msg {msg_id} text: {text}");
                 }
             }
@@ -1340,7 +1337,7 @@ mod tests {
                 match msg_iter.next() {
                     Some(chat::ChatItem::Message { msg_id }) => {
                         let msg = Message::load_from_db(&bob.ctx, msg_id).await.unwrap();
-                        let text = msg.get_text().unwrap();
+                        let text = msg.get_text();
                         match text.contains("alice@example.org verified") {
                             true => {
                                 assert!(msg.is_info());

--- a/src/securejoin/bobstate.rs
+++ b/src/securejoin/bobstate.rs
@@ -422,7 +422,7 @@ async fn send_handshake_message(
 ) -> Result<()> {
     let mut msg = Message {
         viewtype: Viewtype::Text,
-        text: Some(step.body_text(invite)),
+        text: step.body_text(invite),
         hidden: true,
         ..Default::default()
     };

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -245,7 +245,7 @@ impl Sql {
             // So, for people who have delete_server enabled, disable it and add a hint to the devicechat:
             if context.get_config_delete_server_after().await?.is_some() {
                 let mut msg = Message::new(Viewtype::Text);
-                msg.text = Some(stock_str::delete_server_turned_off(context).await);
+                msg.set_text(stock_str::delete_server_turned_off(context).await);
                 add_device_msg(context, None, Some(&mut msg)).await?;
                 context
                     .set_config(Config::DeleteServerAfter, Some("0"))
@@ -1102,13 +1102,13 @@ mod tests {
 
         let chat = t.create_chat_with_contact("bob", "bob@example.com").await;
         let mut new_draft = Message::new(Viewtype::Text);
-        new_draft.set_text(Some("This is my draft".to_string()));
+        new_draft.set_text("This is my draft".to_string());
         chat.id.set_draft(&t, Some(&mut new_draft)).await.unwrap();
 
         housekeeping(&t).await.unwrap();
 
         let loaded_draft = chat.id.get_draft(&t).await.unwrap();
-        assert_eq!(loaded_draft.unwrap().text.unwrap(), "This is my draft");
+        assert_eq!(loaded_draft.unwrap().text, "This is my draft");
     }
 
     /// Tests that `housekeeping` deletes the blobs backup dir which is created normally by

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -1313,7 +1313,7 @@ impl Context {
         chat::add_device_msg(self, Some("core-welcome-image"), Some(&mut msg)).await?;
 
         let mut msg = Message::new(Viewtype::Text);
-        msg.text = Some(welcome_message(self).await);
+        msg.text = welcome_message(self).await;
         chat::add_device_msg(self, Some("core-welcome"), Some(&mut msg)).await?;
         Ok(())
     }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -175,16 +175,12 @@ impl Message {
             return prefix;
         }
 
-        let summary_content = if let Some(text) = &self.text {
-            if text.is_empty() {
-                prefix
-            } else if prefix.is_empty() {
-                text.to_string()
-            } else {
-                format!("{prefix} – {text}")
-            }
-        } else {
+        let summary_content = if self.text.is_empty() {
             prefix
+        } else if prefix.is_empty() {
+            self.text.to_string()
+        } else {
+            format!("{prefix} – {}", self.text)
         };
 
         let summary = if self.is_forwarded() {
@@ -211,19 +207,16 @@ mod tests {
         let d = test::TestContext::new().await;
         let ctx = &d.ctx;
 
-        let some_text = Some(" bla \t\n\tbla\n\t".to_string());
-        let empty_text = Some("".to_string());
-        let no_text: Option<String> = None;
+        let some_text = " bla \t\n\tbla\n\t".to_string();
 
         let mut msg = Message::new(Viewtype::Text);
-        msg.set_text(some_text.clone());
+        msg.set_text(some_text.to_string());
         assert_eq!(
             msg.get_summary_text(ctx).await,
             "bla bla" // for simple text, the type is not added to the summary
         );
 
         let mut msg = Message::new(Viewtype::Image);
-        msg.set_text(no_text.clone());
         msg.set_file("foo.bar", None);
         assert_eq!(
             msg.get_summary_text(ctx).await,
@@ -231,7 +224,6 @@ mod tests {
         );
 
         let mut msg = Message::new(Viewtype::Video);
-        msg.set_text(no_text.clone());
         msg.set_file("foo.bar", None);
         assert_eq!(
             msg.get_summary_text(ctx).await,
@@ -239,7 +231,6 @@ mod tests {
         );
 
         let mut msg = Message::new(Viewtype::Gif);
-        msg.set_text(no_text.clone());
         msg.set_file("foo.bar", None);
         assert_eq!(
             msg.get_summary_text(ctx).await,
@@ -247,7 +238,6 @@ mod tests {
         );
 
         let mut msg = Message::new(Viewtype::Sticker);
-        msg.set_text(no_text.clone());
         msg.set_file("foo.bar", None);
         assert_eq!(
             msg.get_summary_text(ctx).await,
@@ -255,7 +245,6 @@ mod tests {
         );
 
         let mut msg = Message::new(Viewtype::Voice);
-        msg.set_text(empty_text.clone());
         msg.set_file("foo.bar", None);
         assert_eq!(
             msg.get_summary_text(ctx).await,
@@ -263,7 +252,6 @@ mod tests {
         );
 
         let mut msg = Message::new(Viewtype::Voice);
-        msg.set_text(no_text.clone());
         msg.set_file("foo.bar", None);
         assert_eq!(
             msg.get_summary_text(ctx).await,
@@ -279,7 +267,6 @@ mod tests {
         );
 
         let mut msg = Message::new(Viewtype::Audio);
-        msg.set_text(no_text.clone());
         msg.set_file("foo.bar", None);
         assert_eq!(
             msg.get_summary_text(ctx).await,
@@ -287,7 +274,6 @@ mod tests {
         );
 
         let mut msg = Message::new(Viewtype::Audio);
-        msg.set_text(empty_text.clone());
         msg.set_file("foo.bar", None);
         assert_eq!(
             msg.get_summary_text(ctx).await,
@@ -329,7 +315,6 @@ mod tests {
         );
 
         let mut msg = Message::new(Viewtype::File);
-        msg.set_text(no_text.clone());
         msg.param.set(Param::File, "foo.bar");
         msg.param.set_cmd(SystemMessage::AutocryptSetupMessage);
         assert_eq!(

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -130,7 +130,7 @@ impl Context {
             let mut msg = Message {
                 chat_id,
                 viewtype: Viewtype::Text,
-                text: Some(stock_str::sync_msg_body(self).await),
+                text: stock_str::sync_msg_body(self).await,
                 hidden: true,
                 subject: stock_str::sync_msg_subject(self).await,
                 ..Default::default()

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -118,7 +118,7 @@ impl TestContextManager {
     /// - Assert that the message arrived
     pub async fn send_recv(&self, from: &TestContext, to: &TestContext, msg: &str) -> Message {
         let received_msg = self.try_send_recv(from, to, msg).await;
-        assert_eq!(received_msg.text.as_ref().unwrap(), msg);
+        assert_eq!(received_msg.text, msg);
         received_msg
     }
 
@@ -608,7 +608,7 @@ impl TestContext {
     /// the message.
     pub async fn send_text(&self, chat_id: ChatId, txt: &str) -> SentMessage<'_> {
         let mut msg = Message::new(Viewtype::Text);
-        msg.set_text(Some(txt.to_string()));
+        msg.text = txt.to_string();
         self.send_msg(chat_id, &mut msg).await
     }
 
@@ -1104,7 +1104,7 @@ async fn write_msg(context: &Context, prefix: &str, msg: &Message, buf: &mut Str
         if msg.has_location() { "📍" } else { "" },
         &contact_name,
         contact_id,
-        msgtext.unwrap_or_default(),
+        msgtext,
         if msg.get_from_id() == ContactId::SELF {
             ""
         } else if msg.get_state() == MessageState::InSeen {

--- a/src/tests/aeap.rs
+++ b/src/tests/aeap.rs
@@ -32,7 +32,7 @@ async fn test_change_primary_self_addr() -> Result<()> {
     // Alice set up message forwarding so that she still receives
     // the message with her new address
     let alice_msg = alice.recv_msg(&sent).await;
-    assert_eq!(alice_msg.text, Some("hi back".to_string()));
+    assert_eq!(alice_msg.text, "hi back".to_string());
     assert_eq!(alice_msg.get_showpadlock(), true);
     let alice_bob_chat = alice.create_chat(&bob).await;
     assert_eq!(alice_msg.chat_id, alice_bob_chat.id);
@@ -57,10 +57,7 @@ Message w/out In-Reply-To
 
     let alice_msg = alice.get_last_msg().await;
 
-    assert_eq!(
-        alice_msg.text,
-        Some("Message w/out In-Reply-To".to_string())
-    );
+    assert_eq!(alice_msg.text, "Message w/out In-Reply-To");
     assert_eq!(alice_msg.get_showpadlock(), false);
     assert_eq!(alice_msg.chat_id, alice_bob_chat.id);
 
@@ -216,7 +213,7 @@ async fn check_aeap_transition(
         .await;
     let recvd = bob.recv_msg(&sent).await;
     let sent_timestamp = recvd.timestamp_sent;
-    assert_eq!(recvd.text.unwrap(), "Hello from my new addr!");
+    assert_eq!(recvd.text, "Hello from my new addr!");
 
     tcm.section("Check that the AEAP transition worked");
     check_that_transition_worked(
@@ -245,7 +242,7 @@ async fn check_aeap_transition(
         .send_text(chat_to_send, "Hello from my old addr!")
         .await;
     let recvd = bob.recv_msg(&sent).await;
-    assert_eq!(recvd.text.unwrap(), "Hello from my old addr!");
+    assert_eq!(recvd.text, "Hello from my old addr!");
 
     check_that_transition_worked(
         &groups[2..],
@@ -291,13 +288,13 @@ async fn check_that_transition_worked(
         let info_msg = get_last_info_msg(bob, *group).await.unwrap();
         let expected_text =
             stock_str::aeap_addr_changed(bob, name, old_alice_addr, new_alice_addr).await;
-        assert_eq!(info_msg.text.unwrap(), expected_text);
+        assert_eq!(info_msg.text, expected_text);
         assert_eq!(info_msg.from_id, ContactId::INFO);
 
         let msg = format!("Sending to group {group}");
         let sent = bob.send_text(*group, &msg).await;
         let recvd = alice.recv_msg(&sent).await;
-        assert_eq!(recvd.text.unwrap(), msg);
+        assert_eq!(recvd.text, msg);
     }
 }
 

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -185,16 +185,14 @@ pub(crate) async fn maybe_add_time_based_warnings(context: &Context) {
 async fn maybe_warn_on_bad_time(context: &Context, now: i64, known_past_timestamp: i64) -> bool {
     if now < known_past_timestamp {
         let mut msg = Message::new(Viewtype::Text);
-        msg.text = Some(
-            stock_str::bad_time_msg_body(
-                context,
-                &Local.timestamp_opt(now, 0).single().map_or_else(
-                    || "YY-MM-DD hh:mm:ss".to_string(),
-                    |ts| ts.format("%Y-%m-%d %H:%M:%S").to_string(),
-                ),
-            )
-            .await,
-        );
+        msg.text = stock_str::bad_time_msg_body(
+            context,
+            &Local.timestamp_opt(now, 0).single().map_or_else(
+                || "YY-MM-DD hh:mm:ss".to_string(),
+                |ts| ts.format("%Y-%m-%d %H:%M:%S").to_string(),
+            ),
+        )
+        .await;
         if let Some(timestamp) = chrono::NaiveDateTime::from_timestamp_opt(now, 0) {
             add_device_msg_with_importance(
                 context,
@@ -221,7 +219,7 @@ async fn maybe_warn_on_bad_time(context: &Context, now: i64, known_past_timestam
 async fn maybe_warn_on_outdated(context: &Context, now: i64, approx_compile_time: i64) {
     if now > approx_compile_time + DC_OUTDATED_WARNING_DAYS * 24 * 60 * 60 {
         let mut msg = Message::new(Viewtype::Text);
-        msg.text = Some(stock_str::update_reminder_msg_body(context).await);
+        msg.text = stock_str::update_reminder_msg_body(context).await;
         if let Some(timestamp) = chrono::NaiveDateTime::from_timestamp_opt(now, 0) {
             add_device_msg(
                 context,

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -518,7 +518,7 @@ impl Context {
                 let mut status_update = Message {
                     chat_id: instance.chat_id,
                     viewtype: Viewtype::Text,
-                    text: Some(descr.to_string()),
+                    text: descr.to_string(),
                     hidden: true,
                     ..Default::default()
                 };
@@ -1464,7 +1464,7 @@ mod tests {
         assert!(alice_update.hidden);
         assert_eq!(alice_update.viewtype, Viewtype::Text);
         assert_eq!(alice_update.get_filename(), None);
-        assert_eq!(alice_update.text, Some("descr text".to_string()));
+        assert_eq!(alice_update.text, "descr text".to_string());
         assert_eq!(alice_update.chat_id, alice_instance.chat_id);
         assert_eq!(
             alice_update.parent(&alice).await?.unwrap().id,
@@ -2131,10 +2131,7 @@ sth_for_the = "future""#
         assert!(info_msg.is_info());
         assert_eq!(info_msg.get_info_type(), SystemMessage::WebxdcInfoMessage);
         assert_eq!(info_msg.from_id, ContactId::SELF);
-        assert_eq!(
-            info_msg.get_text(),
-            Some("this appears in-chat".to_string())
-        );
+        assert_eq!(info_msg.get_text(), "this appears in-chat");
         assert_eq!(
             info_msg.parent(&alice).await?.unwrap().id,
             alice_instance.id
@@ -2156,10 +2153,7 @@ sth_for_the = "future""#
         assert!(info_msg.is_info());
         assert_eq!(info_msg.get_info_type(), SystemMessage::WebxdcInfoMessage);
         assert!(!info_msg.from_id.is_special());
-        assert_eq!(
-            info_msg.get_text(),
-            Some("this appears in-chat".to_string())
-        );
+        assert_eq!(info_msg.get_text(), "this appears in-chat");
         assert_eq!(info_msg.parent(&bob).await?.unwrap().id, bob_instance.id);
         assert!(info_msg.quoted_message(&bob).await?.is_none());
         assert_eq!(
@@ -2178,10 +2172,7 @@ sth_for_the = "future""#
         assert!(info_msg.is_info());
         assert_eq!(info_msg.get_info_type(), SystemMessage::WebxdcInfoMessage);
         assert_eq!(info_msg.from_id, ContactId::SELF);
-        assert_eq!(
-            info_msg.get_text(),
-            Some("this appears in-chat".to_string())
-        );
+        assert_eq!(info_msg.get_text(), "this appears in-chat");
         assert_eq!(
             info_msg.parent(&alice2).await?.unwrap().id,
             alice2_instance.id
@@ -2220,7 +2211,7 @@ sth_for_the = "future""#
         let sent3 = &alice.pop_sent_msg().await;
         assert_eq!(alice_chat.id.get_msg_cnt(&alice).await?, 2);
         let info_msg = alice.get_last_msg().await;
-        assert_eq!(info_msg.get_text(), Some("i2".to_string()));
+        assert_eq!(info_msg.get_text(), "i2");
 
         // When Bob receives the messages, they should be cleaned up as well
         let bob_instance = bob.recv_msg(sent1).await;
@@ -2230,7 +2221,7 @@ sth_for_the = "future""#
         bob.recv_msg(sent3).await;
         assert_eq!(bob_chat_id.get_msg_cnt(&bob).await?, 2);
         let info_msg = bob.get_last_msg().await;
-        assert_eq!(info_msg.get_text(), Some("i2".to_string()));
+        assert_eq!(info_msg.get_text(), "i2");
 
         Ok(())
     }
@@ -2383,26 +2374,20 @@ sth_for_the = "future""#
             include_bytes!("../test-data/webxdc/minimal.xdc"),
         )
         .await?;
-        alice_instance.set_text(Some("user added text".to_string()));
+        alice_instance.set_text("user added text".to_string());
         send_msg(&alice, alice_chat.id, &mut alice_instance).await?;
         let alice_instance = alice.get_last_msg().await;
-        assert_eq!(
-            alice_instance.get_text(),
-            Some("user added text".to_string())
-        );
+        assert_eq!(alice_instance.get_text(), "user added text");
 
         // Bob receives that instance
         let sent1 = alice.pop_sent_msg().await;
         let bob_instance = bob.recv_msg(&sent1).await;
-        assert_eq!(bob_instance.get_text(), Some("user added text".to_string()));
+        assert_eq!(bob_instance.get_text(), "user added text");
 
         // Alice's second device receives the instance as well
         let alice2 = TestContext::new_alice().await;
         let alice2_instance = alice2.recv_msg(&sent1).await;
-        assert_eq!(
-            alice2_instance.get_text(),
-            Some("user added text".to_string())
-        );
+        assert_eq!(alice2_instance.get_text(), "user added text");
 
         Ok(())
     }


### PR DESCRIPTION
Message.set_text() and Message.get_text() are modified accordingly to accept String and return String.

Messages which previously contained None text
are now represented as messages with empty text.
Use Message.set_text("".to_string())
instead of Message.set_text(None).