### PR TITLE
fix: use different member added/removal messages locally and on the network

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1141,10 +1141,28 @@ impl Contact {
         &self.addr
     }
 
+    /// Get a summary of authorized name and address.
+    ///
+    /// The returned string is either "Name (email@domain.com)" or just
+    /// "email@domain.com" if the name is unset.
+    ///
+    /// This string is suitable for sending over email
+    /// as it does not leak the locally set name.
+    pub fn get_authname_n_addr(&self) -> String {
+        if !self.authname.is_empty() {
+            format!("{} ({})", self.authname, self.addr)
+        } else {
+            (&self.addr).into()
+        }
+    }
+
     /// Get a summary of name and address.
     ///
     /// The returned string is either "Name (email@domain.com)" or just
     /// "email@domain.com" if the name is unset.
+    ///
+    /// The result should only be used locally and never sent over the network
+    /// as it leaks the local contact name.
     ///
     /// The summary is typically used when asking the user something about the contact.
     /// The attached email address makes the question unique, eg. "Chat with Alan Miller (am@uniquedomain.com)?"

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1691,9 +1691,9 @@ async fn apply_group_changes(
                 }
 
                 better_msg = if contact_id == from_id {
-                    Some(stock_str::msg_group_left(context, from_id).await)
+                    Some(stock_str::msg_group_left_local(context, from_id).await)
                 } else {
-                    Some(stock_str::msg_del_member(context, removed_addr, from_id).await)
+                    Some(stock_str::msg_del_member_local(context, removed_addr, from_id).await)
                 };
             } else {
                 info!(
@@ -1718,7 +1718,7 @@ async fn apply_group_changes(
                 }
             }
 
-            better_msg = Some(stock_str::msg_add_member(context, added_addr, from_id).await);
+            better_msg = Some(stock_str::msg_add_member_local(context, added_addr, from_id).await);
         } else {
             info!(context, "Ignoring addition of {added_addr:?} to {chat_id}.");
         }


### PR DESCRIPTION
This commit adds new stock strings
"I added member ...",
"I removed member ..." and
"I left the group" that are sent over the network
and are visible in classic MUAs like Thunderbird.

Member name in these messages uses authname
instead of the display name,
so the name set locally does not get leaked when
a member is added or removed.

Fixes #4491 
Fixes #3750