### PR TITLE
chore: update MPL 2.0 license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -361,7 +361,7 @@ Exhibit A - Source Code Form License Notice
 
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE

--- a/python/LICENSE
+++ b/python/LICENSE
@@ -357,7 +357,7 @@ Exhibit A - Source Code Form License Notice
 
   This Source Code Form is subject to the terms of the Mozilla Public
   License, v. 2.0. If a copy of the MPL was not distributed with this
-  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 If it is not possible or desirable to put the notice in a particular
 file, then You may include the notice in a location (such as a LICENSE


### PR DESCRIPTION
New text was downloaded from https://www.mozilla.org/en-US/MPL/, specifically https://www.mozilla.org/media/MPL/2.0/index.f75d2927d3c1.txt

The difference is that the URL is changed from http:// to https://