### PR TITLE
Add send_webxdc_replacement() API

### DIFF
--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -77,6 +77,9 @@ pub enum HeaderDef {
     SecureJoinAuth,
     Sender,
 
+    /// [`Supersedes`](https://www.rfc-editor.org/rfc/rfc4021.html#section-2.1.46) header.
+    Supersedes,
+
     /// Ephemeral message timer.
     EphemeralTimer,
     Received,

--- a/src/message.rs
+++ b/src/message.rs
@@ -435,6 +435,18 @@ pub struct Message {
 
     /// `In-Reply-To` header value.
     pub(crate) in_reply_to: Option<String>,
+
+    /// `Supersedes` header value.
+    ///
+    /// It is only used for sending and not stored in the database.
+    ///
+    /// The header contains `Message-ID` of the original message
+    /// superseded by this one.
+    ///
+    /// The header is specified
+    /// in <https://www.rfc-editor.org/rfc/rfc4021.html#section-2.1.46>.
+    pub(crate) supersedes: Option<String>,
+
     pub(crate) is_dc_message: MessengerMessage,
     pub(crate) mime_modified: bool,
     pub(crate) chat_blocked: Blocked,
@@ -530,6 +542,7 @@ impl Message {
                         download_state: row.get("download_state")?,
                         error: Some(row.get::<_, String>("error")?)
                             .filter(|error| !error.is_empty()),
+                        supersedes: None, // `Supersedes` header is only used for sending and not stored in the database.
                         is_dc_message: row.get("msgrmsg")?,
                         mime_modified: row.get("mime_modified")?,
                         text,

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -549,6 +549,11 @@ impl<'a> MimeFactory<'a> {
             Loaded::Mdn { .. } => create_outgoing_rfc724_mid(None, &self.from_addr),
         };
         let rfc724_mid_headervalue = render_rfc724_mid(&rfc724_mid);
+        if let Some(supersedes) = &self.msg.supersedes {
+            headers
+                .protected
+                .push(Header::new("Supersedes".into(), supersedes.to_string()));
+        }
 
         // Amazon's SMTP servers change the `Message-ID`, just as Outlook's SMTP servers do.
         // Outlook's servers add an `X-Microsoft-Original-Message-ID` header with the original `Message-ID`,
@@ -1248,7 +1253,7 @@ impl<'a> MimeFactory<'a> {
         } else if command == SystemMessage::WebxdcStatusUpdate {
             let json = self.msg.param.get(Param::Arg).unwrap_or_default();
             parts.push(context.build_status_update_part(json));
-        } else if self.msg.viewtype == Viewtype::Webxdc {
+        } else if self.msg.viewtype == Viewtype::Webxdc && self.msg.supersedes.is_none() {
             if let Some(json) = context
                 .render_webxdc_status_update_object(self.msg.id, None)
                 .await?


### PR DESCRIPTION
The PR starts with refactoring to make it possible to `create_send_msg_job()` with a `Message` that is not stored in the database.

The most important part is adding `send_webxdc_replacement()` API that allows the store bot which sends the original `store.xdc` to later upgrade it by using this API to send a follow-up message with a special `Supersedes:` header that says the new .xdc should replace the old one while preserving all the XDC updates. `msg_id` in the database stays the same both on the sender (store bot) and the receiver (store bot user).

Closes #4480 

Depends on #4537 (already merged)