### PR TITLE
fix: Don't create 1:1 chat as protected for contact who doesn't prefer to encrypt

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1999,7 +1999,9 @@ impl ChatIdBlocked {
         }
 
         let peerstate = Peerstate::from_addr(context, contact.get_addr()).await?;
-        let protected = peerstate.map_or(false, |p| p.is_using_verified_key());
+        let protected = peerstate.map_or(false, |p| {
+            p.is_using_verified_key() && p.prefer_encrypt == EncryptPreference::Mutual
+        });
         let smeared_time = create_smeared_timestamp(context);
 
         let chat_id = context


### PR DESCRIPTION
Follow-up for #4315

Part of #4188