### PR TITLE
test: Remove unnecessary inner_set_protection() call

### DIFF
--- a/src/tests/verified_chats.rs
+++ b/src/tests/verified_chats.rs
@@ -449,12 +449,7 @@ async fn test_break_protection_then_verify_again() -> Result<()> {
     mark_as_verified(&alice, &bob).await;
     mark_as_verified(&bob, &alice).await;
 
-    alice
-        .create_chat(&bob)
-        .await
-        .id
-        .inner_set_protection(&alice, ProtectionStatus::Protected)
-        .await?;
+    alice.create_chat(&bob).await;
     assert_verified(&alice, &bob, ProtectionStatus::Protected).await;
 
     tcm.section("Bob reinstalls DC");


### PR DESCRIPTION
1:1 chats are automatically created as protected if the contact is verified, there is no need to explicitly do this.

Plus, by removing this call, the test also tests that automatically creating 1:1 chats as protected works.

Follow-up for #4315

Part of #4188