### PR TITLE
fix: Allow to save a draft if the verification is broken

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -761,14 +761,6 @@ impl ChatId {
             }
         }
 
-        let chat = Chat::load_from_db(context, self).await?;
-        if let Some(cant_send_reason) = chat.why_cant_send(context).await? {
-            bail!(
-                "Can't set a draft because chat is not writeable: {}",
-                cant_send_reason
-            );
-        }
-
         // set back draft information to allow identifying the draft later on -
         // no matter if message object is reused or reloaded from db
         msg.state = MessageState::OutDraft;


### PR DESCRIPTION
If the verification is broken, `can_send()` is false.

But if the user was typing a message right when a verification-breaking message came in, the UI still needs to be able to save it as a draft.

Steps to reproduce the bug:
  - Set a draft
  - Your chat partner breaks verification
  - Go back to the chats list
  - Go to the chat again
  - Accept the breakage
  - Expected: The draft is still there
  - Bug behavior: The draft is gone