### PR TITLE
fix(imap): avoid IMAP move loops when DeltaChat folder is aliased

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -74,7 +74,8 @@ pub async fn receive_imf(
     seen: bool,
 ) -> Result<Option<ReceivedMsg>> {
     let mail = parse_mail(imf_raw).context("can't parse mail")?;
-    let rfc724_mid = imap::prefetch_get_or_create_message_id(&mail.headers);
+    let rfc724_mid =
+        imap::prefetch_get_message_id(&mail.headers).unwrap_or_else(imap::create_message_id);
     receive_imf_inner(context, &rfc724_mid, imf_raw, seen, None, false).await
 }
 


### PR DESCRIPTION
Some Dovecot servers are configured
to alias "INBOX.DeltaChat" and "DeltaChat" to the same folder. In this case Delta Chat moves new emails from "INBOX" to "DeltaChat", but then discovers the same mail in "INBOX.DeltaChat" and tries to move it to "DeltaChat" again.
Each time a MOVE command is issued to move the message from "INBOX.DeltaChat" to "DeltaChat", the message gets a new UID.

To prevent such IMAP move loop between aliased folders, we do not move the message if we have already seen it on IMAP, i.e. we have its Message-ID in the `imap` table.
Note that we do not use `rfc724_mid_exists`,
because it checks the `msgs` table and would consider BCC-self messages seen even before we see them in the Inbox, preventing their move to the DeltaChat folder.

Duplicate messages and messages without Message-IDs are not moved anymore, but this is better
than having an infinite move loop.