### PR TITLE
fix: do not resync IMAP after initial configuration

### DIFF
--- a/python/examples/test_examples.py
+++ b/python/examples/test_examples.py
@@ -24,8 +24,6 @@ def test_echo_quit_plugin(acfactory, lp):
     lp.sec("creating a temp account to contact the bot")
     (ac1,) = acfactory.get_online_accounts(1)
 
-    botproc.await_resync()
-
     lp.sec("sending a message to the bot")
     bot_contact = ac1.create_contact(botproc.addr)
     bot_chat = bot_contact.create_chat()
@@ -53,8 +51,6 @@ def test_group_tracking_plugin(acfactory, lp):
     )
     ac1.add_account_plugin(FFIEventLogger(ac1))
     ac2.add_account_plugin(FFIEventLogger(ac2))
-
-    botproc.await_resync()
 
     lp.sec("creating bot test group with bot")
     bot_contact = ac1.create_contact(botproc.addr)

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -682,13 +682,6 @@ class BotProcess:
                     print("+++IGN:", line)
                     ignored.append(line)
 
-    def await_resync(self):
-        self.fnmatch_lines(
-            """
-            *Resync: collected * message IDs in folder INBOX*
-        """,
-        )
-
 
 @pytest.fixture()
 def tmp_db_path(tmpdir):

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -462,9 +462,12 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
 
     progress!(ctx, 910);
 
-    if ctx.get_config(Config::ConfiguredAddr).await?.as_deref() != Some(&param.addr) {
-        // Switched account, all server UIDs we know are invalid
-        job::schedule_resync(ctx).await?;
+    if let Some(configured_addr) = ctx.get_config(Config::ConfiguredAddr).await? {
+        if configured_addr != param.addr {
+            // Switched account, all server UIDs we know are invalid
+            info!(ctx, "Scheduling resync because the address has changed.");
+            job::schedule_resync(ctx).await?;
+        }
     }
 
     // the trailing underscore is correct


### PR DESCRIPTION
If there was no previous `configured_addr`,
then there is no need to run IMAP resync.

Fixes #4547 