### PR TITLE
test: Don't accidentally accept that a chat protection is broken

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -402,8 +402,8 @@ impl ChatId {
                 if chat.blocked == Blocked::Not
                     && chat.protected == ProtectionStatus::ProtectionBroken =>
             {
-                // The chat was in the 'Request' state because the protection was broken.
-                // The user clicked 'Accept', so, now we want to set the status to Unprotected again:
+                // The protection was broken, then the user clicked 'Accept'/'OK',
+                // so, now we want to set the status to Unprotected again:
                 chat.id
                     .inner_set_protection(context, ProtectionStatus::Unprotected)
                     .await?;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -398,7 +398,10 @@ impl ChatId {
         let chat = Chat::load_from_db(context, self).await?;
 
         match chat.typ {
-            Chattype::Single if chat.protected == ProtectionStatus::ProtectionBroken => {
+            Chattype::Single
+                if chat.blocked == Blocked::Not
+                    && chat.protected == ProtectionStatus::ProtectionBroken =>
+            {
                 // The chat was in the 'Request' state because the protection was broken.
                 // The user clicked 'Accept', so, now we want to set the status to Unprotected again:
                 chat.id

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -119,7 +119,10 @@ impl TestContextManager {
         msg: &str,
     ) -> Message {
         let received_msg = self.send_recv(from, to, msg).await;
-        assert_eq!(received_msg.chat_blocked, Blocked::Request);
+        assert_eq!(
+            received_msg.chat_blocked, Blocked::Request,
+            "`send_recv_accept()` is meant to be used for chat requests. Use `send_recv()` if the chat is already accepted."
+        );
         received_msg.chat_id.accept(to).await.unwrap();
         received_msg
     }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -27,7 +27,7 @@ use crate::chat::{
 };
 use crate::chatlist::Chatlist;
 use crate::config::Config;
-use crate::constants::Chattype;
+use crate::constants::{Blocked, Chattype};
 use crate::constants::{DC_GCL_NO_SPECIALS, DC_MSG_ID_DAYMARKER};
 use crate::contact::{Contact, ContactAddress, ContactId, Modifier, Origin};
 use crate::context::Context;
@@ -119,6 +119,7 @@ impl TestContextManager {
         msg: &str,
     ) -> Message {
         let received_msg = self.send_recv(from, to, msg).await;
+        assert_eq!(received_msg.chat_blocked, Blocked::Request);
         received_msg.chat_id.accept(to).await.unwrap();
         received_msg
     }
@@ -658,7 +659,6 @@ impl TestContext {
         res
     }
 
-    #[allow(unused)]
     pub async fn golden_test_chat(&self, chat_id: ChatId, filename: &str) {
         let filename = Path::new("test-data/golden/").join(filename);
 
@@ -685,8 +685,6 @@ impl TestContext {
     /// You can use this to debug your test by printing the entire chat conversation.
     // This code is mainly the same as `log_msglist` in `cmdline.rs`, so one day, we could
     // merge them to a public function in the `deltachat` crate.
-    #[allow(dead_code)]
-    #[allow(clippy::indexing_slicing)]
     async fn display_chat(&self, chat_id: ChatId) -> String {
         let mut res = String::new();
 

--- a/src/tests/aeap.rs
+++ b/src/tests/aeap.rs
@@ -134,11 +134,11 @@ async fn check_aeap_transition(
         let fiona = tcm.fiona().await;
 
         tcm.send_recv_accept(&fiona, &bob, "Hi").await;
-        tcm.send_recv_accept(&bob, &fiona, "Hi back").await;
+        tcm.send_recv(&bob, &fiona, "Hi back").await;
     }
 
     tcm.send_recv_accept(&alice, &bob, "Hi").await;
-    tcm.send_recv_accept(&bob, &alice, "Hi back").await;
+    tcm.send_recv(&bob, &alice, "Hi back").await;
 
     if verified {
         mark_as_verified(&alice, &bob).await;
@@ -355,7 +355,7 @@ async fn test_aeap_replay_attack() -> Result<()> {
     let bob = tcm.bob().await;
 
     tcm.send_recv_accept(&alice, &bob, "Hi").await;
-    tcm.send_recv_accept(&bob, &alice, "Hi back").await;
+    tcm.send_recv(&bob, &alice, "Hi back").await;
 
     let group =
         chat::create_group_chat(&bob, chat::ProtectionStatus::Unprotected, "Group 0").await?;

--- a/src/tests/verified_chats.rs
+++ b/src/tests/verified_chats.rs
@@ -528,8 +528,7 @@ async fn test_outgoing_mua_msg() -> Result<()> {
     )
     .await?
     .unwrap();
-    tcm.send_recv_accept(&alice, &bob, "Sending with DC again")
-        .await;
+    tcm.send_recv(&alice, &bob, "Sending with DC again").await;
 
     alice
         .golden_test_chat(sent.chat_id, "test_outgoing_mua_msg")
@@ -560,7 +559,7 @@ async fn test_reply() -> Result<()> {
         }
 
         tcm.send_recv_accept(&bob, &alice, "Heyho from DC").await;
-        let encrypted_msg = tcm.send_recv_accept(&alice, &bob, "Heyho back").await;
+        let encrypted_msg = tcm.send_recv(&alice, &bob, "Heyho back").await;
 
         let unencrypted_msg = receive_imf(
             &alice,


### PR DESCRIPTION
In one of the tests I wrote, I called `send_recv_accept()`, which accepted the protection-brokenness, and I spent a long time debugging this.

So, `send_recv_accept()` asserts that the chat is a request, and if a chat is not a request, accept() doesn't accept the protection-brokenness.