### PR TITLE
end-to-end encryption activated if there is an autocrypt  key without prefer_encrypt info

### DIFF
--- a/src/imex.rs
+++ b/src/imex.rs
@@ -319,6 +319,11 @@ async fn set_self_key(
         None => {
             if prefer_encrypt_required {
                 bail!("missing Autocrypt-Prefer-Encrypt header");
+            } else {
+                context
+                    .sql
+                    .set_raw_config_int("e2ee_enabled", 1)
+                    .await?;
             }
         }
     };


### PR DESCRIPTION
fix https://github.com/deltachat/deltachat-android/issues/2617

end-to-end encryption if activated if there is an autocrypt  key without prefer_encrypt info
