### PR TITLE
test: add test_webxdc_download_on_demand

### DIFF
--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -486,6 +486,9 @@ class Message:
         dc_msg = ffi.gc(lib.dc_get_msg(self.account._dc_context, self.id), lib.dc_msg_unref)
         return lib.dc_msg_get_download_state(dc_msg)
 
+    def download_full(self) -> None:
+        lib.dc_download_full_msg(self.account._dc_context, self.id)
+
 
 # some code for handling DC_MSG_* view types
 


### PR DESCRIPTION
The test checks that if webxdc update is too large to download with the current `download_limit`,
it is applied afterwards when the user manually downloads the update message.

This is an unsuccessful attempt to reproduce #4543.