### PR TITLE
fix: base64-encode webxdc updates

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1368,7 +1368,7 @@ impl<'a> MimeFactory<'a> {
 ///
 /// This line length limit is an
 /// [RFC5322 requirement](https://tools.ietf.org/html/rfc5322#section-2.1.1).
-fn wrapped_base64_encode(buf: &[u8]) -> String {
+pub(crate) fn wrapped_base64_encode(buf: &[u8]) -> String {
     let base64 = base64::engine::general_purpose::STANDARD.encode(buf);
     let mut chars = base64.chars();
     std::iter::repeat_with(|| chars.by_ref().take(78).collect::<String>())


### PR DESCRIPTION
Webxdc update messages may contain
long lines that get hard-wrapped
and may corrupt JSON if the message
is not encrypted.

base64-encode the update part
to avoid hard wrapping.

This is not necessary for encrypted
messages, but does not introduce
size overhead as OpenPGP messages
are compressed.