### PR TITLE
api(jsonrpc): add get_message_info_json

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -47,7 +47,7 @@ use types::provider_info::ProviderInfo;
 use types::reactions::JSONRPCReactions;
 use types::webxdc::WebxdcMessageInfo;
 
-use self::types::message::MessageLoadResult;
+use self::types::message::{MessageInfo, MessageLoadResult};
 use self::types::{
     chat::{BasicChat, JSONRPCChatVisibility, MuteDuration},
     location::JsonrpcLocation,
@@ -1124,6 +1124,12 @@ impl CommandApi {
     async fn get_message_info(&self, account_id: u32, message_id: u32) -> Result<String> {
         let ctx = self.get_context(account_id).await?;
         MsgId::new(message_id).get_info(&ctx).await
+    }
+
+    /// Returns additional information for single message.
+    async fn get_message_info_json(&self, account_id: u32, message_id: u32) -> Result<MessageInfo> {
+        let ctx = self.get_context(account_id).await?;
+        MessageInfo::from_msg_id(&ctx, MsgId::new(message_id)).await
     }
 
     /// Returns contacts that sent read receipts and the time of reading.

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -1127,7 +1127,11 @@ impl CommandApi {
     }
 
     /// Returns additional information for single message.
-    async fn get_message_info_object(&self, account_id: u32, message_id: u32) -> Result<MessageInfo> {
+    async fn get_message_info_object(
+        &self,
+        account_id: u32,
+        message_id: u32,
+    ) -> Result<MessageInfo> {
         let ctx = self.get_context(account_id).await?;
         MessageInfo::from_msg_id(&ctx, MsgId::new(message_id)).await
     }

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -1127,7 +1127,7 @@ impl CommandApi {
     }
 
     /// Returns additional information for single message.
-    async fn get_message_info_json(&self, account_id: u32, message_id: u32) -> Result<MessageInfo> {
+    async fn get_message_info_object(&self, account_id: u32, message_id: u32) -> Result<MessageInfo> {
         let ctx = self.get_context(account_id).await?;
         MessageInfo::from_msg_id(&ctx, MsgId::new(message_id)).await
     }

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context as _, Ok, Result};
+use anyhow::{Context as _, Result};
 use deltachat::chat::Chat;
 use deltachat::chat::ChatItem;
 use deltachat::chat::ChatVisibility;
@@ -568,7 +568,7 @@ pub struct MessageInfo {
     // view_type is already in the MessageObject
     // width, height and duration are already in the MessageObject
     rfc724_mid: String,
-    imap_uids: Vec<MessageInfoServerUID>,
+    server_urls: Vec<String>,
     hop_info: Option<String>,
     // Reactions are already in getMessageReactions
 }
@@ -584,11 +584,8 @@ impl MessageInfo {
             None
         };
 
-        let imap_uids = MsgId::get_info_server_uids(context, message.rfc724_mid().to_owned())
-            .await?
-            .into_iter()
-            .map(|(folder, uid)| MessageInfoServerUID { folder, uid })
-            .collect();
+        let server_urls =
+            MsgId::get_info_server_urls(context, message.rfc724_mid().to_owned()).await?;
 
         let hop_info = msg_id.hop_info(context).await?;
 
@@ -598,7 +595,7 @@ impl MessageInfo {
             ephemeral_timestamp,
             error: message.error(),
             rfc724_mid: message.rfc724_mid().to_owned(),
-            imap_uids,
+            server_urls,
             hop_info,
         })
     }
@@ -630,10 +627,4 @@ impl From<deltachat::ephemeral::Timer> for EphemeralTimer {
             }
         }
     }
-}
-
-#[derive(Clone, Serialize, TypeDef, schemars::JsonSchema)]
-struct MessageInfoServerUID {
-    folder: String,
-    uid: u32,
 }

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -571,10 +571,9 @@ impl MessageInfo {
         let message = Message::load_from_db(context, msg_id).await?;
         let rawtext = msg_id.rawtext(context).await?;
         let ephemeral_timer = message.get_ephemeral_timer().into();
-        let ephemeral_timestamp = if message.get_ephemeral_timer().to_u32() == 0 {
-            Some(message.get_ephemeral_timestamp())
-        } else {
-            None
+        let ephemeral_timestamp = match message.get_ephemeral_timer() {
+            deltachat::ephemeral::Timer::Disabled => None,
+            deltachat::ephemeral::Timer::Enabled { .. } => Some(message.get_ephemeral_timestamp()),
         };
 
         let server_urls =

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -557,20 +557,13 @@ pub struct MessageReadReceipt {
 #[serde(rename_all = "camelCase")]
 pub struct MessageInfo {
     rawtext: String,
-    // timestamps are already in the MessageObject
     ephemeral_timer: EphemeralTimer,
     /// When message is ephemeral this contains the timestamp of the message expiry
     ephemeral_timestamp: Option<i64>,
-    // Read state is already in getMessageReadReceipts
-    // message_state, has_location is already in the MessageObject
     error: Option<String>,
-    // file properties are already in the MessageObject
-    // view_type is already in the MessageObject
-    // width, height and duration are already in the MessageObject
     rfc724_mid: String,
     server_urls: Vec<String>,
     hop_info: Option<String>,
-    // Reactions are already in getMessageReactions
 }
 
 impl MessageInfo {

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -556,7 +556,7 @@ pub struct MessageReadReceipt {
 #[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MessageInfo {
-    rawtext: Option<String>,
+    rawtext: String,
     // timestamps are already in the MessageObject
     ephemeral_timer: EphemeralTimer,
     /// When message is ephemeral this contains the timestamp of the message expiry

--- a/src/message.rs
+++ b/src/message.rs
@@ -320,7 +320,7 @@ WHERE id=?;
                 ret += &format!("\n{server_url}");
             }
         }
-        let hop_info: Option<String> = self.hop_info(context).await?;
+        let hop_info = self.hop_info(context).await?;
 
         ret += "\n\n";
         ret += &hop_info.unwrap_or_else(|| "No Hop Info".to_owned());

--- a/src/message.rs
+++ b/src/message.rs
@@ -182,7 +182,7 @@ WHERE id=?;
             .await
     }
 
-    /// Returns informtion about hops of a message, used for message info
+    /// Returns information about hops of a message, used for message info
     pub async fn hop_info(self, context: &Context) -> Result<Option<String>> {
         context
             .sql

--- a/src/message.rs
+++ b/src/message.rs
@@ -151,7 +151,7 @@ WHERE id=?;
     }
 
     /// Returns raw text of a message, used for message info
-    pub async fn get_info_rawtext(self, context: &Context) -> Result<Option<String>> {
+    pub async fn rawtext(self, context: &Context) -> Result<Option<String>> {
         context
             .sql
             .query_get_value("SELECT txt_raw FROM msgs WHERE id=?", (self,))
@@ -182,17 +182,17 @@ WHERE id=?;
     }
 
     /// Returns informtion about hops of a message, used for message info
-    pub async fn get_info_hop_info(self, context: &Context) -> Result<Option<String>> {
+    pub async fn hop_info(self, context: &Context) -> Result<Option<String>> {
         context
             .sql
-            .query_get_value("SELECT hop_info FROM msgs WHERE id=?;", (self,))
+            .query_get_value("SELECT hop_info FROM msgs WHERE id=?", (self,))
             .await
     }
 
     /// Returns detailed message information in a multi-line text form.
     pub async fn get_info(self, context: &Context) -> Result<String> {
         let msg = Message::load_from_db(context, self).await?;
-        let rawtxt: Option<String> = self.get_info_rawtext(context).await?;
+        let rawtxt: Option<String> = self.rawtext(context).await?;
 
         let mut ret = String::new();
 
@@ -325,7 +325,7 @@ WHERE id=?;
                 ret += &format!("\n</{folder}/;UID={uid}>");
             }
         }
-        let hop_info: Option<String> = self.get_info_hop_info(context).await?;
+        let hop_info: Option<String> = self.hop_info(context).await?;
 
         ret += "\n\n";
         ret += &hop_info.unwrap_or_else(|| "No Hop Info".to_owned());
@@ -669,7 +669,7 @@ impl Message {
 
     /// Returns the rfc724 message ID
     /// May be empty
-    pub fn get_rfc724_mid(&self) -> &str {
+    pub fn rfc724_mid(&self) -> &str {
         &self.rfc724_mid
     }
 


### PR DESCRIPTION
~~I couldn't find where `Param::ErroneousE2ee` is set or what format it is, so this is still todo. Because I would like to show the 
state when TB enrypted but did not sign the message correctly, so we can point people to a FAQ article on how to solve it.~~
link2xt told me `Param::ErroneousE2ee` is not set anymore, so let's postpone the e2e encryption errors and let this pr just address #4556.


closes #4556
