### PR TITLE
fix(deltachat-jsonrpc): make MessageObject.text non-optional

### DIFF
--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -34,7 +34,7 @@ pub struct MessageObject {
     quote: Option<MessageQuote>,
     parent_id: Option<u32>,
 
-    text: Option<String>,
+    text: String,
     has_location: bool,
     has_html: bool,
     view_type: MessageViewtype,
@@ -180,7 +180,7 @@ impl MessageObject {
             from_id: message.get_from_id().to_u32(),
             quote,
             parent_id,
-            text: Some(message.get_text()).filter(|s| !s.is_empty()),
+            text: message.get_text(),
             has_location: message.has_location(),
             has_html: message.has_html(),
             view_type: message.get_viewtype().into(),

--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -101,6 +101,16 @@ async def test_account(acfactory) -> None:
     assert await alice.get_fresh_messages()
     assert await alice.get_next_messages()
 
+    # Test sending empty message.
+    assert len(await bob.wait_next_messages()) == 0
+    await alice_chat_bob.send_text("")
+    messages = await bob.wait_next_messages()
+    assert len(messages) == 1
+    message = messages[0]
+    snapshot = await message.get_snapshot()
+    assert snapshot.text == ""
+    await bob.mark_seen_messages([message])
+
     group = await alice.create_group("test group")
     await group.add_contact(alice_contact_bob)
     group_msg = await group.send_message(text="hello")


### PR DESCRIPTION
This is already non-optional on the `deltachat` crate side since <https://github.com/deltachat/deltachat-core-rust/pull/4517>