### PR TITLE
feat: Don't show a contact as verified if their key changed since the verification

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1211,7 +1211,6 @@ impl Contact {
     /// and if the key has not changed since this verification.
     ///
     /// The UI may draw a checkbox or something like that beside verified contacts.
-    ///
     pub async fn is_verified(&self, context: &Context) -> Result<VerifiedStatus> {
         // We're always sort of secured-verified as we could verify the key on this device any time with the key
         // on this device
@@ -1220,7 +1219,7 @@ impl Contact {
         }
 
         if let Some(peerstate) = Peerstate::from_addr(context, &self.addr).await? {
-            if peerstate.verified_key.is_some() {
+            if peerstate.is_using_verified_key() {
                 return Ok(VerifiedStatus::BidirectVerified);
             }
         }


### PR DESCRIPTION
If a contact's key changed since the verification, then it's very unlikely that they still have the old, verified key. So, don't show them as verified anymore.

This also means that you can't add a contact like this to a verified group, which is good.

The documentation actually already described this (new) behavior:

```rust
/// and if the key has not changed since this verification.
```

so, this adapts the code to the documentation.