### PR TITLE
refactor: remove Chattype::Undefined

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -357,7 +357,7 @@ impl ChatId {
         let chat = Chat::load_from_db(context, self).await?;
 
         match chat.typ {
-            Chattype::Undefined | Chattype::Broadcast => {
+            Chattype::Broadcast => {
                 bail!("Can't block chat of type {:?}", chat.typ)
             }
             Chattype::Single => {
@@ -398,7 +398,6 @@ impl ChatId {
         let chat = Chat::load_from_db(context, self).await?;
 
         match chat.typ {
-            Chattype::Undefined => bail!("Can't accept chat of undefined chattype"),
             Chattype::Single if chat.protected == ProtectionStatus::ProtectionBroken => {
                 // The chat was in the 'Request' state because the protection was broken.
                 // The user clicked 'Accept', so, now we want to set the status to Unprotected again:
@@ -459,7 +458,6 @@ impl ChatId {
                     }
                 }
                 Chattype::Mailinglist => bail!("Cannot protect mailing lists"),
-                Chattype::Undefined => bail!("Undefined group type"),
             },
             ProtectionStatus::Unprotected | ProtectionStatus::ProtectionBroken => {}
         };
@@ -1286,7 +1284,6 @@ impl Chat {
         match self.typ {
             Chattype::Single | Chattype::Broadcast | Chattype::Mailinglist => Ok(true),
             Chattype::Group => is_contact_in_chat(context, self.id, ContactId::SELF).await,
-            Chattype::Undefined => Ok(false),
         }
     }
 

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -324,7 +324,7 @@ impl Chatlist {
                             .context("loading contact failed")?;
                         (Some(lastmsg), Some(lastcontact))
                     }
-                    Chattype::Single | Chattype::Undefined => (Some(lastmsg), None),
+                    Chattype::Single => (Some(lastmsg), None),
                 }
             }
         } else {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -118,7 +118,6 @@ pub const DC_CHAT_ID_LAST_SPECIAL: ChatId = ChatId::new(9);
 /// Chat type.
 #[derive(
     Debug,
-    Default,
     Display,
     Clone,
     Copy,
@@ -134,10 +133,6 @@ pub const DC_CHAT_ID_LAST_SPECIAL: ChatId = ChatId::new(9);
 )]
 #[repr(u32)]
 pub enum Chattype {
-    /// Undefined chat type.
-    #[default]
-    Undefined = 0,
-
     /// 1:1 chat.
     Single = 100,
 
@@ -216,8 +211,6 @@ mod tests {
     #[test]
     fn test_chattype_values() {
         // values may be written to disk and must not change
-        assert_eq!(Chattype::Undefined, Chattype::default());
-        assert_eq!(Chattype::Undefined, Chattype::from_i32(0).unwrap());
         assert_eq!(Chattype::Single, Chattype::from_i32(100).unwrap());
         assert_eq!(Chattype::Group, Chattype::from_i32(120).unwrap());
         assert_eq!(Chattype::Mailinglist, Chattype::from_i32(140).unwrap());

--- a/src/message.rs
+++ b/src/message.rs
@@ -755,7 +755,7 @@ impl Message {
                 Chattype::Group | Chattype::Broadcast | Chattype::Mailinglist => {
                     Some(Contact::get_by_id(context, self.from_id).await?)
                 }
-                Chattype::Single | Chattype::Undefined => None,
+                Chattype::Single => None,
             }
         } else {
             None

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -897,7 +897,6 @@ impl<'a> MimeFactory<'a> {
         let mut meta_part = None;
 
         let send_verified_headers = match chat.typ {
-            Chattype::Undefined => bail!("Undefined chat type"),
             // In single chats, the protection status isn't necessarily the same for both sides,
             // so we don't send the Chat-Verified header:
             Chattype::Single => false,

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -2182,7 +2182,7 @@ async fn ndn_maybe_add_info_msg(
             // If we get an NDN for the mailing list, just issue a warning.
             warn!(context, "ignoring NDN for mailing list.");
         }
-        Chattype::Single | Chattype::Undefined => {}
+        Chattype::Single => {}
     }
     Ok(())
 }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -82,7 +82,7 @@ impl Summary {
                             .map(SummaryPrefix::Username)
                     }
                 }
-                Chattype::Single | Chattype::Undefined => None,
+                Chattype::Single => None,
             }
         };
 


### PR DESCRIPTION
There is still `DC_CHAT_TYPE_UNDEFINED`, but it is just a way to signal an error in C.