### PR TITLE
test: Directly unwrap in TestContext::get_chat()

### DIFF
--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -2941,7 +2941,7 @@ async fn test_outgoing_private_reply_multidevice() -> Result<()> {
     let received = alice2.get_last_msg().await;
 
     // That's a regression test for https://github.com/deltachat/deltachat-core-rust/issues/2949:
-    assert_eq!(received.chat_id, alice2.get_chat(&bob).await.unwrap().id);
+    assert_eq!(received.chat_id, alice2.get_chat(&bob).await.id);
 
     let alice2_bob_contact = alice2.add_or_lookup_contact(&bob).await;
     assert_eq!(received.from_id, ContactId::SELF);

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -1287,10 +1287,7 @@ mod tests {
             // Now Alice's chat with Bob should still be hidden, the verified message should
             // appear in the group chat.
 
-            let chat = alice
-                .get_chat(&bob)
-                .await
-                .expect("Alice has no 1:1 chat with bob");
+            let chat = alice.get_chat(&bob).await;
             assert_eq!(
                 chat.blocked,
                 Blocked::Yes,
@@ -1325,10 +1322,7 @@ mod tests {
                 contact_alice.is_verified(&bob.ctx).await?,
                 VerifiedStatus::BidirectVerified
             );
-            let chat = bob
-                .get_chat(&alice)
-                .await
-                .expect("Bob has no 1:1 chat with Alice");
+            let chat = bob.get_chat(&alice).await;
             assert_eq!(
                 chat.blocked,
                 Blocked::Yes,

--- a/src/tests/verified_chats.rs
+++ b/src/tests/verified_chats.rs
@@ -159,7 +159,7 @@ async fn test_create_verified_oneonone_chat() -> Result<()> {
 
     // The chat should be and stay unprotected
     {
-        let chat = alice.get_chat(&fiona_new).await.unwrap();
+        let chat = alice.get_chat(&fiona_new).await;
         assert!(!chat.is_protected());
         assert!(chat.is_protection_broken());
 
@@ -287,21 +287,21 @@ async fn test_verified_oneonone_chat_enable_disable() -> Result<()> {
         )
         .await?;
 
-        let chat = alice.get_chat(&bob).await.unwrap();
+        let chat = alice.get_chat(&bob).await;
         assert!(!chat.is_protected());
         assert!(chat.is_protection_broken());
 
         if alice_accepts_breakage {
             tcm.section("Alice clicks 'Accept' on the input-bar-dialog");
             chat.id.accept(&alice).await?;
-            let chat = alice.get_chat(&bob).await.unwrap();
+            let chat = alice.get_chat(&bob).await;
             assert!(!chat.is_protected());
             assert!(!chat.is_protection_broken());
         }
 
         // Bob sends a message from DC again
         tcm.send_recv(&bob, &alice, "Hello from DC").await;
-        let chat = alice.get_chat(&bob).await.unwrap();
+        let chat = alice.get_chat(&bob).await;
         assert!(chat.is_protected());
         assert!(!chat.is_protection_broken());
     }
@@ -436,7 +436,7 @@ async fn test_old_message_3() -> Result<()> {
     .await?;
 
     alice
-        .golden_test_chat(alice.get_chat(&bob).await.unwrap().id, "test_old_message_3")
+        .golden_test_chat(alice.get_chat(&bob).await.id, "test_old_message_3")
         .await;
 
     Ok(())
@@ -636,12 +636,12 @@ async fn test_break_protection_then_verify_again() -> Result<()> {
         // him as unverified:
         VerifiedStatus::Unverified
     );
-    let chat = alice.get_chat(&bob_new).await.unwrap();
+    let chat = alice.get_chat(&bob_new).await;
     assert_eq!(chat.is_protected(), false);
     assert_eq!(chat.is_protection_broken(), true);
 
     {
-        let alice_bob_chat = alice.get_chat(&bob_new).await.unwrap();
+        let alice_bob_chat = alice.get_chat(&bob_new).await;
         assert!(!alice_bob_chat.can_send(&alice).await?);
 
         // Alice's UI should still be able to save a draft, which Alice started to type right when she got Bob's message:
@@ -706,7 +706,7 @@ async fn assert_verified(this: &TestContext, other: &TestContext, protected: Pro
         VerifiedStatus::BidirectVerified
     );
 
-    let chat = this.get_chat(other).await.unwrap();
+    let chat = this.get_chat(other).await;
     let (expect_protected, expect_broken) = match protected {
         ProtectionStatus::Unprotected => (false, false),
         ProtectionStatus::Protected => (true, false),


### PR DESCRIPTION
Turns out that all usages of get_chat() directly unwrapped, because in a test it doesn't make sense to handle the error of there being no chat.

I had this on my computer for a while, but forgot to push. (I'm still mostly offline, but just had some IDLE time)