### PR TITLE
ci: Run Rust tests with RUST_BACKTRACE set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,8 @@ jobs:
         uses: swatinem/rust-cache@v2
 
       - name: Tests
+        env:
+          RUST_BACKTRACE: 1
         run: cargo test --workspace
 
       - name: Test cargo vendor


### PR DESCRIPTION
It can make debugging such failures easier: https://github.com/deltachat/deltachat-core-rust/actions/runs/5835594006/job/15827494064?pr=4344 . As for DCC_MIME_DEBUG, it helped me several times, but looks like it slows down running tests