### PR TITLE
fix: receive_imf: Update peerstate from db after handling Securejoin handshake (#4600)

### DIFF
--- a/python/tests/test_0_complex_or_slow.py
+++ b/python/tests/test_0_complex_or_slow.py
@@ -136,6 +136,7 @@ def test_qr_verified_group_and_chatting(acfactory, lp):
     lp.sec("ac2: read member added message")
     msg = ac2._evtracker.wait_next_incoming_message()
     assert msg.is_encrypted()
+    assert msg.is_system_message()
     assert "added" in msg.text.lower()
 
     lp.sec("ac1: send message")
@@ -182,8 +183,9 @@ def test_qr_verified_group_and_chatting(acfactory, lp):
 
     lp.sec("ac2: send message and let ac3 read it")
     chat2.send_text("hi")
-    # Skip system message about added member
-    ac3._evtracker.wait_next_incoming_message()
+    # System message about the added member.
+    msg = ac3._evtracker.wait_next_incoming_message()
+    assert msg.is_system_message()
     msg = ac3._evtracker.wait_next_incoming_message()
     assert msg.text == "hi"
     assert msg.is_encrypted()
@@ -524,7 +526,8 @@ def test_see_new_verified_member_after_going_online(acfactory, tmp_path, lp):
     lp.sec("ac2: sending message")
     # Message can be sent only after a receipt of "vg-member-added" message. Just wait for
     # "Member Me (<addr>) added by <addr>." message.
-    ac2._evtracker.wait_next_incoming_message()
+    msg_in = ac2._evtracker.wait_next_incoming_message()
+    assert msg_in.is_system_message()
     msg_out = chat2.send_text("hello")
 
     lp.sec("ac1: receiving message")

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -516,6 +516,10 @@ async fn add_parts(
                     securejoin_seen = true;
                 }
             }
+            // Peerstate could be updated by handling the Securejoin handshake.
+            let contact = Contact::get_by_id(context, from_id).await?;
+            mime_parser.decryption_info.peerstate =
+                Peerstate::from_addr(context, contact.get_addr()).await?;
         } else {
             securejoin_seen = false;
         }


### PR DESCRIPTION
Otherwise has_verified_encryption() would check a stale Peerstate object.