### PR TITLE
fix: receive_imf: Don't break 1:1 chat protection if received an unverified message (#4597)

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -769,12 +769,12 @@ async fn add_parts(
                         new_protection =
                             match decryption_info.autocrypt_header.as_ref().filter(|ah| {
                                 Some(&ah.public_key.fingerprint())
-                                    == decryption_info
+                                    != decryption_info
                                         .peerstate
                                         .as_ref()
                                         .and_then(|p| p.verified_key_fingerprint.as_ref())
                             }) {
-                                Some(_) => {
+                                None => {
                                     if let Some(new_chat_id) = create_adhoc_group(
                                         context,
                                         mime_parser,
@@ -801,7 +801,7 @@ async fn add_parts(
                                     }
                                     chat.protected
                                 }
-                                None => ProtectionStatus::ProtectionBroken,
+                                Some(_) => ProtectionStatus::ProtectionBroken,
                             };
                     }
                     if chat.protected != new_protection {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -136,6 +136,22 @@ impl TestContextManager {
         received_msg
     }
 
+    /// - Let one TestContext send a message.
+    /// - Let the other TestContext receive it.
+    /// - Assert that the message text is the formatted `err`.
+    /// - Assert that the message info contains the original text.
+    pub async fn send_recv_with_err(
+        &self,
+        from: &TestContext,
+        to: &TestContext,
+        err: &str,
+        msg: &str,
+    ) -> Message {
+        let received_msg = self.try_send_recv(from, to, msg).await;
+        check_msg_with_err(to, &received_msg, err, msg).await;
+        received_msg
+    }
+
     /// - Let one TestContext send a message
     /// - Let the other TestContext receive it
     pub async fn try_send_recv(&self, from: &TestContext, to: &TestContext, msg: &str) -> Message {
@@ -1196,6 +1212,18 @@ async fn write_msg(context: &Context, prefix: &str, msg: &Message, buf: &mut Str
         statestr,
     )
     .unwrap();
+}
+
+/// - Assert that the message text is the formatted error `err`.
+/// - Assert that the message info contains the original text.
+pub async fn check_msg_with_err(ctx: &TestContext, msg: &Message, err: &str, text: &str) {
+    assert_eq!(msg.text, format!("[{err}]"));
+    assert!(msg
+        .id
+        .get_info(ctx)
+        .await
+        .unwrap()
+        .contains(&format!("\n\n{text}\n\n")));
 }
 
 #[cfg(test)]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -136,22 +136,6 @@ impl TestContextManager {
         received_msg
     }
 
-    /// - Let one TestContext send a message.
-    /// - Let the other TestContext receive it.
-    /// - Assert that the message text is the formatted `err`.
-    /// - Assert that the message info contains the original text.
-    pub async fn send_recv_with_err(
-        &self,
-        from: &TestContext,
-        to: &TestContext,
-        err: &str,
-        msg: &str,
-    ) -> Message {
-        let received_msg = self.try_send_recv(from, to, msg).await;
-        check_msg_with_err(to, &received_msg, err, msg).await;
-        received_msg
-    }
-
     /// - Let one TestContext send a message
     /// - Let the other TestContext receive it
     pub async fn try_send_recv(&self, from: &TestContext, to: &TestContext, msg: &str) -> Message {
@@ -1212,18 +1196,6 @@ async fn write_msg(context: &Context, prefix: &str, msg: &Message, buf: &mut Str
         statestr,
     )
     .unwrap();
-}
-
-/// - Assert that the message text is the formatted error `err`.
-/// - Assert that the message info contains the original text.
-pub async fn check_msg_with_err(ctx: &TestContext, msg: &Message, err: &str, text: &str) {
-    assert_eq!(msg.text, format!("[{err}]"));
-    assert!(msg
-        .id
-        .get_info(ctx)
-        .await
-        .unwrap()
-        .contains(&format!("\n\n{text}\n\n")));
 }
 
 #[cfg(test)]

--- a/test-data/golden/verified_chats_test_unencrypted
+++ b/test-data/golden/verified_chats_test_unencrypted
@@ -1,6 +1,4 @@
 Single#Chat#10: bob@example.net [bob@example.net] 🛡️
 --------------------------------------------------------------------------------
 Msg#10: info (Contact#Contact#Info): Messages are guaranteed to be end-to-end encrypted from now on. [NOTICED][INFO 🛡️]
-Msg#11:  (Contact#Contact#10): [This message is not encrypted. See 'Info' for more details] [FRESH]
-Msg#12:  (Contact#Contact#10): [This message is not encrypted. See 'Info' for more details] [FRESH]
 --------------------------------------------------------------------------------

--- a/test-data/golden/verified_chats_test_unencrypted
+++ b/test-data/golden/verified_chats_test_unencrypted
@@ -1,0 +1,6 @@
+Single#Chat#10: bob@example.net [bob@example.net] 🛡️
+--------------------------------------------------------------------------------
+Msg#10: info (Contact#Contact#Info): Messages are guaranteed to be end-to-end encrypted from now on. [NOTICED][INFO 🛡️]
+Msg#11:  (Contact#Contact#10): [This message is not encrypted. See 'Info' for more details] [FRESH]
+Msg#12:  (Contact#Contact#10): [This message is not encrypted. See 'Info' for more details] [FRESH]
+--------------------------------------------------------------------------------


### PR DESCRIPTION
**fix: receive_imf: Don't break 1:1 chat protection if received the verified Autocrypt key (#4597)**

    For example, broadcast list messages are sent unencrypted, but their Autocrypt header still contains
    the verified key. Thus we're sure that we still can encrypt to the peer and there's no need to break
    the existing protection.

**feat: Move unverified messages carrying current Autocrypt key from protected 1:1 chats to ad-hoc groups**

    TODO: This should be squashed with the previous commit if we decide to go this way.
    
**feat: Move unverified messages which don't introduce a new Autocrypt key from protected 1:1 chats to ad-hoc groups**
    
    This prevents protected 1:1 chats from breaking by messages sent by classical MUAs.
    
    TODO: Some `tests::verified_chats` tests are failing, but as far as i see from the log, the tests
    must be fixed, the change itself looks ok. Not fixing the tests now, not sure we will merge this as
    it's just POC.