### PR TITLE
fix: Allow membership changes by a MUA if we're not in the group (#4624)

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1655,19 +1655,22 @@ async fn apply_group_changes(
         };
 
     // Whether to allow any changes to the member list at all.
-    let allow_member_list_changes =
-        if chat::is_contact_in_chat(context, chat_id, ContactId::SELF).await? || self_added {
-            // Reject old group changes.
-            chat_id
-                .update_timestamp(context, Param::MemberListTimestamp, sent_timestamp)
-                .await?
-        } else {
-            // Member list changes are not allowed if we're not in the group
-            // and are not explicitly added.
-            // This message comes from a Delta Chat that restored an old backup
-            // or the message is a MUA reply to an old message.
-            false
-        };
+    let allow_member_list_changes = if chat::is_contact_in_chat(context, chat_id, ContactId::SELF)
+        .await?
+        || self_added
+        || !mime_parser.has_chat_version()
+    {
+        // Reject old group changes.
+        chat_id
+            .update_timestamp(context, Param::MemberListTimestamp, sent_timestamp)
+            .await?
+    } else {
+        // Member list changes are not allowed if we're not in the group
+        // and are not explicitly added.
+        // This message comes from a Delta Chat that restored an old backup
+        // or the message is a MUA reply to an old message.
+        false
+    };
 
     // Whether to rebuild the member list from scratch.
     let recreate_member_list = if allow_member_list_changes {

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -3560,3 +3560,52 @@ async fn test_mua_can_add() -> Result<()> {
     );
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mua_can_readd() -> Result<()> {
+    let alice = TestContext::new_alice().await;
+
+    // Alice creates chat with 3 contacts.
+    let msg = receive_imf(
+        &alice,
+        b"Subject: =?utf-8?q?Message_from_alice=40example=2Eorg?=\r\n\
+            From: alice@example.org\r\n\
+            To: <bob@example.net>, <claire@example.org>, <fiona@example.org> \r\n\
+            Date: Mon, 12 Dec 2022 14:30:39 +0000\r\n\
+            Message-ID: <Mr.alices_original_mail@example.org>\r\n\
+            Chat-Version: 1.0\r\n\
+            \r\n\
+            Hi!\r\n",
+        false,
+    )
+    .await?
+    .unwrap();
+    let alice_chat = Chat::load_from_db(&alice, msg.chat_id).await?;
+    assert_eq!(alice_chat.typ, Chattype::Group);
+    assert!(is_contact_in_chat(&alice, alice_chat.id, ContactId::SELF).await?);
+
+    // And leaves it.
+    remove_contact_from_chat(&alice, alice_chat.id, ContactId::SELF).await?;
+    let alice_chat = Chat::load_from_db(&alice, alice_chat.id).await?;
+    assert!(!is_contact_in_chat(&alice, alice_chat.id, ContactId::SELF).await?);
+
+    // Bob uses a classical MUA to answer, adding Alice back.
+    receive_imf(
+        &alice,
+        b"Subject: Re: Message from alice\r\n\
+            From: <bob@example.net>\r\n\
+            To: <alice@example.org>, <claire@example.org>, <fiona@example.org>\r\n\
+            Date: Mon, 12 Dec 2022 14:32:39 +0000\r\n\
+            Message-ID: <bobs_answer_to_two_recipients@example.net>\r\n\
+            In-Reply-To: <Mr.alices_original_mail@example.org>\r\n\
+            \r\n\
+            Hi back!\r\n",
+        false,
+    )
+    .await?
+    .unwrap();
+
+    let alice_chat = Chat::load_from_db(&alice, alice_chat.id).await?;
+    assert!(is_contact_in_chat(&alice, alice_chat.id, ContactId::SELF).await?);
+    Ok(())
+}


### PR DESCRIPTION
Other MUAs don't set add/remove headers, so the only way for them to re-add us to the group is to add us to To/CC/wherever. Previously it worked only for other members that are still in the group so that they properly handled our re-addition, but we didn't.

Fixes #4624