### PR TITLE
fix: Return from dc_get_chatlist(DC_GCL_FOR_FORWARDING) only chats where we can send (#4616)

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1241,13 +1241,14 @@ impl Chat {
     pub(crate) async fn why_cant_send(&self, context: &Context) -> Result<Option<CantSendReason>> {
         use CantSendReason::*;
 
+        // NB: Don't forget to update Chatlist::try_load() when changing this function!
         let reason = if self.id.is_special() {
             Some(SpecialChat)
         } else if self.is_device_talk() {
             Some(DeviceChat)
         } else if self.is_contact_request() {
             Some(ContactRequest)
-        } else if self.is_mailing_list() && self.param.get(Param::ListPost).is_none_or_empty() {
+        } else if self.is_mailing_list() && self.get_mailinglist_addr().is_none_or_empty() {
             Some(ReadOnlyMailingList)
         } else if !self.is_self_in_chat(context).await? {
             Some(NotAMember)

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -8,7 +8,7 @@ use crate::chat::{
 };
 use crate::chat::{get_chat_msgs, ChatItem, ChatVisibility};
 use crate::chatlist::Chatlist;
-use crate::constants::DC_GCL_NO_SPECIALS;
+use crate::constants::{DC_GCL_FOR_FORWARDING, DC_GCL_NO_SPECIALS};
 use crate::imap::prefetch_should_download;
 use crate::message::Message;
 use crate::test_utils::{get_chat_msg, TestContext, TestContextManager};
@@ -793,6 +793,8 @@ async fn test_github_mailing_list() -> Result<()> {
 
     let chats = Chatlist::try_load(&t.ctx, 0, None, None).await?;
     assert_eq!(chats.len(), 1);
+    let chats = Chatlist::try_load(&t.ctx, DC_GCL_FOR_FORWARDING, None, None).await?;
+    assert_eq!(chats.len(), 0);
     let contacts = Contact::get_all(&t.ctx, 0, None).await?;
     assert_eq!(contacts.len(), 0); // mailing list recipients and senders do not count as "known contacts"
 


### PR DESCRIPTION
**It's a backport from `master`.**

I.e. exclude from the list the following chats as well:
- Read-only mailing lists.
- Chats we're not a member of.

But as for ProtectionBroken chats, we return them, as that may happen to a verified chat at any time. It may be confusing if a chat that is normally in the list disappears suddenly. The UI need to deal with that case anyway.

(cherry picked from commit 83ef25e7de9c5f2ba8bbe544964aa6f7a96aaf3f)