### PR TITLE
api: add API to get similar chats

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1321,6 +1321,20 @@ int             dc_get_msg_cnt               (dc_context_t* context, uint32_t ch
 int             dc_get_fresh_msg_cnt         (dc_context_t* context, uint32_t chat_id);
 
 
+/**
+ * Returns a list of similar chats.
+ *
+ * @warning This is an experimental API which may change or be removed in the future.
+ *
+ * @memberof dc_context_t
+ * @param context The context object as returned from dc_context_new().
+ * @param chat_id The ID of the chat for which to find similar chats.
+ * @return The list of similar chats.
+ *     On errors, NULL is returned.
+ *     Must be freed using dc_chatlist_unref() when no longer used.
+ */
+dc_chatlist_t*     dc_get_similar_chatlist   (dc_context_t* context, uint32_t chat_id);
+
 
 /**
  * Estimate the number of messages that will be deleted

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1243,6 +1243,30 @@ pub unsafe extern "C" fn dc_get_fresh_msg_cnt(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_get_similar_chatlist(
+    context: *mut dc_context_t,
+    chat_id: u32,
+) -> *mut dc_chatlist_t {
+    if context.is_null() {
+        eprintln!("ignoring careless call to dc_get_similar_chatlist()");
+        return ptr::null_mut();
+    }
+    let ctx = &*context;
+
+    let chat_id = ChatId::new(chat_id);
+    match block_on(chat_id.get_similar_chatlist(ctx))
+        .context("failed to get similar chatlist")
+        .log_err(ctx)
+    {
+        Ok(list) => {
+            let ffi_list = ChatlistWrapper { context, list };
+            Box::into_raw(Box::new(ffi_list))
+        }
+        Err(_) => ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_estimate_deletion_cnt(
     context: *mut dc_context_t,
     from_server: libc::c_int,

--- a/deltachat-jsonrpc/src/api/mod.rs
+++ b/deltachat-jsonrpc/src/api/mod.rs
@@ -39,6 +39,7 @@ pub mod types;
 use num_traits::FromPrimitive;
 use types::account::Account;
 use types::chat::FullChat;
+use types::chat_list::ChatListEntry;
 use types::contact::ContactObject;
 use types::events::Event;
 use types::http::HttpResponse;
@@ -562,6 +563,25 @@ impl CommandApi {
         let mut l: Vec<u32> = Vec::with_capacity(list.len());
         for i in 0..list.len() {
             l.push(list.get_chat_id(i)?.to_u32());
+        }
+        Ok(l)
+    }
+
+    /// Returns chats similar to the given one.
+    async fn get_similar_chatlist_entries(
+        &self,
+        account_id: u32,
+        chat_id: u32,
+    ) -> Result<Vec<ChatListEntry>> {
+        let ctx = self.get_context(account_id).await?;
+        let chat_id = ChatId::new(chat_id);
+        let list = chat_id.get_similar_chatlist(&ctx).await?;
+        let mut l: Vec<ChatListEntry> = Vec::with_capacity(list.len());
+        for i in 0..list.len() {
+            l.push(ChatListEntry(
+                list.get_chat_id(i)?.to_u32(),
+                list.get_msg_id(i)?.unwrap_or_default().to_u32(),
+            ));
         }
         Ok(l)
     }


### PR DESCRIPTION
This is an experimental lightweight chat grouping function, not exactly a replacement for "communities" or "spaces".