### PR TITLE
refactor: make get_abs_path non-generic

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1311,11 +1311,11 @@ impl Chat {
     pub async fn get_profile_image(&self, context: &Context) -> Result<Option<PathBuf>> {
         if let Some(image_rel) = self.param.get(Param::ProfileImage) {
             if !image_rel.is_empty() {
-                return Ok(Some(get_abs_path(context, image_rel)));
+                return Ok(Some(get_abs_path(context, Path::new(&image_rel))));
             }
         } else if self.id.is_archived_link() {
             if let Ok(image_rel) = get_archive_icon(context).await {
-                return Ok(Some(get_abs_path(context, image_rel)));
+                return Ok(Some(get_abs_path(context, Path::new(&image_rel))));
             }
         } else if self.typ == Chattype::Single {
             let contacts = get_chat_contacts(context, self.id).await?;
@@ -1326,7 +1326,7 @@ impl Chat {
             }
         } else if self.typ == Chattype::Broadcast {
             if let Ok(image_rel) = get_broadcast_icon(context).await {
-                return Ok(Some(get_abs_path(context, image_rel)));
+                return Ok(Some(get_abs_path(context, Path::new(&image_rel))));
             }
         }
         Ok(None)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 //! # Key-value configuration management.
 
 use std::env;
+use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::{ensure, Context as _, Result};
@@ -329,7 +330,11 @@ impl Context {
         let value = match key {
             Config::Selfavatar => {
                 let rel_path = self.sql.get_raw_config(key.as_ref()).await?;
-                rel_path.map(|p| get_abs_path(self, p).to_string_lossy().into_owned())
+                rel_path.map(|p| {
+                    get_abs_path(self, Path::new(&p))
+                        .to_string_lossy()
+                        .into_owned()
+                })
             }
             Config::SysVersion => Some((*DC_VERSION_STR).clone()),
             Config::SysMsgsizeMaxRecommended => Some(format!("{RECOMMENDED_FILE_SIZE}")),

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -5,7 +5,7 @@ use std::collections::BinaryHeap;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
 use std::ops::Deref;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{bail, ensure, Context as _, Result};
@@ -1186,7 +1186,7 @@ impl Contact {
             }
         } else if let Some(image_rel) = self.param.get(Param::ProfileImage) {
             if !image_rel.is_empty() {
-                return Ok(Some(get_abs_path(context, image_rel)));
+                return Ok(Some(get_abs_path(context, Path::new(image_rel))));
             }
         }
         Ok(None)

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -323,17 +323,16 @@ pub fn get_filemeta(buf: &[u8]) -> Result<(u32, u32)> {
 ///
 /// If `path` starts with "$BLOBDIR", replaces it with the blobdir path.
 /// Otherwise, returns path as is.
-pub(crate) fn get_abs_path(context: &Context, path: impl AsRef<Path>) -> PathBuf {
-    let p: &Path = path.as_ref();
-    if let Ok(p) = p.strip_prefix("$BLOBDIR") {
+pub(crate) fn get_abs_path(context: &Context, path: &Path) -> PathBuf {
+    if let Ok(p) = path.strip_prefix("$BLOBDIR") {
         context.get_blobdir().join(p)
     } else {
-        p.into()
+        path.into()
     }
 }
 
 pub(crate) async fn get_filebytes(context: &Context, path: impl AsRef<Path>) -> Result<u64> {
-    let path_abs = get_abs_path(context, &path);
+    let path_abs = get_abs_path(context, path.as_ref());
     let meta = fs::metadata(&path_abs).await?;
     Ok(meta.len())
 }
@@ -377,7 +376,7 @@ pub(crate) async fn create_folder(
     context: &Context,
     path: impl AsRef<Path>,
 ) -> Result<(), io::Error> {
-    let path_abs = get_abs_path(context, &path);
+    let path_abs = get_abs_path(context, path.as_ref());
     if !path_abs.exists() {
         match fs::create_dir_all(path_abs).await {
             Ok(_) => Ok(()),
@@ -402,7 +401,7 @@ pub(crate) async fn write_file(
     path: impl AsRef<Path>,
     buf: &[u8],
 ) -> Result<(), io::Error> {
-    let path_abs = get_abs_path(context, &path);
+    let path_abs = get_abs_path(context, path.as_ref());
     fs::write(&path_abs, buf).await.map_err(|err| {
         warn!(
             context,
@@ -417,7 +416,7 @@ pub(crate) async fn write_file(
 
 /// Reads the file and returns its context as a byte vector.
 pub async fn read_file(context: &Context, path: impl AsRef<Path>) -> Result<Vec<u8>> {
-    let path_abs = get_abs_path(context, &path);
+    let path_abs = get_abs_path(context, path.as_ref());
 
     match fs::read(&path_abs).await {
         Ok(bytes) => Ok(bytes),
@@ -434,7 +433,7 @@ pub async fn read_file(context: &Context, path: impl AsRef<Path>) -> Result<Vec<
 }
 
 pub async fn open_file(context: &Context, path: impl AsRef<Path>) -> Result<fs::File> {
-    let path_abs = get_abs_path(context, &path);
+    let path_abs = get_abs_path(context, path.as_ref());
 
     match fs::File::open(&path_abs).await {
         Ok(bytes) => Ok(bytes),
@@ -450,12 +449,8 @@ pub async fn open_file(context: &Context, path: impl AsRef<Path>) -> Result<fs::
     }
 }
 
-pub fn open_file_std<P: AsRef<std::path::Path>>(
-    context: &Context,
-    path: P,
-) -> Result<std::fs::File> {
-    let p: PathBuf = path.as_ref().into();
-    let path_abs = get_abs_path(context, p);
+pub fn open_file_std(context: &Context, path: impl AsRef<Path>) -> Result<std::fs::File> {
+    let path_abs = get_abs_path(context, path.as_ref());
 
     match std::fs::File::open(path_abs) {
         Ok(bytes) => Ok(bytes),


### PR DESCRIPTION
Generic functions compile into multiple implementations, increasing number of lines for LLVM to process,
code size and compilation times.