### PR TITLE
fix: do not allow dots at the end of email addresses

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1732,7 +1732,7 @@ mod tests {
         assert_eq!(may_be_valid_addr("dd.tt"), false);
         assert_eq!(may_be_valid_addr("tt.dd@uu"), true);
         assert_eq!(may_be_valid_addr("u@d"), true);
-        assert_eq!(may_be_valid_addr("u@d."), true);
+        assert_eq!(may_be_valid_addr("u@d."), false);
         assert_eq!(may_be_valid_addr("u@d.t"), true);
         assert_eq!(may_be_valid_addr("u@d.tt"), true);
         assert_eq!(may_be_valid_addr("u@.tt"), true);
@@ -1741,6 +1741,7 @@ mod tests {
         assert_eq!(may_be_valid_addr("sk <@d.tt>"), false);
         assert_eq!(may_be_valid_addr("as@sd.de>"), false);
         assert_eq!(may_be_valid_addr("ask dkl@dd.tt"), false);
+        assert_eq!(may_be_valid_addr("user@domain.tld."), false);
     }
 
     #[test]

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -535,6 +535,9 @@ impl EmailAddress {
                 if domain.is_empty() {
                     bail!("missing domain after '@' in {:?}", input);
                 }
+                if domain.ends_with('.') {
+                    bail!("Domain {domain:?} should not contain the dot in the end");
+                }
                 Ok(EmailAddress {
                     local: (*local).to_string(),
                     domain: (*domain).to_string(),
@@ -996,7 +999,7 @@ DKIM Results: Passed=true, Works=true, Allow_Keychange=true";
         assert_eq!(EmailAddress::new("dd.tt").is_ok(), false);
         assert!(EmailAddress::new("tt.dd@uu").is_ok());
         assert!(EmailAddress::new("u@d").is_ok());
-        assert!(EmailAddress::new("u@d.").is_ok());
+        assert!(EmailAddress::new("u@d.").is_err());
         assert!(EmailAddress::new("u@d.t").is_ok());
         assert_eq!(
             EmailAddress::new("u@d.tt").unwrap(),


### PR DESCRIPTION
Fixes #3216