### PR TITLE
build: build node packages on Ubuntu 18.04

### DIFF
--- a/.github/workflows/node-package.yml
+++ b/.github/workflows/node-package.yml
@@ -67,7 +67,9 @@ jobs:
 
     # Build Linux prebuilds inside a container with old glibc for backwards compatibility.
     # Debian 10 contained glibc 2.28 at the time of the writing (2023-06-04): https://packages.debian.org/buster/libc6
-    container: debian:10
+    # Ubuntu 18.04 is at the End of Standard Support since June 2023, but it contains glibc 2.27,
+    # so we are using it to support Ubuntu 18.04 setups that are still not upgraded.
+    container: ubuntu:18.04
     steps:
       # Working directory is owned by 1001:1001 by default.
       # Change it to our user.


### PR DESCRIPTION
Debian 10 has glibc 2.28, so packages built with it do not work on Ubuntu 18.04.