### PR TITLE
fix: reopen all connections on database passpharse change

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -1460,6 +1460,35 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_context_change_passphrase() -> Result<()> {
+        let dir = tempdir()?;
+        let dbfile = dir.path().join("db.sqlite");
+
+        let id = 1;
+        let context = Context::new_closed(&dbfile, id, Events::new(), StockStrings::new())
+            .await
+            .context("failed to create context")?;
+        assert_eq!(context.open("foo".to_string()).await?, true);
+        assert_eq!(context.is_open().await, true);
+
+        context
+            .set_config(Config::Addr, Some("alice@example.org"))
+            .await?;
+
+        context
+            .change_passphrase("bar".to_string())
+            .await
+            .context("Failed to change passphrase")?;
+
+        assert_eq!(
+            context.get_config(Config::Addr).await?.unwrap(),
+            "alice@example.org"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_ongoing() -> Result<()> {
         let context = TestContext::new().await;
 


### PR DESCRIPTION
Previously only one connection, the one used to change the key, was working after passphrase change.

With this fix the whole pool of connections
is recreated on passphrase change, so there is no need to reopen the database manually.

Fixes #4697