### PR TITLE
refactor: ignore public key argument in dc_preconfigure_keypair()

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -822,7 +822,7 @@ void            dc_maybe_network             (dc_context_t* context);
  * @param context The context as created by dc_context_new().
  * @param addr The e-mail address of the user. This must match the
  *    configured_addr setting of the context as well as the UID of the key.
- * @param public_data ASCII armored public key.
+ * @param public_data Ignored, actual public key is extracted from secret_data.
  * @param secret_data ASCII armored secret key.
  * @return 1 on success, 0 on failure.
  */

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -29,7 +29,7 @@ use deltachat::contact::{Contact, ContactId, Origin};
 use deltachat::context::Context;
 use deltachat::ephemeral::Timer as EphemeralTimer;
 use deltachat::imex::BackupProvider;
-use deltachat::key::DcKey;
+use deltachat::key::{DcKey, DcSecretKey};
 use deltachat::message::MsgId;
 use deltachat::net::read_url_blob;
 use deltachat::qr_code_generator::{generate_backup_qr, get_securejoin_qr_svg};
@@ -805,7 +805,7 @@ pub unsafe extern "C" fn dc_maybe_network(context: *mut dc_context_t) {
 pub unsafe extern "C" fn dc_preconfigure_keypair(
     context: *mut dc_context_t,
     addr: *const libc::c_char,
-    public_data: *const libc::c_char,
+    _public_data: *const libc::c_char,
     secret_data: *const libc::c_char,
 ) -> i32 {
     if context.is_null() {
@@ -815,8 +815,8 @@ pub unsafe extern "C" fn dc_preconfigure_keypair(
     let ctx = &*context;
     block_on(async move {
         let addr = tools::EmailAddress::new(&to_string_lossy(addr))?;
-        let public = key::SignedPublicKey::from_asc(&to_string_lossy(public_data))?.0;
         let secret = key::SignedSecretKey::from_asc(&to_string_lossy(secret_data))?.0;
+        let public = secret.split_public_key()?;
         let keypair = key::KeyPair {
             addr,
             public,

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -195,7 +195,7 @@ class Account:
         assert res != ffi.NULL, f"config value not found for: {name!r}"
         return from_dc_charpointer(res)
 
-    def _preconfigure_keypair(self, addr: str, public: str, secret: str) -> None:
+    def _preconfigure_keypair(self, addr: str, secret: str) -> None:
         """See dc_preconfigure_keypair() in deltachat.h.
 
         In other words, you don't need this.
@@ -203,7 +203,7 @@ class Account:
         res = lib.dc_preconfigure_keypair(
             self._dc_context,
             as_dc_charpointer(addr),
-            as_dc_charpointer(public),
+            ffi.NULL,
             as_dc_charpointer(secret),
         )
         if res == 0:

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -478,10 +478,9 @@ class ACFactory:
         except IndexError:
             pass
         else:
-            fname_pub = self.data.read_path(f"key/{keyname}-public.asc")
             fname_sec = self.data.read_path(f"key/{keyname}-secret.asc")
-            if fname_pub and fname_sec:
-                account._preconfigure_keypair(addr, fname_pub, fname_sec)
+            if fname_sec:
+                account._preconfigure_keypair(addr, fname_sec)
                 return True
             print(f"WARN: could not use preconfigured keys for {addr!r}")
 

--- a/python/tests/test_3_offline.py
+++ b/python/tests/test_3_offline.py
@@ -67,10 +67,9 @@ class TestOfflineAccountBasic:
 
     def test_preconfigure_keypair(self, acfactory, data):
         ac = acfactory.get_unconfigured_account()
-        alice_public = data.read_path("key/alice-public.asc")
         alice_secret = data.read_path("key/alice-secret.asc")
-        assert alice_public and alice_secret
-        ac._preconfigure_keypair("alice@example.org", alice_public, alice_secret)
+        assert alice_secret
+        ac._preconfigure_keypair("alice@example.org", alice_secret)
 
     def test_getinfo(self, acfactory):
         ac1 = acfactory.get_unconfigured_account()


### PR DESCRIPTION
Public key can be extracted from the secret key file.

See discussion at the forum: https://support.delta.chat/t/deltachat-fails-to-import-keys/2592