### PR TITLE
refactor: improve comment about `Ratelimit`

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -382,7 +382,7 @@ impl Context {
             translated_stockstrings: stockstrings,
             events,
             scheduler: SchedulerState::new(),
-            ratelimit: RwLock::new(Ratelimit::new(Duration::new(60, 0), 6.0)), // Allow to send 6 messages immediately, no more than once every 10 seconds.
+            ratelimit: RwLock::new(Ratelimit::new(Duration::new(60, 0), 6.0)), // Allow at least 1 message every 10 seconds + a burst of 6
             quota: RwLock::new(None),
             quota_update_request: AtomicBool::new(false),
             resync_request: AtomicBool::new(false),


### PR DESCRIPTION
A few people (including me) got the impression that if you send 6 messages in a burst you'll only be able to send the next one in 60 seconds. Hopefully this can resolve it.