### PR TITLE
api!: return DC_CONTACT_ID_SELF from dc_contact_get_verifier_id() for directly verified contacts

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5047,6 +5047,7 @@ int             dc_contact_is_verified       (dc_contact_t* contact);
  *    A string containing the verifiers address. If it is the same address as the contact itself,
  *    we verified the contact ourself. If it is an empty string, we don't have verifier 
  *    information or the contact is not verified.
+ * @deprecated 2023-09-28, use dc_contact_get_verifier_id instead
  */
 char*           dc_contact_get_verifier_addr       (dc_contact_t* contact);
 
@@ -5059,7 +5060,7 @@ char*           dc_contact_get_verifier_addr       (dc_contact_t* contact);
  * @memberof dc_contact_t
  * @param contact The contact object.
  * @return 
- *    The `ContactId` of the verifiers address. If it is the same address as the contact itself,
+ *    The contact ID of the verifier. If it is DC_CONTACT_ID_SELF,
  *    we verified the contact ourself. If it is 0, we don't have verifier information or 
  *    the contact is not verified.
  */

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1252,11 +1252,22 @@ impl Contact {
 
     /// Returns the ContactId that verified the contact.
     pub async fn get_verifier_id(&self, context: &Context) -> Result<Option<ContactId>> {
-        let verifier_addr = self.get_verifier_addr(context).await?;
-        if let Some(addr) = verifier_addr {
-            Ok(Contact::lookup_id_by_addr(context, &addr, Origin::AddressBook).await?)
-        } else {
-            Ok(None)
+        let Some(verifier_addr) = self.get_verifier_addr(context).await? else {
+            return Ok(None);
+        };
+
+        if verifier_addr == self.addr {
+            // Contact is directly verified via QR code.
+            return Ok(Some(ContactId::SELF));
+        }
+
+        match Contact::lookup_id_by_addr(context, &verifier_addr, Origin::AddressBook).await? {
+            Some(contact_id) => Ok(Some(contact_id)),
+            None => {
+                let addr = &self.addr;
+                warn!(context, "Could not lookup contact with address {verifier_addr} which introduced {addr}.");
+                Ok(None)
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #4748