### PR TITLE
warn->info for "Ignoring nested protected headers"

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -813,7 +813,7 @@ impl MimeMessage {
                     return Ok(false);
                 }
 
-                warn!(context, "Ignoring nested protected headers");
+                info!(context, "Ignoring nested protected headers");
             }
 
             enum MimeS {


### PR DESCRIPTION
the log is emmitted a lot of times, also in the xstore bot but doesn't seem to really be a warning but maybe more a stop-gap for recursion?  anyways, debugging is enough. 