### PR TITLE
Fix link to the template documentation of git-cliff

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -54,7 +54,7 @@ header = """
 # Changelog\n
 """
 # template for the changelog body
-# https://tera.netlify.app/docs/#introduction
+# https://keats.github.io/tera/docs/#templates
 body = """
 {% if version %}\
     ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}


### PR DESCRIPTION
The old link gives me 404