### PR TITLE
refactor: remove incomplete protected header code skipping Legacy Display Part

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -804,18 +804,6 @@ impl MimeMessage {
 
         // Boxed future to deal with recursion
         async move {
-            if mail.ctype.params.get("protected-headers").is_some() {
-                if mail.ctype.mimetype == "text/rfc822-headers" {
-                    warn!(
-                        context,
-                        "Protected headers found in text/rfc822-headers attachment: Will be ignored.",
-                    );
-                    return Ok(false);
-                }
-
-                warn!(context, "Ignoring nested protected headers");
-            }
-
             enum MimeS {
                 Multiple,
                 Single,
@@ -852,7 +840,10 @@ impl MimeMessage {
 
                     self.parse_mime_recursive(context, &mail, is_related).await
                 }
-                MimeS::Single => self.add_single_part_if_known(context, mail, is_related).await,
+                MimeS::Single => {
+                    self.add_single_part_if_known(context, mail, is_related)
+                        .await
+                }
             }
         }
         .boxed()


### PR DESCRIPTION
The code removed is an incomplete implementation of skipping the Legacy Display Part specified in
https://www.ietf.org/archive/id/draft-autocrypt-lamps-protected-headers-02.html#section-5.2

The code does not fully implement the specification, e.g. it does not check that there are exactly two parts.

Delta Chat and Thunderbird are not adding this part anyway, and it is defined as "transitional" in the draft.

This also removes misplaced warning "Ignoring nested protected headers" that is printed for every incoming Delta Chat message since commit 5690c48863cadddd0e9eb4a1f5510456053e9b17 which is part of the PR <https://github.com/deltachat/deltachat-core-rust/pull/982>.