### PR TITLE
fix: ignore special chats in get_similar_chat_ids()

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -918,9 +918,10 @@ impl ChatId {
             .sql
             .query_map(
                 "SELECT chat_id, count(*) AS n
-                 FROM chats_contacts where contact_id > 9
+                 FROM chats_contacts
+                 WHERE contact_id > ? AND chat_id > ?
                  GROUP BY chat_id",
-                (),
+                (ContactId::LAST_SPECIAL, DC_CHAT_ID_LAST_SPECIAL),
                 |row| {
                     let chat_id: ChatId = row.get(0)?;
                     let size: f64 = row.get(1)?;

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -109,7 +109,7 @@ impl ContactId {
 
     /// ID of the contact for device messages.
     pub const DEVICE: ContactId = ContactId::new(5);
-    const LAST_SPECIAL: ContactId = ContactId::new(9);
+    pub(crate) const LAST_SPECIAL: ContactId = ContactId::new(9);
 
     /// Address to go with [`ContactId::DEVICE`].
     ///


### PR DESCRIPTION
For unknown reason trash chat contains members in some existing databases. Workaround this by ignoring chats_contacts entries with special chat_id.

Fixes #4756 