### PR TITLE
fix(deltachat-rpc-client): increase stdio buffer to 64 MiB

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/rpc.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/rpc.py
@@ -29,10 +29,16 @@ class Rpc:
         self.events_task: asyncio.Task
 
     async def start(self) -> None:
+        # Use buffer of 64 MiB.
+        # Default limit as of Python 3.11 is 2**16 bytes, this is too low for some JSON-RPC responses,
+        # such as loading large HTML message content.
+        limit = 2**26
+
         self.process = await asyncio.create_subprocess_exec(
             "deltachat-rpc-server",
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
+            limit=limit,
             **self._kwargs,
         )
         self.id = 0


### PR DESCRIPTION
Otherwise readline() gets stuck when JSON-RPC response is longer that 64 KiB.

Workaround for #4782