### PR TITLE
fix: Remove footer from reactions on the receiver side (#4780)

### DIFF
--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -431,6 +431,32 @@ Content-Disposition: reaction\n\
         assert_eq!(bob_reaction.emojis(), vec!["👍"]);
         assert_eq!(bob_reaction.as_str(), "👍");
 
+        // Alice receives reaction to her message from Bob with a footer.
+        receive_imf(
+            &alice,
+            "To: alice@example.org\n\
+From: bob@example.net\n\
+Date: Today, 29 February 2021 00:00:10 -800\n\
+Message-ID: 56790@example.net\n\
+In-Reply-To: 12345@example.org\n\
+Subject: Meeting\n\
+Mime-Version: 1.0 (1.0)\n\
+Content-Type: text/plain; charset=utf-8\n\
+Content-Disposition: reaction\n\
+\n\
+😀\n\
+\n\
+--\n\
+_______________________________________________\n\
+Here's my footer -- bob@example.net"
+                .as_bytes(),
+            false,
+        )
+        .await?;
+
+        let reactions = get_msg_reactions(&alice, msg.id).await?;
+        assert_eq!(reactions.to_string(), "😀1");
+
         Ok(())
     }
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -35,6 +35,7 @@ use crate::param::{Param, Params};
 use crate::peerstate::{Peerstate, PeerstateKeyType, PeerstateVerifiedStatus};
 use crate::reaction::{set_msg_reaction, Reaction};
 use crate::securejoin::{self, handle_securejoin_handshake, observe_securejoin_on_other_device};
+use crate::simplify;
 use crate::sql;
 use crate::stock_str;
 use crate::tools::{
@@ -1092,12 +1093,13 @@ async fn add_parts(
 
     for part in &mut mime_parser.parts {
         if part.is_reaction {
+            let reaction_str = simplify::remove_footers(part.msg.as_str());
             set_msg_reaction(
                 context,
                 &mime_in_reply_to,
                 orig_chat_id.unwrap_or_default(),
                 from_id,
-                Reaction::from(part.msg.as_str()),
+                Reaction::from(reaction_str.as_str()),
             )
             .await?;
         }

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -67,6 +67,15 @@ fn remove_nonstandard_footer<'a>(lines: &'a [&str]) -> (&'a [&'a str], bool) {
     (lines, false)
 }
 
+/// Remove footers if any.
+/// This also makes all newlines "\n", but why not.
+pub(crate) fn remove_footers(msg: &str) -> String {
+    let lines = split_lines(msg);
+    let lines = remove_message_footer(&lines).0;
+    let lines = remove_nonstandard_footer(lines).0;
+    lines.join("\n")
+}
+
 pub(crate) fn split_lines(buf: &str) -> Vec<&str> {
     buf.split('\n').collect()
 }


### PR DESCRIPTION
Reactions do not have footer since 6d2ac30. However, mailing lists still add the footer to the messages, and receiver interpreted words as a reaction.