### PR TITLE
test: test_set_get_group_image(): Log more debug info

### DIFF
--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1930,10 +1930,13 @@ def test_set_get_group_image(acfactory, data, lp):
     chat.send_text("hi")  # sends another message
     assert chat.is_promoted()
 
-    lp.sec("ac2: wait for receiving message from ac1")
+    lp.sec("ac2: receive messages from ac1")
     msg1 = ac2._evtracker.wait_next_incoming_message()
-    assert msg1.is_system_message()  # Member added
+    print(f"ac2: msg1={msg1}")
+    # DEBUG: Postpone assertions to have more info in the log.
     msg2 = ac2._evtracker.wait_next_incoming_message()
+    print(f"ac2: msg2={msg2}")
+    assert msg1.is_system_message()  # Member added
     assert msg2.text == "hi"
     assert msg1.chat.id == msg2.chat.id
 


### PR DESCRIPTION
There was a recent failure: https://github.com/deltachat/deltachat-core-rust/actions/runs/6413378410/job/17412334267?pr=4789
```
>       assert msg1.is_system_message()  # Member added
E       AssertionError: assert False
E        +  where False = <bound method Message.is_system_message of <Message incoming sys=False 'hi' id=12 sender=10/45n2p@ci.testrun.org chat=13/hello>>()
```

Maybe a message reordering happened, but i have no idea why. Let's add more logs to be sure the "Member added" message isn't just lost.