### PR TITLE
Partially downloaded messages fixes

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -23,7 +23,7 @@ use crate::{job_try, stock_str, EventType};
 /// eg. to assign them to the correct chat.
 /// As these messages are typically small,
 /// they're caught by `MIN_DOWNLOAD_LIMIT`.
-const MIN_DOWNLOAD_LIMIT: u32 = 32768;
+pub(crate) const MIN_DOWNLOAD_LIMIT: u32 = 32768;
 
 /// If a message is downloaded only partially
 /// and `delete_server_after` is set to small timeouts (eg. "at once"),

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -110,7 +110,7 @@ pub(crate) struct MimeMessage {
 
     /// The decrypted, raw mime structure.
     ///
-    /// This is non-empty only if the message was actually encrypted.  It is used
+    /// This is non-empty iff `is_mime_modified` and the message was actually encrypted. It is used
     /// for e.g. late-parsing HTML.
     pub decoded_data: Vec<u8>,
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -596,6 +596,7 @@ async fn add_parts(
             if let Some((new_chat_id, new_chat_id_blocked)) = create_or_lookup_group(
                 context,
                 mime_parser,
+                is_partial_download.is_some(),
                 if test_normal_chat.is_none() {
                     allow_creation
                 } else {
@@ -822,6 +823,7 @@ async fn add_parts(
                 if let Some((new_chat_id, new_chat_id_blocked)) = create_or_lookup_group(
                     context,
                     mime_parser,
+                    is_partial_download.is_some(),
                     allow_creation,
                     Blocked::Not,
                     from_id,
@@ -1518,6 +1520,7 @@ async fn is_probably_private_reply(
 async fn create_or_lookup_group(
     context: &Context,
     mime_parser: &mut MimeMessage,
+    is_partial_download: bool,
     allow_creation: bool,
     create_blocked: Blocked,
     from_id: ContactId,
@@ -1648,7 +1651,7 @@ async fn create_or_lookup_group(
 
     if let Some(chat_id) = chat_id {
         Ok(Some((chat_id, chat_id_blocked)))
-    } else if mime_parser.decrypting_failed {
+    } else if is_partial_download || mime_parser.decrypting_failed {
         // It is possible that the message was sent to a valid,
         // yet unknown group, which was rejected because
         // Chat-Group-Name, which is in the encrypted part, was


### PR DESCRIPTION
**fix: Assign encrypted partially downloaded group messages to 1:1 chat (#4757)**
    
    Before they were trashed. Note that for unencrypted ones DC works as expected creating the requested
    group immediately because Chat-Group-Id is duplicated in the Message-Id header and Subject is
    fetched.

**fix: Don't update timestamp, timestamp_rcvd, state when replacing partially downloaded message (#4700)**
    
    Also add a test on downloading a message later. Although it doesn't reproduce #4700 for some reason,
    it fails w/o the fix because before a message state was changing to `InSeen` after a full download
    which doesn't look correct. The result of a full message download should be such as if it was fully
    downloaded initially.