### PR TITLE
fix: set connectivity status to "connected" during fake idle

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -391,6 +391,7 @@ impl Imap {
                     "IMAP-LOGIN as {}",
                     self.config.lp.user
                 )));
+                self.connectivity.set_connected(context).await;
                 info!(context, "Successfully logged into IMAP server");
                 Ok(())
             }


### PR DESCRIPTION
Set connectivity status to "connected" at the end of connect() call. Otherwise for servers that do not support IMAP IDLE connect() is called at the beginning of fake idle
and connectivity stays in "connecting" status most of the time.

Fixes #4797 

I have tested it on desktop with #4803 and https://github.com/deltachat/deltachat-desktop/pull/3427, it works.