### PR TITLE
fix(python): fix scripts/make-python-testenv.sh

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,7 +18,7 @@ and an own build machine.
 - `remote_tests_rust.sh` rsyncs to the build machine and runs
   `run-rust-test.sh` remotely on the build machine. 
 
-- `make-python-testenv.sh` creates or updates local python test development environment.
+- `make-python-testenv.sh` creates local python test development environment.
   Reusing the same environment is faster than running `run-python-test.sh` which always
   recreates environment from scratch and runs additional lints.
 

--- a/scripts/make-python-testenv.sh
+++ b/scripts/make-python-testenv.sh
@@ -4,8 +4,8 @@
 # It rebuilds the core and bindings as needed.
 #
 # After running the script, you can either
-# run `pytest` directly with `env/bin/pytest python/`
-# or activate the environment with `. env/bin/activacte`
+# run `pytest` directly with `venv/bin/pytest python/`
+# or activate the environment with `. venv/bin/activate`
 # and run `pytest` from there.
 set -euo pipefail
 
@@ -13,9 +13,5 @@ export DCC_RS_TARGET=debug
 export DCC_RS_DEV="$PWD"
 cargo build -p deltachat_ffi --features jsonrpc
 
-if test -d env; then
-	env/bin/pip install -e python --force-reinstall
-else
-	tox -e py --devenv env
-	env/bin/pip install --upgrade pip
-fi
+tox -c python -e py --devenv venv
+env/bin/pip install --upgrade pip


### PR DESCRIPTION
Without `-c python` tox does not find tox.ini and creates empty environment.

Renamed env/ into venv/ as it is more common.