### PR TITLE
link2xt/fix verifier id origin

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1261,7 +1261,7 @@ impl Contact {
             return Ok(Some(ContactId::SELF));
         }
 
-        match Contact::lookup_id_by_addr(context, &verifier_addr, Origin::AddressBook).await? {
+        match Contact::lookup_id_by_addr(context, &verifier_addr, Origin::Unknown).await? {
             Some(contact_id) => Ok(Some(contact_id)),
             None => {
                 let addr = &self.addr;


### PR DESCRIPTION
- chore(deltachat-rpc-client): remove AsyncIO classifier
- chore: added more typical virtualenv paths to gitignore
- fix(python): don't automatically set the displayname to 'bot' when setting log level
- feat: validate boolean values passed to set_config
- fix: return verifier contacts regardless of their origin
