### PR TITLE
fix: scale up contacts for bots

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -701,10 +701,14 @@ async fn add_parts(
                 Blocked::Not
             } else {
                 let contact = Contact::get_by_id(context, from_id).await?;
-                match contact.is_blocked() {
-                    true => Blocked::Yes,
-                    false if is_bot => Blocked::Not,
-                    false => Blocked::Request,
+                if is_bot {
+                    Contact::scaleup_origin_by_id(context, from_id, Origin::CreateChat).await?;
+                    Blocked::Not
+                } else {
+                    match contact.is_blocked() {
+                        true => Blocked::Yes,
+                        false => Blocked::Request,
+                    }
                 }
             };
 

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -2973,6 +2973,7 @@ async fn test_auto_accept_for_bots() -> Result<()> {
     let msg = t.get_last_msg().await;
     let chat = chat::Chat::load_from_db(&t, msg.chat_id).await?;
     assert!(!chat.is_contact_request());
+    assert!(Contact::get_all(&t, 0, None).await?.len() == 1);
     Ok(())
 }
 


### PR DESCRIPTION
For bots it might be more convenient to upscale the origin of new chats to `ChatCreated` because this way the created contacts will show up in `Contact::get_all` without using `Chat_id::accept()` explicitly (this should not be needed with the bot-flag anyway).

The fix I added  only works for 1:1 atm I believe so we might think about how to handle groups in this scenario.

PS: `Origin::IncomingReplyTo = 0x100` is the minimal needed origin to show up in `Contact::get_all` and `Origin::CreateChat` is at `0x800` with only `IncomingCC = 0x200` and `IncomingTo = 0x400` in between.