### PR TITLE
fix: show all contacts in Contact::get_all for bots

### DIFF
--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -2974,7 +2974,6 @@ async fn test_auto_accept_for_bots() -> Result<()> {
     let msg = t.get_last_msg().await;
     let chat = chat::Chat::load_from_db(&t, msg.chat_id).await?;
     assert!(!chat.is_contact_request());
-    println!("{:?}", Contact::get_all(&t, 0, None).await?);
     assert!(Contact::get_all(&t, 0, None).await?.len() == 1);
     Ok(())
 }

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -2974,6 +2974,8 @@ async fn test_auto_accept_for_bots() -> Result<()> {
     let msg = t.get_last_msg().await;
     let chat = chat::Chat::load_from_db(&t, msg.chat_id).await?;
     assert!(!chat.is_contact_request());
+    println!("{:?}", Contact::get_all(&t, 0, None).await?);
+    assert!(Contact::get_all(&t, 0, None).await?.len() == 1);
     Ok(())
 }
 


### PR DESCRIPTION
successor of #4810 
