### PR TITLE
test(deltachat-rpc-client): enable logs in pytest

### DIFF
--- a/deltachat-rpc-client/pyproject.toml
+++ b/deltachat-rpc-client/pyproject.toml
@@ -71,3 +71,6 @@ line-length = 120
 
 [tool.isort]
 profile = "black"
+
+[tool.pytest.ini_options]
+log_cli = true


### PR DESCRIPTION
This makes pytest setup a logger for `logging` module.