### PR TITLE
feat: forceSticker viewtype

### DIFF
--- a/deltachat-jsonrpc/src/api/mod.rs
+++ b/deltachat-jsonrpc/src/api/mod.rs
@@ -1750,10 +1750,15 @@ impl CommandApi {
         account_id: u32,
         chat_id: u32,
         sticker_path: String,
+        force: bool,
     ) -> Result<u32> {
         let ctx = self.get_context(account_id).await?;
 
-        let mut msg = Message::new(Viewtype::Sticker);
+        let mut msg = Message::new(if force {
+            Viewtype::ForceSticker
+        } else {
+            Viewtype::Sticker
+        });
         msg.set_file(&sticker_path, None);
 
         let message_id = deltachat::chat::send_msg(&ctx, ChatId::new(chat_id), &mut msg).await?;

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -147,6 +147,7 @@ impl MessageObject {
                         image: if quote.get_viewtype() == Viewtype::Image
                             || quote.get_viewtype() == Viewtype::Gif
                             || quote.get_viewtype() == Viewtype::Sticker
+                            || quote.get_viewtype() == Viewtype::ForceSticker
                         {
                             match quote.get_file(context) {
                                 Some(path_buf) => path_buf.to_str().map(|s| s.to_owned()),
@@ -257,6 +258,12 @@ pub enum MessageViewtype {
     /// A click on a sticker will offer to install the sticker set in some future.
     Sticker,
 
+    /// Message containing a sticker, similar to image.
+    /// If possible, the ui should display the image without borders in a transparent way.
+    /// A click on a sticker will offer to install the sticker set in some future.
+    /// This stick is guaranteed to be displayed as a stick in the ui.
+    ForceSticker,
+
     /// Message containing an Audio file.
     Audio,
 
@@ -285,6 +292,7 @@ impl From<Viewtype> for MessageViewtype {
             Viewtype::Image => MessageViewtype::Image,
             Viewtype::Gif => MessageViewtype::Gif,
             Viewtype::Sticker => MessageViewtype::Sticker,
+            Viewtype::ForceSticker => MessageViewtype::ForceSticker,
             Viewtype::Audio => MessageViewtype::Audio,
             Viewtype::Voice => MessageViewtype::Voice,
             Viewtype::Video => MessageViewtype::Video,
@@ -303,6 +311,7 @@ impl From<MessageViewtype> for Viewtype {
             MessageViewtype::Image => Viewtype::Image,
             MessageViewtype::Gif => Viewtype::Gif,
             MessageViewtype::Sticker => Viewtype::Sticker,
+            MessageViewtype::ForceSticker => Viewtype::ForceSticker,
             MessageViewtype::Audio => Viewtype::Audio,
             MessageViewtype::Voice => Viewtype::Voice,
             MessageViewtype::Video => Viewtype::Video,

--- a/src/message.rs
+++ b/src/message.rs
@@ -1858,6 +1858,12 @@ pub enum Viewtype {
     /// A click on a sticker will offer to install the sticker set in some future.
     Sticker = 23,
 
+    /// Message containing a sticker, similar to image.
+    /// If possible, the ui should display the image without borders in a transparent way.
+    /// A click on a sticker will offer to install the sticker set in some future.
+    /// This stick is guaranteed to be displayed as a stick in the ui.
+    ForceSticker = 24,
+
     /// Message containing an Audio file.
     /// File and duration are set via dc_msg_set_file(), dc_msg_set_duration()
     /// and retrieved via dc_msg_get_file(), dc_msg_get_duration().
@@ -1898,6 +1904,7 @@ impl Viewtype {
             Viewtype::Image => true,
             Viewtype::Gif => true,
             Viewtype::Sticker => true,
+            Viewtype::ForceSticker => true,
             Viewtype::Audio => true,
             Viewtype::Voice => true,
             Viewtype::Video => true,

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1118,7 +1118,7 @@ impl<'a> MimeFactory<'a> {
                 .push(Header::new("Chat-Group-Avatar".into(), filename_as_sent));
         }
 
-        if self.msg.viewtype == Viewtype::Sticker {
+        if self.msg.viewtype == Viewtype::Sticker || self.msg.viewtype == Viewtype::ForceSticker {
             headers
                 .protected
                 .push(Header::new("Chat-Content".into(), "sticker".into()));

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -552,6 +552,7 @@ impl MimeMessage {
                     Viewtype::Image
                     | Viewtype::Gif
                     | Viewtype::Sticker
+                    | Viewtype::ForceSticker
                     | Viewtype::Audio
                     | Viewtype::Voice
                     | Viewtype::Video

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -95,6 +95,7 @@ impl Summary {
         let thumbnail_path = if msg.viewtype == Viewtype::Image
             || msg.viewtype == Viewtype::Gif
             || msg.viewtype == Viewtype::Sticker
+            || msg.viewtype == Viewtype::ForceSticker
         {
             msg.get_file(context)
                 .and_then(|path| path.to_str().map(|p| p.to_owned()))
@@ -124,7 +125,7 @@ impl Message {
         let prefix = match self.viewtype {
             Viewtype::Image => stock_str::image(context).await,
             Viewtype::Gif => stock_str::gif(context).await,
-            Viewtype::Sticker => stock_str::sticker(context).await,
+            Viewtype::Sticker | Viewtype::ForceSticker => stock_str::sticker(context).await,
             Viewtype::Video => stock_str::video(context).await,
             Viewtype::Voice => stock_str::voice_message(context).await,
             Viewtype::Audio | Viewtype::File => {


### PR DESCRIPTION
This PR adds a new Viewtype `ForceSticker` to be able to send any image as a sticker. 
It also adds a new parameter to the json-rpc' function `send_sticker` so that deltachat-desktop can force send images as stickers.

The ForceSticker Viewtype is only used on the sending side and is received as Sticker type on the receiving end.
Maybe we should turn the ForceSticker type into a normal Sticker after `recode_to_image_size` call to eliminate some redundant `(type == Viewtype::Sticker || type == Viewtype::ForceSticker)` but I'm not too opinionated on that.

fixes #4739