### PR TITLE
api: allow to filter by unread in `chatlist:try_load`

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -885,7 +885,8 @@ int             dc_preconfigure_keypair        (dc_context_t* context, const cha
  *     - if the flag DC_GCL_ADD_ALLDONE_HINT is set, DC_CHAT_ID_ALLDONE_HINT
  *       is added as needed.
  * @param query_str An optional query for filtering the list. Only chats matching this query
- *     are returned. Give NULL for no filtering.
+ *     are returned. Give NULL for no filtering. When `is:unread` is contained in the query,
+ *     the chatlist is filtered such that only chats with unread messages show up.
  * @param query_id An optional contact ID for filtering the list. Only chats including this contact ID
  *     are returned. Give 0 for no filtering.
  * @return A chatlist as an dc_chatlist_t object.

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -83,7 +83,8 @@ impl Chatlist {
     /// - if the flag DC_GCL_ADD_ALLDONE_HINT is set, DC_CHAT_ID_ALLDONE_HINT
     ///   is added as needed.
     /// `query`: An optional query for filtering the list. Only chats matching this query
-    ///     are returned.
+    ///     are returned. When `is:unread` is contained in the query, the chatlist is
+    ///     filtered such that only chats with unread messages show up.
     /// `query_contact_id`: An optional contact ID for filtering the list. Only chats including this contact ID
     ///     are returned.
     pub async fn try_load(


### PR DESCRIPTION
Adds the possibility to add `unread` anywhere in the query to only get messages that are unread.

close #4738

