### PR TITLE
test: test_qr_new_group_unblocked(): W/a message reordering on server

### DIFF
--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1698,12 +1698,10 @@ def test_qr_new_group_unblocked(acfactory, lp):
 
     ac1_new_chat = ac1.create_group_chat("Another group")
     ac1_new_chat.add_contact(ac2)
-    ac1_new_chat.send_text("Hello!")
-
     # Receive "Member added" message.
     ac2._evtracker.wait_next_incoming_message()
 
-    # Receive "Hello!" message.
+    ac1_new_chat.send_text("Hello!")
     ac2_msg = ac2._evtracker.wait_next_incoming_message()
     assert ac2_msg.text == "Hello!"
     assert ac2_msg.chat.is_contact_request()


### PR DESCRIPTION
There was a recent failure of the test probably as a result of message reordering on the server: https://github.com/deltachat/deltachat-core-rust/actions/runs/6464605602/job/17549624095?pr=4813.