### PR TITLE
api(json-rpc): force stickers to be sent as stickers

### DIFF
--- a/deltachat-jsonrpc/src/api/mod.rs
+++ b/deltachat-jsonrpc/src/api/mod.rs
@@ -1756,7 +1756,7 @@ impl CommandApi {
         let mut msg = Message::new(Viewtype::Sticker);
         msg.set_file(&sticker_path, None);
 
-        // JSON-rpc does not need heuristical to turn [Viewtype::Sticker] into [Viewtype::Image]
+        // JSON-rpc does not need heuristics to turn [Viewtype::Sticker] into [Viewtype::Image]
         msg.force_sticker();
 
         let message_id = deltachat::chat::send_msg(&ctx, ChatId::new(chat_id), &mut msg).await?;

--- a/deltachat-jsonrpc/src/api/mod.rs
+++ b/deltachat-jsonrpc/src/api/mod.rs
@@ -1756,6 +1756,9 @@ impl CommandApi {
         let mut msg = Message::new(Viewtype::Sticker);
         msg.set_file(&sticker_path, None);
 
+        // JSON-rpc does not need heuristical to turn [Viewtype::Sticker] into [Viewtype::Image]
+        msg.force_sticker();
+
         let message_id = deltachat::chat::send_msg(&ctx, ChatId::new(chat_id), &mut msg).await?;
         Ok(message_id.to_u32())
     }

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1087,22 +1087,6 @@ mod tests {
         )
         .await
         .unwrap();
-
-        // This will be sent as Image, see [`BlobObject::maybe_sticker`] for explanation.
-        send_image_check_mediaquality(
-            Viewtype::Sticker,
-            Some("0"),
-            bytes,
-            "png",
-            false, // no Exif
-            1920,
-            1080,
-            0,
-            1920,
-            1080,
-        )
-        .await
-        .unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1087,6 +1087,22 @@ mod tests {
         )
         .await
         .unwrap();
+
+        // This will be sent as Image, see [`BlobObject::maybe_sticker`] for explanation.
+        send_image_check_mediaquality(
+            Viewtype::Sticker,
+            Some("0"),
+            bytes,
+            "png",
+            false, // no Exif
+            1920,
+            1080,
+            0,
+            1920,
+            1080,
+        )
+        .await
+        .unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2208,11 +2208,11 @@ async fn prepare_msg_blob(context: &Context, msg: &mut Message) -> Result<()> {
             .with_context(|| format!("attachment missing for message of type #{}", msg.viewtype))?;
 
         let mut maybe_sticker = msg.viewtype == Viewtype::Sticker;
-        if msg.viewtype == Viewtype::Image || maybe_sticker {
+        if msg.viewtype == Viewtype::Image || maybe_sticker && !msg.param.exists(Param::ForceSticker){
             blob.recode_to_image_size(context, &mut maybe_sticker)
                 .await?;
 
-            if !maybe_sticker && !msg.param.exists(Param::ForceSticker) {
+            if !maybe_sticker {
                 msg.viewtype = Viewtype::Image;
             }
         }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2211,7 +2211,7 @@ async fn prepare_msg_blob(context: &Context, msg: &mut Message) -> Result<()> {
         if msg.viewtype == Viewtype::Image || maybe_sticker {
             blob.recode_to_image_size(context, &mut maybe_sticker)
                 .await?;
-            if !maybe_sticker {
+            if !maybe_sticker && !msg.force_sticker {
                 msg.viewtype = Viewtype::Image;
             }
         }
@@ -5677,6 +5677,36 @@ mod tests {
             1000,
         )
         .await
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_sticker_jpeg_force() {
+        let alice = TestContext::new_alice().await;
+        let bob = TestContext::new_bob().await;
+        let alice_chat = alice.create_chat(&bob).await;
+
+        let file = alice.get_blobdir().join("sticker.jpg");
+        tokio::fs::write(
+            &file,
+            include_bytes!("../test-data/image/avatar1000x1000.jpg"),
+        )
+        .await
+        .unwrap();
+
+        // Images without force_sticker should be turned into [Viewtype::Image]
+        let mut msg = Message::new(Viewtype::Sticker);
+        msg.set_file(file.to_str().unwrap(), None);
+        let sent_msg = alice.send_msg(alice_chat.id, &mut msg).await;
+        let msg = bob.recv_msg(&sent_msg).await;
+        assert_eq!(msg.get_viewtype(), Viewtype::Image);
+
+        // Images with `force_sticker = true` should keep [Viewtype::Sticker]
+        let mut msg = Message::new(Viewtype::Sticker);
+        msg.set_file(file.to_str().unwrap(), None);
+        msg.force_sticker = true;
+        let sent_msg = alice.send_msg(alice_chat.id, &mut msg).await;
+        let msg = bob.recv_msg(&sent_msg).await;
+        assert_eq!(msg.get_viewtype(), Viewtype::Sticker);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2208,7 +2208,9 @@ async fn prepare_msg_blob(context: &Context, msg: &mut Message) -> Result<()> {
             .with_context(|| format!("attachment missing for message of type #{}", msg.viewtype))?;
 
         let mut maybe_sticker = msg.viewtype == Viewtype::Sticker;
-        if msg.viewtype == Viewtype::Image || maybe_sticker && !msg.param.exists(Param::ForceSticker){
+        if msg.viewtype == Viewtype::Image
+            || maybe_sticker && !msg.param.exists(Param::ForceSticker)
+        {
             blob.recode_to_image_size(context, &mut maybe_sticker)
                 .await?;
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -403,9 +403,6 @@ pub struct Message {
 
     /// Type of the message.
     pub(crate) viewtype: Viewtype,
-    /// Whether the sticker-viewtype should be forced
-    /// e.g it will not be turned to image by the core
-    pub(crate) force_sticker: bool,
 
     /// State of the message.
     pub(crate) state: MessageState,
@@ -521,7 +518,6 @@ impl Message {
                         ephemeral_timer: row.get("ephemeral_timer")?,
                         ephemeral_timestamp: row.get("ephemeral_timestamp")?,
                         viewtype: row.get("type")?,
-                        force_sticker: false,
                         state: row.get("state")?,
                         download_state: row.get("download_state")?,
                         error: Some(row.get::<_, String>("error")?)
@@ -668,9 +664,10 @@ impl Message {
         self.viewtype
     }
 
-    /// Forces the message to **keep** the sticker viewtype.
+    /// Forces the message to **keep** [Viewtype::Sticker]
+    /// e.g the message will not be converted to a [Viewtype::Image].
     pub fn force_sticker(&mut self) {
-        self.force_sticker = true;
+        self.param.set_int(Param::ForceSticker, 1);
     }
 
     /// Returns the state of the message.

--- a/src/message.rs
+++ b/src/message.rs
@@ -403,6 +403,9 @@ pub struct Message {
 
     /// Type of the message.
     pub(crate) viewtype: Viewtype,
+    /// Whether the sticker-viewtype should be forced
+    /// e.g it will not be turned to image by the core
+    pub(crate) force_sticker: bool,
 
     /// State of the message.
     pub(crate) state: MessageState,
@@ -518,6 +521,7 @@ impl Message {
                         ephemeral_timer: row.get("ephemeral_timer")?,
                         ephemeral_timestamp: row.get("ephemeral_timestamp")?,
                         viewtype: row.get("type")?,
+                        force_sticker: false,
                         state: row.get("state")?,
                         download_state: row.get("download_state")?,
                         error: Some(row.get::<_, String>("error")?)
@@ -662,6 +666,11 @@ impl Message {
     /// Returns the type of the message.
     pub fn get_viewtype(&self) -> Viewtype {
         self.viewtype
+    }
+
+    /// Forces the message to **keep** the sticker viewtype.
+    pub fn force_sticker(&mut self) {
+        self.force_sticker = true;
     }
 
     /// Returns the state of the message.

--- a/src/param.rs
+++ b/src/param.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::blob::BlobObject;
 use crate::context::Context;
-use crate::message::MsgId;
+use crate::message::{MsgId};
 use crate::mimeparser::SystemMessage;
 
 /// Available param keys.
@@ -188,7 +188,7 @@ pub enum Param {
     /// For Webxdc Message Instances: timestamp of summary update.
     WebxdcSummaryTimestamp = b'Q',
 
-    /// For messages: Whether [Viewtype::Sticker] should be forced.
+    /// For messages: Whether [crate::message::Viewtype::Sticker] should be forced.
     ForceSticker = b'X',
 }
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -188,7 +188,7 @@ pub enum Param {
     /// For Webxdc Message Instances: timestamp of summary update.
     WebxdcSummaryTimestamp = b'Q',
 
-    /// For messages: Wheter the sticker-viewtype should be forced.
+    /// For messages: Whether [Viewtype::Sticker] should be forced.
     ForceSticker = b'X',
 }
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -187,6 +187,9 @@ pub enum Param {
 
     /// For Webxdc Message Instances: timestamp of summary update.
     WebxdcSummaryTimestamp = b'Q',
+
+    /// For messages: Wheter the sticker-viewtype should be forced.
+    ForceSticker = b'X',
 }
 
 /// An object for handling key=value parameter lists.

--- a/src/param.rs
+++ b/src/param.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::blob::BlobObject;
 use crate::context::Context;
-use crate::message::{MsgId};
+use crate::message::MsgId;
 use crate::mimeparser::SystemMessage;
 
 /// Available param keys.


### PR DESCRIPTION
This approach uses a param field to enable forcing the sticker `viewtype`. The first commit has the memory-only flag implemented, but this flag is not persistent through the database conversion needed for draft/undraft. That's why `param` has to be used.

follow up to #4814 
fixes #4739