### PR TITLE
fix: set soft_heap_limit on SQLite database

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -686,6 +686,7 @@ fn new_connection(path: &Path, passphrase: &str) -> Result<Connection> {
          PRAGMA secure_delete=on;
          PRAGMA busy_timeout = 0; -- fail immediately
          PRAGMA temp_store=memory; -- Avoid SQLITE_IOERR_GETTEMPPATH errors on Android
+         PRAGMA soft_heap_limit = 8388608; -- 8 MiB limit, same as set in Android SQLiteDatabase.
          PRAGMA foreign_keys=on;
          ",
     )?;


### PR DESCRIPTION
This should prevent unlimited growth of memory usage by SQLite for is page cache.