### PR TITLE
fix: do not interrupt IMAP loop from get_connectivity_html()

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -211,9 +211,6 @@ pub struct InnerContext {
     /// Set to `None` if quota was never tried to load.
     pub(crate) quota: RwLock<Option<QuotaInfo>>,
 
-    /// Set to true if quota update is requested.
-    pub(crate) quota_update_request: AtomicBool,
-
     /// IMAP UID resync request.
     pub(crate) resync_request: AtomicBool,
 
@@ -384,7 +381,6 @@ impl Context {
             scheduler: SchedulerState::new(),
             ratelimit: RwLock::new(Ratelimit::new(Duration::new(60, 0), 6.0)), // Allow at least 1 message every 10 seconds + a burst of 6.
             quota: RwLock::new(None),
-            quota_update_request: AtomicBool::new(false),
             resync_request: AtomicBool::new(false),
             new_msgs_notify,
             server_id: RwLock::new(None),

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -8,10 +8,7 @@ use tokio::sync::Mutex;
 
 use crate::events::EventType;
 use crate::imap::{scan_folders::get_watched_folder_configs, FolderMeaning};
-use crate::quota::{
-    QUOTA_ERROR_THRESHOLD_PERCENTAGE, QUOTA_MAX_AGE_SECONDS, QUOTA_WARN_THRESHOLD_PERCENTAGE,
-};
-use crate::tools::time;
+use crate::quota::{QUOTA_ERROR_THRESHOLD_PERCENTAGE, QUOTA_WARN_THRESHOLD_PERCENTAGE};
 use crate::{context::Context, log::LogExt};
 use crate::{stock_str, tools};
 
@@ -472,14 +469,9 @@ impl Context {
                     ret += format!("<li>{e}</li>").as_str();
                 }
             }
-
-            if quota.modified + QUOTA_MAX_AGE_SECONDS < time() {
-                self.schedule_quota_update().await?;
-            }
         } else {
             let not_connected = stock_str::not_connected(self).await;
             ret += &format!("<li>{not_connected}</li>");
-            self.schedule_quota_update().await?;
         }
         ret += "</ul>";
 

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -742,8 +742,6 @@ pub async fn housekeeping(context: &Context) -> Result<()> {
         warn!(context, "Failed to deduplicate peerstates: {:#}.", err)
     }
 
-    context.schedule_quota_update().await?;
-
     // Try to clear the freelist to free some space on the disk. This
     // only works if auto_vacuum is enabled.
     match context


### PR DESCRIPTION
Android calls get_connectivity_html()
every time connectivity changes, which in turn interrupts IMAP loop and triggers change from "not connected" to "connecting" state.

To avoid such infinite loop of IMAP interrupts when there is not connectivity, update quota only when IMAP loop is interrupted otherwise. This anyway happens when a message is received or maybe_network is called.

Also remove outdated comments about `Action::UpdateRecentQuota` job which does not exist anymore.

Fixes #4847