### PR TITLE
fix(deltachat-rpc-server): always run with at least two threads

### DIFF
--- a/deltachat-rpc-server/Cargo.toml
+++ b/deltachat-rpc-server/Cargo.toml
@@ -17,6 +17,7 @@ anyhow = "1"
 env_logger = { version = "0.10.0" }
 futures-lite = "2.0.0"
 log = "0.4"
+num_cpus = "1"
 serde_json = "1.0.105"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.33.0", features = ["io-std"] }


### PR DESCRIPTION
We already run all async tests with
#[tokio::test(flavor = "multi_thread", worker_threads = 2)] as we had problems in the past when running them with one thread.

This is a similar change for deltachat-rpc-server
that hopefully prevents timeouts of deltachat-rpc-client tests on CI.