### PR TITLE
test: increase pytest timeout to 10 minutes

### DIFF
--- a/deltachat-rpc-client/tox.ini
+++ b/deltachat-rpc-client/tox.ini
@@ -28,6 +28,6 @@ commands =
     ruff src/ examples/ tests/
 
 [pytest]
-timeout = 60
+timeout = 300
 log_cli = true
 log_level = info

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -85,7 +85,7 @@ commands =
 addopts = -v -ra --strict-markers
 norecursedirs = .tox 
 xfail_strict=true
-timeout = 150
+timeout = 300
 timeout_func_only = True
 markers = 
     ignored: ignore this test in default test runs, use --ignored to run.


### PR DESCRIPTION
deltachat-rpc-client tests often timeouts on CI,
this hopefully fixes the problem unless the tests actually deadlock.