### PR TITLE
properly add a member triggered by unrelated secure-join protocol

### DIFF
--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1725,12 +1725,7 @@ def test_qr_join_chat_with_pending_bobstate_issue4894(acfactory, lp):
 
     lp.sec("ac1: let ac2 join again but shutoff ac1 in the middle of securejoin")
     ac2.qr_join_chat(ch1.get_join_qr())
-    while 1:
-        ev = ac2._evtracker.get_matching("DC_EVENT_SECUREJOIN_JOINER_PROGRESS")
-        if ev.data2 == 400:  # prevent ac1 from answering request_with_auth
-            ac1.shutdown()
-            break
-
+    ac1.shutdown()
     lp.sec("ac2 now has pending bobstate but ac1 is shutoff")
 
     # we meanwhile expect ac3/ac2 verification started in the beginning to have completed

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1699,6 +1699,68 @@ def test_qr_join_chat(acfactory, lp, verified_one_on_one_chats):
     assert not ch.is_protected()
 
 
+def test_qr_join_chat_with_pending_bobstate_issue4894(acfactory, lp):
+    ac1, ac2, ac3, ac4 = acfactory.get_online_accounts(4)
+
+    lp.sec("ac3: verify with ac2")
+    ac3.qr_setup_contact(ac2.get_setup_contact_qr())
+    ac2._evtracker.wait_securejoin_inviter_progress(1000)
+
+    # in order for ac2 to have pending botstate with a verified group
+    # we first create a fully joined verified group, and then start
+    # joining a second time but interrupt it, to create pending bob state
+
+    lp.sec("ac1: create verified group that ac2 fully joins")
+    ch1 = ac1.create_group_chat("ac1-shutoff group", verified=True)
+    ac2.qr_join_chat(ch1.get_join_qr())
+    ac1._evtracker.wait_securejoin_inviter_progress(1000)
+
+    # ensure ac1 can write and ac2 receives messages in verified chat
+    ch1.send_text("ac1 says hello")
+    while 1:
+        msg = ac2.wait_next_incoming_message()
+        if msg.text == "ac1 says hello":
+            assert msg.chat.is_protected()
+            break
+
+    lp.sec("ac1: let ac2 join again but shutoff ac1 in the middle of securejoin")
+    ch1b = ac2.qr_join_chat(ch1.get_join_qr())
+    while 1:
+        ev = ac2._evtracker.get_matching("DC_EVENT_SECUREJOIN_JOINER_PROGRESS")
+        if ev.data2 == 400:  # prevent ac1 from answering request_with_auth
+            ac1.shutdown()
+            break
+
+    lp.sec("ac2 now has pending bobstate but ac1 is shutoff")
+
+    # we meanwhile expect ac3/ac2 verification started in the beginning to have completed
+    assert ac3.get_contact(ac2).is_verified()
+    assert ac2.get_contact(ac3).is_verified()
+
+    lp.sec("ac3: create a verified group VG with ac2")
+    vg = ac3.create_group_chat("ac3-created", [ac2], verified=True)
+
+    # ensure ac2 receives message in VG
+    vg.send_text("hello")
+    while 1:
+        msg = ac2.wait_next_incoming_message()
+        if msg.text == "hello":
+            assert msg.chat.is_protected()
+            break
+
+    lp.sec("ac3: create a join-code for group VG and let ac4 join, check that ac2 got it")
+    ac4.qr_join_chat(vg.get_join_qr())
+    ac3._evtracker.wait_securejoin_inviter_progress(1000)
+    while 1:
+        ev = ac2._evtracker.get()
+        if "Message does not match expected" in str(ev):
+            pytest.fail("ac2 wrongly used a pending bobstate when seeing a member-added message")
+            break
+
+    import pdb
+    pdb.set_trace()
+
+
 def test_qr_new_group_unblocked(acfactory, lp):
     """Regression test for a bug intoduced in core v1.113.0.
     ac2 scans a verified group QR code created by ac1.

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1706,7 +1706,7 @@ def test_qr_join_chat_with_pending_bobstate_issue4894(acfactory, lp):
     ac3.qr_setup_contact(ac2.get_setup_contact_qr())
     ac2._evtracker.wait_securejoin_inviter_progress(1000)
 
-    # in order for ac2 to have pending botstate with a verified group
+    # in order for ac2 to have pending bobstate with a verified group
     # we first create a fully joined verified group, and then start
     # joining a second time but interrupt it, to create pending bob state
 
@@ -1724,7 +1724,7 @@ def test_qr_join_chat_with_pending_bobstate_issue4894(acfactory, lp):
             break
 
     lp.sec("ac1: let ac2 join again but shutoff ac1 in the middle of securejoin")
-    ch1b = ac2.qr_join_chat(ch1.get_join_qr())
+    ac2.qr_join_chat(ch1.get_join_qr())
     while 1:
         ev = ac2._evtracker.get_matching("DC_EVENT_SECUREJOIN_JOINER_PROGRESS")
         if ev.data2 == 400:  # prevent ac1 from answering request_with_auth
@@ -1753,12 +1753,8 @@ def test_qr_join_chat_with_pending_bobstate_issue4894(acfactory, lp):
     ac3._evtracker.wait_securejoin_inviter_progress(1000)
     while 1:
         ev = ac2._evtracker.get()
-        if "Message does not match expected" in str(ev):
-            pytest.fail("ac2 wrongly used a pending bobstate when seeing a member-added message")
-            break
-
-    import pdb
-    pdb.set_trace()
+        if "added by unrelated SecureJoin" in str(ev):
+            return
 
 
 def test_qr_new_group_unblocked(acfactory, lp):

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -483,6 +483,19 @@ pub(crate) async fn handle_securejoin_handshake(
             ====             Bob - the joiner's side             ====
             ====   Step 7 in "Setup verified contact" protocol   ====
             =======================================================*/
+
+            if let Some(member_added) = mime_message
+                .get_header(HeaderDef::ChatGroupMemberAdded)
+                .map(|s| s.as_str())
+            {
+                if !context.is_self_addr(member_added).await? {
+                    info!(
+                        context,
+                        "Member {member_added} added by unrelated SecureJoin process"
+                    );
+                    return Ok(HandshakeMessage::Propagate);
+                }
+            }
             match BobState::from_db(&context.sql).await? {
                 Some(bobstate) => {
                     bob::handle_contact_confirm(context, bobstate, mime_message).await


### PR DESCRIPTION
Fixes  #4894 
so that a "left-over" bobstate does not block a receiver of a MemberAdded message from adding the member if it was added through an unrelated secure-join process (i.e. the receiver was not the member being added through the secure-join protocol) 