### PR TITLE
fix: Partial messages do not change group state

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -60,7 +60,7 @@ pub(crate) struct MimeMessage {
     /// Message headers.
     headers: HashMap<String, String>,
 
-    /// Addresses are normalized and lowercased:
+    /// Addresses are normalized and lowercase
     pub recipients: Vec<SingleInfo>,
 
     /// `From:` address.


### PR DESCRIPTION
This message makes that partial messages do not change the group state.
A simple fix and a comprehensive test is added. This is a follow up to the former #4841 which took a different approach.