### PR TITLE
docs: contact profile view should not use dc_contact_is_verified()

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3732,8 +3732,25 @@ int             dc_chat_can_send              (const dc_chat_t* chat);
 
 /**
  * Check if a chat is protected.
- * Protected chats contain only verified members and encryption is always enabled.
- * Protected chats are created using dc_create_group_chat() by setting the 'protect' parameter to 1.
+ *
+ * End-to-end encryption is guaranteed in protected chats
+ * and only verified contacts
+ * as determined by dc_contact_is_verified()
+ * can be added to protected chats.
+ *
+ * Protected chats are created using dc_create_group_chat()
+ * by setting the 'protect' parameter to 1.
+ * 1:1 chats become protected or unprotected automatically
+ * if `verified_one_on_one_chats` setting is enabled.
+ *
+ * UI should display a green checkmark
+ * in the chat title,
+ * in the chat profile title and
+ * in the chatlist item
+ * if chat protection is enabled.
+ * UI should also display a green checkmark
+ * in the contact profile
+ * if 1:1 chat with this contact exists and is protected.
  *
  * @memberof dc_chat_t
  * @param chat The chat object.
@@ -5040,11 +5057,14 @@ int             dc_contact_is_blocked        (const dc_contact_t* contact);
  *
  * If contact is verified
  * UI should display green checkmark after the contact name
- * in the title of the contact profile,
- * in contact list items and in chat member list items.
+ * in contact list items and
+ * in chat member list items.
  *
- * Do not use this function when displaying profile view contents.
- * Use dc_contact_get_verifier_id instead.
+ * Do not use this function when displaying the contact profile view.
+ * Display green checkmark in the title of the contact profile
+ * if 1:1 chat with the contact exists and is protected.
+ * Use dc_contact_get_verified_id to display the verifier contact
+ * in the info section of the contact profile.
  *
  * @memberof dc_contact_t
  * @param contact The contact object.

--- a/deltachat-jsonrpc/src/api/types/chat.rs
+++ b/deltachat-jsonrpc/src/api/types/chat.rs
@@ -18,6 +18,17 @@ use super::contact::ContactObject;
 pub struct FullChat {
     id: u32,
     name: String,
+
+    /// True if the chat is protected.
+    ///
+    /// UI should display a green checkmark
+    /// in the chat title,
+    /// in the chat profile title and
+    /// in the chatlist item
+    /// if chat protection is enabled.
+    /// UI should also display a green checkmark
+    /// in the contact profile
+    /// if 1:1 chat with this contact exists and is protected.
     is_protected: bool,
     profile_image: Option<String>, //BLOBS ?
     archived: bool,
@@ -128,6 +139,17 @@ impl FullChat {
 pub struct BasicChat {
     id: u32,
     name: String,
+
+    /// True if the chat is protected.
+    ///
+    /// UI should display a green checkmark
+    /// in the chat title,
+    /// in the chat profile title and
+    /// in the chatlist item
+    /// if chat protection is enabled.
+    /// UI should also display a green checkmark
+    /// in the contact profile
+    /// if 1:1 chat with this contact exists and is protected.
     is_protected: bool,
     profile_image: Option<String>, //BLOBS ?
     archived: bool,

--- a/deltachat-jsonrpc/src/api/types/contact.rs
+++ b/deltachat-jsonrpc/src/api/types/contact.rs
@@ -25,14 +25,16 @@ pub struct ContactObject {
     /// If this is true
     /// UI should display green checkmark after the contact name
     /// in the title of the contact profile,
-    /// in contact list items and in chat member list items.
+    /// in contact list items and
+    /// in chat member list items.
     is_verified: bool,
 
     /// The ID of the contact that verified this contact.
     ///
     /// If this is present,
     /// display a green checkmark and "Introduced by ..."
-    /// string followed by the verifier contact name and address.
+    /// string followed by the verifier contact name and address
+    /// in the contact profile.
     verifier_id: Option<u32>,
 
     /// the contact's last seen timestamp

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1584,6 +1584,15 @@ impl Chat {
     }
 
     /// Returns true if chat protection is enabled.
+    ///
+    /// UI should display a green checkmark
+    /// in the chat title,
+    /// in the chat profile title and
+    /// in the chatlist item
+    /// if chat protection is enabled.
+    /// UI should also display a green checkmark
+    /// in the contact profile
+    /// if 1:1 chat with this contact exists and is protected.
     pub fn is_protected(&self) -> bool {
         self.protected == ProtectionStatus::Protected
     }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1258,11 +1258,14 @@ impl Contact {
     ///
     /// If contact is verified
     /// UI should display green checkmark after the contact name
-    /// in the title of the contact profile,
-    /// in contact list items and in chat member list items.
+    /// in contact list items and
+    /// in chat member list items.
     ///
-    /// Do not use this function when displaying profile view contents.
-    /// Use [Self::get_verifier_id] instead.
+    /// Do not use this function when displaying the contact profile view.
+    /// Display green checkmark in the title of the contact profile
+    /// if 1:1 chat with the contact exists and is protected.
+    /// Use [Self::get_verifier_id] to display the verifier contact
+    /// in the info section of the contact profile.
     pub async fn is_verified(&self, context: &Context) -> Result<VerifiedStatus> {
         // We're always sort of secured-verified as we could verify the key on this device any time with the key
         // on this device


### PR DESCRIPTION
Green checkmark in the contact profile
should only be displayed in the title
if the same checkmark is displayed in the title of 1:1 chat. If 1:1 chat does not exist,
the checkmark should not be displayed in the title of the contact profile.

Also add docs to is_protected
property of FullChat and BasicChat JSON objects.