### PR TITLE
fix(imap): always advance expected UIDNEXT to avoid skipping IDLE in a loop

### DIFF
--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -53,7 +53,7 @@ impl Session {
             if uid_next > expected_uid_next {
                 info!(
                     context,
-                    "Skipping IDLE because UIDNEXT indicates there are new messages."
+                    "Skipping IDLE on {folder:?} because UIDNEXT {uid_next}>{expected_uid_next} indicates there are new messages."
                 );
                 return Ok((self, info));
             }


### PR DESCRIPTION
Ensure the client does not busy loop
skipping IDLE if UIDNEXT of the mailbox is higher than the last seen UID plus 1, e.g. if the message
with UID=UIDNEXT-1 was deleted before we fetched it.

We do not fallback to UIDNEXT=1 anymore
if the STATUS command cannot determine UIDNEXT.
There are no known IMAP servers with broken STATUS so far. This allows to guarantee that select_with_uidvalidity() sets UIDNEXT for the mailbox and use it in fetch_new_messages() to ensure that UIDNEXT always advances even
when there are no messages to fetch.

Fixes #4935 