### PR TITLE
fix: treat reset state as encryption not preferred

### DIFF
--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -67,13 +67,8 @@ impl EncryptHelper {
                         "peerstate for {:?} is {}", addr, peerstate.prefer_encrypt
                     );
                     match peerstate.prefer_encrypt {
-                        EncryptPreference::NoPreference => {}
+                        EncryptPreference::NoPreference | EncryptPreference::Reset => {}
                         EncryptPreference::Mutual => prefer_encrypt_count += 1,
-                        EncryptPreference::Reset => {
-                            if !e2ee_guaranteed {
-                                return Ok(false);
-                            }
-                        }
                     };
                 }
                 None => {


### PR DESCRIPTION
This will still degrade 1:1 chats to no encryption, but will not cause the group to disable encryption simply because one user got into reset state.

Fixes #4941