### PR TITLE
test(deltachat-rpc-client): log all events as debug messages

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/rpc.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/rpc.py
@@ -132,7 +132,9 @@ class Rpc:
                 event = self.get_next_event()
                 account_id = event["contextId"]
                 queue = self.get_queue(account_id)
-                queue.put(event["event"])
+                event = event["event"]
+                logging.debug("account_id=%d got an event %s", account_id, event)
+                queue.put(event)
         except Exception:
             # Log an exception if the event loop dies.
             logging.exception("Exception in the event loop")

--- a/deltachat-rpc-client/tox.ini
+++ b/deltachat-rpc-client/tox.ini
@@ -30,4 +30,4 @@ commands =
 [pytest]
 timeout = 300
 log_cli = true
-log_level = info
+log_level = debug


### PR DESCRIPTION
This is necessary to debug the tests.