### PR TITLE
back to two verification-check functions

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3743,8 +3743,9 @@ int             dc_chat_can_send              (const dc_chat_t* chat);
  * if `verified_one_on_one_chats` setting is enabled.
  *
  * UI should display a green checkmark
- * in the chat title and
+ * in the chat title,
  * in the chatlist item
+ * and in the chat profile
  * if chat protection is enabled.
  *
  * @memberof dc_chat_t
@@ -5052,12 +5053,9 @@ int             dc_contact_is_blocked        (const dc_contact_t* contact);
  *
  * If contact is verified
  * UI should display green checkmark after the contact name
- * in contact list items and
- * in chat member list items.
- *
- * Do not use this function when displaying the contact profile view.
- * Display green checkmark in the title of the contact profile
- * if dc_contact_profile_is_verified() returns true.
+ * in contact list items,
+ * in chat member list items
+ * and in profiles if no chat with the contact exist (otherwise, use dc_chat_is_protected()).
  *
  * @memberof dc_contact_t
  * @param contact The contact object.
@@ -5065,24 +5063,6 @@ int             dc_contact_is_blocked        (const dc_contact_t* contact);
  *    2: SELF and contact have verified their fingerprints in both directions; in the UI typically checkmarks are shown.
  */
 int             dc_contact_is_verified       (dc_contact_t* contact);
-
-
-/**
- * Check if the contact profile title
- * should contain a green checkmark.
- * This indicates whether 1:1 chat with
- * this contact has a green checkmark
- * or will have if such chat is created.
- *
- * Use dc_contact_get_verified_id to display the verifier contact
- * in the info section of the contact profile.
- *
- * @memberof dc_contact_t
- * @param contact The contact object.
- * @return 1=contact profile has a green checkmark in the title,
- *   0=contact profile has no green checkmark in the title.
- */
-int             dc_contact_profile_is_verified (dc_contact_t* contact);
 
 
 /**

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -4120,21 +4120,6 @@ pub unsafe extern "C" fn dc_contact_is_verified(contact: *mut dc_contact_t) -> l
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_contact_profile_is_verified(contact: *mut dc_contact_t) -> libc::c_int {
-    if contact.is_null() {
-        eprintln!("ignoring careless call to dc_contact_profile_is_verified()");
-        return 0;
-    }
-    let ffi_contact = &*contact;
-    let ctx = &*ffi_contact.context;
-
-    block_on(ffi_contact.contact.is_profile_verified(ctx))
-        .context("is_profile_verified failed")
-        .log_err(ctx)
-        .unwrap_or_default() as libc::c_int
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn dc_contact_get_verifier_id(contact: *mut dc_contact_t) -> u32 {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_get_verifier_id()");

--- a/deltachat-jsonrpc/src/api/types/contact.rs
+++ b/deltachat-jsonrpc/src/api/types/contact.rs
@@ -24,15 +24,10 @@ pub struct ContactObject {
     ///
     /// If this is true
     /// UI should display green checkmark after the contact name
-    /// in contact list items and
-    /// in chat member list items.
+    /// in contact list items,
+    /// in chat member list items
+    /// and in profiles if no chat with the contact exist.
     is_verified: bool,
-
-    /// True if the contact profile title should have a green checkmark.
-    ///
-    /// This indicates whether 1:1 chat has a green checkmark
-    /// or will have a green checkmark if created.
-    is_profile_verified: bool,
 
     /// The ID of the contact that verified this contact.
     ///
@@ -57,7 +52,6 @@ impl ContactObject {
             None => None,
         };
         let is_verified = contact.is_verified(context).await? == VerifiedStatus::BidirectVerified;
-        let is_profile_verified = contact.is_profile_verified(context).await?;
 
         let verifier_id = contact
             .get_verifier_id(context)
@@ -76,7 +70,6 @@ impl ContactObject {
             name_and_addr: contact.get_name_n_addr(),
             is_blocked: contact.is_blocked(),
             is_verified,
-            is_profile_verified,
             verifier_id,
             last_seen: contact.last_seen(),
             was_seen_recently: contact.was_seen_recently(),

--- a/deltachat-jsonrpc/src/api/types/contact.rs
+++ b/deltachat-jsonrpc/src/api/types/contact.rs
@@ -29,6 +29,12 @@ pub struct ContactObject {
     /// and in profiles if no chat with the contact exist.
     is_verified: bool,
 
+    /// True if the contact profile title should have a green checkmark.
+    ///
+    /// This indicates whether 1:1 chat has a green checkmark
+    /// or will have a green checkmark if created.
+    is_profile_verified: bool,
+
     /// The ID of the contact that verified this contact.
     ///
     /// If this is present,
@@ -52,6 +58,7 @@ impl ContactObject {
             None => None,
         };
         let is_verified = contact.is_verified(context).await? == VerifiedStatus::BidirectVerified;
+        let is_profile_verified = contact.is_profile_verified(context).await?;
 
         let verifier_id = contact
             .get_verifier_id(context)
@@ -70,6 +77,7 @@ impl ContactObject {
             name_and_addr: contact.get_name_n_addr(),
             is_blocked: contact.is_blocked(),
             is_verified,
+            is_profile_verified,
             verifier_id,
             last_seen: contact.last_seen(),
             was_seen_recently: contact.was_seen_recently(),

--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -19,7 +19,6 @@ def test_qr_setup_contact(acfactory) -> None:
     alice_contact_bob = alice.get_contact_by_addr(bob.get_config("addr"))
     alice_contact_bob_snapshot = alice_contact_bob.get_snapshot()
     assert alice_contact_bob_snapshot.is_verified
-    assert alice_contact_bob_snapshot.is_profile_verified
 
     while True:
         event = bob.wait_for_event()
@@ -30,7 +29,6 @@ def test_qr_setup_contact(acfactory) -> None:
     bob_contact_alice = bob.get_contact_by_addr(alice.get_config("addr"))
     bob_contact_alice_snapshot = bob_contact_alice.get_snapshot()
     assert bob_contact_alice_snapshot.is_verified
-    assert bob_contact_alice_snapshot.is_profile_verified
 
 
 def test_qr_securejoin(acfactory):
@@ -51,7 +49,6 @@ def test_qr_securejoin(acfactory):
     alice_contact_bob = alice.get_contact_by_addr(bob.get_config("addr"))
     alice_contact_bob_snapshot = alice_contact_bob.get_snapshot()
     assert alice_contact_bob_snapshot.is_verified
-    assert alice_contact_bob_snapshot.is_profile_verified
 
     while True:
         event = bob.wait_for_event()
@@ -62,7 +59,6 @@ def test_qr_securejoin(acfactory):
     bob_contact_alice = bob.get_contact_by_addr(alice.get_config("addr"))
     bob_contact_alice_snapshot = bob_contact_alice.get_snapshot()
     assert bob_contact_alice_snapshot.is_verified
-    assert bob_contact_alice_snapshot.is_profile_verified
 
 
 @pytest.mark.xfail()

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1252,6 +1252,16 @@ impl ChatId {
 
         Ok(())
     }
+
+    /// Returns true if the chat is protected.
+    pub async fn is_protected(self, context: &Context) -> Result<ProtectionStatus> {
+        let protection_status = context
+            .sql
+            .query_get_value("SELECT protected FROM chats WHERE id=?", (self,))
+            .await?
+            .unwrap_or_default();
+        Ok(protection_status)
+    }
 }
 
 impl std::fmt::Display for ChatId {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1252,16 +1252,6 @@ impl ChatId {
 
         Ok(())
     }
-
-    /// Returns true if the chat is protected.
-    pub async fn is_protected(self, context: &Context) -> Result<ProtectionStatus> {
-        let protection_status = context
-            .sql
-            .query_get_value("SELECT protected FROM chats WHERE id=?", (self,))
-            .await?
-            .unwrap_or_default();
-        Ok(protection_status)
-    }
 }
 
 impl std::fmt::Display for ChatId {

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -19,7 +19,7 @@ use tokio::task;
 use tokio::time::{timeout, Duration};
 
 use crate::aheader::EncryptPreference;
-use crate::chat::{ChatId, ProtectionStatus};
+use crate::chat::ChatId;
 use crate::color::str_to_color;
 use crate::config::Config;
 use crate::constants::{Blocked, Chattype, DC_GCL_ADD_SELF, DC_GCL_VERIFIED_ONLY};
@@ -1261,9 +1261,8 @@ impl Contact {
     /// in contact list items and
     /// in chat member list items.
     ///
-    /// Do not use this function when displaying the contact profile view.
-    /// Display green checkmark in the title of the contact profile
-    /// if [Self::is_profile_verified] returns true.
+    /// In contact profile view, us this function only if there is no chat with the contact,
+    /// otherwise use is_chat_protected().
     /// Use [Self::get_verifier_id] to display the verifier contact
     /// in the info section of the contact profile.
     pub async fn is_verified(&self, context: &Context) -> Result<VerifiedStatus> {
@@ -1314,22 +1313,6 @@ impl Contact {
                 warn!(context, "Could not lookup contact with address {verifier_addr} which introduced {addr}.");
                 Ok(None)
             }
-        }
-    }
-
-    /// Returns if the contact profile title should display a green checkmark.
-    ///
-    /// This generally should be consistent with the 1:1 chat with the contact
-    /// so 1:1 chat with the contact and the contact profile
-    /// either both display the green checkmark or both don't display a green checkmark.
-    pub async fn is_profile_verified(&self, context: &Context) -> Result<bool> {
-        let contact_id = self.id;
-
-        if let Some(chat_id) = ChatId::lookup_by_contact(context, contact_id).await? {
-            Ok(chat_id.is_protected(context).await? == ProtectionStatus::Protected)
-        } else {
-            // 1:1 chat does not exist.
-            Ok(self.is_verified(context).await? == VerifiedStatus::BidirectVerified)
         }
     }
 


### PR DESCRIPTION
this pr keeps and refines documentation added in #4951, however, reverts the api introduced by #4951
which turns out to be not useful for UI in practise:

UI anyway check for chat/no-chat beforehand,
so a simple condition in profiles as
`green_checkmark = chat_exist ? chat_is_protected() : contact_is_verified()`  
is more useful in practise and is waht UI need and did already in the past. (https://github.com/deltachat/deltachat-android/pull/2836 shows a detailed discussion)

(as a side effect, beside saving code,
this PR saves up to three database calls
(get contact from chat in UI to pass it to profile_is_verified(), get chat from contact in core, load is_protected in core) - instead, core can use already is_protected from already loaded chat object)

/me did check rust-tests, fingers crossed for python tests
/me should re-setup python tests on local machine at some point :)