### PR TITLE
docs: add a draft of a proposed simplified acpeerstates table

### DIFF
--- a/draft/keymanagement.md
+++ b/draft/keymanagement.md
@@ -33,8 +33,6 @@ e.g. if multiple peers gossiped the same key for a contact they all are introduc
 
 `prefer_encrypted` is moved to the `contacts` table.
 
-Maybe fingerprint is the primary key, at least there should be an index.
-
 
 ## Using the table to select the keys
 


### PR DESCRIPTION
Good part is that we can always revert to using `acpeerstates`, there is no need to drop the old table immediately.

Keys gossiped in protected chats are also used in non-protected chats. All gossips are only used in chats with the introducers.