### PR TITLE
fix: encode chat name in the List-ID header

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -596,9 +596,10 @@ impl<'a> MimeFactory<'a> {
 
         if let Loaded::Message { chat } = &self.loaded {
             if chat.typ == Chattype::Broadcast {
+                let encoded_chat_name = encode_words(&chat.name);
                 headers.protected.push(Header::new(
                     "List-ID".into(),
-                    format!("{} <{}>", chat.name, chat.grpid),
+                    format!("{encoded_chat_name} <{}>", chat.grpid),
                 ));
             }
         }


### PR DESCRIPTION
List-ID header is added for broadcast lists.
UTF-8 in email headers is allowed only if
all recipient MTAs support SMTPUTF8 extension,
which is not always the case even if our submission service reports SMTPUTF8 support.

Fixes #4969