### PR TITLE
fix: replace square bracket errors with proper message errors

### DIFF
--- a/python/tests/test_0_complex_or_slow.py
+++ b/python/tests/test_0_complex_or_slow.py
@@ -641,7 +641,7 @@ def test_verified_group_vs_delete_server_after(acfactory, tmp_path, lp):
     ac2_offl.start_io()
     msg_in = ac2_offl._evtracker.wait_next_incoming_message()
     assert not msg_in.is_system_message()
-    assert msg_in.text.startswith("[The message was sent with non-verified encryption")
+    assert msg_in.error.startswith("The message was sent with non-verified encryption")
     ac2_offl_ac1_contact = msg_in.get_sender_contact()
     assert ac2_offl_ac1_contact.addr == ac1.get_config("addr")
     assert not ac2_offl_ac1_contact.is_verified()

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1364,12 +1364,9 @@ impl MimeMessage {
         self.get_mailinglist_header().is_some()
     }
 
-    pub fn replace_msg_by_error(&mut self, error_msg: &str) {
-        self.is_system_message = SystemMessage::Unknown;
-        if let Some(part) = self.parts.first_mut() {
-            part.typ = Viewtype::Text;
-            part.msg = format!("[{error_msg}]");
-            self.parts.truncate(1);
+    pub fn set_error_for_all_parts(&mut self, error_msg: &str) {
+        for part in &mut self.parts {
+            part.error = Some(error_msg.to_string());
         }
     }
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -643,7 +643,7 @@ async fn add_parts(
                         chat_id = None;
                     } else {
                         let s = stock_str::unknown_sender_for_chat(context).await;
-                        mime_parser.replace_msg_by_error(&s);
+                        mime_parser.set_error_for_all_parts(&s);
                     }
                 } else {
                     // In non-protected chats, just mark the sender as overridden. Therefore, the UI will prepend `~`
@@ -1076,8 +1076,7 @@ async fn add_parts(
                 has_verified_encryption(context, mime_parser, from_id, to_ids, chat.typ).await?
             {
                 warn!(context, "Verification problem: {err:#}.");
-                let s = format!("{err}. See 'Info' for more details");
-                mime_parser.replace_msg_by_error(&s);
+                mime_parser.set_error_for_all_parts(&err.to_string());
             }
         }
     }
@@ -1626,8 +1625,7 @@ async fn create_or_lookup_group(
             has_verified_encryption(context, mime_parser, from_id, to_ids, Chattype::Group).await?
         {
             warn!(context, "Verification problem: {err:#}.");
-            let s = format!("{err}. See 'Info' for more details");
-            mime_parser.replace_msg_by_error(&s);
+            mime_parser.set_error_for_all_parts(&err.to_string());
         }
         ProtectionStatus::Protected
     } else {
@@ -1788,8 +1786,7 @@ async fn apply_group_changes(
             has_verified_encryption(context, mime_parser, from_id, to_ids, chat.typ).await?
         {
             warn!(context, "Verification problem: {err:#}.");
-            let s = format!("{err}. See 'Info' for more details");
-            mime_parser.replace_msg_by_error(&s);
+            mime_parser.set_error_for_all_parts(&err.to_string());
         }
 
         if !chat.is_protected() {


### PR DESCRIPTION
Square bracket errors were introduced before we had proper errors, hide the images, reset system messages to non-system messages and may themselves be replaced with "better message" in receive_imf.