### PR TITLE
feat(imap): detect NOTIFY extension

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -296,6 +296,12 @@ pub enum Config {
     #[strum(props(default = "0"))]
     DisableIdle,
 
+    /// Whether to avoid using IMAP NOTIFY even if the server supports it.
+    ///
+    /// This is a developer option for testing prefetch without NOTIFY.
+    #[strum(props(default = "0"))]
+    DisableNotify,
+
     /// Defines the max. size (in bytes) of messages downloaded automatically.
     /// 0 = no limit.
     #[strum(props(default = "0"))]

--- a/src/context.rs
+++ b/src/context.rs
@@ -595,6 +595,7 @@ impl Context {
         let bcc_self = self.get_config_int(Config::BccSelf).await?;
         let sync_msgs = self.get_config_int(Config::SyncMsgs).await?;
         let disable_idle = self.get_config_bool(Config::DisableIdle).await?;
+        let disable_notify = self.get_config_bool(Config::DisableNotify).await?;
 
         let prv_key_cnt = self.sql.count("SELECT COUNT(*) FROM keypairs;", ()).await?;
 
@@ -708,6 +709,7 @@ impl Context {
         res.insert("bcc_self", bcc_self.to_string());
         res.insert("sync_msgs", sync_msgs.to_string());
         res.insert("disable_idle", disable_idle.to_string());
+        res.insert("disable_notify", disable_notify.to_string());
         res.insert("private_key_count", prv_key_cnt.to_string());
         res.insert("public_key_count", pub_key_cnt.to_string());
         res.insert("fingerprint", fingerprint_str);

--- a/src/imap/capabilities.rs
+++ b/src/imap/capabilities.rs
@@ -9,6 +9,10 @@ pub(crate) struct Capabilities {
     /// <https://tools.ietf.org/html/rfc2177>
     pub can_idle: bool,
 
+    /// True if the server has NOTIFY capability as defined in
+    /// <https://tools.ietf.org/html/rfc5465>
+    pub can_notify: bool,
+
     /// True if the server has MOVE capability as defined in
     /// <https://tools.ietf.org/html/rfc6851>
     pub can_move: bool,

--- a/src/imap/client.rs
+++ b/src/imap/client.rs
@@ -56,6 +56,7 @@ async fn determine_capabilities(
     };
     let capabilities = Capabilities {
         can_idle: caps.has_str("IDLE"),
+        can_notify: caps.has_str("NOTIFY"),
         can_move: caps.has_str("MOVE"),
         can_check_quota: caps.has_str("QUOTA"),
         can_condstore: caps.has_str("CONDSTORE"),

--- a/src/imap/session.rs
+++ b/src/imap/session.rs
@@ -19,6 +19,9 @@ pub(crate) struct Session {
     pub selected_mailbox: Option<Mailbox>,
 
     pub selected_folder_needs_expunge: bool,
+
+    /// True if NOTIFY SET command was executed in this session.
+    pub notify_set: bool,
 }
 
 impl Deref for Session {
@@ -46,11 +49,16 @@ impl Session {
             selected_folder: None,
             selected_mailbox: None,
             selected_folder_needs_expunge: false,
+            notify_set: false,
         }
     }
 
     pub fn can_idle(&self) -> bool {
         self.capabilities.can_idle
+    }
+
+    pub fn can_notify(&self) -> bool {
+        self.capabilities.can_notify
     }
 
     pub fn can_move(&self) -> bool {


### PR DESCRIPTION
Started something for #4983

Setting up NOTIFY is going to be part of `prefetch`, because we cannot use NOTIFY to `prefetch_existing_msgs`, we have to do proper prefetch once after setting up a connection and we have to fallback to prefetch if NOTIFY fails.