### PR TITLE
fix: add "setup changed" message for verified key before the message

### DIFF
--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -179,7 +179,7 @@ def test_verified_group_recovery(acfactory, rpc) -> None:
 
     ac1_chat_messages = snapshot.chat.get_messages()
     ac2_addr = ac2.get_config("addr")
-    assert ac1_chat_messages[-1].get_snapshot().text == f"Changed setup for {ac2_addr}"
+    assert ac1_chat_messages[-2].get_snapshot().text == f"Changed setup for {ac2_addr}"
 
 
 def test_verified_group_member_added_recovery(acfactory) -> None:

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -227,8 +227,7 @@ pub(crate) async fn receive_imf_inner(
         .and_then(|value| mailparse::dateparse(value).ok())
         .map_or(rcvd_timestamp, |value| min(value, rcvd_timestamp + 60));
 
-    let updated_verified_key_addr =
-        update_verified_keys(context, &mut mime_parser, from_id).await?;
+    update_verified_keys(context, &mut mime_parser, from_id).await?;
 
     // Add parts
     let received_msg = add_parts(
@@ -280,11 +279,6 @@ pub(crate) async fn receive_imf_inner(
     } else {
         MsgId::new_unset()
     };
-
-    if let Some(addr) = updated_verified_key_addr {
-        let msg = stock_str::contact_setup_changed(context, &addr).await;
-        chat::add_info_msg(context, chat_id, &msg, received_msg.sort_timestamp).await?;
-    }
 
     save_locations(context, &mime_parser, chat_id, from_id, insert_msg_id).await?;
 
@@ -2288,9 +2282,6 @@ enum VerifiedEncryption {
 /// Moves secondary verified key to primary verified key
 /// if the message is signed with a secondary verified key.
 /// Removes secondary verified key if the message is signed with primary key.
-///
-/// Returns address of the peerstate if the primary verified key was updated,
-/// the caller then needs to add "Setup changed" notification somewhere.
 async fn update_verified_keys(
     context: &Context,
     mimeparser: &mut MimeMessage,
@@ -2338,10 +2329,11 @@ async fn update_verified_keys(
         peerstate.verified_key = peerstate.secondary_verified_key.take();
         peerstate.verified_key_fingerprint = peerstate.secondary_verified_key_fingerprint.take();
         peerstate.verifier = peerstate.secondary_verifier.take();
+        peerstate.fingerprint_changed = true;
         peerstate.save_to_db(&context.sql).await?;
 
         // Primary verified key changed.
-        Ok(Some(peerstate.addr.clone()))
+        Ok(None)
     } else {
         Ok(None)
     }


### PR DESCRIPTION
Merge the code paths for verified and autocrypt key. If both are changed, only one will be added.

Existing code path adds a message to all chats with the contact rather than to 1:1 chat. If we later decide that
only 1:1 chat or only verified chats should be notified, we can add a separate `verified_fingerprint_changed` flag.

Fixes #4995