### PR TITLE
fix: ignore special chats when calculating similar chats

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -993,8 +993,9 @@ impl ChatId {
                    AND y.contact_id > 9
                    AND x.chat_id=?
                    AND y.chat_id<>x.chat_id
+                   AND y.chat_id>?
                  GROUP BY y.chat_id",
-                (self,),
+                (self, DC_CHAT_ID_LAST_SPECIAL),
                 |row| {
                     let chat_id: ChatId = row.get(0)?;
                     let intersection: f64 = row.get(1)?;


### PR DESCRIPTION
The second SQL statement calculating chat size
was already fixed in f656cb29be8ac23f854859c13e70109009441f63, but more important statement calculating member list intersection was overlooked.
As a result, trash chat with members added there due to former bugs could still appear in similar chats.

This is a re-fix for #4756, previous attempt was #4763