### PR TITLE
feat: do not post "... verified" messages on QR scan success

### DIFF
--- a/src/securejoin/bob.rs
+++ b/src/securejoin/bob.rs
@@ -222,9 +222,7 @@ impl BobState {
     /// This creates an info message in the chat being joined.
     async fn notify_peer_verified(&self, context: &Context) -> Result<()> {
         let contact = Contact::get_by_id(context, self.invite().contact_id()).await?;
-        let msg = stock_str::contact_verified(context, &contact).await;
         let chat_id = self.joining_chat_id(context).await?;
-        chat::add_info_msg(context, chat_id, &msg, time()).await?;
 
         if context
             .get_config_bool(Config::VerifiedOneOnOneChats)

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -824,6 +824,7 @@ pub(crate) async fn secure_join_group_qr_description(context: &Context, chat: &C
 }
 
 /// Stock string: `%1$s verified.`.
+#[allow(dead_code)]
 pub(crate) async fn contact_verified(context: &Context, contact: &Contact) -> String {
     let addr = &contact.get_name_n_addr();
     translated(context, StockMessage::ContactVerified)


### PR DESCRIPTION
We still post "... not verified" on failure.

Closes #4994 