### PR TITLE
fix: return connectivity html even when IO is stopped.

### DIFF
--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -2,7 +2,7 @@ use core::fmt;
 use std::cmp::min;
 use std::{iter::once, ops::Deref, sync::Arc};
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use humansize::{format_size, BINARY};
 use tokio::sync::Mutex;
 
@@ -299,6 +299,10 @@ impl Context {
                     .yellow {
                         background-color: #fdc625;
                     }
+                    .not-started-error {
+                        font-size: 2em;
+                        color: red;
+                    }
                 </style>
             </head>
             <body>"#
@@ -318,7 +322,8 @@ impl Context {
                 sched.smtp.state.connectivity.clone(),
             ),
             _ => {
-                return Err(anyhow!("Not started"));
+                ret += "<div class=\"not-started-error\">Error: IO Not Started</div><p>Please report this issue to the app developer.</p>\n</body></html>\n";
+                return Ok(ret);
             }
         };
         drop(lock);


### PR DESCRIPTION
The returned error is unexpected and no UI, that I tested with stoped IO, really handled it, besides maybe displaying a toast.
(desktop and iOS do not handle the error, deltatouch shows a toast, all tested UIs show an empty/blank space where the connectivity view should be)

This should not be shown to the user normally, it is only shown to the user, if the UI has a bug, so that bug should be clearly visible.

Now wit this pr looks like this (screenshot from desktop):
<img width="360" alt="Bildschirmfoto 2023-11-15 um 06 05 57" src="https://github.com/deltachat/deltachat-core-rust/assets/18725968/3fed8223-727b-4c02-9fc1-38bb0a5cd646">

CC @lk108