### PR TITLE
feat: Sync chats deletion across devices

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -641,6 +641,15 @@ impl TestContext {
         Chat::load_from_db(self, chat_id).await.unwrap()
     }
 
+    pub async fn assert_no_chat(&self, id: ChatId) {
+        assert!(Chat::load_from_db(self, id).await.is_err());
+        assert!(!self
+            .sql
+            .exists("SELECT COUNT(*) FROM chats WHERE id=?", (id,))
+            .await
+            .unwrap());
+    }
+
     /// Sends out the text message.
     ///
     /// This is not hooked up to any SMTP-IMAP pipeline, so the other account must call


### PR DESCRIPTION
**feat: Sync chats deletion across devices**
    
Motivation: Now broadcast lists creation is synced across devices. Groups creation, in some means, too -- on a group promotion by a first message. So, to make this looking more feature-complete, sync chats deletion too.
    
An approach is to replay a user action on synchronised devices because the chat deletion is a complex procedure affecting several tables, self-chat, emitting the corresponding event etc.
    
Also this commit makes all deletions to happen in a transaction, to be on a safe side.