### PR TITLE
fix: do not use square brackets error for unknown sender

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -636,14 +636,9 @@ async fn add_parts(
         if let Some(group_chat_id) = chat_id {
             if !chat::is_contact_in_chat(context, group_chat_id, from_id).await? {
                 let chat = Chat::load_from_db(context, group_chat_id).await?;
-                if chat.is_protected() {
-                    if chat.typ == Chattype::Single {
-                        // Just assign the message to the 1:1 chat with the actual sender instead.
-                        chat_id = None;
-                    } else {
-                        let s = stock_str::unknown_sender_for_chat(context).await;
-                        mime_parser.replace_msg_by_error(&s);
-                    }
+                if chat.is_protected() && chat.typ == Chattype::Single {
+                    // Just assign the message to the 1:1 chat with the actual sender instead.
+                    chat_id = None;
                 } else {
                     // In non-protected chats, just mark the sender as overridden. Therefore, the UI will prepend `~`
                     // to the sender's name, indicating to the user that he/she is not part of the group.
@@ -651,6 +646,12 @@ async fn add_parts(
                     let name: &str = from.display_name.as_ref().unwrap_or(&from.addr);
                     for part in &mut mime_parser.parts {
                         part.param.set(Param::OverrideSenderDisplayname, name);
+
+                        if chat.is_protected() {
+                            // In protected chat, also mark the message with an error.
+                            let s = stock_str::unknown_sender_for_chat(context).await;
+                            part.error = Some(s);
+                        }
                     }
                 }
             }

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -149,7 +149,7 @@ pub enum StockMessage {
                     however, of course, if they like, you may point them to 👉 https://get.delta.chat"))]
     WelcomeMessage = 71,
 
-    #[strum(props(fallback = "Unknown sender for this chat. See 'info' for more details."))]
+    #[strum(props(fallback = "Unknown sender for this chat."))]
     UnknownSenderForChat = 72,
 
     #[strum(props(fallback = "Message from %1$s"))]
@@ -930,7 +930,7 @@ pub(crate) async fn welcome_message(context: &Context) -> String {
     translated(context, StockMessage::WelcomeMessage).await
 }
 
-/// Stock string: `Unknown sender for this chat. See 'info' for more details.`.
+/// Stock string: `Unknown sender for this chat.`.
 pub(crate) async fn unknown_sender_for_chat(context: &Context) -> String {
     translated(context, StockMessage::UnknownSenderForChat).await
 }


### PR DESCRIPTION
If the sender of the message in protected group chat is not a member of the chat, mark the sender name with `~` as we do it in non-protected chats and set the error instead of replacing the whole message with
"Unknown sender for this chat. See 'info' for more details."

To send a message to a protected group this way
the sender needs to know the group ID
and sign the message with the current verified key. Usually this is just a late message
delivered shortly after the user has left
the group or was removed from it.

Replacing the message with a single error text part as done before this change makes it impossible
to access anything other than text, such as attached images.

Here is an example of what we are trying to get rid of here:
![1](https://github.com/deltachat/deltachat-core-rust/assets/18373967/34db67ae-b656-47ba-ac90-640ead013867)
