### PR TITLE
fix: recognize Chat-Group-Member-Added of self case-insensitively

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -14,7 +14,7 @@ use crate::chat::{self, Chat, ChatId, ChatIdBlocked, ProtectionStatus};
 use crate::config::Config;
 use crate::constants::{Blocked, Chattype, ShowEmails, DC_CHAT_ID_TRASH};
 use crate::contact::{
-    may_be_valid_addr, normalize_name, Contact, ContactAddress, ContactId, Origin,
+    addr_cmp, may_be_valid_addr, normalize_name, Contact, ContactAddress, ContactId, Origin,
 };
 use crate::context::Context;
 use crate::debug_logging::maybe_set_logging_xdc_inner;
@@ -1756,7 +1756,7 @@ async fn apply_group_changes(
     // True if a Delta Chat client has explicitly added our current primary address.
     let self_added =
         if let Some(added_addr) = mime_parser.get_header(HeaderDef::ChatGroupMemberAdded) {
-            context.get_primary_self_addr().await? == *added_addr
+            addr_cmp(&context.get_primary_self_addr().await?, added_addr)
         } else {
             false
         };


### PR DESCRIPTION
If configured address is `Bob@example.net`,
but the message arrives adding `bob@example.net`,
Bob's device should still recognize it as addition of self and fully recreate the group.

This fixes the scenario described in
https://support.delta.chat/t/removed-members-and-re-join-via-qr-code/2768/5?u=link2xt