### PR TITLE
feat: Sync user actions for ad-hoc groups across devices (#5065)

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1842,6 +1842,24 @@ pub(crate) async fn rfc724_mid_exists_and(
     Ok(res)
 }
 
+/// Given a list of Message-IDs, returns the latest message found in the database.
+///
+/// Only messages that are not in the trash chat are considered.
+pub(crate) async fn get_latest_by_rfc724_mids(
+    context: &Context,
+    mids: &[String],
+) -> Result<Option<Message>> {
+    for id in mids.iter().rev() {
+        if let Some(msg_id) = rfc724_mid_exists(context, id).await? {
+            let msg = Message::load_from_db(context, msg_id).await?;
+            if msg.chat_id != DC_CHAT_ID_TRASH {
+                return Ok(Some(msg));
+            }
+        }
+    }
+    Ok(None)
+}
+
 /// How a message is primarily displayed.
 #[derive(
     Debug,


### PR DESCRIPTION
Ad-hoc groups don't have grpid-s that can be used to identify them across devices and thus wasn't synced until now.

The same problem already exists for assigning messages to ad-hoc groups and this assignment is done by `get_parent_message()` and `lookup_chat_by_reply()`. Let's reuse this logic for the synchronisation, it works well enough and this way we have less surprises than if we try to implement grpids for ad-hoc groups. I.e. add an `Msgids` variant to `chat::SyncId` analogous to the "References" header in messages and put two following Message-IDs to a sync message:
- The latest message A having `DownloadState::Done` and the state to be one of `InFresh, InNoticed, InSeen, OutDelivered, OutMdnRcvd`.
- The message that A references in `In-Reply-To`.

This way the logic is almost the same to what we have in `Chat::prepare_msg_raw()` (the difference is that we don't use the oldest Message-ID) and it's easier to reuse the existing code.

NOTE: If a chat has only an OutPending message f.e., the synchronisation wouldn't work, but trying to work in such a corner case has no significant value and isn't worth complicating the code.

Close #5065 