### PR TITLE
feat: increase TCP timeouts from 30 to 60 seconds

### DIFF
--- a/src/imap/client.rs
+++ b/src/imap/client.rs
@@ -17,8 +17,8 @@ use crate::net::tls::wrap_tls;
 use crate::socks::Socks5Config;
 use fast_socks5::client::Socks5Stream;
 
-/// IMAP write and read timeout.
-pub(crate) const IMAP_TIMEOUT: Duration = Duration::from_secs(30);
+/// IMAP connection, write and read timeout.
+pub(crate) const IMAP_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Debug)]
 pub(crate) struct Client {

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -27,8 +27,8 @@ use crate::scheduler::connectivity::ConnectivityStore;
 use crate::socks::Socks5Config;
 use crate::sql;
 
-/// SMTP write and read timeout.
-const SMTP_TIMEOUT: Duration = Duration::from_secs(30);
+/// SMTP connection, write and read timeout.
+const SMTP_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Default)]
 pub(crate) struct Smtp {


### PR DESCRIPTION
GitHub Action tests sometimes fail with TCP connection timeouts, especially for macOS.