### PR TITLE
fix: do not mark recipients as verified if there is no Chat-Verified header

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2454,6 +2454,10 @@ async fn mark_recipients_as_verified(
         return Ok(());
     }
 
+    if mimeparser.get_header(HeaderDef::ChatVerified).is_none() {
+        return Ok(());
+    }
+
     let rows = context
         .sql
         .query_map(


### PR DESCRIPTION
Fixes #5079 