### PR TITLE
refactor: clean up the logs and reduce noise

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -772,7 +772,7 @@ impl Contact {
 
                 sth_modified = Modifier::Created;
                 row_id = u32::try_from(transaction.last_insert_rowid())?;
-                info!(context, "added contact id={} addr={}", row_id, &addr);
+                info!(context, "Added contact id={row_id} addr={addr}.");
             }
             Ok(row_id)
         }).await?;

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -23,32 +23,14 @@ use crate::pgp;
 ///
 /// If the message is wrongly signed, HashSet will be empty.
 pub fn try_decrypt(
-    context: &Context,
     mail: &ParsedMail<'_>,
     private_keyring: &[SignedSecretKey],
     public_keyring_for_validate: &[SignedPublicKey],
 ) -> Result<Option<(Vec<u8>, HashSet<Fingerprint>)>> {
-    let encrypted_data_part = match {
-        let mime = get_autocrypt_mime(mail);
-        if mime.is_some() {
-            info!(context, "Detected Autocrypt-mime message.");
-        }
-        mime
-    }
-    .or_else(|| {
-        let mime = get_mixed_up_mime(mail);
-        if mime.is_some() {
-            info!(context, "Detected mixed-up mime message.");
-        }
-        mime
-    })
-    .or_else(|| {
-        let mime = get_attachment_mime(mail);
-        if mime.is_some() {
-            info!(context, "Detected attached Autocrypt-mime message.");
-        }
-        mime
-    }) {
+    let encrypted_data_part = match get_autocrypt_mime(mail)
+        .or_else(|| get_mixed_up_mime(mail))
+        .or_else(|| get_attachment_mime(mail))
+    {
         None => return Ok(None),
         Some(res) => res,
     };

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -62,21 +62,19 @@ impl EncryptHelper {
         for (peerstate, addr) in peerstates {
             match peerstate {
                 Some(peerstate) => {
-                    info!(
-                        context,
-                        "peerstate for {:?} is {}", addr, peerstate.prefer_encrypt
-                    );
+                    let prefer_encrypt = peerstate.prefer_encrypt;
+                    info!(context, "Peerstate for {addr:?} is {prefer_encrypt}.");
                     match peerstate.prefer_encrypt {
                         EncryptPreference::NoPreference | EncryptPreference::Reset => {}
                         EncryptPreference::Mutual => prefer_encrypt_count += 1,
                     };
                 }
                 None => {
-                    let msg = format!("peerstate for {addr:?} missing, cannot encrypt");
+                    let msg = format!("Peerstate for {addr:?} missing, cannot encrypt");
                     if e2ee_guaranteed {
-                        return Err(format_err!("{}", msg));
+                        return Err(format_err!("{msg}"));
                     } else {
-                        info!(context, "{}", msg);
+                        info!(context, "{msg}.");
                         return Ok(false);
                     }
                 }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -988,8 +988,7 @@ impl<'a> MimeFactory<'a> {
                     {
                         info!(
                             context,
-                            "sending secure-join message \'{}\' >>>>>>>>>>>>>>>>>>>>>>>>>",
-                            "vg-member-added",
+                            "Sending secure-join message {:?}.", "vg-member-added",
                         );
                         headers.protected.push(Header::new(
                             "Secure-Join".to_string(),
@@ -1071,10 +1070,7 @@ impl<'a> MimeFactory<'a> {
                 let msg = &self.msg;
                 let step = msg.param.get(Param::Arg).unwrap_or_default();
                 if !step.is_empty() {
-                    info!(
-                        context,
-                        "sending secure-join message \'{}\' >>>>>>>>>>>>>>>>>>>>>>>>>", step,
-                    );
+                    info!(context, "Sending secure-join message {step:?}.");
                     headers
                         .protected
                         .push(Header::new("Secure-Join".into(), step.into()));

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -278,7 +278,7 @@ impl MimeMessage {
 
         let public_keyring = keyring_from_peerstate(decryption_info.peerstate.as_ref());
         let (mail, mut signatures, encrypted) = match tokio::task::block_in_place(|| {
-            try_decrypt(context, &mail, &private_keyring, &public_keyring)
+            try_decrypt(&mail, &private_keyring, &public_keyring)
         }) {
             Ok(Some((raw, signatures))) => {
                 mail_raw = raw;

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -287,10 +287,7 @@ pub(crate) async fn handle_securejoin_handshake(
         .get_header(HeaderDef::SecureJoin)
         .context("Not a Secure-Join message")?;
 
-    info!(
-        context,
-        ">>>>>>>>>>>>>>>>>>>>>>>>> secure-join message \'{}\' received", step,
-    );
+    info!(context, "Received secure-join message {step:?}.");
 
     let join_vg = step.starts_with("vg-");
 
@@ -316,7 +313,6 @@ pub(crate) async fn handle_securejoin_handshake(
                 warn!(context, "Secure-join denied (bad invitenumber).");
                 return Ok(HandshakeMessage::Ignore);
             }
-            info!(context, "Secure-join requested.",);
 
             inviter_progress(context, contact_id, 300);
 
@@ -554,7 +550,7 @@ pub(crate) async fn observe_securejoin_on_other_device(
     let step = mime_message
         .get_header(HeaderDef::SecureJoin)
         .context("Not a Secure-Join message")?;
-    info!(context, "observing secure-join message \'{}\'", step);
+    info!(context, "Observing secure-join message {step:?}.");
 
     match step.as_str() {
         "vg-request-with-auth"

--- a/src/securejoin/bobstate.rs
+++ b/src/securejoin/bobstate.rs
@@ -291,7 +291,7 @@ impl BobState {
     ) -> Result<Option<BobHandshakeStage>> {
         info!(
             context,
-            "Bob Step 4 - handling vc-auth-require/vg-auth-required message"
+            "Bob Step 4 - handling {{vc,vg}}-auth-required message."
         );
         if !encrypted_and_signed(context, mime_message, Some(self.invite.fingerprint())) {
             let reason = if mime_message.was_encrypted() {
@@ -333,7 +333,7 @@ impl BobState {
     ) -> Result<Option<BobHandshakeStage>> {
         info!(
             context,
-            "Bob Step 7 - handling vc-contact-confirm/vg-member-added message"
+            "Bob Step 7 - handling vc-contact-confirm/vg-member-added message."
         );
         mark_peer_as_verified(
             context,


### PR DESCRIPTION
- Remove "Detected Autocrypt-mime message" logs printed for every incoming Autocrypt message.
- Print only a single line at the beginning of receive_imf with both the Message-ID and seen flag.
- Print Securejoin step only once, inside handle_securejoin_handshake or observe_securejoin_on_other_device.
- Do not log "Not creating ad-hoc group" every time ad-hoc group is not created, log when it is created instead.
- Log ID of the chat where Autocrypt-Gossip for all members is received.
- Do not print "Secure-join requested." for {vg,vc}-request, we already log the step.
- Remove ">>>>>>>>>>>>>>>>>>>>>>>>>" noise from securejoin logs.