### PR TITLE
fix: do not check `lock_task` on iOS before syncing

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -424,11 +424,13 @@ impl Config {
     /// Takes a mutable reference because the saved file is a part of the `Config` state. This
     /// protects from parallel calls resulting to a wrong file contents.
     async fn sync(&mut self) -> Result<()> {
+        #[cfg(not(target_os = "ios"))]
         ensure!(!self
             .lock_task
             .as_ref()
             .context("Config is read-only")?
             .is_finished());
+
         let tmp_path = self.file.with_extension("toml.tmp");
         let mut file = fs::File::create(&tmp_path)
             .await


### PR DESCRIPTION
`lock_task` is anyways always `None` on iOS
to avoid lock files held open and cause 0xdead10cc crashes.

not sure if that is a "good rust way" for handling things, however, it works - feel free to improve or change and take over this PR if neeed

successor of https://github.com/deltachat/deltachat-core-rust/pull/5081 and https://github.com/deltachat/deltachat-core-rust/pull/4314

closes #5083 