### PR TITLE
fix(connectivity): return false from all_work_done() immediately after connecting

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -590,7 +590,7 @@ async fn fetch_idle(ctx: &Context, connection: &mut Imap, folder_meaning: Folder
         .log_err(ctx)
         .ok();
 
-    connection.connectivity.set_connected(ctx).await;
+    connection.connectivity.set_idle(ctx).await;
 
     ctx.emit_event(EventType::ImapInboxIdle);
     let Some(session) = connection.session.take() else {
@@ -727,7 +727,7 @@ async fn smtp_loop(
             // Fake Idle
             info!(ctx, "smtp fake idle - started");
             match &connection.last_send_error {
-                None => connection.connectivity.set_connected(&ctx).await,
+                None => connection.connectivity.set_idle(&ctx).await,
                 Some(err) => connection.connectivity.set_err(&ctx, err).await,
             }
 


### PR DESCRIPTION
    We do not want all_work_done() to return true immediately
    after calling start_io(), but only when connection goes idle.
    
    "Connected" state is set immediately after connecting to the server,
    but it does not mean there is nothing to do.
    
    This change make all_work_done() return false
    from the Connected state and introduces a new Idle
    connectivity state that is only set before connection
    actually goes idle. For idle state all_work_done() returns true.
    
    From the user point of view both old Connected state
    and new Idle state look the same.

This has a regression test and was tested on iOS.

Was probably broken since https://github.com/deltachat/deltachat-core-rust/pull/4804