### PR TITLE
fix: Securejoin: Mark 1:1s as protected regardless of the Config::VerifiedOneOnOneChats

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2454,21 +2454,19 @@ async fn mark_recipients_as_verified(
                         peerstate.set_verified(PeerstateKeyType::GossipKey, fp, verifier_addr)?;
                         peerstate.save_to_db(&context.sql).await?;
 
-                        if !is_verified {
-                            let (to_contact_id, _) = Contact::add_or_lookup(
-                                context,
-                                "",
-                                &ContactAddress::new(&to_addr)?,
-                                Origin::Hidden,
-                            )
-                            .await?;
-                            ChatId::set_protection_for_contact(
-                                context,
-                                to_contact_id,
-                                mimeparser.timestamp_sent,
-                            )
-                            .await?;
-                        }
+                        let (to_contact_id, _) = Contact::add_or_lookup(
+                            context,
+                            "",
+                            &ContactAddress::new(&to_addr)?,
+                            Origin::Hidden,
+                        )
+                        .await?;
+                        ChatId::set_protection_for_contact(
+                            context,
+                            to_contact_id,
+                            mimeparser.timestamp_sent,
+                        )
+                        .await?;
                     }
                 } else {
                     // The contact already has a verified key.

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -689,22 +689,17 @@ async fn secure_connection_established(
     chat_id: ChatId,
     timestamp: i64,
 ) -> Result<()> {
-    if context
-        .get_config_bool(Config::VerifiedOneOnOneChats)
+    let private_chat_id = ChatIdBlocked::get_for_contact(context, contact_id, Blocked::Yes)
         .await?
-    {
-        let private_chat_id = ChatIdBlocked::get_for_contact(context, contact_id, Blocked::Yes)
-            .await?
-            .id;
-        private_chat_id
-            .set_protection(
-                context,
-                ProtectionStatus::Protected,
-                timestamp,
-                Some(contact_id),
-            )
-            .await?;
-    }
+        .id;
+    private_chat_id
+        .set_protection(
+            context,
+            ProtectionStatus::Protected,
+            timestamp,
+            Some(contact_id),
+        )
+        .await?;
     context.emit_event(EventType::ChatModified(chat_id));
     Ok(())
 }

--- a/src/securejoin/bob.rs
+++ b/src/securejoin/bob.rs
@@ -9,7 +9,6 @@ use super::bobstate::{BobHandshakeStage, BobState};
 use super::qrinvite::QrInvite;
 use super::HandshakeMessage;
 use crate::chat::{is_contact_in_chat, ChatId, ProtectionStatus};
-use crate::config::Config;
 use crate::constants::{Blocked, Chattype};
 use crate::contact::Contact;
 use crate::context::Context;
@@ -225,21 +224,14 @@ impl BobState {
     async fn notify_peer_verified(&self, context: &Context, timestamp: i64) -> Result<()> {
         let contact = Contact::get_by_id(context, self.invite().contact_id()).await?;
         let chat_id = self.joining_chat_id(context).await?;
-
-        if context
-            .get_config_bool(Config::VerifiedOneOnOneChats)
-            .await?
-        {
-            self.alice_chat()
-                .set_protection(
-                    context,
-                    ProtectionStatus::Protected,
-                    timestamp,
-                    Some(contact.id),
-                )
-                .await?;
-        }
-
+        self.alice_chat()
+            .set_protection(
+                context,
+                ProtectionStatus::Protected,
+                timestamp,
+                Some(contact.id),
+            )
+            .await?;
         context.emit_event(EventType::ChatModified(chat_id));
         Ok(())
     }


### PR DESCRIPTION
As per the comment in `receive_imf.rs`, `chat.protected` must be maintained regardless of the
`Config::VerifiedOneOnOneChats`. The only thing that mustn't be done if `VerifiedOneOnOneChats` is
unset (i.e. for non-supporting UIs) is marking chats as "protection broken" because this needs
showing the corresponding dialog to a user.