### PR TITLE
fix: Properly escape `target` in receive_imf_inner()

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -458,14 +458,18 @@ pub(crate) async fn receive_imf_inner(
         };
         if target.is_some() || rfc724_mid_orig != rfc724_mid {
             let target_subst = match &target {
-                Some(target) => format!("target='{target}',"),
-                None => "".to_string(),
+                Some(_) => "target=?1,",
+                None => "",
             };
             context
                 .sql
                 .execute(
-                    &format!("UPDATE imap SET {target_subst} rfc724_mid=?1 WHERE rfc724_mid=?2"),
-                    (rfc724_mid_orig, rfc724_mid),
+                    &format!("UPDATE imap SET {target_subst} rfc724_mid=?2 WHERE rfc724_mid=?3"),
+                    (
+                        target.as_deref().unwrap_or_default(),
+                        rfc724_mid_orig,
+                        rfc724_mid,
+                    ),
                 )
                 .await?;
         }


### PR DESCRIPTION
The bug was made in 44227d7b866f4aa173c63ffc989f38b44774e40d. Sql::execute() with placeholders must be used to escape strings, one never should escape them manually as strings themselves can contain escape symbols. Thanks to @link2xt for noticing.