### PR TITLE
fix forwarding messages from encrypted to unencrypted chat without creating a new message object

### DIFF
--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -605,7 +605,7 @@ class ACFactory:
         chat = ac1.create_group_chat("Protected Group", verified=True)
         qr = chat.get_join_qr()
         ac2.qr_join_chat(qr)
-        setupplugin.member_added.wait(timeout=30)
+        setupplugin.member_added.wait()
         msg = ac2.wait_next_incoming_message()
         assert msg.text == "Messages are guaranteed to be end-to-end encrypted from now on."
         msg = ac2.wait_next_incoming_message()

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -606,8 +606,10 @@ class ACFactory:
         qr = chat.get_join_qr()
         ac2.qr_join_chat(qr)
         setupplugin.member_added.wait(timeout=30)
-        ac2.wait_next_incoming_message()
-        ac2.wait_next_incoming_message()
+        msg = ac2.wait_next_incoming_message()
+        assert msg.text == "Messages are guaranteed to be end-to-end encrypted from now on."
+        msg = ac2.wait_next_incoming_message()
+        assert "Member Me " in msg.text and " added by " in msg.text
         return chat
 
     def introduce_each_other(self, accounts, sending=True):

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -10,6 +10,7 @@ import time
 import weakref
 import random
 from queue import Queue
+from threading import Event
 from typing import Callable, Dict, List, Optional, Set
 
 import pytest
@@ -589,6 +590,25 @@ class ACFactory:
     def get_accepted_chat(self, ac1: Account, ac2: Account):
         ac2.create_chat(ac1)
         return ac1.create_chat(ac2)
+
+    def get_protected_chat(self, ac1: Account, ac2: Account):
+        class SetupPlugin:
+            def __init__(self) -> None:
+                self.member_added = Event()
+
+            @account_hookimpl
+            def ac_member_added(self, chat: deltachat.Chat, contact, actor, message):
+                self.member_added.set()
+
+        setupplugin = SetupPlugin()
+        ac1.add_account_plugin(setupplugin)
+        chat = ac1.create_group_chat("Protected Group", verified=True)
+        qr = chat.get_join_qr()
+        ac2.qr_join_chat(qr)
+        setupplugin.member_added.wait(timeout=30)
+        ac2.wait_next_incoming_message()
+        ac2.wait_next_incoming_message()
+        return chat
 
     def introduce_each_other(self, accounts, sending=True):
         to_wait = []

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -498,6 +498,30 @@ def test_forward_messages(acfactory, lp):
     assert not chat3.get_messages()
 
 
+def test_forward_encrypted_to_unencrypted(acfactory, lp):
+    ac1, ac2, ac3 = acfactory.get_online_accounts(3)
+    chat = acfactory.get_accepted_chat(ac1, ac2)
+
+    lp.sec("ac1: send unencrypted message to ac2")
+    txt = "This is still unencrypted"
+    chat.send_text(txt)
+    msg = ac2.wait_next_incoming_message()
+    assert msg.text == txt
+    assert not msg.is_encrypted()
+
+    lp.sec("ac2: send encrypted message to ac1")
+    txt = "This should be encrypted now"
+    msg.chat.send_text(txt)
+    msg2 = ac1.wait_next_incoming_message()
+    assert msg2.is_encrypted()
+
+    lp.sec("ac1: forward message to ac3 unencrypted ")
+    unencrypted_chat = ac1.create_chat(ac3)
+    msg3 = unencrypted_chat.send_msg(msg)
+    assert not msg3.is_encrypted()
+    assert msg2.is_encrypted()
+
+
 def test_forward_own_message(acfactory, lp):
     ac1, ac2 = acfactory.get_online_accounts(2)
     chat = acfactory.get_accepted_chat(ac1, ac2)

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -500,26 +500,20 @@ def test_forward_messages(acfactory, lp):
 
 def test_forward_encrypted_to_unencrypted(acfactory, lp):
     ac1, ac2, ac3 = acfactory.get_online_accounts(3)
-    chat = acfactory.get_accepted_chat(ac1, ac2)
+    chat = acfactory.get_protected_chat(ac1, ac2)
 
-    lp.sec("ac1: send unencrypted message to ac2")
-    txt = "This is still unencrypted"
+    lp.sec("ac1: send encrypted message to ac2")
+    txt = "This should be encrypted"
     chat.send_text(txt)
     msg = ac2.wait_next_incoming_message()
     assert msg.text == txt
-    assert not msg.is_encrypted()
+    assert msg.is_encrypted()
 
-    lp.sec("ac2: send encrypted message to ac1")
-    txt = "This should be encrypted now"
-    msg.chat.send_text(txt)
-    msg2 = ac1.wait_next_incoming_message()
-    assert msg2.is_encrypted()
-
-    lp.sec("ac1: forward message to ac3 unencrypted ")
-    unencrypted_chat = ac1.create_chat(ac3)
-    msg3 = unencrypted_chat.send_msg(msg)
-    assert not msg3.is_encrypted()
-    assert msg2.is_encrypted()
+    lp.sec("ac2: forward message to ac3 unencrypted ")
+    unencrypted_chat = ac2.create_chat(ac3)
+    msg2 = unencrypted_chat.send_msg(msg)
+    assert not msg2.is_encrypted()
+    assert msg.is_encrypted()
 
 
 def test_forward_own_message(acfactory, lp):

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -509,7 +509,7 @@ def test_forward_encrypted_to_unencrypted(acfactory, lp):
     assert msg.text == txt
     assert msg.is_encrypted()
 
-    lp.sec("ac2: forward message to ac3 unencrypted ")
+    lp.sec("ac2: forward message to ac3 unencrypted")
     unencrypted_chat = ac2.create_chat(ac3)
     msg_id = msg.id
     msg2 = unencrypted_chat.send_msg(msg)

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -511,9 +511,11 @@ def test_forward_encrypted_to_unencrypted(acfactory, lp):
 
     lp.sec("ac2: forward message to ac3 unencrypted ")
     unencrypted_chat = ac2.create_chat(ac3)
+    msg_id = msg.id
     msg2 = unencrypted_chat.send_msg(msg)
-    assert not msg2.is_encrypted()
-    assert msg.is_encrypted()
+    assert msg2 == msg
+    assert msg.id != msg_id
+    assert not msg.is_encrypted()
 
 
 def test_forward_own_message(acfactory, lp):

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2657,6 +2657,11 @@ pub async fn send_msg(context: &Context, chat_id: ChatId, msg: &mut Message) -> 
         return send_msg_inner(context, chat_id, msg).await;
     }
 
+    if msg.state != MessageState::Undefined && msg.state != MessageState::OutPreparing {
+        msg.param.remove(Param::GuaranteeE2ee);
+        msg.param.remove(Param::ForcePlaintext);
+        msg.update_param(context).await?;
+    }
     send_msg_inner(context, chat_id, msg).await
 }
 


### PR DESCRIPTION
fixes #5123 

~~the test passes actually, I think it's not the same problem the teams-bot has.~~ seems the test fails for the right reasons now :)