### PR TITLE
fix: Split SMTP jobs already in `chat::create_send_msg_jobs()` (#5115)

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -209,6 +209,11 @@ pub const WORSE_IMAGE_SIZE: u32 = 640;
 // this value can be increased if the folder configuration is changed and must be redone on next program start
 pub(crate) const DC_FOLDERS_CONFIGURED_VERSION: i32 = 4;
 
+// If more recipients are needed in SMTP's `RCPT TO:` header, the recipient list is split into
+// chunks. This does not affect MIME's `To:` header. Can be overwritten by setting
+// `max_smtp_rcpt_to` in the provider db.
+pub(crate) const DEFAULT_MAX_SMTP_RCPT_TO: usize = 50;
+
 #[cfg(test)]
 mod tests {
     use num_traits::FromPrimitive;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1665,7 +1665,10 @@ pub(crate) async fn update_msg_state(
 ) -> Result<()> {
     context
         .sql
-        .execute("UPDATE msgs SET state=? WHERE id=?;", (state, msg_id))
+        .execute(
+            "UPDATE msgs SET state=?1 WHERE id=?2 AND (?1!=?3 OR state<?3)",
+            (state, msg_id, MessageState::OutDelivered),
+        )
         .await?;
     Ok(())
 }


### PR DESCRIPTION
a27e84ad8909a03fb1fb49fec719fadee06d692f "fix: Delete received outgoing messages from SMTP queue" can break sending messages sent as several SMTP messages because they have a lot of recipients: `pub(crate) const DEFAULT_MAX_SMTP_RCPT_TO: usize = 50;`

We should not cancel sending if it is such a message and we received BCC-self because it does not mean the other part was sent successfully. For this, split such messages into separate jobs in the `smtp` table so that only a job containing BCC-self is canceled from `receive_imf_inner()`. Although this doesn't solve the initial problem with timed-out SMTP requests for such messages completely, this enables fine-grained SMTP retries so we don't need to resend all SMTP messages if only some of them failed to be sent.

Close #5115 