### PR TITLE
ci: downgrade `chai` from 4.4.0 to 4.3.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@types/debug": "^4.1.7",
     "@types/node": "^20.8.10",
-    "chai": "^4.2.0",
+    "chai": "~4.3.10",
     "chai-as-promised": "^7.1.1",
     "esm": "^3.2.25",
     "mocha": "^8.2.1",


### PR DESCRIPTION
4.4.0 fails with a syntax error in CI currently.

Fixes #5153