### PR TITLE
fix: Reset message error when scheduling resending (#5119)

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1663,7 +1663,8 @@ pub(crate) async fn update_msg_state(
     msg_id: MsgId,
     state: MessageState,
 ) -> Result<()> {
-    let error_subst = match state >= MessageState::OutDelivered {
+    ensure!(state != MessageState::OutFailed, "use set_msg_failed()!");
+    let error_subst = match state >= MessageState::OutPending {
         true => ", error=''",
         false => "",
     };

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -689,6 +689,9 @@ async fn test_resend_after_ndn() -> Result<()> {
         )
         .await;
     chat::resend_msgs(&t, &[msg_id]).await?;
+    let msg = Message::load_from_db(&t, msg_id).await?;
+    assert_eq!(msg.state, MessageState::OutPending);
+    assert_eq!(msg.error(), None);
     // Alice receives a BCC-self copy of their message.
     receive_imf(
         &t,


### PR DESCRIPTION
@link2xt
> Maybe error state should be reset immediately when "resend" is clicked and not when message is delivered? That would simplyify the code/test even.

I don't see how it can simplify the code, it only adds a couple of additional checks to the test, but overall the suggestion is very reasonable.

Fix #5119 