### PR TITLE
feat: Encrypt MDNs #5168

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1849,14 +1849,14 @@ mod tests {
         // When not encrypted, the MDN should not be encrypted either
         assert!(!rendered_msg.is_encrypted);
 
-        alice.set_config_bool(Config::VerifiedOneOnOneChats, true)
+        alice
+            .set_config_bool(Config::VerifiedOneOnOneChats, true)
             .await
             .unwrap();
 
         bob.set_config_bool(Config::VerifiedOneOnOneChats, true)
             .await
             .unwrap();
-        
 
         mark_as_verified(&alice, &bob).await;
         mark_as_verified(&bob, &alice).await;

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1570,7 +1570,7 @@ mod tests {
     use crate::contact::{ContactAddress, Origin};
     use crate::mimeparser::MimeMessage;
     use crate::receive_imf::receive_imf;
-    use crate::test_utils::{get_chat_msg, mark_as_verified, TestContext, TestContextManager};
+    use crate::test_utils::{get_chat_msg, TestContext, TestContextManager};
 
     #[test]
     fn test_render_email_address() {
@@ -1835,31 +1835,16 @@ mod tests {
         bob.set_config_bool(Config::MdnsEnabled, true).await?;
 
         let mut msg = Message::new(Viewtype::Text);
-        msg.force_plaintext();
         msg.param.set_int(Param::SkipAutocrypt, 1);
         let chat_alice = alice.create_chat(&bob).await.id;
         let sent = alice.send_msg(chat_alice, &mut msg).await;
 
         let rcvd = bob.recv_msg(&sent).await;
         message::markseen_msgs(&bob, vec![rcvd.id]).await?;
-
         let mimefactory = MimeFactory::from_mdn(&bob, &rcvd, vec![]).await?;
         let rendered_msg = mimefactory.render(&bob).await?;
 
-        // When not encrypted, the MDN should not be encrypted either
         assert!(!rendered_msg.is_encrypted);
-
-        alice
-            .set_config_bool(Config::VerifiedOneOnOneChats, true)
-            .await
-            .unwrap();
-
-        bob.set_config_bool(Config::VerifiedOneOnOneChats, true)
-            .await
-            .unwrap();
-
-        mark_as_verified(&alice, &bob).await;
-        mark_as_verified(&bob, &alice).await;
 
         let rcvd = tcm.send_recv(&alice, &bob, "Heyho").await;
         message::markseen_msgs(&bob, vec![rcvd.id]).await?;


### PR DESCRIPTION
This PR stops MDNs from being forced to be sent unencrypted. 
If no encryption is possible (by `should_encrypt`), the fix #5152 still applies.

close #5168  