### PR TITLE
docs: restore "Constants" page in Doxygen >=1.9.8

### DIFF
--- a/deltachat-ffi/DoxygenLayout.xml
+++ b/deltachat-ffi/DoxygenLayout.xml
@@ -9,7 +9,7 @@
       <tab type="hierarchy" visible="no" title="" intro=""/>
       <tab type="classmembers" visible="no" title="" intro=""/>
     </tab>
-    <tab type="modules" visible="yes" title="Constants" intro="Here is a list of constants:"/>
+    <tab type="topics" visible="yes" title="Constants" intro="Here is a list of constants:"/>
     <tab type="pages" visible="yes" title="" intro=""/>
     <tab type="namespaces" visible="yes" title="">
       <tab type="namespacelist" visible="yes" title="" intro=""/>


### PR DESCRIPTION
deltachat.h uses `@defgroup` commands to create topics for groups of constants. Prior to Doxygen 1.9.8
defining a group created a "module"
and all constants were visible from the modules.html page. In Doxygen 1.9.8 "modules" were renamed into "topics" as C++20 modules have taken their place,
so Delta Chat documentation does not have modules
in Doxygen sense anymore.

The change is to replace "modules.html" with "topics.html" in the DoxygenLayout.xml.

See <https://www.doxygen.nl/manual/grouping.html> for Doxygen documentation about groups and their relation to topics.

Closes #5173 