### PR TITLE
feat: Protect From name for verified chats and To names for encrypted chats (#5166)

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -302,7 +302,7 @@ impl MimeMessage {
         // them in signed-only emails, but has no value currently.
         Self::remove_secured_headers(&mut headers);
 
-        let from = from.context("No from in message")?;
+        let mut from = from.context("No from in message")?;
         let private_keyring = load_self_secret_keyring(context).await?;
 
         let mut decryption_info =
@@ -398,6 +398,7 @@ impl MimeMessage {
             if let (Some(inner_from), true) = (inner_from, !signatures.is_empty()) {
                 if addr_cmp(&inner_from.addr, &from.addr) {
                     from_is_signed = true;
+                    from = inner_from;
                 } else {
                     // There is a From: header in the encrypted &
                     // signed part, but it doesn't match the outer one.


### PR DESCRIPTION
    If a display name should be protected (i.e. opportunistically encrypted), only put the corresponding
    address to the unprotected headers. We protect the From display name only for verified chats,
    otherwise this would be incompatible with Thunderbird and K-9 who don't use display names from the
    encrypted part. Still, we always protect To display names as compatibility seems less critical here.
    
    When receiving a messge, overwrite the From display name but not the whole From field as that would
    allow From forgery. For the To field we don't really care. Anyway as soon as we receive a message
    from the user, the display name will be corrected.

close #5166