### PR TITLE
fix(node): run tests with native ESM modules instead of `esm`

### DIFF
--- a/node/lib/deltachat.ts
+++ b/node/lib/deltachat.ts
@@ -178,7 +178,7 @@ export class AccountManager extends EventEmitter {
   static newTemporary() {
     let directory = null
     while (true) {
-      const randomString = Math.random().toString(36).substr(2, 5)
+      const randomString = Math.random().toString(36).substring(2, 5)
       directory = join(tmpdir(), 'deltachat-' + randomString)
       if (!existsSync(directory)) break
     }

--- a/node/test/test.mjs
+++ b/node/test/test.mjs
@@ -8,12 +8,9 @@ import { EventId2EventName, C } from '../dist/constants.js'
 import { join } from 'path'
 import { statSync } from 'fs'
 import { Context } from '../dist/context.js'
-import { log } from 'console'
+import {fileURLToPath} from 'url';
 
-import * as url from 'url';
-const __filename = url.fileURLToPath(import.meta.url);
-const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
-
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 chai.use(chaiAsPromised)
 chai.config.truncateThreshold = 0 // Do not truncate assertion errors.
@@ -45,7 +42,6 @@ describe('static tests', function () {
   })
 
   it('static method maybeValidAddr()', function () {
-    log(DeltaChat)
     expect(DeltaChat.maybeValidAddr(null)).to.equal(false)
     expect(DeltaChat.maybeValidAddr('')).to.equal(false)
     expect(DeltaChat.maybeValidAddr('uuu')).to.equal(false)

--- a/node/test/test.mjs
+++ b/node/test/test.mjs
@@ -1,13 +1,20 @@
 // @ts-check
-import DeltaChat from '../dist'
+import { DeltaChat } from '../dist/index.js'
 
 import { deepStrictEqual, strictEqual } from 'assert'
 import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
-import { EventId2EventName, C } from '../dist/constants'
+import { EventId2EventName, C } from '../dist/constants.js'
 import { join } from 'path'
 import { statSync } from 'fs'
-import { Context } from '../dist/context'
+import { Context } from '../dist/context.js'
+import { log } from 'console'
+
+import * as url from 'url';
+const __filename = url.fileURLToPath(import.meta.url);
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+
+
 chai.use(chaiAsPromised)
 chai.config.truncateThreshold = 0 // Do not truncate assertion errors.
 
@@ -38,6 +45,7 @@ describe('static tests', function () {
   })
 
   it('static method maybeValidAddr()', function () {
+    log(DeltaChat)
     expect(DeltaChat.maybeValidAddr(null)).to.equal(false)
     expect(DeltaChat.maybeValidAddr('')).to.equal(false)
     expect(DeltaChat.maybeValidAddr('uuu')).to.equal(false)

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "@types/node": "^20.8.10",
     "chai": "~4.3.10",
     "chai-as-promised": "^7.1.1",
-    "esm": "^3.2.25",
     "mocha": "^8.2.1",
     "node-gyp": "^10.0.0",
     "prebuildify": "^5.0.1",
@@ -53,7 +52,7 @@
     "prebuildify": "cd node && prebuildify -t 18.0.0 --napi --strip --postinstall \"node scripts/postinstall.js --prebuild\"",
     "test": "npm run test:lint && npm run test:mocha",
     "test:lint": "npm run lint",
-    "test:mocha": "mocha -r esm node/test/test.js --growl --reporter=spec --bail --exit"
+    "test:mocha": "mocha node/test/test.mjs --growl --reporter=spec --bail --exit"
   },
   "types": "node/dist/index.d.ts",
   "version": "1.133.0"


### PR DESCRIPTION
close #5156