### PR TITLE
fix: downgrade OpenSSL from 3.2.0 to 3.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,6 +1127,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "once_cell",
+ "openssl-src",
  "parking_lot",
  "percent-encoding",
  "pgp",
@@ -3189,9 +3190,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.1+3.2.0"
+version = "300.1.6+3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
+checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,14 @@ toml = "0.8"
 url = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
 
+# Pin OpenSSL to 3.1 releases.
+# OpenSSL 3.2 has a regression tracked at <https://github.com/openssl/openssl/issues/23376>
+# which results in broken `deltachat-rpc-server` binaries when cross-compiled using Zig toolchain.
+# See <https://github.com/deltachat/deltachat-core-rust/issues/5206> for Delta Chat issue.
+# According to <https://www.openssl.org/policies/releasestrat.html>
+# 3.1 branch will be supported until 2025-03-14.
+openssl-src = "~300.1"
+
 [dev-dependencies]
 ansi_term = "0.12.0"
 anyhow = { version = "1", features = ["backtrace"] } # Enable `backtrace` feature in tests.


### PR DESCRIPTION
Closes #5206