### PR TITLE
fix: Treat only "Auto-Submitted: auto-generated" messages as bot-sent (#5213)

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -757,7 +757,7 @@ impl Message {
         self.param.get_int(Param::GuaranteeE2ee).unwrap_or_default() != 0
     }
 
-    /// Returns true if message is Auto-Submitted.
+    /// Returns true if message is auto-generated.
     pub fn is_bot(&self) -> bool {
         self.param.get_bool(Param::Bot).unwrap_or_default()
     }

--- a/src/param.rs
+++ b/src/param.rs
@@ -65,7 +65,7 @@ pub enum Param {
     /// For Messages: the message is a reaction.
     Reaction = b'x',
 
-    /// For Messages: a message with Auto-Submitted header ("bot").
+    /// For Messages: a message with "Auto-Submitted: auto-generated" header ("bot").
     Bot = b'b',
 
     /// For Messages: unset or 0=not forwarded,

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -539,7 +539,9 @@ pub(crate) async fn receive_imf_inner(
         .handle_reports(context, from_id, &mime_parser.parts)
         .await;
 
-    from_id.mark_bot(context, mime_parser.is_bot).await?;
+    if let Some(is_bot) = mime_parser.is_bot {
+        from_id.mark_bot(context, is_bot).await?;
+    }
 
     Ok(Some(received_msg))
 }

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -2684,6 +2684,36 @@ async fn test_read_receipts_dont_create_chats() -> Result<()> {
     Ok(())
 }
 
+/// Test that read receipts don't unmark contacts as bots.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_read_receipts_dont_unmark_bots() -> Result<()> {
+    let alice = &TestContext::new_alice().await;
+    let bob = &TestContext::new_bob().await;
+    let ab_contact = alice.add_or_lookup_contact(bob).await;
+    ab_contact.id.mark_bot(alice, true).await?;
+    let alice_chat = alice.create_chat(bob).await;
+
+    // Alice sends and Bob receives a message.
+    bob.recv_msg(&alice.send_text(alice_chat.id, "Message").await)
+        .await;
+    let received_msg = bob.get_last_msg().await;
+
+    // Bob sends a read receipt.
+    let mdn_mimefactory =
+        crate::mimefactory::MimeFactory::from_mdn(bob, &received_msg, vec![]).await?;
+    let rendered_mdn = mdn_mimefactory.render(bob).await?;
+    let mdn_body = rendered_mdn.message;
+
+    // Alice receives the read receipt.
+    receive_imf(alice, mdn_body.as_bytes(), false).await?;
+    let msg = alice.get_last_msg_in(alice_chat.id).await;
+    assert_eq!(msg.state, MessageState::OutMdnRcvd);
+    let ab_contact = alice.add_or_lookup_contact(bob).await;
+    assert!(ab_contact.is_bot());
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_gmx_forwarded_msg() -> Result<()> {
     let t = TestContext::new_alice().await;


### PR DESCRIPTION
See commit messages.

Fix #5213 