### PR TITLE
fix: Guarantee immediate message deletion if delete_server_after == 0 (#5201)

### DIFF
--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -590,7 +590,11 @@ pub(crate) async fn delete_expired_imap_messages(context: &Context) -> Result<()
         match context.get_config_delete_server_after().await? {
             None => (0, 0),
             Some(delete_server_after) => (
-                now - delete_server_after,
+                match delete_server_after {
+                    // Guarantee immediate deletion.
+                    0 => i64::MAX,
+                    _ => now - delete_server_after,
+                },
                 now - max(delete_server_after, MIN_DELETE_SERVER_AFTER),
             ),
         };


### PR DESCRIPTION
This should fix most of the failures of `test_verified_group_vs_delete_server_after()`. But sometimes it fails in a different way, maybe we have some race in IMAP handling (see https://github.com/deltachat/deltachat-core-rust/issues/5201#issuecomment-1915239566), so let's leave the issue open for now.

EDIT: Looks like this should be tested in the Rust test `test_delete_expired_imap_messages()`.