### PR TITLE
do not change db schema in an incompatible way

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -294,11 +294,17 @@ pub async fn store_self_keypair(
                 KeyPairUse::ReadOnly => false,
             };
 
+            // `addr` and `is_default` written for compatibility with older versions,
+            // until new cores are rolled out everywhere.
+            // otherwise "add second device" or "backup" may break.
+            // moreover, this allows downgrades to the previous version.
+            // writing of `addr` and `is_default` can be removed ~ 2024-08
+            let addr = keypair.addr.to_string();
             transaction
                 .execute(
-                    "INSERT OR REPLACE INTO keypairs (public_key, private_key)
-                     VALUES (?,?)",
-                    (&public_key, &secret_key),
+                    "INSERT OR REPLACE INTO keypairs (public_key, private_key, addr, is_default)
+                     VALUES (?,?,?,?)",
+                    (&public_key, &secret_key, addr, &is_default),
                 )
                 .context("Failed to insert keypair")?;
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -304,7 +304,7 @@ pub async fn store_self_keypair(
                 .execute(
                     "INSERT OR REPLACE INTO keypairs (public_key, private_key, addr, is_default)
                      VALUES (?,?,?,?)",
-                    (&public_key, &secret_key, addr, &is_default),
+                    (&public_key, &secret_key, addr, is_default),
                 )
                 .context("Failed to insert keypair")?;
 

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -811,9 +811,12 @@ CREATE INDEX msgs_status_updates_index2 ON msgs_status_updates (uid);
             "CREATE TABLE new_keypairs (
                id INTEGER PRIMARY KEY AUTOINCREMENT,
                private_key UNIQUE NOT NULL,
-               public_key UNIQUE NOT NULL
+               public_key UNIQUE NOT NULL,
+               addr TEXT DEFAULT '' COLLATE NOCASE,
+               is_default INTEGER DEFAULT 0,
+               created INTEGER DEFAULT 0
              );
-             INSERT OR IGNORE INTO new_keypairs SELECT id, private_key, public_key FROM keypairs;
+             INSERT OR IGNORE INTO new_keypairs SELECT id, private_key, public_key, addr, is_default, created FROM keypairs;
 
              INSERT OR IGNORE
              INTO config (keyname, value)
@@ -824,11 +827,7 @@ CREATE INDEX msgs_status_updates_index2 ON msgs_status_updates (uid);
                             WHERE addr=(SELECT value FROM config WHERE keyname='configured_addr')
                             AND is_default=1)));
 
-             -- We do not drop the old `keypairs` table for now,
-             -- but move it to `old_keypairs`. We can remove it later
-             -- in next migrations. This may be needed for recovery
-             -- in case something is wrong with the migration.
-             ALTER TABLE keypairs RENAME TO old_keypairs;
+             DROP TABLE keypairs;
              ALTER TABLE new_keypairs RENAME TO keypairs;
              ",
             107,


### PR DESCRIPTION
PR #5099 removed some columns in the database that were actually in use.

usually, to not worsen UX unnecessarily
(releases take time - in between, "Add Second Device", "Backup" etc. would fail), we try to avoid such schema changes (checking for db-version would avoid import etc. but would still worse UX),
see discussion at #2294.

these are the errors, the user will be confronted with otherwise:

<img width=400 src=https://github.com/deltachat/deltachat-core-rust/assets/9800740/e3f0fd6e-a7a9-43f6-9023-0ae003985425>

it is not great to maintain the old columns, but well :)

as no official releases with newer cores are rolled out yet, i think, it is fine to change the "107" migration
and not copy things a second time in a newer migration.

(this issue happens to me during testing, and is probably also the issue reported by @lk108 for ubuntu-touch)