### PR TITLE
fix: Create new Peerstate for unencrypted message with already known Autocrypt key, but a new address

### DIFF
--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -811,30 +811,6 @@ enum PeerstateChange {
     Aeap(String),
 }
 
-/// Removes duplicate peerstates from `acpeerstates` database table.
-///
-/// Normally there should be no more than one peerstate per address.
-/// However, the database does not enforce this condition.
-///
-/// Previously there were bugs that caused creation of additional
-/// peerstates when existing peerstate could not be read due to a
-/// temporary database error or a failure to parse stored data.  This
-/// procedure fixes the problem by removing duplicate records.
-pub(crate) async fn deduplicate_peerstates(sql: &Sql) -> Result<()> {
-    sql.execute(
-        "DELETE FROM acpeerstates
-         WHERE id NOT IN (
-         SELECT MIN(id)
-         FROM acpeerstates
-         GROUP BY addr
-         )",
-        (),
-    )
-    .await?;
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -18,7 +18,7 @@ use crate::imex::BLOBS_BACKUP_NAME;
 use crate::log::LogExt;
 use crate::message::{Message, MsgId, Viewtype};
 use crate::param::{Param, Params};
-use crate::peerstate::{deduplicate_peerstates, Peerstate};
+use crate::peerstate::Peerstate;
 use crate::stock_str;
 use crate::tools::{delete_file, time, SystemTime};
 
@@ -728,10 +728,6 @@ pub async fn housekeeping(context: &Context) -> Result<()> {
             context,
             "Housekeeping: Cannot prune message tombstones: {:#}.", err
         );
-    }
-
-    if let Err(err) = deduplicate_peerstates(&context.sql).await {
-        warn!(context, "Failed to deduplicate peerstates: {:#}.", err)
     }
 
     // Try to clear the freelist to free some space on the disk. This

--- a/src/tests/aeap.rs
+++ b/src/tests/aeap.rs
@@ -177,7 +177,7 @@ async fn check_aeap_transition(
 
     // Already add the new contact to one of the groups.
     // We can then later check that the contact isn't in the group twice.
-    let already_new_contact = Contact::create(&bob, "Alice", "fiona@example.net")
+    let already_new_contact = Contact::create(&bob, "Alice", ALICE_NEW_ADDR)
         .await
         .unwrap();
     if verified {
@@ -282,7 +282,10 @@ async fn check_that_transition_worked(
             new_contact,
             ContactId::SELF
         );
-        assert!(members.contains(&new_contact));
+        assert!(
+            members.contains(&new_contact),
+            "Group {group} lacks {new_contact}"
+        );
         assert!(members.contains(&ContactId::SELF));
 
         let info_msg = get_last_info_msg(bob, *group).await.unwrap();


### PR DESCRIPTION
See commit messages.

This is aimed to solve the @adbenitez's problem with sharing the same key by several accounts.