### PR TITLE
feat: Send Chat-Group-Avatar as inline base64 (#5253)

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -265,8 +265,10 @@ impl MimeMessage {
                 for field in &part.headers {
                     let key = field.get_key().to_lowercase();
 
-                    // For now only Chat-User-Avatar can be hidden.
-                    if !headers.contains_key(&key) && key == "chat-user-avatar" {
+                    // For now only avatar headers can be hidden.
+                    if !headers.contains_key(&key)
+                        && (key == "chat-user-avatar" || key == "chat-group-avatar")
+                    {
                         headers.insert(key.to_string(), field.get_value());
                     }
                 }


### PR DESCRIPTION
Before group avatar was sent as an attachment. Let's do the same as with user avatar and send group avatar as base64. Receiver code uses the same functions for user and chat avatars, so base64 avatars are supported for most receivers already.

Close #5253 