### PR TITLE
feat: dc_accounts_set_push_device_token API

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -686,6 +686,24 @@ int             dc_get_connectivity          (dc_context_t* context);
 char*           dc_get_connectivity_html     (dc_context_t* context);
 
 
+#define DC_PUSH_NOT_CONNECTED 0
+#define DC_PUSH_HEARTBEAT     1
+#define DC_PUSH_CONNECTED     2
+
+/**
+ * Get the current push notification state.
+ * One of:
+ * - DC_PUSH_NOT_CONNECTED
+ * - DC_PUSH_HEARTBEAT
+ * - DC_PUSH_CONNECTED
+ *
+ * @memberof dc_context_t
+ * @param context The context object.
+ * @return Push notification state.
+ */
+int              dc_get_push_state           (dc_context_t* context);
+
+
 /**
  * Standalone version of dc_accounts_all_work_done().
  * Only used by the python tests.
@@ -3164,6 +3182,16 @@ void           dc_accounts_maybe_network_lost    (dc_accounts_t* accounts);
  * @return Return 1 if DC_EVENT_ACCOUNTS_BACKGROUND_FETCH_DONE was emitted and 0 otherwise.
  */
 int            dc_accounts_background_fetch    (dc_accounts_t* accounts, uint64_t timeout);
+
+
+/**
+ * Sets device token for Apple Push Notification service.
+ * Returns immediately.
+ *
+ * @memberof dc_accounts_t
+ * @param token Hexadecimal device token
+ */
+void           dc_accounts_set_push_device_token (dc_accounts_t* accounts, const char *token);
 
 /**
  * Create the event emitter that is used to receive events.

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -384,7 +384,7 @@ pub unsafe extern "C" fn dc_get_connectivity(context: *const dc_context_t) -> li
         return 0;
     }
     let ctx = &*context;
-    block_on(async move { ctx.get_connectivity().await as u32 as libc::c_int })
+    block_on(ctx.get_connectivity()) as u32 as libc::c_int
 }
 
 #[no_mangle]
@@ -405,6 +405,16 @@ pub unsafe extern "C" fn dc_get_connectivity_html(
             }
         }
     })
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dc_get_push_state(context: *const dc_context_t) -> libc::c_int {
+    if context.is_null() {
+        eprintln!("ignoring careless call to dc_get_push_state()");
+        return 0;
+    }
+    let ctx = &*context;
+    block_on(ctx.push_state()) as libc::c_int
 }
 
 #[no_mangle]
@@ -4917,6 +4927,29 @@ pub unsafe extern "C" fn dc_accounts_background_fetch(
             .await;
     });
     1
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn dc_accounts_set_push_device_token(
+    accounts: *mut dc_accounts_t,
+    token: *const libc::c_char,
+) {
+    if accounts.is_null() {
+        eprintln!("ignoring careless call to dc_accounts_set_push_device_token()");
+        return;
+    }
+
+    let accounts = &*accounts;
+    let token = to_string_lossy(token);
+
+    block_on(async move {
+        let mut accounts = accounts.write().await;
+        if let Err(err) = accounts.set_push_device_token(&token).await {
+            accounts.emit_event(EventType::Error(format!(
+                "Failed to set notify token: {err:#}."
+            )));
+        }
+    })
 }
 
 #[no_mangle]

--- a/src/imap/capabilities.rs
+++ b/src/imap/capabilities.rs
@@ -25,6 +25,13 @@ pub(crate) struct Capabilities {
     /// <https://tools.ietf.org/html/rfc5464>
     pub can_metadata: bool,
 
+    /// True if the server supports XDELTAPUSH capability.
+    /// This capability means setting /private/devicetoken IMAP METADATA
+    /// on the INBOX results in new mail notifications
+    /// via notifications.delta.chat service.
+    /// This is supported by <https://github.com/deltachat/chatmail>
+    pub can_push: bool,
+
     /// Server ID if the server supports ID capability.
     pub server_id: Option<HashMap<String, String>>,
 }

--- a/src/imap/client.rs
+++ b/src/imap/client.rs
@@ -60,6 +60,7 @@ async fn determine_capabilities(
         can_check_quota: caps.has_str("QUOTA"),
         can_condstore: caps.has_str("CONDSTORE"),
         can_metadata: caps.has_str("METADATA"),
+        can_push: caps.has_str("XDELTAPUSH"),
         server_id,
     };
     Ok(capabilities)

--- a/src/imap/session.rs
+++ b/src/imap/session.rs
@@ -90,6 +90,10 @@ impl Session {
         self.capabilities.can_metadata
     }
 
+    pub fn can_push(&self) -> bool {
+        self.capabilities.can_push
+    }
+
     /// Returns the names of all folders on the IMAP server.
     pub async fn list_folders(&mut self) -> Result<Vec<async_imap::types::Name>> {
         let list = self.list(Some(""), Some("*")).await?.try_collect().await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ mod color;
 pub mod html;
 pub mod net;
 pub mod plaintext;
+mod push;
 pub mod summary;
 
 mod debug_logging;

--- a/src/push.rs
+++ b/src/push.rs
@@ -1,0 +1,115 @@
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use anyhow::Result;
+use tokio::sync::RwLock;
+
+use crate::context::Context;
+use crate::net::http;
+
+/// Manages subscription to Apple Push Notification services.
+///
+/// This structure is created by account manager and is shared between accounts.
+/// To enable notifications, application should request the device token as described in
+/// <https://developer.apple.com/documentation/usernotifications/registering-your-app-with-apns>
+/// and give it to the account manager, which will forward the token in this structure.
+///
+/// Each account (context) can then retrieve device token
+/// from this structure and give it to the email server.
+/// If email server does not support push notifications,
+/// account can call `subscribe` method
+/// to register device token with the heartbeat
+/// notification provider server as a fallback.
+#[derive(Debug, Clone, Default)]
+pub struct PushSubscriber {
+    inner: Arc<RwLock<PushSubscriberState>>,
+}
+
+impl PushSubscriber {
+    /// Creates new push notification subscriber.
+    pub(crate) fn new() -> Self {
+        Default::default()
+    }
+
+    /// Sets device token for Apple Push Notification service.
+    pub(crate) async fn set_device_token(&mut self, token: &str) {
+        self.inner.write().await.device_token = Some(token.to_string());
+    }
+
+    /// Retrieves device token.
+    ///
+    /// Token may be not available if application is not running on Apple platform,
+    /// failed to register for remote notifications or is in the process of registering.
+    ///
+    /// IMAP loop should periodically check if device token is available
+    /// and send the token to the email server if it supports push notifications.
+    pub(crate) async fn device_token(&self) -> Option<String> {
+        self.inner.read().await.device_token.clone()
+    }
+
+    /// Subscribes for heartbeat notifications with previously set device token.
+    pub(crate) async fn subscribe(&self) -> Result<()> {
+        let mut state = self.inner.write().await;
+
+        if state.heartbeat_subscribed {
+            return Ok(());
+        }
+
+        let Some(ref token) = state.device_token else {
+            return Ok(());
+        };
+
+        let socks5_config = None;
+        let response = http::get_client(socks5_config)?
+            .post("https://notifications.delta.chat/register")
+            .body(format!("{{\"token\":\"{token}\"}}"))
+            .send()
+            .await?;
+
+        let response_status = response.status();
+        if response_status.is_success() {
+            state.heartbeat_subscribed = true;
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn heartbeat_subscribed(&self) -> bool {
+        self.inner.read().await.heartbeat_subscribed
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct PushSubscriberState {
+    /// Device token.
+    device_token: Option<String>,
+
+    /// If subscribed to heartbeat push notifications.
+    heartbeat_subscribed: bool,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, FromPrimitive, ToPrimitive)]
+#[repr(i8)]
+pub enum NotifyState {
+    /// Not subscribed to push notifications.
+    #[default]
+    NotConnected = 0,
+
+    /// Subscribed to heartbeat push notifications.
+    Heartbeat = 1,
+
+    /// Subscribed to push notifications for new messages.
+    Connected = 2,
+}
+
+impl Context {
+    /// Returns push notification subscriber state.
+    pub async fn push_state(&self) -> NotifyState {
+        if self.push_subscribed.load(Ordering::Relaxed) {
+            NotifyState::Connected
+        } else if self.push_subscriber.heartbeat_subscribed().await {
+            NotifyState::Heartbeat
+        } else {
+            NotifyState::NotConnected
+        }
+    }
+}

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -525,6 +525,10 @@ async fn inbox_fetch_idle(ctx: &Context, imap: &mut Imap, mut session: Session) 
         .fetch_metadata(ctx)
         .await
         .context("Failed to fetch metadata")?;
+    session
+        .register_token(ctx)
+        .await
+        .context("Failed to register push token")?;
 
     let session = fetch_idle(ctx, imap, session, FolderMeaning::Inbox).await?;
     Ok(session)


### PR DESCRIPTION
# Based on PR #5315

PR adds two new APIs:
- `dc_accounts_set_push_device_token(accounts, token)` to provide device token from the application to the core. This can be called as soon as the token becomes available, possibly even after starting I/O. Core will make sure to register the token with the email server (currently not possible, chatmail server does not have notification implementation) or, if it is not possible, register with the heartbeat server.
- `dc_get_push_state(context)` to get the status of the push server registration. iOS currently needs this, later we may deprecate this and integrate into connectivity view.

Currently missing:
- [x] Register with the heartbeat server asynchronously so `dc_accounts_set_push_device_token()` returns immediately.
- [x] Register with the heartbeat server only once IMAP client connects to the server and determines that the server does not support push. This should currently happen every time, but prevent heartbeat registration when there are no configured accounts with working IMAP.
- [x] Store encrypted device ID on mail server via SETMETADATA if the server supports it. Corresponding chatmail PR: https://github.com/deltachat/chatmail/pull/201
- [x] Add `DC_PUSH_CONNECTED` state