### PR TITLE
build: unpin OpenSSL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1128,7 +1128,6 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "once_cell",
- "openssl-src",
  "parking_lot",
  "percent-encoding",
  "pgp",
@@ -3216,9 +3215,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.63"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
@@ -3248,18 +3247,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.1.6+3.1.4"
+version = "300.2.3+3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
+checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.99"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,14 +100,6 @@ toml = "0.8"
 url = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
 
-# Pin OpenSSL to 3.1 releases.
-# OpenSSL 3.2 has a regression tracked at <https://github.com/openssl/openssl/issues/23376>
-# which results in broken `deltachat-rpc-server` binaries when cross-compiled using Zig toolchain.
-# See <https://github.com/deltachat/deltachat-core-rust/issues/5206> for Delta Chat issue.
-# According to <https://www.openssl.org/policies/releasestrat.html>
-# 3.1 branch will be supported until 2025-03-14.
-openssl-src = "~300.1"
-
 [dev-dependencies]
 ansi_term = "0.12.0"
 anyhow = { version = "1", features = ["backtrace"] } # Enable `backtrace` feature in tests.


### PR DESCRIPTION
`deltachat-rpc-server` releases are built
with Nix and LLVM/clang toolchains now
that fully support atomics.
Zig toolchain that required disabling atomics
and resulted in problems with OpenSSL 3.2 releases is not used anymore.