### PR TITLE
some fixes to make push-token ffi compile on mac

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3189,7 +3189,7 @@ int            dc_accounts_background_fetch    (dc_accounts_t* accounts, uint64_
  * @memberof dc_accounts_t
  * @param token Hexadecimal device token
  */
-void           dc_accounts_set_push_device_token (dc_accounts_t* accounts, char *token);
+void           dc_accounts_set_push_device_token (dc_accounts_t* accounts, const char *token);
 
 /**
  * Create the event emitter that is used to receive events.

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -411,15 +411,13 @@ pub unsafe extern "C" fn dc_get_connectivity_html(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_get_push_state(
-    context: *const dc_context_t,
-) -> libc::c_int {
+pub unsafe extern "C" fn dc_get_push_state(context: *const dc_context_t) -> libc::c_int {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_push_state()");
         return 0;
     }
     let ctx = &*context;
-    block_on(ctx.push_state())
+    block_on(ctx.push_state()) as libc::c_int
 }
 
 #[no_mangle]
@@ -4948,7 +4946,7 @@ pub unsafe extern "C" fn dc_accounts_set_push_device_token(
     let token = to_string_lossy(token);
 
     block_on(async move {
-        let accounts = accounts.read().await;
+        let mut accounts = accounts.write().await;
         if let Err(err) = accounts.set_push_device_token(&token).await {
             accounts.emit_event(EventType::Error(format!(
                 "Failed to set notify token: {err:#}."


### PR DESCRIPTION
just some small fixes that were needed to make https://github.com/deltachat/deltachat-core-rust/pull/5286 compile on mac; moreover, dc_context_new_closed() does not compile, but that is not used on iOS, so i skipped it :)

with these changes, https://github.com/deltachat/deltachat-ios/pull/2080 compiles; could not test, if it actually _works_.

feel free to close or to merge this pr :)