### PR TITLE
test: get_protected_chat(): Use FFIEventTracker instead of dc_wait_next_msgs() (#5207)

### DIFF
--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -375,22 +375,6 @@ class Account:
         dc_array = ffi.gc(lib.dc_get_fresh_msgs(self._dc_context), lib.dc_array_unref)
         return (x for x in iter_array(dc_array, lambda x: Message.from_db(self, x)) if x is not None)
 
-    def _wait_next_message_ids(self) -> List[int]:
-        """Return IDs of all next messages from all chats."""
-        dc_array = ffi.gc(lib.dc_wait_next_msgs(self._dc_context), lib.dc_array_unref)
-        return [lib.dc_array_get_id(dc_array, i) for i in range(lib.dc_array_get_cnt(dc_array))]
-
-    def wait_next_incoming_message(self) -> Message:
-        """Waits until the next incoming message
-        with ID higher than given is received and returns it."""
-        while True:
-            message_ids = self._wait_next_message_ids()
-            for msg_id in message_ids:
-                message = Message.from_db(self, msg_id)
-                if message and not message.is_from_self() and not message.is_from_device():
-                    self.set_config("last_msg_id", str(msg_id))
-                    return message
-
     def create_chat(self, obj) -> Chat:
         """Create a 1:1 chat with Account, Contact or e-mail address."""
         return self.create_contact(obj).create_chat()

--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -182,6 +182,12 @@ class FFIEventTracker:
                 print(f"** SECUREJOINT-INVITER PROGRESS {target}", self.account)
                 break
 
+    def wait_securejoin_joiner_progress(self, target):
+        while True:
+            event = self.get_matching("DC_EVENT_SECUREJOIN_JOINER_PROGRESS")
+            if event.data2 >= target:
+                break
+
     def wait_idle_inbox_ready(self):
         """Has to be called after start_io() to wait for fetch_existing_msgs to run
         so that new messages are not mistaken for old ones:

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -44,21 +44,21 @@ def test_configure_generate_key(acfactory, lp):
     lp.sec("ac1: send unencrypted message to ac2")
     chat.send_text("message1")
     lp.sec("ac2: waiting for message from ac1")
-    msg_in = ac2.wait_next_incoming_message()
+    msg_in = ac2._evtracker.wait_next_incoming_message()
     assert msg_in.text == "message1"
     assert not msg_in.is_encrypted()
 
     lp.sec("ac2: send encrypted message to ac1")
     msg_in.chat.send_text("message2")
     lp.sec("ac1: waiting for message from ac2")
-    msg2_in = ac1.wait_next_incoming_message()
+    msg2_in = ac1._evtracker.wait_next_incoming_message()
     assert msg2_in.text == "message2"
     assert msg2_in.is_encrypted()
 
     lp.sec("ac1: send encrypted message to ac2")
     msg2_in.chat.send_text("message3")
     lp.sec("ac2: waiting for message from ac1")
-    msg3_in = ac2.wait_next_incoming_message()
+    msg3_in = ac2._evtracker.wait_next_incoming_message()
     assert msg3_in.text == "message3"
     assert msg3_in.is_encrypted()
 
@@ -520,7 +520,7 @@ def test_forward_encrypted_to_unencrypted(acfactory, lp):
     lp.sec("ac1: send encrypted message to ac2")
     txt = "This should be encrypted"
     chat.send_text(txt)
-    msg = ac2.wait_next_incoming_message()
+    msg = ac2._evtracker.wait_next_incoming_message()
     assert msg.text == txt
     assert msg.is_encrypted()
 


### PR DESCRIPTION
The way it was implemented it threw out all remaining messages after finding the next incoming message. Better use FFIEventTracker functions, they are used in all the tests anyway.

Close #5207 
Not sure this actually fixes the problem, but quite possible. Let's see if this helps.