### PR TITLE
build: do not vendor OpenSSL when cross-compiling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -165,9 +165,6 @@
             version = manifest.version;
             strictDeps = true;
             src = pkgs.lib.cleanSource ./.;
-            nativeBuildInputs = [
-              pkgs.perl # Needed to build vendored OpenSSL.
-            ];
             auditable = false; # Avoid cargo-auditable failures.
             doCheck = false; # Disable test as it requires network access.
 
@@ -180,6 +177,11 @@
 
             CC = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
             LD = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
+
+            OPENSSL_LIB_DIR = "${pkgsCross.pkgsStatic.openssl.out}/lib";
+            OPENSSL_INCLUDE_DIR = "${pkgsCross.pkgsStatic.openssl.dev}/include";
+            OPENSSL_STATIC = "1";
+            OPENSSL_NO_VENDOR = "1";
           };
 
         mk-aarch64-RustPackage = mkCrossRustPackage "aarch64-unknown-linux-musl" "aarch64-unknown-linux-musl";


### PR DESCRIPTION
Compilation of vendored OpenSSL inside Nix is broken since <https://github.com/alexcrichton/openssl-src-rs/pull/229> due to build script changes.

There is anyway no need to compile vendored OpenSSL as nixpkgs already contains OpenSSL package.

This fixes `nix build .#deltachat-rpc-server-x86_64-linux` and similar commands which are used during releases.