### PR TITLE
fix pytest compat

### DIFF
--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -115,7 +115,7 @@ def pytest_configure(config):
     deltachat.register_global_plugin(la)
 
 
-def pytest_report_header(config, startdir):
+def pytest_report_header(config):
     info = get_core_info()
     summary = [
         "Deltachat core={} sqlite={} journal_mode={}".format(


### PR DESCRIPTION
seems pytest_report_header has changed with pytest incompatible but we don't need it anyway so we can just leave it out. 