### PR TITLE
Attempt to fix OpenSSL build under nix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3244,8 +3244,7 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 [[package]]
 name = "openssl-src"
 version = "300.2.3+3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+source = "git+https://github.com/link2xt/openssl-src-rs.git?branch=link2xt/copy-symlink#68efa9733ace4aae3372646838d7430b8f974c67"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ opt-level = "z"
 codegen-units = 1
 strip = true
 
+[patch.crates-io]
+openssl-src = { git = "https://github.com/link2xt/openssl-src-rs.git", branch = "link2xt/copy-symlink" }
+
 [dependencies]
 deltachat_derive = { path = "./deltachat_derive" }
 deltachat-time = { path = "./deltachat-time" }

--- a/flake.nix
+++ b/flake.nix
@@ -168,6 +168,9 @@
             auditable = false; # Avoid cargo-auditable failures.
             doCheck = false; # Disable test as it requires network access.
 
+            nativeBuildInputs = [
+              pkgs.perl # Needed to build vendored OpenSSL.
+            ];
             CARGO_BUILD_TARGET = rustTarget;
             TARGET_CC = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
             CARGO_BUILD_RUSTFLAGS = [
@@ -177,11 +180,6 @@
 
             CC = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
             LD = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
-
-            OPENSSL_LIB_DIR = "${pkgsCross.pkgsStatic.openssl.out}/lib";
-            OPENSSL_INCLUDE_DIR = "${pkgsCross.pkgsStatic.openssl.dev}/include";
-            OPENSSL_STATIC = "1";
-            OPENSSL_NO_VENDOR = "1";
           };
 
         mk-aarch64-RustPackage = mkCrossRustPackage "aarch64-unknown-linux-musl" "aarch64-unknown-linux-musl";


### PR DESCRIPTION
Trying to use https://github.com/alexcrichton/openssl-src-rs/pull/236

This fails with a new error:
```
$ nix build .#deltachat-rpc-server-x86_64-linux
error: builder for '/nix/store/cbk8amj58m8znxlcx0p4d0fxhq7grkc4-deltachat-deps-1.136.0.drv' failed with exit code 101;
       last 25 log lines:
       >   cargo:rerun-if-env-changed=RANLIBFLAGS_x86_64-unknown-linux-musl
       >   RANLIBFLAGS_x86_64-unknown-linux-musl = None
       >   cargo:rerun-if-env-changed=RANLIBFLAGS_x86_64_unknown_linux_musl
       >   RANLIBFLAGS_x86_64_unknown_linux_musl = None
       >   cargo:rerun-if-env-changed=TARGET_RANLIBFLAGS
       >   TARGET_RANLIBFLAGS = None
       >   cargo:rerun-if-env-changed=RANLIBFLAGS
       >   RANLIBFLAGS = None
       >   running cd "/build/dummy-src/target/x86_64-unknown-linux-musl/release/build/openssl-sys-462ecfdd0a9cb8e3/out/openssl-build/build/src" && env -u CROSS_COMPILE AR="ar" CC="/nix/store/j9zmg94bapyyv5pni864cl4rqwsp03h3-x86_64-unknown-linux-musl-gcc-wrapper-13.2.0/bin/x86_64-unknown-linux-musl-cc" RANLIB="ranlib" "perl" "./Configure" "--prefix=/build/dummy-src/target/x86_64-unknown-linux-musl/release/build/openssl-sys-462ecfdd0a9cb8e3/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-dso" "no-shared" "no-ssl3" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "no-engine" "no-async" "linux-x86_64" "-O2" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "-DOPENSSL_NO_SECURE_MEMORY"
       >
       >   --- stderr
       >   Can't open perl script "./Configure": No such file or directory
       >   thread 'main' panicked at /nix/store/fqvrp4b4k0fx6gyigxj622ibhrg6gifa-git-dependencies/openssl-src-300.2.3+3.2.1-link2xt_copy-symlink/src/lib.rs:616:9:
       >
       >
       >
       >   Error configuring OpenSSL build:
       >       Command: cd "/build/dummy-src/target/x86_64-unknown-linux-musl/release/build/openssl-sys-462ecfdd0a9cb8e3/out/openssl-build/build/src" && env -u CROSS_COMPILE AR="ar" CC="/nix/store/j9zmg94bapyyv5pni864cl4rqwsp03h3-x86_64-unknown-linux-musl-gcc-wrapper-13.2.0/bin/x86_64-unknown-linux-musl-cc" RANLIB="ranlib" "perl" "./Configure" "--prefix=/build/dummy-src/target/x86_64-unknown-linux-musl/release/build/openssl-sys-462ecfdd0a9cb8e3/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-dso" "no-shared" "no-ssl3" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "no-engine" "no-async" "linux-x86_64" "-O2" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "-DOPENSSL_NO_SECURE_MEMORY"
       >       Exit status: exit status: 2
       >
       >
       >
       >   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
       > warning: build failed, waiting for other jobs to finish...
       > [naersk] cargo returned with exit code 101, exiting
       For full logs, run 'nix log /nix/store/cbk8amj58m8znxlcx0p4d0fxhq7grkc4-deltachat-deps-1.136.0.drv'.
error: 1 dependencies of derivation '/nix/store/i31jwq5zp7smcf26fl1pvk2qy7l6b88x-deltachat-1.136.0.drv' failed to build
```

This is likely due to https://github.com/nix-community/naersk/issues/287

```
$ ls /nix/store/fqvrp4b4k0fx6gyigxj622ibhrg6gifa-git-dependencies/openssl-src-300.2.3+3.2.1-link2xt_copy-symlink/src
lib.rs
$ ls /nix/store/fqvrp4b4k0fx6gyigxj622ibhrg6gifa-git-dependencies/openssl-src-300.2.3+3.2.1-link2xt_copy-symlink/openssl
```

Seems `openssl` submodule is not cloned in case of git dependency.
