### PR TITLE
feat: Case-insensitive search for non-ASCII messages (#5052)

### DIFF
--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -447,7 +447,7 @@ pub(crate) async fn delete_expired_messages(context: &Context, now: i64) -> Resu
                 for (msg_id, chat_id, viewtype, location_id) in rows {
                     transaction.execute(
                         "UPDATE msgs
-                     SET chat_id=?, txt='', subject='', txt_raw='',
+                     SET chat_id=?, txt='', txt_normalized=NULL, subject='', txt_raw='',
                          mime_headers='', from_id=0, to_id=0, param=''
                      WHERE id=?",
                         (DC_CHAT_ID_TRASH, msg_id),

--- a/src/message.rs
+++ b/src/message.rs
@@ -113,7 +113,7 @@ impl MsgId {
                 r#"
 UPDATE msgs 
 SET 
-  chat_id=?, txt='', 
+  chat_id=?, txt='', txt_normalized=NULL, 
   subject='', txt_raw='', 
   mime_headers='', 
   from_id=0, to_id=0, 
@@ -2070,6 +2070,15 @@ impl Viewtype {
             Viewtype::Vcard => true,
         }
     }
+}
+
+/// Returns text for storing in the `msgs.txt_normalized` column (to make case-insensitive search
+/// possible for non-ASCII messages).
+pub(crate) fn normalize_text(text: &str) -> Option<String> {
+    if text.is_ascii() {
+        return None;
+    };
+    Some(text.to_lowercase()).filter(|t| t != text)
 }
 
 #[cfg(test)]

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1540,7 +1540,7 @@ INSERT INTO msgs
     rfc724_mid, chat_id,
     from_id, to_id, timestamp, timestamp_sent, 
     timestamp_rcvd, type, state, msgrmsg, 
-    txt, subject, txt_raw, param, hidden,
+    txt, txt_normalized, subject, txt_raw, param, hidden,
     bytes, mime_headers, mime_compressed, mime_in_reply_to,
     mime_references, mime_modified, error, ephemeral_timer,
     ephemeral_timestamp, download_state, hop_info
@@ -1550,7 +1550,7 @@ INSERT INTO msgs
     ?, ?, ?, ?,
     ?, ?, ?, ?,
     ?, ?, ?, ?, ?,
-    ?, ?, ?, ?, 1,
+    ?, ?, ?, ?, ?, 1,
     ?, ?, ?, ?,
     ?, ?, ?, ?
   )
@@ -1558,7 +1558,8 @@ ON CONFLICT (id) DO UPDATE
 SET rfc724_mid=excluded.rfc724_mid, chat_id=excluded.chat_id,
     from_id=excluded.from_id, to_id=excluded.to_id, timestamp_sent=excluded.timestamp_sent,
     type=excluded.type, msgrmsg=excluded.msgrmsg,
-    txt=excluded.txt, subject=excluded.subject, txt_raw=excluded.txt_raw, param=excluded.param,
+    txt=excluded.txt, txt_normalized=excluded.txt_normalized, subject=excluded.subject,
+    txt_raw=excluded.txt_raw, param=excluded.param,
     hidden=excluded.hidden,bytes=excluded.bytes, mime_headers=excluded.mime_headers,
     mime_compressed=excluded.mime_compressed, mime_in_reply_to=excluded.mime_in_reply_to,
     mime_references=excluded.mime_references, mime_modified=excluded.mime_modified, error=excluded.error, ephemeral_timer=excluded.ephemeral_timer,
@@ -1578,6 +1579,7 @@ RETURNING id
                     state,
                     is_dc_message,
                     if trash { "" } else { msg },
+                    if trash { None } else { message::normalize_text(msg) },
                     if trash { "" } else { &subject },
                     // txt_raw might contain invalid utf8
                     if trash { "" } else { &txt_raw },

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -937,6 +937,11 @@ CREATE INDEX msgs_status_updates_index2 ON msgs_status_updates (uid);
             .await?;
     }
 
+    if dbversion < 115 {
+        sql.execute_migration("ALTER TABLE msgs ADD COLUMN txt_normalized TEXT", 115)
+            .await?;
+    }
+
     let new_version = sql
         .get_raw_config_int(VERSION_CFG)
         .await?


### PR DESCRIPTION
SQLite search with `LIKE` is case-insensitive only for ASCII chars. To make it case-insensitive for all messages, create a new column `msgs.txt_normalized` defaulting to `NULL` (so we do not bump up the database size in a migration) and storing lowercased/normalized text there when the row is created/updated. When doing a search, search over `IFNULL(txt_normalized, txt)`.

Close #5052 