### PR TITLE
fix: Remove leading whitespace from Subject (#5106)

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -807,6 +807,7 @@ impl MimeMessage {
 
     pub(crate) fn get_subject(&self) -> Option<String> {
         self.get_header(HeaderDef::Subject)
+            .map(|s| s.trim_start())
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string())
     }

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -4286,3 +4286,25 @@ async fn test_forged_from() -> Result<()> {
     assert!(msg.chat_id.is_trash());
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_multiline_iso_8859_1_subject() -> Result<()> {
+    let t = &TestContext::new_alice().await;
+    let mail = b"Received: (Postfix, from userid 1000); Mon, 4 Dec 2006 14:51:39 +0100 (CET)\n\
+        From: bob@example.com\n\
+        To: alice@example.org, claire@example.com\n\
+        Subject:\n \
+        =?iso-8859-1?Q?Weihnachten_&_Silvester:_Feiern,_genie=DFen_&_entspannen_i?=\n \
+        =?iso-8859-1?Q?nmitten_der_Weing=E4rten?=\n\
+        Message-ID: <3333@example.com>\n\
+        Date: Sun, 22 Mar 2020 22:37:57 +0000\n\
+        \n\
+        hello\n";
+    receive_imf(t, mail, false).await?;
+    let msg = t.get_last_msg().await;
+    assert_eq!(
+        msg.get_subject(),
+        "Weihnachten & Silvester: Feiern, genießen & entspannen inmitten der Weingärten"
+    );
+    Ok(())
+}


### PR DESCRIPTION
If Subject is multiline-formatted, `mailparse` adds the leading whitespace to it. The solution is to always remove the leading whitespace, because if Subject isn't multiline-formatted, it never contains the leading whitespace anyway. But as for the trailing whitespace -- i checked -- it's never removed, so let's keep this as is.

Fix #5106 