### PR TITLE
test: Set fetch_existing_msgs for bots (#4976)

### DIFF
--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -547,6 +547,9 @@ class ACFactory:
         fn = module.__file__
 
         bot_cfg = self.get_next_liveconfig()
+        # The bot process is run asynchronously, so some messages can arrive before the bot is fully
+        # initialised.
+        bot_cfg["fetch_existing_msgs"] = "1"
         bot_ac = self.prepare_account_from_liveconfig(bot_cfg)
 
         # Forget ac as it will be opened by the bot subprocess


### PR DESCRIPTION
A bot process is run asynchronously, so some messages can arrive before the bot is fully initialised.

Close #4976 