### PR TITLE
build: build deltachat-rpc-server wheels with nix

### DIFF
--- a/.github/workflows/deltachat-rpc-server.yml
+++ b/.github/workflows/deltachat-rpc-server.yml
@@ -104,6 +104,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
+      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: Download Linux aarch64 binary
         uses: actions/download-artifact@v4
@@ -182,9 +184,28 @@ jobs:
         run: pip install wheel
 
       - name: Build deltachat-rpc-server Python wheels and source package
-        run: scripts/wheel-rpc-server.py
+        run: |
+          nix build .#deltachat-rpc-server-x86_64-linux-wheel
+          cp result/*.whl dist/
+          nix build .#deltachat-rpc-server-armv7l-linux-wheel
+          cp result/*.whl dist/
+          nix build .#deltachat-rpc-server-armv6l-linux-wheel
+          cp result/*.whl dist/
+          nix build .#deltachat-rpc-server-aarch64-linux-wheel
+          cp result/*.whl dist/
+          nix build .#deltachat-rpc-server-i686-linux-wheel
+          cp result/*.whl dist/
+          nix build .#deltachat-rpc-server-win64-wheel
+          cp result/*.whl dist/
+          nix build .#deltachat-rpc-server-win32-wheel
+          cp result/*.whl dist/
+          nix build .#deltachat-rpc-server-source
+          cp result/*.tar.gz dist/
+          python3 scripts/wheel-rpc-server.py 1.136.3 x86_64-darwin dist/deltachat-rpc-server-x86_64-macos
+          python3 scripts/wheel-rpc-server.py 1.136.3 aarch64-darwin dist/deltachat-rpc-server-aarch64-macos
+          mv *.whl dist/
 
-      - name: List downloaded artifacts
+      - name: List artifacts
         run: ls -l dist/
 
       - name: Upload binaries to the GitHub release


### PR DESCRIPTION
This makes `nix build .#deltachat-rpc-server-x86_64-linux-wheel` and similar commands build Python wheels in a nix environment, hopefully making wheels reproducible like the binaries already are. Flake wheel output depends on binary output, so with proper caching there is no need to build the binary second time if it was already built previously.

We will not be able to build wheels for macOS until #5326 is ready, but we can build them outside of nix for now.

For example:
```
$ nix build .#deltachat-rpc-server-x86_64-linux-wheel
$ zipinfo result/deltachat_rpc_server-1.136.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.musllinux_1_1_x86_64.whl 
Archive:  result/deltachat_rpc_server-1.136.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.musllinux_1_1_x86_64.whl
Zip file size: 9134569 bytes, number of entries: 8
-rw-r--r--  2.0 unx    16914 b- defN 80-Jan-01 00:00 deltachat_rpc_server/LICENSE
-rw-r--r--  2.0 unx     1331 b- defN 80-Jan-01 00:00 deltachat_rpc_server/README.md
-rw-rw-r--  2.0 unx      147 b- defN 80-Jan-01 00:00 deltachat_rpc_server/__init__.py
-rwxr-xr-x  2.0 unx 21231152 b- defN 80-Jan-01 00:00 deltachat_rpc_server/deltachat-rpc-server
-rw-rw-r--  2.0 unx      102 b- defN 80-Jan-01 00:00 deltachat_rpc_server-1.136.3.dist-info/METADATA
-rw-rw-r--  2.0 unx       52 b- defN 80-Jan-01 00:00 deltachat_rpc_server-1.136.3.dist-info/WHEEL
-rw-rw-r--  2.0 unx       66 b- defN 80-Jan-01 00:00 deltachat_rpc_server-1.136.3.dist-info/entry_points.txt
-rw-rw-r--  2.0 unx      723 b- defN 80-Jan-01 00:00 deltachat_rpc_server-1.136.3.dist-info/RECORD
8 files, 21250487 bytes uncompressed, 9133295 bytes compressed:  57.0%
```