### PR TITLE
ci: add workflow for automatic publishing of deltachat-rpc-client

### DIFF
--- a/.github/workflows/publish-deltachat-rpc-client-pypi.yml
+++ b/.github/workflows/publish-deltachat-rpc-client-pypi.yml
@@ -1,0 +1,47 @@
+name: Publish deltachat-rpc-client to PyPI
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - name: Install pypa/build
+        run: python3 -m pip install build
+      - name: Build a binary wheel and a source tarball
+        working-directory: deltachat-rpc-client
+        run: python3 -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: deltachat-rpc-client/dist/
+
+  publish-to-pypi:
+    name: Publish Python distribution to PyPI
+    if: github.event_name == 'release'
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/deltachat-rpc-client
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish deltachat-rpc-client to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This is an attempt to start publishing `deltachat-rpc-client` automatically using https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/ guide.

We will see how it works with the next release, otherwise I can still upload it manually. Once deltachat-rpc-client publishing works I also want to automate deltachat-rpc-server publishing similarly.

In #5332 there is a plan to automate uploading of deltachat-rpc-server to npm as well.