### PR TITLE
fix: Update MemberListTimestamp when sending a group message

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2805,6 +2805,12 @@ pub(crate) async fn create_send_msg_jobs(context: &Context, msg: &mut Message) -
         msg.chat_id.set_gossiped_timestamp(context, now).await?;
     }
 
+    if rendered_msg.is_group {
+        msg.chat_id
+            .update_timestamp(context, Param::MemberListTimestamp, now)
+            .await?;
+    }
+
     if let Some(last_added_location_id) = rendered_msg.last_added_location_id {
         if let Err(err) = location::set_kml_sent_timestamp(context, msg.chat_id, now).await {
             error!(context, "Failed to set kml sent_timestamp: {err:#}.");

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -85,6 +85,7 @@ pub struct RenderedEmail {
     // pub envelope: Envelope,
     pub is_encrypted: bool,
     pub is_gossiped: bool,
+    pub is_group: bool,
     pub last_added_location_id: Option<u32>,
 
     /// A comma-separated string of sync-IDs that are used by the rendered email
@@ -587,6 +588,8 @@ impl<'a> MimeFactory<'a> {
             ));
         }
 
+        let mut is_group = false;
+
         if let Loaded::Message { chat } = &self.loaded {
             if chat.typ == Chattype::Broadcast {
                 let encoded_chat_name = encode_words(&chat.name);
@@ -594,6 +597,8 @@ impl<'a> MimeFactory<'a> {
                     "List-ID".into(),
                     format!("{encoded_chat_name} <{}>", chat.grpid),
                 ));
+            } else if chat.typ == Chattype::Group {
+                is_group = true;
             }
         }
 
@@ -865,6 +870,7 @@ impl<'a> MimeFactory<'a> {
             // envelope: Envelope::new,
             is_encrypted,
             is_gossiped,
+            is_group,
             last_added_location_id,
             sync_ids_to_delete: self.sync_ids_to_delete,
             rfc724_mid,


### PR DESCRIPTION
`Param::MemberListTimestamp` was updated only from `receive_imf::apply_group_changes()` i.e. for received messages. If we sent a message, that timestamp wasn't updated, so remote group membership changes always overrode local ones. Especially that was a problem when a message is sent offline so that it doesn't incorporate recent group membership changes.