### PR TITLE
fix: on iOS, use FILE (default) instead of MEMORY

### DIFF
--- a/src/sql.rs
+++ b/src/sql.rs
@@ -684,7 +684,7 @@ fn new_connection(path: &Path, passphrase: &str) -> Result<Connection> {
 
     // Avoid SQLITE_IOERR_GETTEMPPATH errors on Android and maybe other systems.
     // Downside is more RAM consumption esp. on VACUUM.
-    // Therefore, on system known to have working gettemppath(), stay with the default.
+    // Therefore, on systems known to have working default (using files), stay with that.
     if cfg!(not(target_os = "ios")) {
         conn.pragma_update(None, "temp_store", "memory")?;
     }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -677,11 +677,18 @@ fn new_connection(path: &Path, passphrase: &str) -> Result<Connection> {
         "PRAGMA cipher_memory_security = OFF; -- Too slow on Android
          PRAGMA secure_delete=on;
          PRAGMA busy_timeout = 0; -- fail immediately
-         PRAGMA temp_store=memory; -- Avoid SQLITE_IOERR_GETTEMPPATH errors on Android
          PRAGMA soft_heap_limit = 8388608; -- 8 MiB limit, same as set in Android SQLiteDatabase.
          PRAGMA foreign_keys=on;
          ",
     )?;
+
+    // Avoid SQLITE_IOERR_GETTEMPPATH errors on Android and maybe other systems.
+    // Downside is more RAM consumption esp. on VACUUM.
+    // Therefore, on system known to have working gettemppath(), stay with the default.
+    if cfg!(not(target_os = "ios")) {
+        conn.pragma_update(None, "temp_store", "memory")?;
+    }
+
     conn.pragma_update(None, "key", passphrase)?;
     // Try to enable auto_vacuum. This will only be
     // applied if the database is new or after successful


### PR DESCRIPTION
this PR fixes one of the issues we had with an (honestly accidentally) huge database of >2gb.

this database could not be exported on iOS, as ram memory is limited there, leading to the app just crashing.

it is unclear if that would be better on eg. Android, however, temp_store=FILE is not working as well there, this is the smaller drawback there.

before merging, this PR should be tested on time with export/import on iOS (export/import uses VACUUM which uses /tmp) EDIT: did so, works on iphone7 with ios15