### PR TITLE
add `save_mime_headers` to debug info

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -805,6 +805,12 @@ impl Context {
             self.get_config_int(Config::ShowEmails).await?.to_string(),
         );
         res.insert(
+            "save_mime_headers",
+            self.get_config_bool(Config::SaveMimeHeaders)
+                .await?
+                .to_string(),
+        );
+        res.insert(
             "download_limit",
             self.get_config_int(Config::DownloadLimit)
                 .await?
@@ -1605,7 +1611,6 @@ mod tests {
             "mail_port",
             "mail_security",
             "notify_about_wrong_pw",
-            "save_mime_headers",
             "self_reporting_id",
             "selfstatus",
             "send_server",


### PR DESCRIPTION
as turned out on recent researches wrt a slow database, setting `save_mime_headers` will result in 25x larger databases.

this is definetely something we want to know at least in the debug info.

(the option cannot be enabled in current UIs,
however, esp. devs find options to set this.
apart from that, save_mime_headers is only used in some python tests)

ftr: the huge database was more than 10 times slower, leading to missing notifications on ios (as things do not finish within the few seconds iOS gave us).
moreover, the hugeness also avoids exporting; this is fixed by https://github.com/deltachat/deltachat-core-rust/pull/5349