### PR TITLE
api!: remove data from DC_EVENT_INCOMING_MSG_BUNCH

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -6074,10 +6074,12 @@ void dc_event_unref(dc_event_t* event);
  * Downloading a bunch of messages just finished. This is an
  * event to allow the UI to only show one notification per message bunch,
  * instead of cluttering the user with many notifications.
- * For each of the msg_ids, an additional #DC_EVENT_INCOMING_MSG event was emitted before.
+ * UI may store #DC_EVENT_INCOMING_MSG events
+ * and display notifications for all messages at once
+ * when this event arrives.
  * 
  * @param data1 0
- * @param data2 (char*) msg_ids, a json object with the message ids.
+ * @param data2 0
  */
 #define DC_EVENT_INCOMING_MSG_BUNCH       2006
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -719,7 +719,8 @@ pub unsafe extern "C" fn dc_event_get_data2_str(event: *mut dc_event_t) -> *mut 
         | EventType::WebxdcStatusUpdate { .. }
         | EventType::WebxdcInstanceDeleted { .. }
         | EventType::AccountsBackgroundFetchDone
-        | EventType::ChatEphemeralTimerModified { .. } => ptr::null_mut(),
+        | EventType::ChatEphemeralTimerModified { .. }
+        | EventType::IncomingMsgBunch { .. } => ptr::null_mut(),
         EventType::ConfigureProgress { comment, .. } => {
             if let Some(comment) = comment {
                 comment.to_c_string().unwrap_or_default().into_raw()
@@ -731,11 +732,6 @@ pub unsafe extern "C" fn dc_event_get_data2_str(event: *mut dc_event_t) -> *mut 
             let data2 = file.to_c_string().unwrap_or_default();
             data2.into_raw()
         }
-        EventType::IncomingMsgBunch { msg_ids } => serde_json::to_string(msg_ids)
-            .unwrap_or_default()
-            .to_c_string()
-            .unwrap_or_default()
-            .into_raw(),
         EventType::ConfigSynced { key } => {
             let data2 = key.to_string().to_c_string().unwrap_or_default();
             data2.into_raw()

--- a/deltachat-jsonrpc/src/api/types/events.rs
+++ b/deltachat-jsonrpc/src/api/types/events.rs
@@ -101,17 +101,15 @@ pub enum EventType {
     /// There is a fresh message. Typically, the user will show an notification
     /// when receiving this message.
     ///
-    /// There is no extra #DC_EVENT_MSGS_CHANGED event send together with this event.
+    /// There is no extra #DC_EVENT_MSGS_CHANGED event sent together with this event.
     #[serde(rename_all = "camelCase")]
     IncomingMsg { chat_id: u32, msg_id: u32 },
 
-    /// Downloading a bunch of messages just finished. This is an experimental
+    /// Downloading a bunch of messages just finished. This is an
     /// event to allow the UI to only show one notification per message bunch,
     /// instead of cluttering the user with many notifications.
-    ///
-    /// msg_ids contains the message ids.
     #[serde(rename_all = "camelCase")]
-    IncomingMsgBunch { msg_ids: Vec<u32> },
+    IncomingMsgBunch,
 
     /// Messages were seen or noticed.
     /// chat id is always set.
@@ -287,9 +285,7 @@ impl From<CoreEventType> for EventType {
                 chat_id: chat_id.to_u32(),
                 msg_id: msg_id.to_u32(),
             },
-            CoreEventType::IncomingMsgBunch { msg_ids } => IncomingMsgBunch {
-                msg_ids: msg_ids.into_iter().map(|id| id.to_u32()).collect(),
-            },
+            CoreEventType::IncomingMsgBunch => IncomingMsgBunch,
             CoreEventType::MsgsNoticed(chat_id) => MsgsNoticed {
                 chat_id: chat_id.to_u32(),
             },

--- a/src/events/payload.rs
+++ b/src/events/payload.rs
@@ -107,10 +107,7 @@ pub enum EventType {
     },
 
     /// Downloading a bunch of messages just finished.
-    IncomingMsgBunch {
-        /// List of incoming message IDs.
-        msg_ids: Vec<MsgId>,
-    },
+    IncomingMsgBunch,
 
     /// Messages were seen or noticed.
     /// chat id is always set.

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -717,12 +717,8 @@ impl Imap {
 
         info!(context, "{} mails read from \"{}\".", read_cnt, folder);
 
-        let msg_ids: Vec<MsgId> = received_msgs
-            .iter()
-            .flat_map(|m| m.msg_ids.clone())
-            .collect();
-        if !msg_ids.is_empty() {
-            context.emit_event(EventType::IncomingMsgBunch { msg_ids });
+        if !received_msgs.is_empty() {
+            context.emit_event(EventType::IncomingMsgBunch);
         }
 
         chat::mark_old_messages_as_noticed(context, received_msgs).await?;


### PR DESCRIPTION
It is not used by existing clients
and incorrectly included all downloaded messages,
including outgoing messages and MDNs.

Closes #5351