### PR TITLE
feat: do not include provider hostname in Message-ID

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1793,8 +1793,7 @@ impl Chat {
         let mut to_id = 0;
         let mut location_id = 0;
 
-        let from = context.get_primary_self_addr().await?;
-        let new_rfc724_mid = create_outgoing_rfc724_mid(&from);
+        let new_rfc724_mid = create_outgoing_rfc724_mid();
 
         if self.typ == Chattype::Single {
             if let Some(id) = context
@@ -4150,7 +4149,7 @@ pub async fn add_device_msg_with_importance(
     if let Some(msg) = msg {
         chat_id = ChatId::get_for_contact(context, ContactId::DEVICE).await?;
 
-        let rfc724_mid = create_outgoing_rfc724_mid("@device");
+        let rfc724_mid = create_outgoing_rfc724_mid();
         prepare_msg_blob(context, msg).await?;
 
         let timestamp_sent = create_smeared_timestamp(context);
@@ -4290,7 +4289,7 @@ pub(crate) async fn add_info_msg_with_cmd(
     parent: Option<&Message>,
     from_id: Option<ContactId>,
 ) -> Result<MsgId> {
-    let rfc724_mid = create_outgoing_rfc724_mid("@device");
+    let rfc724_mid = create_outgoing_rfc724_mid();
     let ephemeral_timer = chat_id.get_ephemeral_timer(context).await?;
 
     let mut param = Params::new();

--- a/src/context.rs
+++ b/src/context.rs
@@ -1395,7 +1395,7 @@ mod tests {
              \n\
              hello\n",
             contact.get_addr(),
-            create_outgoing_rfc724_mid(contact.get_addr())
+            create_outgoing_rfc724_mid()
         );
         println!("{msg}");
         receive_imf(t, msg.as_bytes(), false).await.unwrap();

--- a/src/message.rs
+++ b/src/message.rs
@@ -2016,7 +2016,7 @@ mod tests {
         assert_eq!(_msg2.get_filemime(), None);
     }
 
-    /// Tests that message cannot be prepared if account has no configured address.
+    /// Tests that message can be prepared even if account has no configured address.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_prepare_not_configured() {
         let d = test::TestContext::new().await;
@@ -2026,7 +2026,7 @@ mod tests {
 
         let mut msg = Message::new(Viewtype::Text);
 
-        assert!(chat::prepare_msg(ctx, chat.id, &mut msg).await.is_err());
+        assert!(chat::prepare_msg(ctx, chat.id, &mut msg).await.is_ok());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -556,7 +556,7 @@ impl<'a> MimeFactory<'a> {
 
         let rfc724_mid = match self.loaded {
             Loaded::Message { .. } => self.msg.rfc724_mid.clone(),
-            Loaded::Mdn { .. } => create_outgoing_rfc724_mid(&self.from_addr),
+            Loaded::Mdn { .. } => create_outgoing_rfc724_mid(),
         };
         let rfc724_mid_headervalue = render_rfc724_mid(&rfc724_mid);
         let rfc724_mid_header = Header::new("Message-ID".into(), rfc724_mid_headervalue);

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -289,12 +289,8 @@ pub(crate) fn validate_id(s: &str) -> bool {
 /// - this function is called for all outgoing messages.
 /// - the message ID should be globally unique
 /// - do not add a counter or any private data as this leaks information unnecessarily
-pub(crate) fn create_outgoing_rfc724_mid(from_addr: &str) -> String {
-    let hostname = from_addr
-        .find('@')
-        .and_then(|k| from_addr.get(k..))
-        .unwrap_or("@nohost");
-    format!("Mr.{}.{}{}", create_id(), create_id(), hostname)
+pub(crate) fn create_outgoing_rfc724_mid() -> String {
+    format!("Mr.{}.{}@localhost", create_id(), create_id())
 }
 
 /// Extract the group id (grpid) from a message id (mid)
@@ -1039,9 +1035,9 @@ DKIM Results: Passed=true, Works=true, Allow_Keychange=true";
 
     #[test]
     fn test_create_outgoing_rfc724_mid() {
-        let mid = create_outgoing_rfc724_mid("foo@bar.de");
+        let mid = create_outgoing_rfc724_mid();
         assert!(mid.starts_with("Mr."));
-        assert!(mid.ends_with("bar.de"));
+        assert!(mid.ends_with("@localhost"));
         assert!(extract_grpid_from_rfc724_mid(mid.as_str()).is_none());
     }
 


### PR DESCRIPTION
It is leaked by anonymous mailing lists,
making it possible to tell which provider the sender is using. Use `localhost` as the hostname instead.