### PR TITLE
feat: include 3 recent Message-IDs in `References` header

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -64,7 +64,15 @@ pub struct MimeFactory<'a> {
     loaded: Loaded,
     msg: &'a Message,
     in_reply_to: String,
+
+    /// Space-separated list of Message-IDs for `References` header.
+    ///
+    /// Each Message-ID in the list
+    /// may or may not be enclosed in angle brackets,
+    /// angle brackets must be added during message rendering
+    /// as needed.
     references: String,
+
     req_mdn: bool,
     last_added_location_id: Option<u32>,
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2683,7 +2683,6 @@ async fn get_rfc724_mid_in_list(context: &Context, mid_list: &str) -> Result<Opt
 ///
 /// If none found, tries In-Reply-To: as a fallback for classic MUAs that don't set the
 /// References: header.
-// TODO also save first entry of References and look for this?
 async fn get_parent_message(
     context: &Context,
     mime_parser: &MimeMessage,


### PR DESCRIPTION
Do not include oldest reference, because chat members
which have been added later and have not seen the first message
do not have referenced message in the database.

Instead, include up to 3 recent Message-IDs.
