### PR TITLE
refactor: use Rust 1.77.0 support for recursion in async functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     name: Lint Rust
     runs-on: ubuntu-latest
     env:
-      RUSTUP_TOOLCHAIN: 1.77.0
+      RUSTUP_TOOLCHAIN: 1.77.1
     steps:
       - uses: actions/checkout@v4
         with:
@@ -83,15 +83,15 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            rust: 1.77.0
+            rust: 1.77.1
           - os: windows-latest
-            rust: 1.77.0
+            rust: 1.77.1
           - os: macos-latest
-            rust: 1.77.0
+            rust: 1.77.1
 
-          # Minimum Supported Rust Version = 1.70.0
+          # Minimum Supported Rust Version = 1.77.0
           - os: ubuntu-latest
-            rust: 1.70.0
+            rust: 1.77.0
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "deltachat"
 version = "1.137.1"
 edition = "2021"
 license = "MPL-2.0"
-rust-version = "1.70"
+rust-version = "1.77"
 repository = "https://github.com/deltachat/deltachat-core-rust"
 
 [profile.dev]

--- a/scripts/coredeps/install-rust.sh
+++ b/scripts/coredeps/install-rust.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 #
 # Avoid using rustup here as it depends on reading /proc/self/exe and
 # has problems running under QEMU.
-RUST_VERSION=1.77.0
+RUST_VERSION=1.77.1
 
 ARCH="$(uname -m)"
 test -f "/lib/libc.musl-$ARCH.so.1" && LIBC=musl || LIBC=gnu


### PR DESCRIPTION
Postponed at least until GitHub actions runners are updated to 1.77.0. We also need to bump toolchains used to build Android and iOS to 1.77 first.