### PR TITLE
test: Remove flaky time check from test_list_from()

### DIFF
--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -4408,7 +4408,7 @@ async fn test_list_from() -> Result<()> {
         "clubinfo@donotreply.oeamtc.at"
     );
     let info = msg.id.get_info(t).await?;
-    assert!(info.contains("Sent: 2024.03.20 09:00:01 by ~ÖAMTC (clubinfo@donotreply.oeamtc.at)"));
+    assert!(info.contains(" by ~ÖAMTC (clubinfo@donotreply.oeamtc.at)"));
 
     Ok(())
 }


### PR DESCRIPTION
the rendered time output seems different on different systems and timezomes, eg. on my local machine, it is
`Sent: 2024.03.20 10:00:01 ` and not `Sent: 2024.03.20 09:00:01`, maybe because of winter/summer time, idk.

as the gist of the test is to check the name,
however, i just removed the whole time check.