### PR TITLE
api: remove unused `dc_accounts_all_work_done()`

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -705,7 +705,6 @@ int              dc_get_push_state           (dc_context_t* context);
 
 
 /**
- * Standalone version of dc_accounts_all_work_done().
  * Only used by the python tests.
  */
 int             dc_all_work_done             (dc_context_t* context);
@@ -3097,23 +3096,6 @@ dc_context_t*  dc_accounts_get_selected_account (dc_accounts_t* accounts);
  * @return 1=success, 0=error
  */
 int            dc_accounts_select_account       (dc_accounts_t* accounts, uint32_t account_id);
-
-
-/**
- * This is meant especially for iOS, because iOS needs to tell the system when its background work is done.
- *
- * iOS can:
- * - call dc_start_io() (in case IO was not running)
- * - call dc_maybe_network()
- * - while dc_accounts_all_work_done() returns false:
- *   - Wait for #DC_EVENT_CONNECTIVITY_CHANGED
- *
- * @memberof dc_accounts_t
- * @param accounts The account manager as created by dc_accounts_new().
- * @return Whether all accounts finished their background work.
- *      #DC_EVENT_CONNECTIVITY_CHANGED will be sent when this turns to true.
- */
-int            dc_accounts_all_work_done        (dc_accounts_t* accounts);
 
 
 /**

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -4852,16 +4852,6 @@ pub unsafe extern "C" fn dc_accounts_get_all(accounts: *mut dc_accounts_t) -> *m
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_accounts_all_work_done(accounts: *mut dc_accounts_t) -> libc::c_int {
-    if accounts.is_null() {
-        eprintln!("ignoring careless call to dc_accounts_all_work_done()");
-        return 0;
-    }
-    let accounts = &*accounts;
-    block_on(async move { accounts.read().await.all_work_done().await as libc::c_int })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn dc_accounts_start_io(accounts: *mut dc_accounts_t) {
     if accounts.is_null() {
         eprintln!("ignoring careless call to dc_accounts_start_io()");

--- a/node/src/module.c
+++ b/node/src/module.c
@@ -3048,14 +3048,6 @@ NAPI_METHOD(dcn_accounts_select_account) {
   NAPI_RETURN_UINT32(result);
 }
 
-NAPI_METHOD(dcn_accounts_all_work_done) {
-  NAPI_ARGV(1);
-  NAPI_DCN_ACCOUNTS();
-
-  int result = dc_accounts_all_work_done(dcn_accounts->dc_accounts);
-  NAPI_RETURN_INT32(result);
-}
-
 NAPI_METHOD(dcn_accounts_start_io) {
   NAPI_ARGV(1);
   NAPI_DCN_ACCOUNTS();
@@ -3382,7 +3374,6 @@ NAPI_INIT() {
   NAPI_EXPORT_FUNCTION(dcn_accounts_get_account);
   NAPI_EXPORT_FUNCTION(dcn_accounts_get_selected_account);
   NAPI_EXPORT_FUNCTION(dcn_accounts_select_account);
-  NAPI_EXPORT_FUNCTION(dcn_accounts_all_work_done);
   NAPI_EXPORT_FUNCTION(dcn_accounts_start_io);
   NAPI_EXPORT_FUNCTION(dcn_accounts_stop_io);
   NAPI_EXPORT_FUNCTION(dcn_accounts_maybe_network);

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -253,25 +253,6 @@ impl Accounts {
         self.accounts.keys().copied().collect()
     }
 
-    /// This is meant especially for iOS, because iOS needs to tell the system when its background work is done.
-    ///
-    /// Returns whether all accounts finished their background work.
-    /// DC_EVENT_CONNECTIVITY_CHANGED will be sent when this turns to true.
-    ///
-    /// iOS can:
-    /// - call dc_start_io() (in case IO was not running)
-    /// - call dc_maybe_network()
-    /// - while dc_accounts_all_work_done() returns false:
-    ///   -  Wait for DC_EVENT_CONNECTIVITY_CHANGED
-    pub async fn all_work_done(&self) -> bool {
-        for account in self.accounts.values() {
-            if !account.all_work_done().await {
-                return false;
-            }
-        }
-        true
-    }
-
     /// Starts background tasks such as IMAP and SMTP loops for all accounts.
     pub async fn start_io(&mut self) {
         for account in self.accounts.values_mut() {

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -170,7 +170,7 @@ impl ConnectivityStore {
 }
 
 /// Set all folder states to InterruptingIdle in case they were `Connected` before.
-/// Called during `dc_maybe_network()` to make sure that `dc_accounts_all_work_done()`
+/// Called during `dc_maybe_network()` to make sure that `dc_all_work_done()`
 /// returns false immediately after `dc_maybe_network()`.
 pub(crate) async fn idle_interrupted(inbox: ConnectivityStore, oboxes: Vec<ConnectivityStore>) {
     let mut connectivity_lock = inbox.0.lock().await;


### PR DESCRIPTION
it was used by iOS to know when a background fetch was complete; meanwhile the superiour `dc_accounts_background_fetch()` is used for that.

there is still the corresponding context function `dc_all_work_done()`, this not used by any UI as well, however, it is in use by a python tests.

not sure, what to do with it, at a first glance, the test still seems useful.