### PR TITLE
cleanup `jobs` and `Params` relicts

### DIFF
--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -33,14 +33,6 @@ use tokio::fs;
 /// e.g. bitmask 7 triggers actions defined with bits 1, 2 and 4.
 async fn reset_tables(context: &Context, bits: i32) {
     println!("Resetting tables ({bits})...");
-    if 0 != bits & 1 {
-        context
-            .sql()
-            .execute("DELETE FROM jobs;", ())
-            .await
-            .unwrap();
-        println!("(1) Jobs reset.");
-    }
     if 0 != bits & 2 {
         context
             .sql()

--- a/src/param.rs
+++ b/src/param.rs
@@ -9,7 +9,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::blob::BlobObject;
 use crate::context::Context;
-use crate::message::MsgId;
 use crate::mimeparser::SystemMessage;
 
 /// Available param keys.
@@ -18,7 +17,7 @@ use crate::mimeparser::SystemMessage;
 )]
 #[repr(u8)]
 pub enum Param {
-    /// For messages and jobs
+    /// For messages
     File = b'f',
 
     /// For messages: original filename (as shown in chat)
@@ -107,17 +106,11 @@ pub enum Param {
     /// is used to also send all the forwarded messages.
     PrepForwards = b'P',
 
-    /// For Jobs
+    /// For Messages
     SetLatitude = b'l',
 
-    /// For Jobs
+    /// For Messages
     SetLongitude = b'n',
-
-    /// For Jobs
-    AlsoMove = b'M',
-
-    /// For MDN-sending job
-    MsgId = b'I',
 
     /// For Groups
     ///
@@ -173,9 +166,6 @@ pub enum Param {
     /// For Chats: timestamp of member list update.
     MemberListTimestamp = b'k',
 
-    /// For Chats: timestamp of protection settings update.
-    ProtectionSettingsTimestamp = b'L',
-
     /// For Webxdc Message Instances: Current document name
     WebxdcDocument = b'R',
 
@@ -190,6 +180,7 @@ pub enum Param {
 
     /// For messages: Whether [crate::message::Viewtype::Sticker] should be forced.
     ForceSticker = b'X',
+    // 'L' was defined as ProtectionSettingsTimestamp for Chats, however, never used in production.
 }
 
 /// An object for handling key=value parameter lists.
@@ -397,12 +388,6 @@ impl Params {
             ParamsFile::Blob(blob) => blob.to_abs_path(),
         };
         Ok(Some(path))
-    }
-
-    pub fn get_msg_id(&self) -> Option<MsgId> {
-        self.get(Param::MsgId)
-            .and_then(|x| x.parse().ok())
-            .map(MsgId::new)
     }
 
     /// Set the given parameter to the passed in `i32`.

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -809,13 +809,6 @@ pub async fn remove_unused_files(context: &Context) -> Result<()> {
     maybe_add_from_param(
         &context.sql,
         &mut files_in_use,
-        "SELECT param FROM jobs;",
-        Param::File,
-    )
-    .await?;
-    maybe_add_from_param(
-        &context.sql,
-        &mut files_in_use,
         "SELECT param FROM chats;",
         Param::ProfileImage,
     )


### PR DESCRIPTION
this PR does some cleanup on `jobs` and `Params`:

- the `jobs` table is no longer in use, no need to track files on housekeeping, no need to clear it from repl tool

- some `Params` were used for jobs table only, they can be used freely for other purposes on other tables. param 'protection settings timestamp' was never used in practise, its code is removed as well, so we can free the Param as well.