### PR TITLE
feat: show reactions in summaries

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -7296,6 +7296,22 @@ void dc_event_unref(dc_event_t* event);
 /// `%1$s` will be replaced by the provider's domain.
 #define DC_STR_INVALID_UNENCRYPTED_MAIL 174
 
+/// "You reacted %1$s to '%2$s'"
+///
+/// `%1$s` will be replaced by the reaction, usually an emoji
+/// `%2$s` will be replaced by the summary of the message the reaction refers to
+///
+/// Used in summaries.
+#define DC_STR_YOU_REACTED 176
+
+/// "%1$s reacted %2$s to '%3$s'"
+///
+/// `%1$s` will be replaced by the name the contact who reacted
+/// `%2$s` will be replaced by the reaction, usually an emoji
+/// `%3$s` will be replaced by the summary of the message the reaction refers to
+///
+/// Used in summaries.
+#define DC_STR_REACTED_BY 177
 
 /**
  * @}

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -416,7 +416,7 @@ impl Chatlist {
         if chat.id.is_archived_link() {
             Ok(Default::default())
         } else if let Some(lastmsg) = lastmsg.filter(|msg| msg.from_id != ContactId::UNDEFINED) {
-            Ok(Summary::new(context, &lastmsg, chat, lastcontact.as_ref()).await)
+            Summary::new(context, &lastmsg, chat, lastcontact.as_ref()).await
         } else {
             Ok(Summary {
                 text: stock_str::no_messages(context).await,

--- a/src/message.rs
+++ b/src/message.rs
@@ -796,7 +796,7 @@ impl Message {
             None
         };
 
-        Ok(Summary::new(context, self, chat, contact.as_ref()).await)
+        Summary::new(context, self, chat, contact.as_ref()).await
     }
 
     // It's a little unfortunate that the UI has to first call `dc_msg_get_override_sender_name` and then if it was `NULL`, call

--- a/src/param.rs
+++ b/src/param.rs
@@ -64,6 +64,15 @@ pub enum Param {
     /// For Messages: the message is a reaction.
     Reaction = b'x',
 
+    /// For Chats: the timestamp of the last reaction.
+    LastReactionTimestamp = b'y',
+
+    /// For Chats: Message ID of the last reaction.
+    LastReactionMsgId = b'Y',
+
+    /// For Chats: Contact ID of the last reaction.
+    LastReactionContactId = b'1',
+
     /// For Messages: a message with "Auto-Submitted: auto-generated" header ("bot").
     Bot = b'b',
 

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -389,7 +389,7 @@ mod tests {
     use crate::receive_imf::{receive_imf, receive_imf_from_inbox};
     use crate::test_utils::TestContext;
     use crate::test_utils::TestContextManager;
-    use deltachat_time::SystemTimeTools;
+    use crate::tools::SystemTime;
     use std::time::Duration;
 
     #[test]
@@ -640,7 +640,7 @@ Here's my footer -- bob@example.net"
         let bob_msg1 = bob.recv_msg(&alice_msg1).await;
 
         // Bob reacts to Alice's message, this is shown in the summaries
-        SystemTimeTools::shift(Duration::from_secs(10));
+        SystemTime::shift(Duration::from_secs(10));
         bob_msg1.chat_id.accept(&bob).await?;
         send_reaction(&bob, bob_msg1.id, "👍").await?;
         let bob_send_reaction = bob.pop_sent_msg().await;
@@ -657,7 +657,7 @@ Here's my footer -- bob@example.net"
         assert_summary(&alice, "BOB reacted 👍 to \"Party?\"").await;
 
         // Alice reacts to own message as well
-        SystemTimeTools::shift(Duration::from_secs(10));
+        SystemTime::shift(Duration::from_secs(10));
         send_reaction(&alice, alice_msg1.sender_msg_id, "🍿").await?;
         let alice_send_reaction = alice.pop_sent_msg().await;
         bob.recv_msg(&alice_send_reaction).await;
@@ -666,7 +666,7 @@ Here's my footer -- bob@example.net"
         assert_summary(&bob, "ALICE reacted 🍿 to \"Party?\"").await;
 
         // Alice sends a newer message, this overwrites reaction summaries
-        SystemTimeTools::shift(Duration::from_secs(10));
+        SystemTime::shift(Duration::from_secs(10));
         let alice_msg2 = alice.send_text(alice_chat.id, "kewl").await;
         bob.recv_msg(&alice_msg2).await;
 
@@ -674,7 +674,7 @@ Here's my footer -- bob@example.net"
         assert_summary(&bob, "kewl").await;
 
         // Reactions to older messages still overwrite newer messages
-        SystemTimeTools::shift(Duration::from_secs(10));
+        SystemTime::shift(Duration::from_secs(10));
         send_reaction(&alice, alice_msg1.sender_msg_id, "🤘").await?;
         let alice_send_reaction = alice.pop_sent_msg().await;
         bob.recv_msg(&alice_send_reaction).await;
@@ -683,7 +683,7 @@ Here's my footer -- bob@example.net"
         assert_summary(&bob, "ALICE reacted 🤘 to \"Party?\"").await;
 
         // Retracted reactions remove all summary reactions
-        SystemTimeTools::shift(Duration::from_secs(10));
+        SystemTime::shift(Duration::from_secs(10));
         send_reaction(&alice, alice_msg1.sender_msg_id, "").await?;
         let alice_remove_reaction = alice.pop_sent_msg().await;
         bob.recv_msg(&alice_remove_reaction).await;
@@ -692,7 +692,7 @@ Here's my footer -- bob@example.net"
         assert_summary(&bob, "kewl").await;
 
         // Alice adds another reaction and then deletes the message reacted to; this will also delete reaction summary
-        SystemTimeTools::shift(Duration::from_secs(10));
+        SystemTime::shift(Duration::from_secs(10));
         send_reaction(&alice, alice_msg1.sender_msg_id, "🧹").await?;
         assert_summary(&alice, "You reacted 🧹 to \"Party?\"").await;
 
@@ -711,7 +711,7 @@ Here's my footer -- bob@example.net"
         let msg_id = send_text_msg(&alice0, chat.id, "mom's birthday!".to_string()).await?;
         alice1.recv_msg(&alice0.pop_sent_msg().await).await;
 
-        SystemTimeTools::shift(Duration::from_secs(10));
+        SystemTime::shift(Duration::from_secs(10));
         send_reaction(&alice0, msg_id, "👆").await?;
         let sync = alice0.pop_sent_msg().await;
         receive_imf(&alice1, sync.payload().as_bytes(), false).await?;

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -241,7 +241,7 @@ pub async fn send_reaction(context: &Context, msg_id: MsgId, reaction: &str) -> 
         msg_id,
         msg.chat_id,
         ContactId::SELF,
-        reaction_msg.get_timestamp(),
+        reaction_msg.timestamp_sort,
         reaction,
     )
     .await?;

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1374,6 +1374,7 @@ async fn add_parts(
                 &mime_in_reply_to,
                 orig_chat_id.unwrap_or_default(),
                 from_id,
+                sort_timestamp,
                 Reaction::from(reaction_str.as_str()),
             )
             .await?;

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -429,6 +429,12 @@ pub enum StockMessage {
         fallback = "⚠️ It seems you are using Delta Chat on multiple devices that cannot decrypt each other's outgoing messages. To fix this, on the older device use \"Settings / Add Second Device\" and follow the instructions."
     ))]
     CantDecryptOutgoingMsgs = 175,
+
+    #[strum(props(fallback = "You reacted %1$s to \"%2$s\""))]
+    MsgYouReacted = 176,
+
+    #[strum(props(fallback = "%1$s reacted %2$s to \"%3$s\""))]
+    MsgReactedBy = 177,
 }
 
 impl StockMessage {
@@ -727,6 +733,27 @@ pub(crate) async fn msg_group_left_local(context: &Context, by_contact: ContactI
         translated(context, StockMessage::MsgGroupLeftBy)
             .await
             .replace1(&by_contact.get_stock_name_n_addr(context).await)
+    }
+}
+
+/// Stock string: `You reacted %1$s to "%2$s"` or `%1$s reacted %2$s to "%3$s"`.
+pub(crate) async fn msg_reacted(
+    context: &Context,
+    by_contact: ContactId,
+    reaction: &str,
+    summary: &str,
+) -> String {
+    if by_contact == ContactId::SELF {
+        translated(context, StockMessage::MsgYouReacted)
+            .await
+            .replace1(reaction)
+            .replace2(summary)
+    } else {
+        translated(context, StockMessage::MsgReactedBy)
+            .await
+            .replace1(&by_contact.get_stock_name(context).await)
+            .replace2(reaction)
+            .replace3(summary)
     }
 }
 

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -76,7 +76,7 @@ impl Summary {
             return Ok(Summary {
                 prefix: None,
                 text: msg_reacted(context, reaction_contact_id, &reaction, &summary).await,
-                timestamp: msg.get_timestamp(), // message timestamp (not reaction) - otherwise sorting is wrong
+                timestamp: msg.get_timestamp(), // message timestamp (not reaction) to make timestamps more consistent with chats ordering
                 state: msg.state, // message state (not reaction) - indicating if it was me sending the last message
                 thumbnail_path: None,
             });

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -66,7 +66,7 @@ impl Summary {
         contact: Option<&Contact>,
     ) -> Result<Summary> {
         if let Some((reaction_msg, reaction_contact_id, reaction)) = chat
-            .get_last_reaction_if_newer_than(context, msg.get_timestamp())
+            .get_last_reaction_if_newer_than(context, msg.timestamp_sort)
             .await?
         {
             // there is a reaction newer than the latest message, show that.


### PR DESCRIPTION
this PR **shows the last reaction in chatlist's summaries if there is no newer message.** 

the reason to show reactions in the summary, is to make them a _little_ more visible when one is not in the chat. esp. in not-so-chatty or in one-to-ones chats this becomes handy: imaging a question and someone "answers" with "thumbs up" ... 🥚

otoh, reactions are still tuned down on purpose: no notifications, chats are opend as usual, the chatlist is not sorted by reactions and also the date in the summary refer to the last message - i thought quite a bit about that, this seems to be good compromise and will raise the fewest questions. it is somehow clear to the users that reactions are not the same as a real message. also, it is comparable easy to implement - **no UI changes required :)**

all that is very close to what whatsapp is doing (figured that out by quite some testing ... to cite @adbenitez: if in doubt, we can blame whatsapp :)

this is how it looks like: 🥚

<img width=320 src=https://github.com/deltachat/deltachat-core-rust/assets/9800740/178e1aa0-19b6-41f9-ad03-fd7faa5af68a>

technically, i first wanted to go for the "big solution" and  add two more columns, chat_id and timestamp, however, it seemed a bit bloated if we really only need the last one. therefore, i just added the last reaction information to the chat's param, which seems more performant but also easier to code :)

btw: there is no index over the msg_id - no index at all in the reactions table? or did i miss sth?

🥚 