### PR TITLE
fix: Keep webxdc instance for delete_device_after period after a status update (#5365)

### DIFF
--- a/src/debug_logging.rs
+++ b/src/debug_logging.rs
@@ -64,6 +64,7 @@ pub async fn debug_logging_loop(context: &Context, events: Receiver<DebugEventLo
                     document: None,
                     uid: None,
                 },
+                time,
             )
             .await
         {

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -392,7 +392,8 @@ WHERE
 SELECT id, chat_id, type
 FROM msgs
 WHERE
-  timestamp < ?
+  timestamp < ?1
+  AND timestamp_rcvd < ?1
   AND chat_id > ?
   AND chat_id != ?
   AND chat_id != ?
@@ -490,7 +491,7 @@ async fn next_delete_device_after_timestamp(context: &Context) -> Result<Option<
             .sql
             .query_get_value(
                 r#"
-                SELECT min(timestamp)
+                SELECT min(max(timestamp, timestamp_rcvd))
                 FROM msgs
                 WHERE chat_id > ?
                   AND chat_id != ?


### PR DESCRIPTION
If `delete_device_after` is configured, that period should be counted for webxdc instances from the last status update, otherwise nothing prevents from deleting them. Use `msgs.timestamp_rcvd` to store the last status update timestamp, it anyway isn't used for anything except displaying a detailed message info. Also, as `ephemeral::select_expired_messages()` now also checks `timestamp_rcvd`, we have an improvement that a message is guaranteed not to be deleted for the `delete_device_after` period since its receipt. Before only the sort timestamp was checked which is derived from the "sent" timestamp.

Fix #5365 