### PR TITLE
build(python): remove setuptools_scm dependency

### DIFF
--- a/deltachat-rpc-client/pyproject.toml
+++ b/deltachat-rpc-client/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
-requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=45"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "deltachat-rpc-client"
+version = "1.136.6"
 description = "Python client for Delta Chat core JSON-RPC interface"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -19,9 +20,6 @@ classifiers = [
     "Topic :: Communications :: Chat",
     "Topic :: Communications :: Email"
 ]
-dynamic = [
-    "version"
-]
 readme = "README.md"
 
 [tool.setuptools.package-data]
@@ -31,9 +29,6 @@ deltachat_rpc_client = [
 
 [project.entry-points.pytest11]
 "deltachat_rpc_client.pytestplugin" = "deltachat_rpc_client.pytestplugin"
-
-[tool.setuptools_scm]
-root = ".."
 
 [tool.black]
 line-length = 120

--- a/flake.nix
+++ b/flake.nix
@@ -495,7 +495,6 @@
                 format = "pyproject";
                 propagatedBuildInputs = [
                   pkgs.python3Packages.setuptools
-                  pkgs.python3Packages.setuptools_scm
                 ];
               };
 
@@ -513,7 +512,6 @@
                 ];
                 propagatedBuildInputs = [
                   pkgs.python3Packages.setuptools
-                  pkgs.python3Packages.setuptools_scm
                   pkgs.python3Packages.pkgconfig
                   pkgs.python3Packages.cffi
                   pkgs.python3Packages.imap-tools

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2", "cffi>=1.0.0", "pkgconfig"]
+requires = ["setuptools>=45", "wheel", "cffi>=1.0.0", "pkgconfig"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "deltachat"
+version = "1.136.6"
 description = "Python bindings for the Delta Chat Core library using CFFI against the Rust-implemented libdeltachat"
 readme = "README.rst"
 requires-python = ">=3.7"
@@ -26,9 +27,6 @@ dependencies = [
     "pluggy",
     "requests",
 ]
-dynamic = [
-    "version"
-]
 
 [project.urls]
 "Home" = "https://github.com/deltachat/deltachat-core-rust/"
@@ -43,11 +41,6 @@ dynamic = [
 deltachat = [
     "py.typed"
 ]
-
-[tool.setuptools_scm]
-root = ".."
-tag_regex = '^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$'
-git_describe_command = "git describe --dirty --tags --long --match v*.*"
 
 [tool.black]
 line-length = 120

--- a/scripts/set_core_version.py
+++ b/scripts/set_core_version.py
@@ -73,6 +73,8 @@ def main():
         "deltachat-jsonrpc/Cargo.toml",
         "deltachat-rpc-server/Cargo.toml",
         "deltachat-repl/Cargo.toml",
+        "python/pyproject.toml",
+        "deltachat-rpc-client/pyproject.toml",
     ]
     try:
         opts = parser.parse_args()


### PR DESCRIPTION
We update version in several .toml and .json files on every release anyway, so updating pyproject.toml is easy.

setuptools_scm makes it more difficult to build
python packages for software distributions
because it requires full git checkout
with tags rather than just a worktree.
It is also possible to remove or move tags
after the release, so git revision no longer
pins python package version if setuptools_scm is used.