### PR TITLE
refactor: is_probably_private_reply: Remove reaction-specific code

### DIFF
--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -875,8 +875,7 @@ Here's my footer -- bob@example.net"
         let alice1_msg = alice1.recv_msg(&alice0.pop_sent_msg().await).await;
 
         send_reaction(&alice0, alice0_msg_id, "👀").await?;
-        let sync = alice0.pop_sent_msg().await;
-        receive_imf(&alice1, sync.payload().as_bytes(), false).await?;
+        alice1.recv_msg(&alice0.pop_sent_msg().await).await;
 
         expect_reactions_changed_event(&alice0, chat_id, alice0_msg_id, ContactId::SELF).await?;
         expect_reactions_changed_event(&alice1, alice1_msg.chat_id, alice1_msg.id, ContactId::SELF)

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1077,6 +1077,12 @@ async fn add_parts(
                     chat_id_blocked = chat.blocked;
                 }
             }
+            if chat_id.is_none() && is_dc_message == MessengerMessage::Yes {
+                if let Some(chat) = ChatIdBlocked::lookup_by_contact(context, to_id).await? {
+                    chat_id = Some(chat.id);
+                    chat_id_blocked = chat.blocked;
+                }
+            }
 
             // automatically unblock chat when the user sends a message
             if chat_id_blocked != Blocked::Not {
@@ -1720,11 +1726,6 @@ async fn is_probably_private_reply(
         if chat_contacts.len() == 2 && chat_contacts.contains(&ContactId::SELF) {
             return Ok(false);
         }
-    }
-
-    let is_reaction = mime_parser.parts.iter().any(|part| part.is_reaction);
-    if is_reaction {
-        return Ok(false);
     }
 
     Ok(true)

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -9,7 +9,7 @@ use crate::chat::{
     ChatVisibility,
 };
 use crate::chatlist::Chatlist;
-use crate::constants::{DC_GCL_FOR_FORWARDING, DC_GCL_NO_SPECIALS};
+use crate::constants::{ShowEmails, DC_GCL_FOR_FORWARDING, DC_GCL_NO_SPECIALS};
 use crate::download::MIN_DOWNLOAD_LIMIT;
 use crate::imap::prefetch_should_download;
 use crate::imex::{imex, ImexMode};
@@ -140,6 +140,35 @@ async fn test_adhoc_group_show_accepted_contact_unknown() {
     // adhoc-group with unknown contacts with show_emails=accepted is ignored for unknown contacts
     let chats = Chatlist::try_load(&t, 0, None, None).await.unwrap();
     assert_eq!(chats.len(), 0);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_adhoc_group_outgoing_show_accepted_contact_unaccepted() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = &tcm.alice().await;
+    let bob = &tcm.bob().await;
+    bob.set_config(
+        Config::ShowEmails,
+        Some(&ShowEmails::AcceptedContacts.to_string()),
+    )
+    .await?;
+    tcm.send_recv(alice, bob, "hi").await;
+    receive_imf(
+        bob,
+        b"From: bob@example.net\n\
+        To: alice@example.org, claire@example.com\n\
+        Message-ID: <3333@example.net>\n\
+        Date: Sun, 22 Mar 2020 22:37:57 +0000\n\
+        \n\
+        hello\n",
+        false,
+    )
+    .await?;
+    let chats = Chatlist::try_load(bob, 0, None, None).await?;
+    assert_eq!(chats.len(), 1);
+    let chat_id = chats.get_chat_id(0)?;
+    assert_eq!(chat_id.get_msg_cnt(bob).await?, 1);
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
Instead, look up the 1:1 chat in `receive_imf::add_parts()`. This is a more generic approach to fix assigning outgoing reactions to 1:1 chats in the multi-device setup. Although currently both approaches give the same result, this way we can even implement a "react privately" functionality. Maybe it sounds useless, but it seems better to have less reaction-specific code.