### PR TITLE
fix: do not show empty summary if message reacted to is deleted

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -459,7 +459,19 @@ impl Message {
     }
 
     /// Loads message with given ID from the database.
+    ///
+    /// Returns an error if the message does not exist.
     pub async fn load_from_db(context: &Context, id: MsgId) -> Result<Message> {
+        let message = Self::load_from_db_optional(context, id)
+            .await?
+            .context("Message {id} does not exist")?;
+        Ok(message)
+    }
+
+    /// Loads message with given ID from the database.
+    ///
+    /// Returns `None` if the message does not exist.
+    pub async fn load_from_db_optional(context: &Context, id: MsgId) -> Result<Option<Message>> {
         ensure!(
             !id.is_special(),
             "Can not load special message ID {} from DB",
@@ -467,7 +479,7 @@ impl Message {
         );
         let msg = context
             .sql
-            .query_row(
+            .query_row_optional(
                 concat!(
                     "SELECT",
                     "    m.id AS id,",

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -348,7 +348,9 @@ impl Chat {
                 // The message reacted to may be deleted physically (`load_from_db()` fails) or marked as a tombstone (`is_trash()`).
                 // These are no errors as `Param::LastReaction*` are just weak pointers.
                 // Instead, just return `Ok(None)` and let the caller create another summary.
-                if let Ok(reaction_msg) = Message::load_from_db(context, reaction_msg_id).await {
+                if let Some(reaction_msg) =
+                    Message::load_from_db_optional(context, reaction_msg_id).await?
+                {
                     if !reaction_msg.chat_id.is_trash() {
                         let reaction_contact_id = ContactId::new(
                             self.param


### PR DESCRIPTION
we [checked for tombstones already using `is_trash()`](https://github.com/deltachat/deltachat-core-rust/pull/5387/files#diff-0f1f65bfdc551eeaa293befb40ac1d6c8b3eadaa142d2f7b88f5af9ea30f210cR352), however, we've overseen that tombstones get deleted at some point :)

therefore, just do not treat loading failures of the weak msg_id as errors - usually, they are not - and if, just the normal summary is shown. in theory, we could check for existence explicitly before trying load_from_db, however, that would be additional code (and maybe another database call) and not worth the effort.

anyways, this commit also adds an explicit test
for physical deletion after housekeeping.

