### PR TITLE
fix: Don't try to do fetch_move_delete() if Trash is needed but not yet configured

### DIFF
--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -2230,17 +2230,21 @@ def test_delete_multiple_messages(acfactory, lp):
 
 def test_trash_multiple_messages(acfactory, lp):
     ac1, ac2 = acfactory.get_online_accounts(2)
+    ac2.stop_io()
 
-    # Create the Trash folder on IMAP server
-    # and recreate the account so Trash folder is configured.
+    # Create the Trash folder on IMAP server and configure deletion to it. There was a bug that if
+    # Trash wasn't configured initially, it can't be configured later, let's check this.
     lp.sec("Creating trash folder")
     ac2.direct_imap.create_folder("Trash")
-    lp.sec("Creating new accounts")
-    ac2 = acfactory.new_online_configuring_account(cloned_from=ac2)
-    acfactory.bring_accounts_online()
-
     ac2.set_config("delete_to_trash", "1")
-    assert ac2.get_config("configured_trash_folder")
+
+    lp.sec("Check that Trash can be configured initially as well")
+    ac3 = acfactory.new_online_configuring_account(cloned_from=ac2)
+    acfactory.bring_accounts_online()
+    assert ac3.get_config("configured_trash_folder")
+    ac3.stop_io()
+
+    ac2.start_io()
     chat12 = acfactory.get_accepted_chat(ac1, ac2)
 
     lp.sec("ac1: sending 3 messages")
@@ -2255,6 +2259,9 @@ def test_trash_multiple_messages(acfactory, lp):
         assert msg.text in texts
         if text != "second":
             to_delete.append(msg)
+    # ac2 has received some messages, this is impossible w/o the trash folder configured, let's
+    # check the configuration.
+    assert ac2.get_config("configured_trash_folder") == "Trash"
 
     lp.sec("ac2: deleting all messages except second")
     assert len(to_delete) == len(texts) - 1


### PR DESCRIPTION
This fixes things for Gmail f.e. Before, `Imap::fetch_move_delete()` was called before looking for Trash and returned an error because of that failing the whole `fetch_idle()` which prevented configuring Trash in turn.

EDIT: Haven't yet tested it. The bug was reported to me by a Gmail user.
EDIT: The user said also that they don’t like that this critical error also wasn't perceived by the app and reported to the user. Probably we need to report such errors somehow.
EDIT: Going to add a Python test on this... DONE.