### PR TITLE
fix: `Message::get_summary()` must not return reaction summary

### DIFF
--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -416,7 +416,7 @@ impl Chatlist {
         if chat.id.is_archived_link() {
             Ok(Default::default())
         } else if let Some(lastmsg) = lastmsg.filter(|msg| msg.from_id != ContactId::UNDEFINED) {
-            Summary::new(context, &lastmsg, chat, lastcontact.as_ref()).await
+            Summary::new_with_reaction_details(context, &lastmsg, chat, lastcontact.as_ref()).await
         } else {
             Ok(Summary {
                 text: stock_str::no_messages(context).await,

--- a/src/message.rs
+++ b/src/message.rs
@@ -1987,8 +1987,9 @@ mod tests {
     use num_traits::FromPrimitive;
 
     use super::*;
-    use crate::chat::{self, marknoticed_chat, ChatItem};
+    use crate::chat::{self, marknoticed_chat, send_text_msg, ChatItem};
     use crate::chatlist::Chatlist;
+    use crate::reaction::send_reaction;
     use crate::receive_imf::receive_imf;
     use crate::test_utils as test;
     use crate::test_utils::{TestContext, TestContextManager};
@@ -2474,6 +2475,24 @@ mod tests {
         assert_eq!(received.text, "> Second quote");
         assert!(received.quoted_text().is_none());
         assert!(received.quoted_message(&bob).await?.is_none());
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_get_message_summary_text() -> Result<()> {
+        let t = TestContext::new_alice().await;
+        let chat = t.get_self_chat().await;
+        let msg_id = send_text_msg(&t, chat.id, "foo".to_string()).await?;
+        let msg = Message::load_from_db(&t, msg_id).await?;
+        let summary = msg.get_summary(&t, None).await?;
+        assert_eq!(summary.text, "foo");
+
+        // message summary does not change when reactions are applied (in contrast to chatlist summary)
+        send_reaction(&t, msg_id, "🫵").await?;
+        let msg = Message::load_from_db(&t, msg_id).await?;
+        let summary = msg.get_summary(&t, None).await?;
+        assert_eq!(summary.text, "foo");
 
         Ok(())
     }

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -59,7 +59,7 @@ pub struct Summary {
 impl Summary {
     /// Constructs chatlist summary
     /// from the provided message, chat and message author contact snapshots.
-    pub async fn new(
+    pub async fn new_with_reaction_details(
         context: &Context,
         msg: &Message,
         chat: &Chat,
@@ -81,7 +81,17 @@ impl Summary {
                 thumbnail_path: None,
             });
         }
+        Self::new(context, msg, chat, contact).await
+    }
 
+    /// Constructs search result summary
+    /// from the provided message, chat and message author contact snapshots.
+    pub async fn new(
+        context: &Context,
+        msg: &Message,
+        chat: &Chat,
+        contact: Option<&Contact>,
+    ) -> Result<Summary> {
         let prefix = if msg.state == MessageState::OutDraft {
             Some(SummaryPrefix::Draft(stock_str::draft(context).await))
         } else if msg.from_id == ContactId::SELF {


### PR DESCRIPTION
this PR fixes a bug in `Message::get_summary()`, that must not return reaction summary. the PR introduces an explicit function when a reaction summary is really wanted.

the bug was introduced by https://github.com/deltachat/deltachat-core-rust/pull/5387 and is not part of any official release.

closes https://github.com/deltachat/deltachat-core-rust/issues/5437