### PR TITLE
Adapt target install path if env var CARGO_BUILD_TARGET is set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,12 @@ else()
        set(DYNAMIC_EXT "dll")
 endif()
 
+if(DEFINED ENV{CARGO_BUILD_TARGET})
+    set(ARCH_DIR "$ENV{CARGO_BUILD_TARGET}")
+else()
+    set(ARCH_DIR "./")
+endif()
+
 add_custom_command(
 	OUTPUT
 	"${CMAKE_BINARY_DIR}/target/release/libdeltachat.a"
@@ -35,6 +41,6 @@ add_custom_target(
 )
 
 install(FILES "deltachat-ffi/deltachat.h" DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(FILES "${CMAKE_BINARY_DIR}/target/release/libdeltachat.a" DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES "${CMAKE_BINARY_DIR}/target/release/libdeltachat.${DYNAMIC_EXT}" DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES "${CMAKE_BINARY_DIR}/target/release/pkgconfig/deltachat.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+install(FILES "${CMAKE_BINARY_DIR}/target/${ARCH_DIR}/release/libdeltachat.a" DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES "${CMAKE_BINARY_DIR}/target/${ARCH_DIR}/release/libdeltachat.${DYNAMIC_EXT}" DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(FILES "${CMAKE_BINARY_DIR}/target/${ARCH_DIR}/release/pkgconfig/deltachat.pc" DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)


### PR DESCRIPTION
When the env var CARGO_BUILD_TARGET is set, cargo will cross-build for the given target platform triple. In this case, the targets will not be put into target/release/, but into target/$CARGO_BUILD_TARGET/release/. This PR adds this sub-directory to the target path for the install commands, if needed.