### PR TITLE
fix(deltachat-rpc-client): construct Thread with `target` keyword argument

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/_utils.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/_utils.py
@@ -104,7 +104,11 @@ def _run_cli(
         if not client.is_configured():
             assert args.email, "Account is not configured and email must be provided"
             assert args.password, "Account is not configured and password must be provided"
-            configure_thread = Thread(run=client.configure, kwargs={"email": args.email, "password": args.password})
+            configure_thread = Thread(
+                target=client.configure,
+                daemon=True,
+                kwargs={"email": args.email, "password": args.password},
+            )
             configure_thread.start()
         client.run_forever()
 


### PR DESCRIPTION
`run` argument does not exist.

Fixes #5144