### PR TITLE
fix: use clone_from()

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1527,7 +1527,7 @@ impl Chat {
                     Ok(contacts) => {
                         if let Some(contact_id) = contacts.first() {
                             if let Ok(contact) = Contact::get_by_id(context, *contact_id).await {
-                                chat_name = contact.get_display_name().to_owned();
+                                contact.get_display_name().clone_into(&mut chat_name);
                             }
                         }
                     }
@@ -2861,7 +2861,7 @@ pub(crate) async fn create_send_msg_jobs(context: &Context, msg: &mut Message) -
         msg.update_param(context).await?;
     }
 
-    msg.subject = rendered_msg.subject.clone();
+    msg.subject.clone_from(&rendered_msg.subject);
     msg.update_subject(context).await?;
     let chunk_size = context
         .get_configured_provider()

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -356,8 +356,8 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
         let mut smtp_configured = false;
         let mut errors = Vec::new();
         for smtp_server in smtp_servers {
-            smtp_param.user = smtp_server.username.clone();
-            smtp_param.server = smtp_server.hostname.clone();
+            smtp_param.user.clone_from(&smtp_server.username);
+            smtp_param.server.clone_from(&smtp_server.hostname);
             smtp_param.port = smtp_server.port;
             smtp_param.security = smtp_server.socket;
             smtp_param.certificate_checks = match smtp_server.strict_tls {
@@ -403,8 +403,8 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
     let imap_servers_count = imap_servers.len();
     let mut errors = Vec::new();
     for (imap_server_index, imap_server) in imap_servers.into_iter().enumerate() {
-        param.imap.user = imap_server.username.clone();
-        param.imap.server = imap_server.hostname.clone();
+        param.imap.user.clone_from(&imap_server.username);
+        param.imap.server.clone_from(&imap_server.hostname);
         param.imap.port = imap_server.port;
         param.imap.security = imap_server.socket;
         param.imap.certificate_checks = match imap_server.strict_tls {

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -388,7 +388,7 @@ impl Imap {
             Ok(session) => {
                 // Store server ID in the context to display in account info.
                 let mut lock = context.server_id.write().await;
-                *lock = session.capabilities.server_id.clone();
+                lock.clone_from(&session.capabilities.server_id);
 
                 self.login_failed_once = false;
                 context.emit_event(EventType::ImapConnected(format!(
@@ -420,7 +420,7 @@ impl Imap {
                     drop(lock);
 
                     let mut msg = Message::new(Viewtype::Text);
-                    msg.text = message.clone();
+                    msg.text.clone_from(&message);
                     if let Err(e) =
                         chat::add_device_msg_with_importance(context, None, Some(&mut msg), true)
                             .await

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -80,7 +80,7 @@ impl LoginParam {
         // Only check for IMAP password, SMTP password is an "advanced" setting.
         ensure!(!param.imap.password.is_empty(), "Missing (IMAP) password.");
         if param.smtp.password.is_empty() {
-            param.smtp.password = param.imap.password.clone()
+            param.smtp.password.clone_from(&param.imap.password)
         }
         Ok(param)
     }

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -604,7 +604,7 @@ impl MimeMessage {
                 let mut filepart = self.parts.swap_remove(1);
 
                 // insert new one
-                filepart.msg = self.parts[0].msg.clone();
+                filepart.msg.clone_from(&self.parts[0].msg);
                 if let Some(quote) = self.parts[0].param.get(Param::Quote) {
                     filepart.param.set(Param::Quote, quote);
                 }

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -784,7 +784,7 @@ pub(crate) async fn maybe_do_aeap_transition(
             .await?;
 
         let old_addr = mem::take(&mut peerstate.addr);
-        peerstate.addr = info.from.clone();
+        peerstate.addr.clone_from(&info.from);
         let header = info.autocrypt_header.as_ref().context(
             "Internal error: Tried to do an AEAP transition without an autocrypt header??",
         )?;

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2079,7 +2079,7 @@ async fn apply_group_changes(
             } else if let Some(added_id) = added_id {
                 diff.insert(added_id);
             }
-            new_members = chat_contacts.clone();
+            new_members.clone_from(&chat_contacts);
             // Don't delete any members locally, but instead add absent ones to provide group
             // membership consistency for all members:
             // - Classical MUA users usually don't intend to remove users from an email thread, so
@@ -2268,7 +2268,7 @@ fn compute_mailinglist_name(
     // and we can detect these lists by a unique `ListId`-suffix.
     if listid.ends_with(".list-id.mcsv.net") {
         if let Some(display_name) = &mime_parser.from.display_name {
-            name = display_name.clone();
+            name.clone_from(display_name);
         }
     }
 
@@ -2296,7 +2296,7 @@ fn compute_mailinglist_name(
             || listid.ends_with(".xt.local"))
     {
         if let Some(display_name) = &mime_parser.from.display_name {
-            name = display_name.clone();
+            name.clone_from(display_name);
         }
     }
 


### PR DESCRIPTION
`a.clone_from(&b)` is equivalent to `a = b.clone()` in functionality, but can be overridden to reuse the resources of a to avoid unnecessary allocations.