### PR TITLE
build(nix): use stable Rust in flake.nix devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -525,15 +525,12 @@
 
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            (fenixPkgs.complete.withComponents [
-              "cargo"
-              "clippy"
-              "rust-src"
-              "rustc"
-              "rustfmt"
-            ])
+            cargo
+            clippy
+            rustc
+            rustfmt
+            rust-analyzer
             cargo-deny
-            fenixPkgs.rust-analyzer
             perl # needed to build vendored OpenSSL
           ];
         };


### PR DESCRIPTION
This way nightly clippy warnings are not generated when devshell is used.

Nighly Rust is also not cached, e.g. rust-analyzer has to be rebuilt if version from fenix is used.