### PR TITLE
ci: Run doc tests with cargo test --workspace --doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,11 @@ jobs:
           RUST_BACKTRACE: 1
         run: cargo nextest run --workspace
 
+      - name: Doc-Tests
+        env:
+          RUST_BACKTRACE: 1
+        run: cargo test --workspace --doc
+
       - name: Test cargo vendor
         run: cargo vendor
 


### PR DESCRIPTION
Nextest doesn't run doc tests, so we need to run them with `cargo test --workspace --doc`.

See https://github.com/nextest-rs/nextest/issues/16

Follow-up for #5457