### PR TITLE
api: don't load trashed messages with Message::load_from_db

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -448,10 +448,9 @@ mod tests {
         )
         .await?;
         assert_eq!(get_chat_msgs(&bob, chat_id).await?.len(), 0);
-        assert!(Message::load_from_db(&bob, msg.id)
+        assert!(Message::load_from_db_optional(&bob, msg.id)
             .await?
-            .chat_id
-            .is_trash());
+            .is_none());
 
         Ok(())
     }
@@ -507,10 +506,9 @@ mod tests {
         // (usually mdn are too small for not being downloaded directly)
         receive_imf_from_inbox(&bob, "bar@example.org", raw, false, None, false).await?;
         assert_eq!(get_chat_msgs(&bob, chat_id).await?.len(), 0);
-        assert!(Message::load_from_db(&bob, msg.id)
+        assert!(Message::load_from_db_optional(&bob, msg.id)
             .await?
-            .chat_id
-            .is_trash());
+            .is_none());
 
         Ok(())
     }

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -1098,8 +1098,8 @@ mod tests {
             })
             .await;
 
-        let loaded = Message::load_from_db(t, msg_id).await?;
-        assert_eq!(loaded.chat_id, DC_CHAT_ID_TRASH);
+        let loaded = Message::load_from_db_optional(t, msg_id).await?;
+        assert!(loaded.is_none());
 
         // Check that the msg was deleted locally.
         check_msg_is_deleted(t, chat, msg_id).await;

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -1158,7 +1158,8 @@ mod tests {
         // Send a message that cannot be decrypted because the keys are
         // not synchronized yet.
         let sent = alice2.send_text(msg.chat_id, "Test").await;
-        alice.recv_msg(&sent).await;
+        let trashed_message = alice.recv_msg_opt(&sent).await;
+        assert!(trashed_message.is_none());
         assert_ne!(alice.get_last_msg().await.get_text(), "Test");
 
         // Transfer the key.

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -4014,8 +4014,7 @@ async fn test_member_left_does_not_create_chat() -> Result<()> {
     // which some members simply deleted and some members left,
     // recreating the chat for others.
     remove_contact_from_chat(&alice, alice_chat_id, ContactId::SELF).await?;
-    let bob_chat_id = bob.recv_msg(&alice.pop_sent_msg().await).await.chat_id;
-    assert!(bob_chat_id.is_trash());
+    bob.recv_msg_trash(&alice.pop_sent_msg().await).await;
 
     Ok(())
 }
@@ -4365,8 +4364,8 @@ async fn test_forged_from() -> Result<()> {
         .payload
         .replace("bob@example.net", "notbob@example.net");
 
-    let msg = alice.recv_msg(&sent_msg).await;
-    assert!(msg.chat_id.is_trash());
+    let msg = alice.recv_msg_opt(&sent_msg).await;
+    assert!(msg.is_none());
     Ok(())
 }
 

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -833,7 +833,7 @@ mod tests {
         assert!(msg.get_header(HeaderDef::SecureJoinInvitenumber).is_some());
 
         // Step 3: Alice receives vc-request, sends vc-auth-required
-        alice.recv_msg(&sent).await;
+        alice.recv_msg_trash(&sent).await;
         assert_eq!(
             Chatlist::try_load(&alice, 0, None, None)
                 .await
@@ -851,7 +851,7 @@ mod tests {
         );
 
         // Step 4: Bob receives vc-auth-required, sends vc-request-with-auth
-        bob.recv_msg(&sent).await;
+        bob.recv_msg_trash(&sent).await;
 
         // Check Bob emitted the JoinerProgress event.
         let event = bob
@@ -933,7 +933,7 @@ mod tests {
         }
 
         // Step 5+6: Alice receives vc-request-with-auth, sends vc-contact-confirm
-        alice.recv_msg(&sent).await;
+        alice.recv_msg_trash(&sent).await;
         assert_eq!(contact_bob.is_verified(&alice.ctx).await.unwrap(), true);
 
         // exactly one one-to-one chat should be visible for both now
@@ -982,7 +982,7 @@ mod tests {
         assert_eq!(contact_bob.is_verified(&bob.ctx).await.unwrap(), false);
 
         // Step 7: Bob receives vc-contact-confirm
-        bob.recv_msg(&sent).await;
+        bob.recv_msg_trash(&sent).await;
         assert_eq!(contact_alice.is_verified(&bob.ctx).await.unwrap(), true);
 
         // Check Bob got the verified message in his 1:1 chat.
@@ -1083,7 +1083,7 @@ mod tests {
         assert_eq!(contact_bob.is_verified(&alice.ctx).await?, false);
 
         // Step 5+6: Alice receives vc-request-with-auth, sends vc-contact-confirm
-        alice.recv_msg(&sent).await;
+        alice.recv_msg_trash(&sent).await;
         assert_eq!(contact_bob.is_verified(&alice.ctx).await?, true);
 
         let sent = alice.pop_sent_msg().await;
@@ -1104,7 +1104,7 @@ mod tests {
         assert_eq!(contact_bob.is_verified(&bob.ctx).await?, false);
 
         // Step 7: Bob receives vc-contact-confirm
-        bob.recv_msg(&sent).await;
+        bob.recv_msg_trash(&sent).await;
         assert_eq!(contact_alice.is_verified(&bob.ctx).await?, true);
 
         Ok(())
@@ -1182,7 +1182,7 @@ mod tests {
         assert!(msg.get_header(HeaderDef::SecureJoinGroup).is_none());
 
         // Step 3: Alice receives vg-request, sends vg-auth-required
-        alice.recv_msg(&sent).await;
+        alice.recv_msg_trash(&sent).await;
 
         let sent = alice.pop_sent_msg().await;
         let msg = bob.parse_msg(&sent).await;
@@ -1193,7 +1193,7 @@ mod tests {
         );
 
         // Step 4: Bob receives vg-auth-required, sends vg-request-with-auth
-        bob.recv_msg(&sent).await;
+        bob.recv_msg_trash(&sent).await;
         let sent = bob.pop_sent_msg().await;
 
         // Check Bob emitted the JoinerProgress event.
@@ -1240,7 +1240,7 @@ mod tests {
         assert_eq!(contact_bob.is_verified(&alice.ctx).await?, false);
 
         // Step 5+6: Alice receives vg-request-with-auth, sends vg-member-added
-        alice.recv_msg(&sent).await;
+        alice.recv_msg_trash(&sent).await;
         assert_eq!(contact_bob.is_verified(&alice.ctx).await?, true);
 
         let sent = alice.pop_sent_msg().await;
@@ -1388,15 +1388,15 @@ First thread."#;
 
         // vc-request
         let sent = bob.pop_sent_msg().await;
-        alice.recv_msg(&sent).await;
+        alice.recv_msg_trash(&sent).await;
 
         // vc-auth-required
         let sent = alice.pop_sent_msg().await;
-        bob.recv_msg(&sent).await;
+        bob.recv_msg_trash(&sent).await;
 
         // vc-request-with-auth
         let sent = bob.pop_sent_msg().await;
-        alice.recv_msg(&sent).await;
+        alice.recv_msg_trash(&sent).await;
 
         // Alice has Bob verified now.
         let contact_bob_id =

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -571,7 +571,7 @@ mod tests {
         let sent_msg = alice.pop_sent_msg().await;
         let alice2 = TestContext::new_alice().await;
         alice2.set_config_bool(Config::SyncMsgs, true).await?;
-        alice2.recv_msg(&sent_msg).await;
+        alice2.recv_msg_trash(&sent_msg).await;
         assert!(token::exists(&alice2, token::Namespace::Auth, "testtoken").await?);
         assert_eq!(Chatlist::try_load(&alice2, 0, None, None).await?.len(), 0);
 


### PR DESCRIPTION
API now pretends that trashed messages don't exist. This way callers don't have to check if loaded message belongs to trash chat.
If message may be trashed by the time it is attempted to be loaded, callers should use Message::load_from_db_optional.

Most changes are around receive_status_update() function because previously it relied on loading trashed status update messages immediately after adding them to the database.