### PR TITLE
Fix CI after stopping returning trashed messages from `Message::load_from_db()`

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2010,7 +2010,7 @@ pub unsafe extern "C" fn dc_get_msg(context: *mut dc_context_t, msg_id: u32) -> 
                     );
                     message::Message::default()
                 } else {
-                    error!(ctx, "dc_get_msg could not retrieve msg_id {msg_id}: {e:#}");
+                    warn!(ctx, "dc_get_msg could not retrieve msg_id {msg_id}: {e:#}");
                     return ptr::null_mut();
                 }
             }

--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -328,10 +328,12 @@ class EventThread(threading.Thread):
         elif name == "DC_EVENT_REACTIONS_CHANGED":
             assert ffi_event.data1 > 0
             msg = account.get_message_by_id(ffi_event.data2)
-            yield "ac_reactions_changed", {"message": msg}
+            if msg is not None:
+                yield "ac_reactions_changed", {"message": msg}
         elif name == "DC_EVENT_MSG_DELIVERED":
             msg = account.get_message_by_id(ffi_event.data2)
-            yield "ac_message_delivered", {"message": msg}
+            if msg is not None:
+                yield "ac_message_delivered", {"message": msg}
         elif name == "DC_EVENT_CHAT_MODIFIED":
             chat = account.get_chat_by_id(ffi_event.data1)
             yield "ac_chat_modified", {"chat": chat}

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -395,7 +395,7 @@ class Message:
 
     def is_outgoing(self):
         """Return True if Message is outgoing."""
-        return self._msgstate in (
+        return lib.dc_msg_get_state(self._dc_msg) in (
             const.DC_STATE_OUT_PREPARING,
             const.DC_STATE_OUT_PENDING,
             const.DC_STATE_OUT_FAILED,

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -364,6 +364,9 @@ class Message:
         else:
             # load message from db to get a fresh/current state
             dc_msg = ffi.gc(lib.dc_get_msg(self.account._dc_context, self.id), lib.dc_msg_unref)
+            # Message could be trashed, use the cached object if so.
+            if dc_msg == ffi.NULL:
+                dc_msg = self._dc_msg
         return lib.dc_msg_get_state(dc_msg)
 
     def is_in_fresh(self):
@@ -484,6 +487,9 @@ class Message:
 
         # load message from db to get a fresh/current state
         dc_msg = ffi.gc(lib.dc_get_msg(self.account._dc_context, self.id), lib.dc_msg_unref)
+        # Message could be trashed, use the cached object if so.
+        if dc_msg == ffi.NULL:
+            dc_msg = self._dc_msg
         return lib.dc_msg_get_download_state(dc_msg)
 
     def download_full(self) -> None:


### PR DESCRIPTION
Moving some commits out of #5382 as they should fix spurious CI failures like https://github.com/deltachat/deltachat-core-rust/actions/runs/8747466951/job/24006074895