### PR TITLE
fix(node): undefine NAPI_EXPERIMENTAL

### DIFF
--- a/node/src/module.c
+++ b/node/src/module.c
@@ -1,5 +1,4 @@
 #define NAPI_VERSION 4
-#define NAPI_EXPERIMENTAL
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
This fixes build with new clang
which treats -Wincompatible-function-pointer-types as an error.

Related upstream issue: <https://github.com/nodejs/node/issues/52229>