### PR TITLE
fix: do not fail if Autocrypt Setup Message has no encryption preference

### DIFF
--- a/test-data/message/k-9-autocrypt-setup-message.eml
+++ b/test-data/message/k-9-autocrypt-setup-message.eml
@@ -1,0 +1,65 @@
+Return-Path: <autocrypt@nine.testrun.org>
+Delivered-To: autocrypt@nine.testrun.org
+Received: from nine.testrun.org
+	by nine with LMTP
+	id wNinAKX2J2YWDwEAPdT8mA
+	(envelope-from <autocrypt@nine.testrun.org>)
+	for <autocrypt@nine.testrun.org>; Tue, 23 Apr 2024 19:57:57 +0200
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=nine.testrun.org;
+	s=opendkim; t=1713895076;
+	bh=yuHuHSbYX5hE/xr8aU2fy/SlqfTL7XjfV2m1eEePTz4=;
+	h=Subject:Date:From:To:From;
+	b=ZbVNpJ8zjHmgrCqiRnqzENcR/PwR/G182hL18U5bp5CZmkyWcuhQU0EkhkJpCCv1n
+	 8bZ9WlOT0cmzBHpWU43t7HufuUM56NwwuVqEuz2agpVzQV8zKIPhthrBzbYIeR4Prg
+	 1DgwWr8EhotoV6yPgzxi9sMyO3l4spJeaREisB5MPOIdKeIxtRPLR+Woo5hQWNTFoh
+	 ZQtCcY7w5vxXGhBMVPXOjbrrzOCsE5gGB5QYSAR8Bv3ZdJn/mHvIRCEJG5hJGSxXjQ
+	 fD0UGJ5m5RVrF0tWnZ7U5tpoRD/UVV1+Us9Woq733R97ZchpoE4hNpMG9zYW90z4QU
+	 kBajbsH81Nm0A==
+MIME-Version: 1.0
+Content-Type: multipart/mixed;
+ boundary=----X2OJUZLGILKJEHMTO29ZMST9701ZDH
+Content-Transfer-Encoding: 7bit
+Subject: Autocrypt Setup Message
+Autocrypt-Setup-Message: v1
+Date: Tue, 23 Apr 2024 19:57:57 +0200
+From: autocrypt@nine.testrun.org
+To: autocrypt@nine.testrun.org
+Message-Id: <20240423175756.F19EB17C214A@nine.testrun.org>
+
+------X2OJUZLGILKJEHMTO29ZMST9701ZDH
+Content-Type: text/plain;
+ charset=utf-8
+Content-Transfer-Encoding: quoted-printable
+
+This message contains all information to transfer your Autocrypt settings a=
+long with your secret key securely from your original device=2E To set up y=
+our new device for Autocrypt, please follow the instructions that should be=
+ presented by your new device=2E You can keep this message and use it as a =
+backup for your secret key=2E If you want to do this, you should write down=
+ the password and store it securely=2E
+------X2OJUZLGILKJEHMTO29ZMST9701ZDH
+Content-Transfer-Encoding: 7bit
+Content-Type: application/autocrypt-setup
+Content-Disposition: attachment; filename="autocrypt-setup-message"
+
+-----BEGIN PGP MESSAGE-----
+Passphrase-Format: numeric9x4
+Passphrase-Begin: 06
+
+ww0ECQMCAhlJ+TRwb2Fg0sGXAUc+92rmg4k57Sd4D3O/SPQNzShbVdlKsoFzyH+B
+YhimOr/8C5ZHyg/WjRGlk4pD+t57WfVdE7LYnv8qsK86h2kffZAGlj+B9Lh9+qbV
+KgJLpHUKg7ZGa/9aMq7KuFoNSNTbcHtzJ/Ml9GVe+opimER87mpFCjmaEHCcCp0a
+ZeS5VU8gTV7AKuPW40BBipyEmKpUvE/ZWfz3KSI4RZyIwM8v8kXBMojT4WLqWm93
+JoEKUyeh+3JKMvsfyRbmHXrHprG9f2e8PLvNkAiie68YJniFnwA8nmNSnPv9S9rf
+7oUHtnTDKJ4FIpmfPgj1v/KIWWW9KaZWHi7K5mFUCTb4pBoCRIGaFh+JzbSlNL9i
+fz7HIiN95bFJ4xXXL4gcU9wO5//npkVDUncaeHhUy1VBLu0NFYvze+s+eAIesqec
+X3x++U9d+Slbpa1G2Z5Knj50mBY+k9aNwVMZGu50hzhPvdwesqmbr+GTSh0O1bxI
+gw/cDq5s58Ewze3WvYaLxJz/RcwOCGSV8k21FM4WTnEahs4yfLbzNuusYvvciU6l
+w0eZC+vEmh+bINSSRX/mcvkQcIkkCsqvfWyxdSNIBCwmR86oalWnxZniBLbbbZHD
+0KAsv0w7t00Y715gyyFWyiEiT5Lyl4TA+cUIHKmmpKOaVubz50UD1z5rqT7joJ7G
+KRmWtQW8MScgcmK7+tyavLQOxwe8i8i9JkUy+d9jhj17XZil/If26Q3V3epqCXq3
+FdvEvvNGJF0DyJ4YAe9QMBumf22sMmX/XVock9/k0pB46mciMhPL3VA=
+=LYx9
+-----END PGP MESSAGE-----
+
+------X2OJUZLGILKJEHMTO29ZMST9701ZDH--


### PR DESCRIPTION
According to Autocrypt specification
Autocrypt Setup Message SHOULD
contain Autocrypt-Prefer-Encrypt header,
but K-9 6.802 does not include it.

Fixes #4312
