### PR TITLE
fix: do not fail to send encrypted quotes to unencrypted chats

### DIFF
--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1343,7 +1343,6 @@ def test_quote_encrypted(acfactory, lp):
 
     for quoted_msg in msg1, msg3:
         # Save the draft with a quote.
-        # It should be encrypted if quoted message is encrypted.
         msg_draft = Message.new_empty(ac1, "text")
         msg_draft.set_text("message reply")
         msg_draft.quote = quoted_msg
@@ -1357,10 +1356,14 @@ def test_quote_encrypted(acfactory, lp):
         chat.set_draft(None)
         assert chat.get_draft() is None
 
+        # Quote should be replaced with "..." if quoted message is encrypted.
         msg_in = ac2._evtracker.wait_next_incoming_message()
         assert msg_in.text == "message reply"
-        assert msg_in.quoted_text == quoted_msg.text
-        assert msg_in.is_encrypted() == quoted_msg.is_encrypted()
+        assert not msg_in.is_encrypted()
+        if quoted_msg.is_encrypted():
+            assert msg_in.quoted_text == "..."
+        else:
+            assert msg_in.quoted_text == quoted_msg.text
 
 
 def test_quote_attachment(tmp_path, acfactory, lp):

--- a/src/message.rs
+++ b/src/message.rs
@@ -1112,7 +1112,7 @@ impl Message {
                 .get_bool(Param::GuaranteeE2ee)
                 .unwrap_or_default()
             {
-                self.param.set(Param::GuaranteeE2ee, "1");
+                self.param.set(Param::ProtectQuote, "1");
             }
 
             let text = quote.get_text();
@@ -2000,7 +2000,9 @@ mod tests {
     use num_traits::FromPrimitive;
 
     use super::*;
-    use crate::chat::{self, marknoticed_chat, send_text_msg, ChatItem};
+    use crate::chat::{
+        self, add_contact_to_chat, marknoticed_chat, send_text_msg, ChatItem, ProtectionStatus,
+    };
     use crate::chatlist::Chatlist;
     use crate::config::Config;
     use crate::reaction::send_reaction;
@@ -2194,6 +2196,42 @@ mod tests {
             .expect("error while retrieving quoted message")
             .expect("quoted message not found");
         assert_eq!(quoted_msg.get_text(), msg2.quoted_text().unwrap());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_unencrypted_quote_encrypted_message() -> Result<()> {
+        let mut tcm = TestContextManager::new();
+
+        let alice = &tcm.alice().await;
+        let bob = &tcm.bob().await;
+
+        let alice_group = alice
+            .create_group_with_members(ProtectionStatus::Unprotected, "Group chat", &[bob])
+            .await;
+        let sent = alice.send_text(alice_group, "Hi! I created a group").await;
+        let bob_received_message = bob.recv_msg(&sent).await;
+
+        let bob_group = bob_received_message.chat_id;
+        bob_group.accept(bob).await?;
+        let sent = bob.send_text(bob_group, "Encrypted message").await;
+        let alice_received_message = alice.recv_msg(&sent).await;
+        assert!(alice_received_message.get_showpadlock());
+
+        // Alice adds contact without key so chat becomes unencrypted.
+        let alice_flubby_contact_id =
+            Contact::create(alice, "Flubby", "flubby@example.org").await?;
+        add_contact_to_chat(alice, alice_group, alice_flubby_contact_id).await?;
+
+        // Alice quotes encrypted message in unencrypted chat.
+        let mut msg = Message::new(Viewtype::Text);
+        msg.set_quote(alice, Some(&alice_received_message)).await?;
+        chat::send_msg(alice, alice_group, &mut msg).await?;
+
+        let bob_received_message = bob.recv_msg(&alice.pop_sent_msg().await).await;
+        assert_eq!(bob_received_message.quoted_text().unwrap(), "...");
+        assert_eq!(bob_received_message.get_showpadlock(), false);
+
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/param.rs
+++ b/src/param.rs
@@ -48,6 +48,11 @@ pub enum Param {
     /// For Messages: message is encrypted, outgoing: guarantee E2EE or the message is not send
     GuaranteeE2ee = b'c',
 
+    /// For Messages: quoted message is encrypted.
+    ///
+    /// If this message is sent unencrypted, quote text should be replaced.
+    ProtectQuote = b'0',
+
     /// For Messages: decrypted with validation errors or without mutual set, if neither
     /// 'c' nor 'e' are preset, the messages is only transport encrypted.
     ErroneousE2ee = b'e',


### PR DESCRIPTION
Replace quote text with "..." instead.

Fixes #2985 