### PR TITLE
ci: replace `black` with `ruff format`

### DIFF
--- a/deltachat-rpc-client/examples/echobot.py
+++ b/deltachat-rpc-client/examples/echobot.py
@@ -4,6 +4,7 @@
 it will echo back any text send to it, it also will print to console all Delta Chat core events.
 Pass --help to the CLI to see available options.
 """
+
 from deltachat_rpc_client import events, run_bot_cli
 
 hooks = events.HookCollection()

--- a/deltachat-rpc-client/examples/echobot_advanced.py
+++ b/deltachat-rpc-client/examples/echobot_advanced.py
@@ -3,6 +3,7 @@
 
 it will echo back any message that has non-empty text and also supports the /help command.
 """
+
 import logging
 import sys
 from threading import Thread

--- a/deltachat-rpc-client/examples/echobot_no_hooks.py
+++ b/deltachat-rpc-client/examples/echobot_no_hooks.py
@@ -2,6 +2,7 @@
 """
 Example echo bot without using hooks
 """
+
 import logging
 import sys
 

--- a/deltachat-rpc-client/tox.ini
+++ b/deltachat-rpc-client/tox.ini
@@ -22,9 +22,8 @@ skipsdist = True
 skip_install = True
 deps =
     ruff
-    black
 commands =
-    black --quiet --check --diff src/ examples/ tests/
+    ruff format --quiet --diff src/ examples/ tests/
     ruff check src/ examples/ tests/
 
 [pytest]

--- a/python/tox.ini
+++ b/python/tox.ini
@@ -41,12 +41,11 @@ skipsdist = True
 skip_install = True
 deps =
     ruff
-    black
     # pygments required by rst-lint
     pygments
     restructuredtext_lint 
 commands =
-    black --quiet --check --diff setup.py src/deltachat examples/ tests/
+    ruff format --quiet --diff setup.py src/deltachat examples/ tests/
     ruff check src/deltachat tests/ examples/
     rst-lint --encoding 'utf-8' README.rst
 


### PR DESCRIPTION
We use `ruff` anyway, so it is one less dependency.