### PR TITLE
fix: Update special chats icons even if they are blocked (#5509)

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2235,8 +2235,9 @@ pub struct ChatInfo {
 }
 
 pub(crate) async fn update_saved_messages_icon(context: &Context) -> Result<()> {
-    // if there is no saved-messages chat, there is nothing to update. this is no error.
-    if let Some(chat_id) = ChatId::lookup_by_contact(context, ContactId::SELF).await? {
+    if let Some(ChatIdBlocked { id: chat_id, .. }) =
+        ChatIdBlocked::lookup_by_contact(context, ContactId::SELF).await?
+    {
         let icon = include_bytes!("../assets/icon-saved-messages.png");
         let blob = BlobObject::create(context, "icon-saved-messages.png", icon).await?;
         let icon = blob.as_name().to_string();
@@ -2249,8 +2250,9 @@ pub(crate) async fn update_saved_messages_icon(context: &Context) -> Result<()> 
 }
 
 pub(crate) async fn update_device_icon(context: &Context) -> Result<()> {
-    // if there is no device-chat, there is nothing to update. this is no error.
-    if let Some(chat_id) = ChatId::lookup_by_contact(context, ContactId::DEVICE).await? {
+    if let Some(ChatIdBlocked { id: chat_id, .. }) =
+        ChatIdBlocked::lookup_by_contact(context, ContactId::DEVICE).await?
+    {
         let icon = include_bytes!("../assets/icon-device.png");
         let blob = BlobObject::create(context, "icon-device.png", icon).await?;
         let icon = blob.as_name().to_string();

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2303,7 +2303,9 @@ async fn update_special_chat_name(
     contact_id: ContactId,
     name: String,
 ) -> Result<()> {
-    if let Some(chat_id) = ChatId::lookup_by_contact(context, contact_id).await? {
+    if let Some(ChatIdBlocked { id: chat_id, .. }) =
+        ChatIdBlocked::lookup_by_contact(context, contact_id).await?
+    {
         // the `!= name` condition avoids unneeded writes
         context
             .sql
@@ -4473,9 +4475,10 @@ impl Context {
                     }
                     _ => (),
                 }
-                ChatId::lookup_by_contact(self, contact_id)
+                ChatIdBlocked::lookup_by_contact(self, contact_id)
                     .await?
                     .with_context(|| format!("No chat for addr '{addr}'"))?
+                    .id
             }
             SyncId::Grpid(grpid) => {
                 if let SyncAction::CreateBroadcast(name) = action {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1007,6 +1007,15 @@ mod tests {
             .set_config(Config::Selfavatar, Some(file.to_str().unwrap()))
             .await?;
         sync(&alice0, &alice1).await;
+        // There was a bug that a sync message creates the self-chat with the user avatar instead of
+        // the special icon and that remains so when the self-chat becomes user-visible. Let's check
+        // this.
+        let self_chat = alice0.get_self_chat().await;
+        let self_chat_avatar_path = self_chat.get_profile_image(&alice0).await?.unwrap();
+        assert_eq!(
+            self_chat_avatar_path,
+            alice0.get_blobdir().join("icon-saved-messages.png")
+        );
         assert!(alice1
             .get_config(Config::Selfavatar)
             .await?

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -20,7 +20,7 @@ use tokio::task;
 use tokio::time::{timeout, Duration};
 
 use crate::aheader::EncryptPreference;
-use crate::chat::{ChatId, ProtectionStatus};
+use crate::chat::{ChatId, ChatIdBlocked, ProtectionStatus};
 use crate::color::str_to_color;
 use crate::config::Config;
 use crate::constants::{Blocked, Chattype, DC_GCL_ADD_SELF, DC_GCL_VERIFIED_ONLY};
@@ -1315,7 +1315,9 @@ impl Contact {
     pub async fn is_profile_verified(&self, context: &Context) -> Result<bool> {
         let contact_id = self.id;
 
-        if let Some(chat_id) = ChatId::lookup_by_contact(context, contact_id).await? {
+        if let Some(ChatIdBlocked { id: chat_id, .. }) =
+            ChatIdBlocked::lookup_by_contact(context, contact_id).await?
+        {
             Ok(chat_id.is_protected(context).await? == ProtectionStatus::Protected)
         } else {
             // 1:1 chat does not exist.

--- a/src/message.rs
+++ b/src/message.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use tokio::{fs, io};
 
 use crate::blob::BlobObject;
-use crate::chat::{Chat, ChatId};
+use crate::chat::{Chat, ChatId, ChatIdBlocked};
 use crate::chatlist_events;
 use crate::config::Config;
 use crate::constants::{
@@ -1811,8 +1811,9 @@ pub async fn estimate_deletion_cnt(
     from_server: bool,
     seconds: i64,
 ) -> Result<usize> {
-    let self_chat_id = ChatId::lookup_by_contact(context, ContactId::SELF)
+    let self_chat_id = ChatIdBlocked::lookup_by_contact(context, ContactId::SELF)
         .await?
+        .map(|c| c.id)
         .unwrap_or_default();
     let threshold_timestamp = time() - seconds;
 


### PR DESCRIPTION
E.g. the multi-device synchronisation creates the "Saved Messages" chat as blocked, in this case the chat icon wasn't updated before and the user avatar was displayed instead.

Fix #5509 

EDIT: In the most other places `ChatIdBlocked`'s method must be used as well, fixed them too.