### PR TITLE
limit quote replies

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2596,12 +2596,8 @@ async fn prepare_msg_common(
     // Check a quote reply is not leaking data from other chats.
     // This is meant as a last line of defence, the UI should check that before as well.
     // (We allow Chattype::Single in general for "Reply Privately";
-    // checking for exact contact_id will produce false positives when ppl just left the group.
-    // "Forwarding" is allowed as well)
-    if chat.typ != Chattype::Single
-        && !msg.is_forwarded()
-        && !context.get_config_bool(Config::Bot).await?
-    {
+    // checking for exact contact_id will produce false positives when ppl just left the group)
+    if chat.typ != Chattype::Single && !context.get_config_bool(Config::Bot).await? {
         if let Some(quoted_message) = msg.quoted_message(context).await? {
             if quoted_message.chat_id != chat_id {
                 bail!("Bad quote reply");

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2604,7 +2604,7 @@ async fn prepare_msg_common(
     {
         if let Some(quoted_message) = msg.quoted_message(context).await? {
             if quoted_message.chat_id != chat_id {
-                bail!("bad quote reply");
+                bail!("Bad quote reply");
             }
         }
     }


### PR DESCRIPTION
this PR checks if the quotes are used in a reasonable way:

- quoted messages should be send to the same chat
- or to one-to-one chats

if the quote's chat ID is not the same than the sending chat _and_ the sending chat is not a one-to-one chat, sending is aborted.

usually, the UIs does not allow quoting in other ways, so, this check is only a "last defence line" to avoid leaking data in case the UI has bugs, as recently in https://github.com/deltachat/deltachat-android/issues/3032

@iequidoo @link2xt @adbenitez i am not 100% sure about this PR, maybe i've overseen a reasonable usecase where other quotes make sense