### PR TITLE
ci: give CI job permission to publish binaries to the release

### DIFF
--- a/.github/workflows/deltachat-rpc-server.yml
+++ b/.github/workflows/deltachat-rpc-server.yml
@@ -273,7 +273,9 @@ jobs:
     runs-on: "ubuntu-latest"
     permissions:
       id-token: write
-      contents: read
+
+      # Needed to publish the binaries to the release.
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Otherwise it fails on `gh release upload` step.