### PR TITLE
fix: rpc npm: fix local desktop development

### DIFF
--- a/deltachat-rpc-server/npm-package/.gitignore
+++ b/deltachat-rpc-server/npm-package/.gitignore
@@ -1,2 +1,3 @@
 platform_package
 *.tgz
+package-lock.json

--- a/deltachat-rpc-server/npm-package/scripts/make_local_dev_version.py
+++ b/deltachat-rpc-server/npm-package/scripts/make_local_dev_version.py
@@ -29,3 +29,6 @@ subprocess.run(["python", "scripts/build_platform_package.py", host_target], cap
 
 # run update_optional_dependencies_and_version.js to adjust the package / make it installable locally
 subprocess.run(["node", "scripts/update_optional_dependencies_and_version.js", "--local"], capture_output=False, check=True)
+
+# typescript / npm local package installing/linking needs that this package has it's own node_modules folder
+subprocess.run(["npm", "i"], capture_output=False, check=True)

--- a/deltachat-rpc-server/npm-package/scripts/update_optional_dependencies_and_version.js
+++ b/deltachat-rpc-server/npm-package/scripts/update_optional_dependencies_and_version.js
@@ -54,4 +54,10 @@ for (const { folder_name, package_name } of platform_package_names) {
     : version;
 }
 
+if (is_local) {
+  package_json.peerDependencies["@deltachat/jsonrpc-client"] = 'file:../../deltachat-jsonrpc/typescript'
+} else {
+  package_json.peerDependencies["@deltachat/jsonrpc-client"] = "*"
+}
+
 await fs.writeFile("./package.json", JSON.stringify(package_json, null, 4));


### PR DESCRIPTION
typescript was complaining about missing `@deltachat/jsonrpc-client` when it wasn't installed locally
