### PR TITLE
fix: db migration 59 and 27

### DIFF
--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -137,9 +137,9 @@ ALTER TABLE acpeerstates ADD COLUMN gossip_key;"#,
         // the current ones are defined by chats.blocked=2
         sql.execute_migration(
             r#"
-DELETE FROM msgs WHERE chat_id=1 OR chat_id=2;"
-CREATE INDEX chats_contacts_index2 ON chats_contacts (contact_id);"
-ALTER TABLE msgs ADD COLUMN timestamp_sent INTEGER DEFAULT 0;")
+DELETE FROM msgs WHERE chat_id=1 OR chat_id=2;
+CREATE INDEX chats_contacts_index2 ON chats_contacts (contact_id);
+ALTER TABLE msgs ADD COLUMN timestamp_sent INTEGER DEFAULT 0;
 ALTER TABLE msgs ADD COLUMN timestamp_rcvd INTEGER DEFAULT 0;"#,
             27,
         )

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -267,7 +267,7 @@ CREATE INDEX msgs_index6 ON msgs (location_id);"#,
         // so, msg_id may or may not exist.
         sql.execute_migration(
             r#"
-CREATE TABLE devmsglabels (id INTEGER PRIMARY KEY AUTOINCREMENT, label TEXT, msg_id INTEGER DEFAULT 0);",
+CREATE TABLE devmsglabels (id INTEGER PRIMARY KEY AUTOINCREMENT, label TEXT, msg_id INTEGER DEFAULT 0);
 CREATE INDEX devmsglabels_index1 ON devmsglabels (label);"#, 59)
             .await?;
         if exists_before_update && sql.get_raw_config_int("bcc_self").await?.is_none() {


### PR DESCRIPTION
- **fix: db migration version 59, it contained an sql syntax error**
- **fix: sql syntax error in db migration 27**

The sql commands contained syntax errors.
