### PR TITLE
npm rpc server don't search path by default

### DIFF
--- a/deltachat-rpc-server/npm-package/README.md
+++ b/deltachat-rpc-server/npm-package/README.md
@@ -46,11 +46,10 @@ references:
 When you import this package it searches for the rpc server in the following locations and order:
 
 1. `DELTA_CHAT_RPC_SERVER` environment variable
-2. in PATH
-   - unless `DELTA_CHAT_SKIP_PATH=1` is specified
-   - searches in .cargo/bin directory first
-   - but there an additional version check is performed
+2. use the PATH when `{takeVersionFromPATH: true}` is supplied in the options. 
 3. prebuilds in npm packages
+
+so by default it uses the prebuilds.
 
 ## How do you built this package in CI
 

--- a/deltachat-rpc-server/npm-package/index.d.ts
+++ b/deltachat-rpc-server/npm-package/index.d.ts
@@ -1,8 +1,8 @@
 import { StdioDeltaChat } from "@deltachat/jsonrpc-client";
 
 export interface SearchOptions {
-  /** whether to disable looking for deltachat-rpc-server inside of $PATH */
-  skipSearchInPath: boolean;
+  /** whether take deltachat-rpc-server inside of $PATH*/
+  takeVersionFromPATH: boolean;
 
   /** whether to disable the DELTA_CHAT_RPC_SERVER environment variable */
   disableEnvPath: boolean;

--- a/deltachat-rpc-server/npm-package/index.js
+++ b/deltachat-rpc-server/npm-package/index.js
@@ -123,7 +123,14 @@ export async function getRPCServerPath(
 import { StdioDeltaChat } from "@deltachat/jsonrpc-client";
 
 /** @type {import("./index").FnTypes.startDeltaChat} */
-export async function startDeltaChat(directory, options) {
+export async function startDeltaChat(
+  directory,
+  options = {
+    skipSearchInPath: false,
+    disableEnvPath: false,
+    muteStdErr: false,
+  }
+) {
   const pathToServerBinary = await getRPCServerPath(options);
   const server = spawn(pathToServerBinary, {
     env: {

--- a/deltachat-rpc-server/npm-package/src/const.js
+++ b/deltachat-rpc-server/npm-package/src/const.js
@@ -3,4 +3,3 @@
 export const PATH_EXECUTABLE_NAME = 'deltachat-rpc-server'
 
 export const ENV_VAR_NAME = "DELTA_CHAT_RPC_SERVER"
-export const SKIP_SEARCH_IN_PATH = "DELTA_CHAT_SKIP_PATH"


### PR DESCRIPTION
- **fix: npm rpc: set default options for `startDeltaChat`**
- **api!(npm rpc server): change api: don't search in path unless `options.takeVersionFromPATH` is set to `true`**
