### PR TITLE
fix: Don't recode images in `Viewtype::File` messages (#5617)

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1191,6 +1191,21 @@ mod tests {
         .await
         .unwrap();
 
+        send_image_check_mediaquality(
+            Viewtype::File,
+            Some("1"),
+            bytes,
+            "png",
+            false, // no Exif
+            1920,
+            1080,
+            0,
+            1920,
+            1080,
+        )
+        .await
+        .unwrap();
+
         // This will be sent as Image, see [`BlobObject::maybe_sticker`] for explanation.
         send_image_check_mediaquality(
             Viewtype::Sticker,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2619,6 +2619,7 @@ async fn prepare_msg_blob(context: &Context, msg: &mut Message) -> Result<()> {
             .get_blob(Param::File, context, !msg.is_increation())
             .await?
             .with_context(|| format!("attachment missing for message of type #{}", msg.viewtype))?;
+        let send_as_is = msg.viewtype == Viewtype::File;
 
         if msg.viewtype == Viewtype::File || msg.viewtype == Viewtype::Image {
             // Correct the type, take care not to correct already very special
@@ -2645,8 +2646,9 @@ async fn prepare_msg_blob(context: &Context, msg: &mut Message) -> Result<()> {
         }
 
         let mut maybe_sticker = msg.viewtype == Viewtype::Sticker;
-        if msg.viewtype == Viewtype::Image
-            || maybe_sticker && !msg.param.exists(Param::ForceSticker)
+        if !send_as_is
+            && (msg.viewtype == Viewtype::Image
+                || maybe_sticker && !msg.param.exists(Param::ForceSticker))
         {
             blob.recode_to_image_size(context, &mut maybe_sticker)
                 .await?;


### PR DESCRIPTION
Fix #5617 