### PR TITLE
fix(@deltachat/stdio-rpc-server): do not set RUST_LOG to "info" by default

### DIFF
--- a/deltachat-rpc-server/npm-package/index.js
+++ b/deltachat-rpc-server/npm-package/index.js
@@ -70,7 +70,7 @@ export async function startDeltaChat(directory, options = {}) {
   const pathToServerBinary = await getRPCServerPath(options);
   const server = spawn(pathToServerBinary, {
     env: {
-      RUST_LOG: process.env.RUST_LOG || "info",
+      RUST_LOG: process.env.RUST_LOG,
       DC_ACCOUNTS_PATH: directory,
     },
     stdio: ["pipe", "pipe", options.muteStdErr ? "ignore" : "inherit"],


### PR DESCRIPTION
`info` enables info level logging for all libraries, e.g. iroh starts printing very verbose logs
to stderr this way.

Closes #5622 