### PR TITLE
Don't create/unarchive groups on member removal messages (#5618)

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1664,7 +1664,13 @@ RETURNING id
         replace_msg_id.trash(context, on_server).await?;
     }
 
-    chat_id.unarchive_if_not_muted(context, state).await?;
+    let unarchive = match mime_parser.get_header(HeaderDef::ChatGroupMemberRemoved) {
+        Some(addr) => context.is_self_addr(addr).await?,
+        None => true,
+    };
+    if unarchive {
+        chat_id.unarchive_if_not_muted(context, state).await?;
+    }
 
     info!(
         context,


### PR DESCRIPTION
Close #5618
Although the task is about "group left" messages, i think it's ok to not create/unarchive groups for all member removal messages. At least currently for DC-style groups `create_group()` already avoids group creation for any member removals. Then, if we don't consider member removal messages important enough to create groups, why unarchive already existing ones.