### PR TITLE
fix: AEAP: Remove old peerstate verified_key instead of removing the whole peerstate (#5535)

### DIFF
--- a/src/tests/aeap.rs
+++ b/src/tests/aeap.rs
@@ -327,6 +327,12 @@ async fn check_no_transition_done(groups: &[ChatId], old_alice_addr: &str, bob: 
             last_info_msg.is_none(),
             "{last_info_msg:?} shouldn't be there (or it's an unrelated info msg)"
         );
+
+        let sent = bob.send_text(*group, "hi").await;
+        let msg = Message::load_from_db(bob, sent.sender_msg_id)
+            .await
+            .unwrap();
+        assert_eq!(msg.get_showpadlock(), true);
     }
 }
 


### PR DESCRIPTION
When doing an AEAP transition, we mustn't just delete the old peerstate as this would break encryption to it. This is critical for non-verified groups -- if we can't encrypt to the old address, we can't securely remove it from the group (to add the new one instead).

I think this is the minimal fix making encryption to the old address and unverified groups continue to work as it was before b6db0152b0ef0e0e317a5520b966315664ebc84c.

Fix #5535