### PR TITLE
feat: Map *.wav to Viewtype::Audio (#5633)

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1433,7 +1433,7 @@ pub(crate) fn guess_msgtype_from_suffix(path: &Path) -> Option<(Viewtype, &str)>
         "txt" => (Viewtype::File, "text/plain"),
         "vcard" => (Viewtype::Vcard, "text/vcard"),
         "vcf" => (Viewtype::Vcard, "text/vcard"),
-        "wav" => (Viewtype::File, "audio/wav"),
+        "wav" => (Viewtype::Audio, "audio/wav"),
         "weba" => (Viewtype::File, "audio/webm"),
         "webm" => (Viewtype::Video, "video/webm"),
         "webp" => (Viewtype::Image, "image/webp"), // iOS via SDWebImage, Android since 4.0


### PR DESCRIPTION
It seems there are no problems with playing WAV on all modern platforms, so such files should be displayed in the "AUDIO", not "FILES" tab in the UIs.