### PR TITLE
ci: remove cargo-nextest bug workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,9 +125,6 @@ jobs:
       - name: Tests
         env:
           RUST_BACKTRACE: 1
-
-          # Workaround for <https://github.com/nextest-rs/nextest/issues/1493>.
-          RUSTUP_WINDOWS_PATH_ADD_BIN: 1
         run: cargo nextest run --workspace
 
       - name: Doc-Tests


### PR DESCRIPTION
The problem should be fixed
since nextest 0.9.72.