### PR TITLE
build: unpin OpenSSL version and update to OpenSSL 3.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1367,7 +1367,6 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "once_cell",
- "openssl-src",
  "parking_lot",
  "percent-encoding",
  "pgp",
@@ -4093,9 +4092,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.63"
+version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
@@ -4125,18 +4124,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.1.6+3.1.4"
+version = "300.3.0+3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
+checksum = "eba8804a1c5765b18c4b3f907e6897ebabeedebc9830e1a0046c4a4cf44663e1"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.99"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,14 +104,6 @@ toml = "0.8"
 url = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
 
-# Pin OpenSSL to 3.1 releases.
-# OpenSSL 3.2 has a regression tracked at <https://github.com/openssl/openssl/issues/23376>
-# which results in broken `deltachat-rpc-server` binaries when cross-compiled using Zig toolchain.
-# See <https://github.com/deltachat/deltachat-core-rust/issues/5206> for Delta Chat issue.
-# According to <https://www.openssl.org/policies/releasestrat.html>
-# 3.1 branch will be supported until 2025-03-14.
-openssl-src = "~300.1"
-
 [dev-dependencies]
 ansi_term = "0.12.0"
 anyhow = { version = "1", features = ["backtrace"] } # Enable `backtrace` feature in tests.


### PR DESCRIPTION
Previously OpenSSL was pinned due to problems
with Zig toolchain used back then
and then not unpinned even after switching from Zig to Nix due to <https://github.com/alexcrichton/openssl-src-rs/issues/235>. The problem should be fixed now
and we can try to unpin OpenSSL again.