### PR TITLE
fix: allow creation of groups by outgoing messages without recipients

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1098,23 +1098,24 @@ async fn add_parts(
             }
         }
 
-        if !to_ids.is_empty() {
-            if chat_id.is_none() && allow_creation {
-                if let Some((new_chat_id, new_chat_id_blocked)) = create_group(
-                    context,
-                    mime_parser,
-                    is_partial_download.is_some(),
-                    Blocked::Not,
-                    from_id,
-                    to_ids,
-                    &verified_encryption,
-                )
-                .await?
-                {
-                    chat_id = Some(new_chat_id);
-                    chat_id_blocked = new_chat_id_blocked;
-                }
+        if chat_id.is_none() && allow_creation {
+            if let Some((new_chat_id, new_chat_id_blocked)) = create_group(
+                context,
+                mime_parser,
+                is_partial_download.is_some(),
+                Blocked::Not,
+                from_id,
+                to_ids,
+                &verified_encryption,
+            )
+            .await?
+            {
+                chat_id = Some(new_chat_id);
+                chat_id_blocked = new_chat_id_blocked;
             }
+        }
+
+        if !to_ids.is_empty() {
             if chat_id.is_none() && allow_creation {
                 let to_contact = Contact::get_by_id(context, to_id).await?;
                 if let Some(list_id) = to_contact.param.get(Param::ListId) {

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -4593,3 +4593,22 @@ async fn test_receive_vcard() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_group_no_recipients() -> Result<()> {
+    let t = &TestContext::new_alice().await;
+    let raw = b"From: alice@example.org\n\
+                    Subject: Group\n\
+                    Chat-Version: 1.0\n\
+                    Chat-Group-Name: Group\n\
+                    Chat-Group-ID: GePFDkwEj2K\n\
+                    Message-ID: <foobar@localhost>\n\
+                    \n\
+                    Hello!";
+    let received = receive_imf(t, raw, false).await?.unwrap();
+    let msg = Message::load_from_db(t, *received.msg_ids.last().unwrap()).await?;
+    let chat = Chat::load_from_db(t, msg.chat_id).await?;
+    assert_eq!(chat.typ, Chattype::Group);
+
+    Ok(())
+}


### PR DESCRIPTION
`!to_ids().is_empty()` check is needed in cases of 1:1 chat creation
because otherwise `to_id` is undefined,
but in case of outgoing group message without recipients
observed on a second device creating a group should be allowed.