### PR TITLE
fix: Remove existing/new group member locally if send_msg() fails (#5508)

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3760,7 +3760,10 @@ pub(crate) async fn add_contact_to_chat_ex(
         msg.param.set_cmd(SystemMessage::MemberAddedToGroup);
         msg.param.set(Param::Arg, contact_addr);
         msg.param.set_int(Param::Arg2, from_handshake.into());
-        msg.id = send_msg(context, chat_id, &mut msg).await?;
+        if let Err(e) = send_msg(context, chat_id, &mut msg).await {
+            remove_from_chat_contacts_table(context, chat_id, contact_id).await?;
+            return Err(e);
+        }
         sync = Nosync;
     }
     context.emit_event(EventType::ChatModified(chat_id));

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -1403,6 +1403,7 @@ First thread."#;
 
         let alice_bob_contact_id = Contact::create(&alice, "Bob", "bob@example.net").await?;
         remove_contact_from_chat(&alice, alice_chat_id, alice_bob_contact_id).await?;
+        alice.pop_sent_msg().await;
 
         // The message from Bob is delivered late, Bob is already removed.
         let msg = alice.recv_msg(&sent).await;

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -2588,6 +2588,7 @@ sth_for_the = "future""#
         );
 
         remove_contact_from_chat(&alice, chat_id, contact_bob).await?;
+        alice.pop_sent_msg().await;
         let status =
             helper_send_receive_status_update(&bob, &alice, &bob_instance, &instance).await?;
 

--- a/test-data/golden/chat_test_msg_with_implicit_member_add
+++ b/test-data/golden/chat_test_msg_with_implicit_member_add
@@ -2,7 +2,7 @@ Group#Chat#10: Group chat [3 member(s)]
 --------------------------------------------------------------------------------
 Msg#10:  (Contact#Contact#11): I created a group [FRESH]
 Msg#11:  (Contact#Contact#11): Member Fiona (fiona@example.net) added by alice@example.org. [FRESH][INFO]
-Msg#12: Me (Contact#Contact#Self): You removed member Fiona (fiona@example.net). [INFO] o
+Msg#12: Me (Contact#Contact#Self): You removed member Fiona (fiona@example.net). [INFO] √
 Msg#13:  (Contact#Contact#11): Welcome, Fiona! [FRESH]
 Msg#14: info (Contact#Contact#Info): Member Fiona (fiona@example.net) added. [NOTICED][INFO]
 Msg#15:  (Contact#Contact#11): Welcome back, Fiona! [FRESH]

--- a/test-data/golden/chat_test_parallel_member_remove
+++ b/test-data/golden/chat_test_parallel_member_remove
@@ -1,7 +1,7 @@
 Group#Chat#10: Group chat [4 member(s)] 
 --------------------------------------------------------------------------------
 Msg#10:  (Contact#Contact#10): Hi! I created a group. [FRESH]
-Msg#11: Me (Contact#Contact#Self): You left the group. [INFO] o
+Msg#11: Me (Contact#Contact#Self): You left the group. [INFO] √
 Msg#12:  (Contact#Contact#10): Member claire@example.net added by alice@example.org. [FRESH][INFO]
 Msg#13: info (Contact#Contact#Info): Member Me (bob@example.net) added. [NOTICED][INFO]
 Msg#14:  (Contact#Contact#10): What a silence! [FRESH]


### PR DESCRIPTION
See commit messages.

@adbenitez, so, i can't reproduce the problem you described in #5508. Also i checked it code-wise, `remove_contact_from_chat()` first sends the message and only then removes the contact. There's even a comment:
```
            // we remove the member from the chat after constructing the                                                                                                                                             
            // to-be-send message. If between send_msg() and here the                                                                                                                                                
            // process dies the user will have to re-do the action.  It's                                                                                                                                            
            // better than the other way round: you removed                                                                                                                                                          
            // someone from DB but no peer or device gets to know about it and                                                                                                                                       
            // group membership is thus different on different devices.                                                                                                                                              
            // Note also that sending a message needs all recipients                                                                                                                                                 
            // in order to correctly determine encryption so if we                                                                                                                                                   
            // removed it first, it would complicate the                                                                                                                                                             
            // check/encryption logic.
```
But you suggested to remove other members locally even if sending the removal message fails. For me it also seems reasonable, going to change this. In the worst case a removed member will be added back due to the group membership consistency algo. **EDIT: Done.**

You also suggested to revert a member addition if the message can't be sent, i'm going to check how difficult it is. **EDIT: Done.**

Close #5508 