### PR TITLE
feat: Add a db index for reactions by msg_id (#5507)

### DIFF
--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -932,6 +932,11 @@ CREATE INDEX msgs_status_updates_index2 ON msgs_status_updates (uid);
         .await?;
     }
 
+    if dbversion < 114 {
+        sql.execute_migration("CREATE INDEX reactions_index1 ON reactions (msg_id)", 114)
+            .await?;
+    }
+
     let new_version = sql
         .get_raw_config_int(VERSION_CFG)
         .await?


### PR DESCRIPTION
    This should speed up `get_msg_reactions()` filtering reactions by `msg_id`, but also queries in
    other places involving both `msg_id` and `contact_id`.
    
Close #5507 