### PR TITLE
fix: Set Config::IsChatmail in configure()

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -459,6 +459,7 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
     progress!(ctx, 900);
 
     if imap_session.is_chatmail() {
+        ctx.set_config(Config::IsChatmail, Some("1")).await?;
         ctx.set_config(Config::SentboxWatch, None).await?;
         ctx.set_config(Config::MvboxMove, Some("0")).await?;
         ctx.set_config(Config::OnlyFetchMvbox, None).await?;


### PR DESCRIPTION
`IsChatmail` is set also by `inbox_fetch_idle()`, but it isn't called during `configure()`. Setting `IsChatmail` from `inbox_fetch_idle()` is necessary to handle client/server upgrades, but `IsChatmail` also should be available for the app after configuring an account, e.g. DC Android needs it to know whether to ask the user to disable battery optimisations.