### PR TITLE
test(deltachat-rpc-client): reenable log_cli

### DIFF
--- a/deltachat-rpc-client/tox.ini
+++ b/deltachat-rpc-client/tox.ini
@@ -28,5 +28,5 @@ commands =
 
 [pytest]
 timeout = 300
-#log_cli = true
+log_cli = true
 log_level = debug


### PR DESCRIPTION
It was accidentally disabled in f4dfc79808137d0d45a78698ec71c9a9ff26edd3