### PR TITLE
fix: Allow fetch_existing_msgs for bots (#4976)

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -766,10 +766,6 @@ impl Imap {
         context: &Context,
         session: &mut Session,
     ) -> Result<()> {
-        if context.get_config_bool(Config::Bot).await? {
-            return Ok(()); // Bots don't want those messages
-        }
-
         add_all_recipients_as_contacts(context, session, Config::ConfiguredSentboxFolder)
             .await
             .context("failed to get recipients from the sentbox")?;


### PR DESCRIPTION
There was a comment in `fetch_existing_msgs()`: "Bots don't want those messages". If a bot doesn't want this setting, why enable it? It's disabled by default anyway.

Close #4976 