### PR TITLE
fix: npm rpc: make local non-symlinked installation possible by using absolute paths got local dev version

### DIFF
--- a/deltachat-rpc-server/npm-package/scripts/update_optional_dependencies_and_version.js
+++ b/deltachat-rpc-server/npm-package/scripts/update_optional_dependencies_and_version.js
@@ -55,9 +55,10 @@ for (const { folder_name, package_name } of platform_package_names) {
 }
 
 if (is_local) {
-  package_json.peerDependencies["@deltachat/jsonrpc-client"] = 'file:../../deltachat-jsonrpc/typescript'
+  package_json.peerDependencies["@deltachat/jsonrpc-client"] =
+    `file:${join(expected_cwd, "/../../deltachat-jsonrpc/typescript")}`;
 } else {
-  package_json.peerDependencies["@deltachat/jsonrpc-client"] = "*"
+  package_json.peerDependencies["@deltachat/jsonrpc-client"] = "*";
 }
 
 await fs.writeFile("./package.json", JSON.stringify(package_json, null, 4));


### PR DESCRIPTION
this fixes the local non-symlinked (copied) instalation with `npm i --install-links=true` possible

I probably need this for flatpak building.
