### PR TITLE
docs: remove outdated documentation comment from `send_smtp_messages`

### DIFF
--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -661,9 +661,6 @@ async fn send_mdns(context: &Context, connection: &mut Smtp) -> Result<()> {
 }
 
 /// Tries to send all messages currently in `smtp`, `smtp_status_updates` and `smtp_mdns` tables.
-///
-/// Logs and ignores SMTP errors to ensure that a single SMTP message constantly failing to be sent
-/// does not block other messages in the queue from being sent.
 pub(crate) async fn send_smtp_messages(context: &Context, connection: &mut Smtp) -> Result<()> {
     let ratelimited = if context.ratelimit.read().await.can_send() {
         // add status updates and sync messages to end of sending queue


### PR DESCRIPTION
Since commit c0a17df3448b43afcf22de584257f9787b0707d3 (PR https://github.com/deltachat/deltachat-core-rust/pull/3402) `send_smtp_messages` returns an error
as soon as it encounters the first message it failed to send.

Since this worked like this for about 2 years
without any problems, there is no need to revert the change, but outdated comment should be removed.

Closes #5666