### PR TITLE
feat: Don't reveal profile data to a not yet verified contact and in MDNs (#5166)

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -566,18 +566,12 @@ impl TestContext {
 
     /// Returns the [`Contact`] for the other [`TestContext`], creating it if necessary.
     pub async fn add_or_lookup_contact(&self, other: &TestContext) -> Contact {
-        let name = other
-            .ctx
-            .get_config(Config::Displayname)
-            .await
-            .unwrap_or_default()
-            .unwrap_or_default();
         let primary_self_addr = other.ctx.get_primary_self_addr().await.unwrap();
         let addr = ContactAddress::new(&primary_self_addr).unwrap();
         // MailinglistAddress is the lowest allowed origin, we'd prefer to not modify the
         // origin when creating this contact.
         let (contact_id, modified) =
-            Contact::add_or_lookup(self, &name, &addr, Origin::MailinglistAddress)
+            Contact::add_or_lookup(self, "", &addr, Origin::MailinglistAddress)
                 .await
                 .expect("add_or_lookup");
         match modified {


### PR DESCRIPTION
**feat: Don't reveal profile data to a not yet verified contact (#5166)**
    
Follow-up to b77131159392daa0bfb8e2ce99c219e1f7bd4823. Since that commit names are not revealed in
    verified chats, but during verification (i.e. SecureJoin) they are still sent unencrypted. Moreover,
    all profile data mustn't be sent even encrypted before the contact verification, i.e. before
    "v{c,g}-request-with-auth". That was done for the selfavatar in
    304e902fcec36ce8fde263aa7a45759ed9a2fdaf, now it's done for From/To names and the self-status as
    well. Moreover, "v{c,g}-request" and "v{c,g}-auth-required" messages are deleted right after
    processing, so other devices won't see the received profile data anyway.

**feat: Don't reveal profile data in MDNs (#5166)**
    
Looks like it has no sense to send any profile data (From/To names, self-status; self-avatar was
    never sent even before) in MDNs, they aren't normal messages and aren't seen in a MUA. Better not to
    reveal profile data to the network and even to contacts in MDNs and make them more lightweight.
    
Close #5166 