### PR TITLE
refactor: Deduplicate dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ async_zip = { version = "0.0.12", default-features = false, features = ["deflate
 backtrace = "0.3"
 base64 = { workspace = true }
 brotli = { version = "6", default-features=false, features = ["std"] }
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["alloc", "clock", "std"] }
 email = { git = "https://github.com/deltachat/rust-email", branch = "master" }
 encoded-words = { git = "https://github.com/async-email/encoded-words", branch = "master" }
 escaper = "0.1"
@@ -86,7 +86,7 @@ rusqlite = { workspace = true, features = ["sqlcipher"] }
 rust-hsluv = "0.1"
 sanitize-filename = { workspace = true }
 serde_json = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 sha-1 = "0.10"
 sha2 = "0.10"
 smallvec = "1.13.2"
@@ -162,7 +162,7 @@ anyhow = "1"
 ansi_term = "0.12.1"
 async-channel = "2.3.1"
 base64 = "0.22"
-chrono = { version = "0.4.38", default-features = false, features = ["alloc", "clock", "std"] }
+chrono = { version = "0.4.38", default-features = false }
 futures = "0.3.30"
 futures-lite = "2.3.0"
 libc = "0.2"
@@ -174,12 +174,12 @@ regex = "1.10"
 rusqlite = "0.31"
 sanitize-filename = "0.5"
 serde_json = "1"
-serde = { version = "1.0", features = ["derive"] }
+serde = "1.0"
 tempfile = "3.10.1"
 thiserror = "1"
 tokio = "1.38.0"
 tokio-util = "0.7.11"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = "0.3"
 yerpc = "0.5.2"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,13 +40,13 @@ ratelimit = { path = "./deltachat-ratelimit" }
 
 anyhow = { workspace = true }
 async-broadcast = "0.7.0"
-async-channel = "2.3.1"
+async-channel = { workspace = true }
 async-imap = { version = "0.9.7", default-features = false, features = ["runtime-tokio"] }
 async-native-tls = { version = "0.5", default-features = false, features = ["runtime-tokio"] }
 async-smtp = { version = "0.9", default-features = false, features = ["runtime-tokio"] }
 async_zip = { version = "0.0.12", default-features = false, features = ["deflate", "fs"] }
 backtrace = "0.3"
-base64 = "0.22"
+base64 = { workspace = true }
 brotli = { version = "6", default-features=false, features = ["std"] }
 chrono = { workspace = true }
 email = { git = "https://github.com/deltachat/rust-email", branch = "master" }
@@ -54,8 +54,8 @@ encoded-words = { git = "https://github.com/async-email/encoded-words", branch =
 escaper = "0.1"
 fast-socks5 = "0.9"
 fd-lock = "4"
-futures = "0.3"
-futures-lite = "2.3.0"
+futures = { workspace = true }
+futures-lite = { workspace = true }
 hex = "0.4.0"
 hickory-resolver = "0.24"
 humansize = "2"
@@ -66,12 +66,12 @@ iroh-gossip = { version = "0.17.0", features = ["net"] }
 quinn = "0.10.0"
 kamadak-exif = "0.5.3"
 lettre_email = { git = "https://github.com/deltachat/lettre", branch = "master" }
-libc = "0.2"
+libc = { workspace = true }
 mailparse = "0.15"
 mime = "0.3.17"
 num_cpus = "1.16"
 num-derive = "0.4"
-num-traits = "0.2"
+num-traits = { workspace = true }
 once_cell = { workspace = true }
 percent-encoding = "2.3"
 parking_lot = "0.12"
@@ -79,14 +79,14 @@ pgp = { version = "0.11", default-features = false }
 qrcodegen = "1.7.0"
 quick-xml = "0.31"
 quoted_printable = "0.5"
-rand = "0.8"
+rand = { workspace = true }
 regex = { workspace = true }
 reqwest = { version = "0.11.27", features = ["json"] }
 rusqlite = { workspace = true, features = ["sqlcipher"] }
 rust-hsluv = "0.1"
-sanitize-filename = "0.5"
-serde_json = "1"
-serde = { version = "1.0", features = ["derive"] }
+sanitize-filename = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
 sha-1 = "0.10"
 sha2 = "0.10"
 smallvec = "1.13.2"
@@ -94,26 +94,26 @@ strum = "0.26"
 strum_macros = "0.26"
 tagger = "4.3.4"
 textwrap = "0.16.1"
-thiserror = "1"
-tokio = { version = "1.38.0", features = ["fs", "rt-multi-thread", "macros"] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs", "rt-multi-thread", "macros"] }
 tokio-io-timeout = "1.2.0"
 tokio-stream = { version = "0.1.15", features = ["fs"] }
 tokio-tar = { version = "0.3" } # TODO: integrate tokio into async-tar
-tokio-util = "0.7.11"
+tokio-util = { workspace = true }
 toml = "0.8"
 url = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
 
 [dev-dependencies]
-ansi_term = "0.12.0"
-anyhow = { version = "1", features = ["backtrace"] } # Enable `backtrace` feature in tests.
+ansi_term = { workspace = true }
+anyhow = { workspace = true, features = ["backtrace"] } # Enable `backtrace` feature in tests.
 criterion = { version = "0.5.1", features = ["async_tokio"] }
-futures-lite = "2.3.0"
-log = "0.4"
+futures-lite = { workspace = true }
+log = { workspace = true }
 proptest = { version = "1", default-features = false, features = ["std"] }
-tempfile = "3"
+tempfile = { workspace = true }
 testdir = "0.9.0"
-tokio = { version = "1.38.0", features = ["parking_lot", "rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 pretty_assertions = "1.3.0"
 
 [workspace]
@@ -159,10 +159,28 @@ harness = false
 
 [workspace.dependencies]
 anyhow = "1"
+ansi_term = "0.12.1"
+async-channel = "2.3.1"
+base64 = "0.22"
+chrono = { version = "0.4.38", default-features = false, features = ["alloc", "clock", "std"] }
+futures = "0.3.30"
+futures-lite = "2.3.0"
+libc = "0.2"
+log = "0.4"
+num-traits = "0.2"
 once_cell = "1.18.0"
+rand = "0.8"
 regex = "1.10"
 rusqlite = "0.31"
-chrono = { version = "0.4.38", default-features=false, features = ["alloc", "clock", "std"] }
+sanitize-filename = "0.5"
+serde_json = "1"
+serde = { version = "1.0", features = ["derive"] }
+tempfile = "3.10.1"
+thiserror = "1"
+tokio = "1.38.0"
+tokio-util = "0.7.11"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+yerpc = "0.5.2"
 
 [features]
 default = ["vendored"]

--- a/deltachat-contact-tools/Cargo.toml
+++ b/deltachat-contact-tools/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
 rusqlite = { workspace = true } # Needed in order to `impl rusqlite::types::ToSql for EmailAddress`. Could easily be put behind a feature.
-chrono = { workspace = true }
+chrono = { workspace = true, features = ["alloc", "clock", "std"] }
 
 [dev-dependencies]
 anyhow = { workspace = true, features = ["backtrace"] } # Enable `backtrace` feature in tests.

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -16,16 +16,16 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 deltachat = { path = "../", default-features = false }
 deltachat-jsonrpc = { path = "../deltachat-jsonrpc", optional = true }
-libc = "0.2"
+libc = { workspace = true }
 human-panic = { version = "2", default-features = false }
-num-traits = "0.2"
-serde_json = "1.0"
-tokio = { version = "1.38.0", features = ["rt-multi-thread"] }
-anyhow = "1"
-thiserror = "1"
-rand = "0.8"
-once_cell = "1.18.0"
-yerpc = { version = "0.5.1", features = ["anyhow_expose"] }
+num-traits = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+rand = { workspace = true }
+once_cell = { workspace = true }
+yerpc = { workspace = true, features = ["anyhow_expose"] }
 
 [features]
 default = ["vendored"]

--- a/deltachat-jsonrpc/Cargo.toml
+++ b/deltachat-jsonrpc/Cargo.toml
@@ -18,7 +18,7 @@ deltachat = { path = ".." }
 deltachat-contact-tools = { path = "../deltachat-contact-tools" }
 num-traits = { workspace = true }
 schemars = "0.8.21"
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 tempfile = { workspace = true }
 log = { workspace = true }
 async-channel = { workspace = true }

--- a/deltachat-jsonrpc/Cargo.toml
+++ b/deltachat-jsonrpc/Cargo.toml
@@ -13,30 +13,30 @@ path = "src/webserver.rs"
 required-features = ["webserver"]
 
 [dependencies]
-anyhow = "1"
+anyhow = { workspace = true }
 deltachat = { path = ".." }
 deltachat-contact-tools = { path = "../deltachat-contact-tools" }
-num-traits = "0.2"
+num-traits = { workspace = true }
 schemars = "0.8.21"
-serde = { version = "1.0", features = ["derive"] }
-tempfile = "3.10.1"
-log = "0.4"
-async-channel = { version = "2.3.1" }
-futures = { version = "0.3.30" }
-serde_json = "1"
-yerpc = { version = "0.5.2", features = ["anyhow_expose", "openrpc"] }
+serde = { workspace = true }
+tempfile = { workspace = true }
+log = { workspace = true }
+async-channel = { workspace = true }
+futures = { workspace = true }
+serde_json = { workspace = true }
+yerpc = { workspace = true, features = ["anyhow_expose", "openrpc"] }
 typescript-type-def = { version = "0.5.8", features = ["json_value"] }
-tokio = { version = "1.38.0" }
-sanitize-filename = "0.5"
+tokio = { workspace = true }
+sanitize-filename = { workspace = true }
 walkdir = "2.5.0"
-base64 = "0.22"
+base64 = { workspace = true }
 
 # optional dependencies
 axum = { version = "0.7", optional = true, features = ["ws"] }
 env_logger = { version = "0.11.3", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.38.0", features = ["full", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["full", "rt-multi-thread"] }
 
 
 [features]

--- a/deltachat-repl/Cargo.toml
+++ b/deltachat-repl/Cargo.toml
@@ -14,7 +14,7 @@ log = { workspace = true }
 rusqlite = { workspace = true }
 rustyline = "14"
 tokio = { workspace = true, features = ["fs", "rt-multi-thread", "macros"] }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 [features]
 default = ["vendored"]

--- a/deltachat-repl/Cargo.toml
+++ b/deltachat-repl/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2021"
 repository = "https://github.com/deltachat/deltachat-core-rust"
 
 [dependencies]
-ansi_term = "0.12.1"
-anyhow = "1"
+ansi_term = { workspace = true }
+anyhow = { workspace = true }
 deltachat = { path = "..", features = ["internals"]}
 dirs = "5"
-log = "0.4.21"
-rusqlite = "0.31"
+log = { workspace = true }
+rusqlite = { workspace = true }
 rustyline = "14"
-tokio = { version = "1.38.0", features = ["fs", "rt-multi-thread", "macros"] }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tokio = { workspace = true, features = ["fs", "rt-multi-thread", "macros"] }
+tracing-subscriber = { workspace = true }
 
 [features]
 default = ["vendored"]

--- a/deltachat-rpc-server/Cargo.toml
+++ b/deltachat-rpc-server/Cargo.toml
@@ -17,10 +17,10 @@ anyhow = { workspace = true }
 futures-lite = { workspace = true }
 log = { workspace = true }
 serde_json = { workspace = true }
-serde = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["io-std"] }
 tokio-util = { workspace = true }
-tracing-subscriber = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 yerpc = { workspace = true, features = ["anyhow_expose", "openrpc"] }
 
 [features]

--- a/deltachat-rpc-server/Cargo.toml
+++ b/deltachat-rpc-server/Cargo.toml
@@ -13,15 +13,15 @@ categories = ["cryptography", "std", "email"]
 deltachat-jsonrpc = { path = "../deltachat-jsonrpc", default-features = false }
 deltachat = { path = "..", default-features = false }
 
-anyhow = "1"
-futures-lite = "2.3.0"
-log = "0.4"
-serde_json = "1"
-serde = { version = "1.0", features = ["derive"] }
-tokio = { version = "1.38.0", features = ["io-std"] }
-tokio-util = "0.7.11"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-yerpc = { version = "0.5.2", features = ["anyhow_expose", "openrpc"] }
+anyhow = { workspace = true }
+futures-lite = { workspace = true }
+log = { workspace = true }
+serde_json = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true, features = ["io-std"] }
+tokio-util = { workspace = true }
+tracing-subscriber = { workspace = true }
+yerpc = { workspace = true, features = ["anyhow_expose", "openrpc"] }
 
 [features]
 default = ["vendored"]


### PR DESCRIPTION
Deduplicate dependency versions by specifying them only once in Cargo.toml for the whole workspace under `[workspace.dependencies]`.

Where possible, also deduplicate the dependencies' features (if different crates use different set of features, of course these can't be deduplicated).