### PR TITLE
fix: Fetch existing messages for bots as `InFresh` (#4976)

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -481,8 +481,9 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  * - `bot`          = Set to "1" if this is a bot.
  *                    Prevents adding the "Device messages" and "Saved messages" chats,
  *                    adds Auto-Submitted header to outgoing messages,
- *                    accepts contact requests automatically (calling dc_accept_chat() is not needed for bots)
- *                    and does not cut large incoming text messages.
+ *                    accepts contact requests automatically (calling dc_accept_chat() is not needed),
+ *                    does not cut large incoming text messages,
+ *                    handles existing messages the same way as new ones if `fetch_existing_msgs=1`.
  * - `last_msg_id` = database ID of the last message processed by the bot.
  *                   This ID and IDs below it are guaranteed not to be returned
  *                   by dc_get_next_msgs() and dc_wait_next_msgs().
@@ -493,8 +494,8 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                   For most bots calling `dc_markseen_msgs()` is the
  *                   recommended way to update this value
  *                   even for self-sent messages.
- * - `fetch_existing_msgs` = 1=fetch most recent existing messages on configure (default),
- *                    0=do not fetch existing messages on configure.
+ * - `fetch_existing_msgs` = 0=do not fetch existing messages on configure (default),
+ *                    1=fetch most recent existing messages on configure.
  *                    In both cases, existing recipients are added to the contact database.
  * - `disable_idle` = 1=disable IMAP IDLE even if the server supports it,
  *                    0=use IMAP IDLE if the server supports it.

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -552,8 +552,9 @@ class ACFactory:
 
         bot_cfg = self.get_next_liveconfig()
         # The bot process is run asynchronously, so some messages can arrive before the bot is fully
-        # initialised.
+        # initialised. Also delete messages immediately to not process them again after restart.
         bot_cfg["fetch_existing_msgs"] = "1"
+        bot_cfg["delete_server_after"] = "1"
         bot_ac = self.prepare_account_from_liveconfig(bot_cfg)
 
         # Forget ac as it will be opened by the bot subprocess

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -696,6 +696,9 @@ async fn add_parts(
     prevent_rename: bool,
     verified_encryption: VerifiedEncryption,
 ) -> Result<ReceivedMsg> {
+    let is_bot = context.get_config_bool(Config::Bot).await?;
+    // Bots handle existing messages the same way as new ones.
+    let fetching_existing_messages = fetching_existing_messages && !is_bot;
     let rfc724_mid_orig = &mime_parser
         .get_rfc724_mid()
         .unwrap_or(rfc724_mid.to_string());
@@ -787,9 +790,6 @@ async fn add_parts(
             chat_id = Some(DC_CHAT_ID_TRASH);
             info!(context, "Message is an MDN (TRASH).",);
         }
-
-        // signals whether the current user is a bot
-        let is_bot = context.get_config_bool(Config::Bot).await?;
 
         let create_blocked_default = if is_bot {
             Blocked::Not


### PR DESCRIPTION
See commit messages.
This should finally fix #4976

After the second commit only webxdc realtime tests are failing.