### PR TITLE
docs: remove misleading configuration comment

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -513,8 +513,8 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
 
 /// Retrieve available autoconfigurations.
 ///
-/// A Search configurations from the domain used in the email-address, prefer encrypted
-/// B. If we have no configuration yet, search configuration in Thunderbird's centeral database
+/// A. Search configurations from the domain used in the email-address
+/// B. If we have no configuration yet, search configuration in Thunderbird's central database
 async fn get_autoconfig(
     ctx: &Context,
     param: &LoginParam,

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -24,7 +24,7 @@ pub struct Response {
     /// Response body.
     pub blob: Vec<u8>,
 
-    /// MIME type exntracted from the `Content-Type` header, if any.
+    /// MIME type extracted from the `Content-Type` header, if any.
     pub mimetype: Option<String>,
 
     /// Encoding extracted from the `Content-Type` header, if any.


### PR DESCRIPTION
saying it is 'preferred' encrypted is misleading,
therfore, just remove it.
i do not think, it is worth saying that we do not query 'http', this is clear from the source code.

moreover, fix two typos.

target #5706 