### PR TITLE
feat: Sync `Config::MvboxMove` across devices (#5680)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -608,7 +608,7 @@ impl Context {
         mut value: Option<&str>,
     ) -> Result<()> {
         Self::check_config(key, value)?;
-        let sync = sync == Sync && key.is_synced();
+        let sync = sync == Sync && key.is_synced() && self.is_configured().await?;
         let better_value;
 
         match key {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1346,7 +1346,7 @@ impl Context {
         Ok(sentbox.as_deref() == Some(folder_name))
     }
 
-    /// Returns true if given folder name is the name of the "Delta Chat" folder.
+    /// Returns true if given folder name is the name of the "DeltaChat" folder.
     pub async fn is_mvbox(&self, folder_name: &str) -> Result<bool> {
         let mvbox = self.get_config(Config::ConfiguredMvboxFolder).await?;
         Ok(mvbox.as_deref() == Some(folder_name))


### PR DESCRIPTION
NB: We don't restart IO from the synchronisation code, so `MvboxMove` isn't effective immediately if `ConfiguredMvboxFolder` is unset, but only after a reconnect to IMAP.

Close #5680 