### PR TITLE
refactor(mimefactory): factor out header confidentiality policy

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -751,7 +751,7 @@ impl MimeFactory {
                 }
             } else if header_name == "to" {
                 protected_headers.push(header.clone());
-                if is_encrypted && verified || is_securejoin_message {
+                if is_encrypted {
                     unprotected_headers.push(
                         Header::new_with_value(
                             header.name,


### PR DESCRIPTION
Instead of constructing lists of protected,
unprotected and hidden headers,
construct a single list of headers
and then sort them into separate lists
based on the well-defined policy.

This also fixes the bug
where Subject was not present in the IMF header
for signed-only messages.

Closes #5713