### PR TITLE
fix: Update quota if it's stale, not fresh (#5683)

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -547,7 +547,7 @@ impl Context {
                 .as_ref()
                 .filter(|quota| {
                     time_elapsed(&quota.modified)
-                        > Duration::from_secs(DC_BACKGROUND_FETCH_QUOTA_CHECK_RATELIMIT)
+                        < Duration::from_secs(DC_BACKGROUND_FETCH_QUOTA_CHECK_RATELIMIT)
                 })
                 .is_none()
         };

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -477,7 +477,7 @@ async fn inbox_fetch_idle(ctx: &Context, imap: &mut Imap, mut session: Session) 
         let quota = ctx.quota.read().await;
         quota
             .as_ref()
-            .filter(|quota| time_elapsed(&quota.modified) > Duration::from_secs(60))
+            .filter(|quota| time_elapsed(&quota.modified) < Duration::from_secs(60))
             .is_none()
     };
     if quota_needs_update {


### PR DESCRIPTION
Looks like this can be covered by the Python tests btw, one minute is less than 300 s (the current timeout).