### PR TITLE
fix: Don't fail if going to send plaintext, but some peerstate is missing

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -286,14 +286,11 @@ impl MimeFactory {
     fn is_e2ee_guaranteed(&self) -> bool {
         match &self.loaded {
             Loaded::Message { chat, msg } => {
-                if chat.is_protected() {
-                    return true;
-                }
-
                 !msg.param
                     .get_bool(Param::ForcePlaintext)
                     .unwrap_or_default()
-                    && msg.param.get_bool(Param::GuaranteeE2ee).unwrap_or_default()
+                    && (chat.is_protected()
+                        || msg.param.get_bool(Param::GuaranteeE2ee).unwrap_or_default())
             }
             Loaded::Mdn { .. } => false,
         }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -615,7 +615,6 @@ impl MimeFactory {
 
         let verified = self.verified();
         let grpimage = self.grpimage();
-        let force_plaintext = self.should_force_plaintext();
         let skip_autocrypt = self.should_skip_autocrypt();
         let e2ee_guaranteed = self.is_e2ee_guaranteed();
         let encrypt_helper = EncryptHelper::new(context).await?;
@@ -642,9 +641,8 @@ impl MimeFactory {
         let mut is_gossiped = false;
 
         let peerstates = self.peerstates_for_recipients(context).await?;
-        let should_encrypt =
-            encrypt_helper.should_encrypt(context, e2ee_guaranteed, &peerstates)?;
-        let is_encrypted = should_encrypt && !force_plaintext;
+        let is_encrypted = !self.should_force_plaintext()
+            && encrypt_helper.should_encrypt(context, e2ee_guaranteed, &peerstates)?;
         let is_securejoin_message = if let Loaded::Message { msg, .. } = &self.loaded {
             msg.param.get_cmd() == SystemMessage::SecurejoinMessage
         } else {

--- a/src/tests/verified_chats.rs
+++ b/src/tests/verified_chats.rs
@@ -180,6 +180,26 @@ async fn test_create_verified_oneonone_chat() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_missing_peerstate_reexecute_securejoin() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = &tcm.alice().await;
+    let alice_addr = alice.get_config(Config::Addr).await?.unwrap();
+    let bob = &tcm.bob().await;
+    enable_verified_oneonone_chats(&[alice, bob]).await;
+    tcm.execute_securejoin(bob, alice).await;
+    let chat = bob.get_chat(alice).await;
+    assert!(chat.is_protected());
+    bob.sql
+        .execute("DELETE FROM acpeerstates WHERE addr=?", (&alice_addr,))
+        .await?;
+    tcm.execute_securejoin(bob, alice).await;
+    let chat = bob.get_chat(alice).await;
+    assert!(chat.is_protected());
+    assert!(!chat.is_protection_broken());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_create_unverified_oneonone_chat() -> Result<()> {
     let mut tcm = TestContextManager::new();
     let alice = tcm.alice().await;


### PR DESCRIPTION
See commit messages. In fact both commits are fixes, but as the first fixes the bug, the second one becomes just a refactoring.