### PR TITLE
chore: Remove two TODOs that are not worth fixing

### DIFF
--- a/deltachat-contact-tools/src/lib.rs
+++ b/deltachat-contact-tools/src/lib.rs
@@ -36,9 +36,6 @@ use chrono::{DateTime, NaiveDateTime};
 use once_cell::sync::Lazy;
 use regex::Regex;
 
-// TODOs to clean up:
-// - Apply lints everywhere (https://doc.rust-lang.org/cargo/reference/workspaces.html#the-lints-table)
-
 #[derive(Debug)]
 /// A Contact, as represented in a VCard.
 pub struct VcardContact {
@@ -115,7 +112,9 @@ pub fn parse_vcard(vcard: &str) -> Vec<VcardContact> {
         // If `s` is `EMAIL;TYPE=work:alice@example.com` and `property` is `EMAIL`,
         // then `remainder` is now `;TYPE=work:alice@example.com`
 
-        // TODO this doesn't handle the case where there are quotes around a colon
+        // Note: This doesn't handle the case where there are quotes around a colon,
+        // like `NAME;Foo="Some quoted text: that contains a colon":value`.
+        // This could be improved in the future, but for now, the parsing is good enough.
         let (params, value) = remainder.split_once(':')?;
         // In the example from above, `params` is now `;TYPE=work`
         // and `value` is now `alice@example.com`


### PR DESCRIPTION
About the first TODO: I tried this out, but it didn't actually improve things, for two reasons:
1. The trick with `#![cfg_attr(not(test), warn(clippy::indexing_slicing))]` that enables the lint everywhere except for tests doesn't work with workspace-wide lints. (Context: We want to lint against indexing because it might panic, but in a test panicking is fine, so we don't want to enable the lint in tests).
2. Most of our crates have different sets of lints right now, so it would only be very few crates that use the workspace-wide list of lints.

About the second TODO:
It's not feasible right now to fully parse vCards, and for our good-enough parser the current behavior is fine, I think. If we fail to parse some realworld vCards because of this, we can still improve it.