### PR TITLE
fix(imap): reset new_mail if folder is ignored

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -540,6 +540,7 @@ impl Imap {
     ) -> Result<bool> {
         if should_ignore_folder(context, folder, folder_meaning).await? {
             info!(context, "Not fetching from {folder:?}.");
+            session.new_mail = false;
             return Ok(false);
         }
 


### PR DESCRIPTION
This prevents skipping IDLE in infinite loop
if folder is not fetched.
This happens on the INBOX
when OnlyFetchMvbox setting is enabled.

Fixes #5722