### PR TITLE
feat: Contact::create_ex: Don't send sync message if nothing changed (#5705)

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -642,7 +642,7 @@ impl Contact {
             set_blocked(context, Nosync, contact_id, false).await?;
         }
 
-        if sync.into() {
+        if sync.into() && sth_modified != Modifier::None {
             chat::sync(
                 context,
                 chat::SyncId::ContactAddr(addr.to_string()),


### PR DESCRIPTION
Follow-up to 5fa7cff46. Let's still not send a sync message if the contact wasn't modified. This is not very important, but just for consistency with the `chat::rename_ex()` behaviour.