### PR TITLE
feat: Always move outgoing auto-generated messages to the mvbox

### DIFF
--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -484,6 +484,16 @@ def test_move_works_on_self_sent(acfactory):
     ac1._evtracker.get_matching("DC_EVENT_IMAP_MESSAGE_MOVED")
 
 
+def test_move_sync_msgs(acfactory):
+    ac1 = acfactory.new_online_configuring_account(bcc_self=True, sync_msgs=True, fix_is_chatmail=True)
+    acfactory.bring_accounts_online()
+
+    ac1.set_config("displayname", "Alice")
+    ac1._evtracker.get_matching("DC_EVENT_IMAP_MESSAGE_MOVED")
+    ac1.set_config("displayname", "Bob")
+    ac1._evtracker.get_matching("DC_EVENT_IMAP_MESSAGE_MOVED")
+
+
 def test_forward_messages(acfactory, lp):
     ac1, ac2 = acfactory.get_online_accounts(2)
     chat = ac1.create_chat(ac2)

--- a/src/config.rs
+++ b/src/config.rs
@@ -257,6 +257,9 @@ pub enum Config {
     /// True if account is a chatmail account.
     IsChatmail,
 
+    /// True if `IsChatmail` mustn't be autoconfigured. For tests.
+    FixIsChatmail,
+
     /// True if account is muted.
     IsMuted,
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -477,8 +477,7 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
         ctx.set_config(Config::E2eeEnabled, Some("1")).await?;
     }
 
-    let create_mvbox = ctx.should_watch_mvbox().await?;
-
+    let create_mvbox = !is_chatmail;
     imap.configure_folders(ctx, &mut imap_session, create_mvbox)
         .await?;
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -209,7 +209,7 @@ pub const WORSE_IMAGE_SIZE: u32 = 640;
 // Key for the folder configuration version (see below).
 pub(crate) const DC_FOLDERS_CONFIGURED_KEY: &str = "folders_configured";
 // this value can be increased if the folder configuration is changed and must be redone on next program start
-pub(crate) const DC_FOLDERS_CONFIGURED_VERSION: i32 = 4;
+pub(crate) const DC_FOLDERS_CONFIGURED_VERSION: i32 = 5;
 
 // If more recipients are needed in SMTP's `RCPT TO:` header, the recipient list is split into
 // chunks. This does not affect MIME's `To:` header. Can be overwritten by setting

--- a/src/context.rs
+++ b/src/context.rs
@@ -815,6 +815,12 @@ impl Context {
 
         res.insert("is_chatmail", self.is_chatmail().await?.to_string());
         res.insert(
+            "fix_is_chatmail",
+            self.get_config_bool(Config::FixIsChatmail)
+                .await?
+                .to_string(),
+        );
+        res.insert(
             "is_muted",
             self.get_config_bool(Config::IsMuted).await?.to_string(),
         );

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -11,6 +11,7 @@ pub enum HeaderDef {
     Date,
     From_,
     To,
+    AutoSubmitted,
 
     /// Carbon copy.
     Cc,

--- a/src/imap/session.rs
+++ b/src/imap/session.rs
@@ -24,6 +24,7 @@ const PREFETCH_FLAGS: &str = "(UID INTERNALDATE RFC822.SIZE BODY.PEEK[HEADER.FIE
                               FROM \
                               IN-REPLY-TO REFERENCES \
                               CHAT-VERSION \
+                              AUTO-SUBMITTED \
                               AUTOCRYPT-SETUP-MESSAGE\
                               )])";
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -466,11 +466,13 @@ pub async fn convert_folder_meaning(
 }
 
 async fn inbox_fetch_idle(ctx: &Context, imap: &mut Imap, mut session: Session) -> Result<Session> {
-    ctx.set_config_internal(
-        Config::IsChatmail,
-        crate::config::from_bool(session.is_chatmail()),
-    )
-    .await?;
+    if !ctx.get_config_bool(Config::FixIsChatmail).await? {
+        ctx.set_config_internal(
+            Config::IsChatmail,
+            crate::config::from_bool(session.is_chatmail()),
+        )
+        .await?;
+    }
 
     // Update quota no more than once a minute.
     if ctx.quota_needs_update(60).await {


### PR DESCRIPTION
Recently there are many questions on the Delta Chat forum why some unexpected encrypted messages appear in Inbox. Seems they are mainly sync messages, though that also obviously happens to SecureJoin messages. Anyway, regardless of the `MvboxMove` setting, auto-generated outgoing messages should be moved to the DeltaChat folder so as not to complicate co-using Delta Chat with other MUAs.