### PR TITLE
fix: MimeFactory::verified: Return true for self-chat

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -299,19 +299,12 @@ impl MimeFactory {
     fn verified(&self) -> bool {
         match &self.loaded {
             Loaded::Message { chat, msg } => {
-                if chat.is_protected() {
-                    if msg.get_info_type() == SystemMessage::SecurejoinMessage {
-                        // Securejoin messages are supposed to verify a key.
-                        // In order to do this, it is necessary that they can be sent
-                        // to a key that is not yet verified.
-                        // This has to work independently of whether the chat is protected right now.
-                        false
-                    } else {
-                        true
-                    }
-                } else {
-                    false
-                }
+                chat.is_self_talk() ||
+                    // Securejoin messages are supposed to verify a key.
+                    // In order to do this, it is necessary that they can be sent
+                    // to a key that is not yet verified.
+                    // This has to work independently of whether the chat is protected right now.
+                    chat.is_protected() && msg.get_info_type() != SystemMessage::SecurejoinMessage
             }
             Loaded::Mdn { .. } => false,
         }

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -2095,6 +2095,18 @@ Message content",
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_no_unencrypted_name_in_self_chat() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let bob = &tcm.bob().await;
+    bob.set_config(Config::Displayname, Some("Bob Smith"))
+        .await?;
+    let chat_id = bob.get_self_chat().await.id;
+    let msg = bob.send_text(chat_id, "Happy birthday to me").await;
+    assert_eq!(msg.payload.contains("Bob Smith"), false);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_outgoing_classic_mail_creates_chat() {
     let alice = TestContext::new_alice().await;
 


### PR DESCRIPTION
For purposes of building a message it's better to consider the self-chat as verified. Particularly, this removes unencrypted name from the "From" header.