### PR TITLE
fix: create topic before asking for it

### DIFF
--- a/src/peer_channels.rs
+++ b/src/peer_channels.rs
@@ -672,7 +672,10 @@ mod tests {
         send_msg(alice, alice_chat.id, &mut instance).await.unwrap();
         let webxdc = alice.pop_sent_msg().await;
         let bob_webdxc = bob.recv_msg(&webxdc).await;
-        assert!(get_iroh_topic_for_msg(bob, bob_webdxc.id).await.unwrap().is_some())
+        assert!(get_iroh_topic_for_msg(bob, bob_webdxc.id)
+            .await
+            .unwrap()
+            .is_some())
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1439,32 +1439,6 @@ async fn add_parts(
         .await?;
     }
 
-    if let Some(node_addr) = mime_parser.get_header(HeaderDef::IrohNodeAddr) {
-        match serde_json::from_str::<NodeAddr>(node_addr).context("Failed to parse node address") {
-            Ok(node_addr) => {
-                info!(context, "Adding iroh peer with address {node_addr:?}.");
-                let instance_id = parent.context("Failed to get parent message")?.id;
-                if let Some(topic) = get_iroh_topic_for_msg(context, instance_id).await? {
-                    let node_id = node_addr.node_id;
-                    let relay_server = node_addr.relay_url().map(|relay| relay.as_str());
-                    iroh_add_peer_for_topic(context, instance_id, topic, node_id, relay_server)
-                        .await?;
-                    let iroh = context.get_or_try_init_peer_channel().await?;
-                    iroh.maybe_add_gossip_peers(topic, vec![node_addr]).await?;
-                } else {
-                    warn!(
-                        context,
-                        "Could not add iroh peer because {instance_id} has no topic"
-                    );
-                }
-                chat_id = DC_CHAT_ID_TRASH;
-            }
-            Err(err) => {
-                warn!(context, "Couldn't parse NodeAddr: {err:#}.");
-            }
-        }
-    }
-
     for part in &mime_parser.parts {
         if part.is_reaction {
             let reaction_str = simplify::remove_footers(part.msg.as_str());
@@ -1654,6 +1628,32 @@ RETURNING id
             *msg_id,
         )
         .await?;
+    }
+
+    if let Some(node_addr) = mime_parser.get_header(HeaderDef::IrohNodeAddr) {
+        match serde_json::from_str::<NodeAddr>(node_addr).context("Failed to parse node address") {
+            Ok(node_addr) => {
+                info!(context, "Adding iroh peer with address {node_addr:?}.");
+                let instance_id = parent.context("Failed to get parent message")?.id;
+                if let Some(topic) = get_iroh_topic_for_msg(context, instance_id).await? {
+                    let node_id = node_addr.node_id;
+                    let relay_server = node_addr.relay_url().map(|relay| relay.as_str());
+                    iroh_add_peer_for_topic(context, instance_id, topic, node_id, relay_server)
+                        .await?;
+                    let iroh = context.get_or_try_init_peer_channel().await?;
+                    iroh.maybe_add_gossip_peers(topic, vec![node_addr]).await?;
+                } else {
+                    warn!(
+                        context,
+                        "Could not add iroh peer because {instance_id} has no topic"
+                    );
+                }
+                chat_id = DC_CHAT_ID_TRASH;
+            }
+            Err(err) => {
+                warn!(context, "Couldn't parse NodeAddr: {err:#}.");
+            }
+        }
     }
 
     if let Some(replace_msg_id) = replace_msg_id {


### PR DESCRIPTION
There is a problem that sometimes the topic ID is missing for new webxdcs.  Moving topic lookup behind the code that stores the topic to the DB might solve this. 