### PR TITLE
WIP: refactor: add failing test: arhive updated event

### DIFF
--- a/src/events/chatlist_events.rs
+++ b/src/events/chatlist_events.rs
@@ -198,9 +198,12 @@ mod test_chatlist_events {
         Ok(())
     }
 
+    /// Mark noticed on a chat in archive should update the unread counter on archive
+    // async fn test_archived_counter_update_on_mark_chat_in_archive_noticed() -> Result<()> {
+
     /// Mark noticed on archive-link chatlistitem should update the unread counter on it
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_archived_counter_update_on_mark_noticed() -> Result<()> {
+    async fn test_archived_counter_update_on_mark_whole_archive_noticed() -> Result<()> {
         let mut tcm = TestContextManager::new();
         let alice = tcm.alice().await;
         let bob = tcm.bob().await;


### PR DESCRIPTION
This is a stub MR to highlight the issue.

This makes the test fail (and rightly so).

This is the cause of https://github.com/deltachat/deltachat-core-rust/issues/5768

TBH I have no idea how to fix it, where to add `emit_msgs_changed(DC_CHAT_ID_ARCHIVED_LINK` when a chat is noticed, there doesn't seem to be one universal place for it, it's all mostly SQL.

But if someone has an idea, I could try to finish this, or just share my findings.

Also perhaps you would disagree with changing the test this way because these kids of tests are mostly put in `chatlist_event.rs`. But IDK seems a little weird to me to split them like this.

For reference, here is the history of related changes:
1. https://github.com/deltachat/deltachat-core-rust/pull/3918
2. https://github.com/deltachat/deltachat-core-rust/pull/3959 - We emit when the counter increases, but not when it decreases, so IMO it doesn't actually close https://github.com/deltachat/deltachat-core-rust/issues/3940
3. https://github.com/deltachat/deltachat-core-rust/pull/4476 - this doesn't affect archive events too much, apparently, it only adds extra `ChatlistItemChanged` and `ChatlistChanged` events on top of `MsgsChanged`