### PR TITLE
feat: set imap ALPN when connecting to IMAP servers

### DIFF
--- a/src/imap/client.rs
+++ b/src/imap/client.rs
@@ -105,7 +105,7 @@ impl Client {
         strict_tls: bool,
     ) -> Result<Self> {
         let tcp_stream = connect_tcp(context, hostname, port, IMAP_TIMEOUT, strict_tls).await?;
-        let tls_stream = wrap_tls(strict_tls, hostname, tcp_stream).await?;
+        let tls_stream = wrap_tls(strict_tls, hostname, &["imap"], tcp_stream).await?;
         let buffered_stream = BufWriter::new(tls_stream);
         let session_stream: Box<dyn SessionStream> = Box::new(buffered_stream);
         let mut client = Client::new(session_stream);
@@ -150,7 +150,7 @@ impl Client {
         let buffered_tcp_stream = client.into_inner();
         let tcp_stream = buffered_tcp_stream.into_inner();
 
-        let tls_stream = wrap_tls(strict_tls, hostname, tcp_stream)
+        let tls_stream = wrap_tls(strict_tls, hostname, &["imap"], tcp_stream)
             .await
             .context("STARTTLS upgrade failed")?;
 
@@ -170,7 +170,7 @@ impl Client {
         let socks5_stream = socks5_config
             .connect(context, domain, port, IMAP_TIMEOUT, strict_tls)
             .await?;
-        let tls_stream = wrap_tls(strict_tls, domain, socks5_stream).await?;
+        let tls_stream = wrap_tls(strict_tls, domain, &["imap"], socks5_stream).await?;
         let buffered_stream = BufWriter::new(tls_stream);
         let session_stream: Box<dyn SessionStream> = Box::new(buffered_stream);
         let mut client = Client::new(session_stream);
@@ -225,7 +225,7 @@ impl Client {
         let buffered_socks5_stream = client.into_inner();
         let socks5_stream: Socks5Stream<_> = buffered_socks5_stream.into_inner();
 
-        let tls_stream = wrap_tls(strict_tls, hostname, socks5_stream)
+        let tls_stream = wrap_tls(strict_tls, hostname, &["imap"], socks5_stream)
             .await
             .context("STARTTLS upgrade failed")?;
         let buffered_stream = BufWriter::new(tls_stream);

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -120,7 +120,7 @@ impl Smtp {
         let socks5_stream = socks5_config
             .connect(context, hostname, port, SMTP_TIMEOUT, strict_tls)
             .await?;
-        let tls_stream = wrap_tls(strict_tls, hostname, socks5_stream).await?;
+        let tls_stream = wrap_tls(strict_tls, hostname, &[], socks5_stream).await?;
         let buffered_stream = BufStream::new(tls_stream);
         let session_stream: Box<dyn SessionBufStream> = Box::new(buffered_stream);
         let client = smtp::SmtpClient::new().smtp_utf8(true);
@@ -144,7 +144,7 @@ impl Smtp {
         let client = smtp::SmtpClient::new().smtp_utf8(true);
         let transport = SmtpTransport::new(client, BufStream::new(socks5_stream)).await?;
         let tcp_stream = transport.starttls().await?.into_inner();
-        let tls_stream = wrap_tls(strict_tls, hostname, tcp_stream)
+        let tls_stream = wrap_tls(strict_tls, hostname, &[], tcp_stream)
             .await
             .context("STARTTLS upgrade failed")?;
         let buffered_stream = BufStream::new(tls_stream);
@@ -179,7 +179,7 @@ impl Smtp {
         strict_tls: bool,
     ) -> Result<SmtpTransport<Box<dyn SessionBufStream>>> {
         let tcp_stream = connect_tcp(context, hostname, port, SMTP_TIMEOUT, false).await?;
-        let tls_stream = wrap_tls(strict_tls, hostname, tcp_stream).await?;
+        let tls_stream = wrap_tls(strict_tls, hostname, &[], tcp_stream).await?;
         let buffered_stream = BufStream::new(tls_stream);
         let session_stream: Box<dyn SessionBufStream> = Box::new(buffered_stream);
         let client = smtp::SmtpClient::new().smtp_utf8(true);
@@ -200,7 +200,7 @@ impl Smtp {
         let client = smtp::SmtpClient::new().smtp_utf8(true);
         let transport = SmtpTransport::new(client, BufStream::new(tcp_stream)).await?;
         let tcp_stream = transport.starttls().await?.into_inner();
-        let tls_stream = wrap_tls(strict_tls, hostname, tcp_stream)
+        let tls_stream = wrap_tls(strict_tls, hostname, &[], tcp_stream)
             .await
             .context("STARTTLS upgrade failed")?;
         let buffered_stream = BufStream::new(tls_stream);


### PR DESCRIPTION
IMAP has a registered protocol ID
listed at <https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids>

Requesting specific ALPN on the client
should allow the server to
multiplex multiple protocols on the same
port and dispatch
requests to the correct backend on the proxy such as HAProxy.