### PR TITLE
bulid(node): pin node-gyp to version 10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "chai": "~4.3.10",
     "chai-as-promised": "^7.1.1",
     "mocha": "^8.2.1",
-    "node-gyp": "^10.0.0",
+    "node-gyp": "~10.1.0",
     "prebuildify": "^5.0.1",
     "prebuildify-ci": "^1.0.5",
     "prettier": "^3.0.3",


### PR DESCRIPTION
Newer node-gyp uses newer gyp
which requires newer python
that is not available in Debian 10
container that is
used for building node prebuilds
with old glibc.