### PR TITLE
fix: Emit MsgsChanged if the number of unnoticed archived chats could decrease (#5768)

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1201,6 +1201,9 @@ impl Session {
         set_modseq(context, folder, highest_modseq)
             .await
             .with_context(|| format!("failed to set MODSEQ for folder {folder}"))?;
+        if !updated_chat_ids.is_empty() {
+            context.on_archived_chats_maybe_noticed();
+        }
         for updated_chat_id in updated_chat_ids {
             context.emit_event(EventType::MsgsNoticed(updated_chat_id));
             chatlist_events::emit_chatlist_item_changed(context, updated_chat_id);


### PR DESCRIPTION
Follow-up to 3cf78749df36126d35d8c6a88e2f2b598e7edb77 "Emit DC_EVENT_MSGS_CHANGED for DC_CHAT_ID_ARCHIVED_LINK when the number of archived chats with unread messages increases (#3940)".

In general we don't want to make an extra db query to know if a noticied chat is archived. Emitting events should be cheap, better to allow false-positive `MsgsChanged` events.

Fix #5768