### PR TITLE
feat: Assign message to ad-hoc group with matching name and members (#5385)

### DIFF
--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -1028,6 +1028,15 @@ CREATE INDEX msgs_status_updates_index2 ON msgs_status_updates (uid);
         .await?;
     }
 
+    inc_and_check(&mut migration_version, 121)?;
+    if dbversion < migration_version {
+        sql.execute_migration(
+            "CREATE INDEX chats_index4 ON chats (name)",
+            migration_version,
+        )
+        .await?;
+    }
+
     let new_version = sql
         .get_raw_config_int(VERSION_CFG)
         .await?


### PR DESCRIPTION
    This should fix ad-hoc groups splitting when messages are fetched out of order from different
    folders or otherwise reordered, or some messages are missing so that the messages reference chain is
    broken, or a member was removed from the thread and readded later, etc. Even if this way two
    different threads are merged, it looks acceptable, having many threads with the same name/subject
    and members isn't a common use case.
    
Fix #5385 