### PR TITLE
fix: Call `send_sync_msg()` only from the SMTP loop (#5780)

### DIFF
--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -103,12 +103,12 @@ def test_account(acfactory) -> None:
     assert alice.get_chatlist(snapshot=True)
     assert alice.get_qr_code()
     assert alice.get_fresh_messages()
-    assert alice.get_next_messages()
 
     # Test sending empty message.
     assert len(bob.wait_next_messages()) == 0
     alice_chat_bob.send_text("")
     messages = bob.wait_next_messages()
+    assert bob.get_next_messages() == messages
     assert len(messages) == 1
     message = messages[0]
     snapshot = message.get_snapshot()

--- a/src/config.rs
+++ b/src/config.rs
@@ -688,7 +688,7 @@ impl Context {
         {
             return Ok(());
         }
-        Box::pin(self.send_sync_msg()).await.log_err(self).ok();
+        self.scheduler.interrupt_smtp().await;
         Ok(())
     }
 
@@ -1054,7 +1054,8 @@ mod tests {
 
         let status = "Synced via usual message";
         alice0.set_config(Config::Selfstatus, Some(status)).await?;
-        alice0.pop_sent_msg().await; // Sync message
+        alice0.send_sync_msg().await?;
+        alice0.pop_sent_msg().await;
         let status1 = "Synced via sync message";
         alice1.set_config(Config::Selfstatus, Some(status1)).await?;
         tcm.send_recv(alice0, alice1, "hi Alice!").await;
@@ -1077,7 +1078,8 @@ mod tests {
         alice0
             .set_config(Config::Selfavatar, Some(file.to_str().unwrap()))
             .await?;
-        alice0.pop_sent_msg().await; // Sync message
+        alice0.send_sync_msg().await?;
+        alice0.pop_sent_msg().await;
         let file = alice1.dir.path().join("avatar.jpg");
         let bytes = include_bytes!("../test-data/image/avatar1000x1000.jpg");
         tokio::fs::write(&file, bytes).await?;

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -652,7 +652,6 @@ pub async fn set_config_from_qr(context: &Context, qr: &str) -> Result<()> {
             context
                 .sync_qr_code_token_deletion(invitenumber, authcode)
                 .await?;
-            context.send_sync_msg().await?;
         }
         Qr::WithdrawVerifyGroup {
             invitenumber,
@@ -664,7 +663,6 @@ pub async fn set_config_from_qr(context: &Context, qr: &str) -> Result<()> {
             context
                 .sync_qr_code_token_deletion(invitenumber, authcode)
                 .await?;
-            context.send_sync_msg().await?;
         }
         Qr::ReviveVerifyContact {
             invitenumber,
@@ -674,7 +672,7 @@ pub async fn set_config_from_qr(context: &Context, qr: &str) -> Result<()> {
             token::save(context, token::Namespace::InviteNumber, None, &invitenumber).await?;
             token::save(context, token::Namespace::Auth, None, &authcode).await?;
             context.sync_qr_code_tokens(None).await?;
-            context.send_sync_msg().await?;
+            context.scheduler.interrupt_smtp().await;
         }
         Qr::ReviveVerifyGroup {
             invitenumber,
@@ -694,7 +692,7 @@ pub async fn set_config_from_qr(context: &Context, qr: &str) -> Result<()> {
             .await?;
             token::save(context, token::Namespace::Auth, chat_id, &authcode).await?;
             context.sync_qr_code_tokens(chat_id).await?;
-            context.send_sync_msg().await?;
+            context.scheduler.interrupt_smtp().await;
         }
         Qr::Login { address, options } => {
             configure_from_login_qr(context, &address, options).await?

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -98,6 +98,7 @@ pub async fn get_securejoin_qr(context: &Context, group: Option<ChatId>) -> Resu
         let group_name_urlencoded = utf8_percent_encode(group_name, NON_ALPHANUMERIC).to_string();
         if sync_token {
             context.sync_qr_code_tokens(Some(chat.id)).await?;
+            context.scheduler.interrupt_smtp().await;
         }
         format!(
             "OPENPGP4FPR:{}#a={}&g={}&x={}&i={}&s={}",
@@ -112,6 +113,7 @@ pub async fn get_securejoin_qr(context: &Context, group: Option<ChatId>) -> Resu
         // parameters used: a=n=i=s=
         if sync_token {
             context.sync_qr_code_tokens(None).await?;
+            context.scheduler.interrupt_smtp().await;
         }
         format!(
             "OPENPGP4FPR:{}#a={}&n={}&i={}&s={}",

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1104,6 +1104,7 @@ pub(crate) async fn mark_as_verified(this: &TestContext, other: &TestContext) {
 /// Pops a sync message from alice0 and receives it on alice1. Should be used after an action on
 /// alice0's side that implies sending a sync message.
 pub(crate) async fn sync(alice0: &TestContext, alice1: &TestContext) {
+    alice0.send_sync_msg().await.unwrap();
     let sync_msg = alice0.pop_sent_msg().await;
     let no_msg = alice1.recv_msg_opt(&sync_msg).await;
     assert!(no_msg.is_none());


### PR DESCRIPTION
`Context::send_sync_msg()` mustn't be called from multiple tasks in parallel to avoid sending the same sync items twice because sync items are removed from the db only after successful sending. Let's guarantee this by calling `send_sync_msg()` only from the SMTP loop. Before `send_sync_msg()` could be called in parallel from the SMTP loop and another task doing e.g. `chat::sync()` which led to `test_multidevice_sync_chat` being flaky because of events triggered by duplicated sync messages.

Fix #5780 