### PR TITLE
feat: Set summary thumbnail path for WebXDCs to "webxdc-icon://last-msg-id" (#5782)

### DIFF
--- a/src/summary.rs
+++ b/src/summary.rs
@@ -129,6 +129,8 @@ impl Summary {
         {
             msg.get_file(context)
                 .and_then(|path| path.to_str().map(|p| p.to_owned()))
+        } else if msg.viewtype == Viewtype::Webxdc {
+            Some("webxdc-icon://last-msg-id".to_string())
         } else {
             None
         };
@@ -355,6 +357,18 @@ mod tests {
         msg.set_text(some_text.clone());
         msg.set_file("foo.mp3", None);
         assert_summary_texts(&msg, ctx, "🎵 foo.mp3 \u{2013} bla bla").await; // file name and text added for audio
+
+        let mut msg = Message::new(Viewtype::File);
+        let bytes = include_bytes!("../test-data/webxdc/with-minimal-manifest.xdc");
+        msg.set_file_from_bytes(ctx, "foo.xdc", bytes, None)
+            .await
+            .unwrap();
+        chat_id.set_draft(ctx, Some(&mut msg)).await.unwrap();
+        assert_eq!(msg.viewtype, Viewtype::Webxdc);
+        assert_summary_texts(&msg, ctx, "nice app!").await;
+        msg.set_text(some_text.clone());
+        chat_id.set_draft(ctx, Some(&mut msg)).await.unwrap();
+        assert_summary_texts(&msg, ctx, "nice app! \u{2013} bla bla").await;
 
         let mut msg = Message::new(Viewtype::File);
         msg.set_file("foo.bar", None);

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -2650,6 +2650,7 @@ sth_for_the = "future""#
         assert_eq!(chatlist.len(), 1);
         let summary = chatlist.get_summary(&t, 0, None).await?;
         assert_eq!(summary.text, "nice app!".to_string());
+        assert_eq!(summary.thumbnail_path.unwrap(), "webxdc-icon://last-msg-id");
 
         Ok(())
     }


### PR DESCRIPTION
This is a hint for apps that a WebXDC icon should be shown in the summary, e.g. in the chatlist. Otherwise it's not clear when it should be shown, e.g. it shouldn't be shown in a reaction summary.

#5782 should be closed after the corresponding DC Desktop fix.