### PR TITLE
feat: do not show the address in invite QR code SVG

### DIFF
--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -37,6 +37,28 @@ def test_qr_setup_contact(acfactory, tmp_path) -> None:
     assert not bob_contact_alice_snapshot.is_verified
 
 
+def test_qr_setup_contact_svg(acfactory) -> None:
+    alice = acfactory.new_configured_account()
+    _, _, domain = alice.get_config("addr").rpartition("@")
+
+    _qr_code, svg = alice.get_qr_code_svg()
+
+    # Test that email address is in SVG
+    # when we have no display name.
+    # Check only the domain name, because
+    # long address may be split over multiple lines
+    # and not matched.
+    assert domain in svg
+
+    alice.set_config("displayname", "Alice")
+
+    # Test that display name is used
+    # in SVG and no address is visible.
+    _qr_code, svg = alice.get_qr_code_svg()
+    assert domain not in svg
+    assert "Alice" in svg
+
+
 @pytest.mark.parametrize("protect", [True, False])
 def test_qr_securejoin(acfactory, protect):
     alice, bob = acfactory.get_online_accounts(2)

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -859,10 +859,10 @@ pub(crate) async fn setup_contact_qr_description(
     display_name: &str,
     addr: &str,
 ) -> String {
-    let name = if display_name == addr {
+    let name = if display_name.is_empty() {
         addr.to_owned()
     } else {
-        format!("{display_name} ({addr})")
+        display_name.to_owned()
     };
     translated(context, StockMessage::SetupContactQRDescription)
         .await


### PR DESCRIPTION
Addresses take space and sometimes
do not fit. We generally want
to deemphasize addresses in the UI,
especially randomized chatmail
addresses.