### PR TITLE
chore(cargo): update `image` crate to 0.25.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,6 +748,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3227,12 +3233,12 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.25.1"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd54d660e773627692c524beaad361aca785a4f9f5730ce91f42aabe5bce3d11"
+checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
 dependencies = [
  "bytemuck",
- "byteorder",
+ "byteorder-lite",
  "color_quant",
  "gif",
  "image-webp",

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -12,7 +12,7 @@ use anyhow::{format_err, Context as _, Result};
 use base64::Engine as _;
 use futures::StreamExt;
 use image::codecs::jpeg::JpegEncoder;
-use image::io::Reader as ImageReader;
+use image::ImageReader;
 use image::{DynamicImage, GenericImage, GenericImageView, ImageFormat, Pixel, Rgba};
 use num_traits::FromPrimitive;
 use tokio::io::AsyncWriteExt;

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -305,7 +305,7 @@ pub fn get_filesuffix_lc(path_filename: &str) -> Option<String> {
 
 /// Returns the `(width, height)` of the given image buffer.
 pub fn get_filemeta(buf: &[u8]) -> Result<(u32, u32)> {
-    let image = image::io::Reader::new(Cursor::new(buf)).with_guessed_format()?;
+    let image = image::ImageReader::new(Cursor::new(buf)).with_guessed_format()?;
     let dimensions = image.into_dimensions()?;
     Ok(dimensions)
 }


### PR DESCRIPTION
This version deprecated `image::io::Reader`,
requires changes to avoid warnings.