### PR TITLE
fix: await the tasks after aborting them

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1913,8 +1913,13 @@ impl RecentlySeenLoop {
             .unwrap();
     }
 
-    pub(crate) fn abort(self) {
+    pub(crate) async fn abort(self) {
         self.handle.abort();
+
+        // Await aborted task to ensure the `Future` is dropped
+        // with all resources moved inside such as the `Context`
+        // reference to `InnerContext`.
+        self.handle.await.ok();
     }
 }
 


### PR DESCRIPTION
This is an alternative fix for #5809 
I tested that it fixes the problem without #5814, but let's keep both fixes to be sure.