### PR TITLE
chore(cargo): update bytemuck from 0.14.3 to 0.16.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,9 +737,9 @@ checksum = "8ea184aa71bb362a1157c896979544cc23974e08fd265f29ea96b59f0b4a555b"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.3"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef034f05691a48569bd920a96c81b9d91bbad1ab5ac7c4616c1f6ef36cb79f"
+checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
 
 [[package]]
 name = "byteorder"


### PR DESCRIPTION
Version 0.14.3 is yanked.