### PR TITLE
Fix cargo warnings about default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,8 +164,8 @@ async-channel = "2.3.1"
 base64 = "0.22"
 chrono = { version = "0.4.38", default-features = false }
 deltachat-contact-tools = { path = "deltachat-contact-tools" }
-deltachat-jsonrpc = { path = "deltachat-jsonrpc" }
-deltachat = { path = "." }
+deltachat-jsonrpc = { path = "deltachat-jsonrpc", default-features = false }
+deltachat = { path = ".", default-features = false }
 futures = "0.3.30"
 futures-lite = "2.3.0"
 libc = "0.2"

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -29,6 +29,6 @@ yerpc = { workspace = true, features = ["anyhow_expose"] }
 
 [features]
 default = ["vendored"]
-vendored = ["deltachat/vendored"]
+vendored = ["deltachat/vendored", "deltachat-jsonrpc/vendored"]
 jsonrpc = ["dep:deltachat-jsonrpc"]
 

--- a/deltachat-rpc-server/Cargo.toml
+++ b/deltachat-rpc-server/Cargo.toml
@@ -10,8 +10,8 @@ keywords = ["deltachat", "chat", "openpgp", "email", "encryption"]
 categories = ["cryptography", "std", "email"]
 
 [dependencies]
-deltachat-jsonrpc = { workspace = true, default-features = false }
-deltachat = { workspace = true, default-features = false }
+deltachat-jsonrpc = { workspace = true }
+deltachat = { workspace = true }
 
 anyhow = { workspace = true }
 futures-lite = { workspace = true }


### PR DESCRIPTION
Otherwise cargo emits these warnings:
warning: .../deltachat-core-rust/deltachat-ffi/Cargo.toml: `default-features` is ignored for deltachat, since `default-features` was not specified for `workspace.dependencies.deltachat`, this could become a hard error in the future warning: .../deltachat-core-rust/deltachat-rpc-server/Cargo.toml: `default-features` is ignored for deltachat, since `default-features` was not specified for `workspace.dependencies.deltachat`, this could become a hard error in the future warning: .../deltachat-core-rust/deltachat-rpc-server/Cargo.toml: `default-features` is ignored for deltachat-jsonrpc, since `default-features` was not specified for `workspace.dependencies.deltachat-jsonrpc`, this could become a hard error in the future