### PR TITLE
feat: Add "Auto-Submitted: auto-replied" header to appropriate SecureJoin messages

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1193,6 +1193,12 @@ impl MimeFactory {
                     if let Some(id) = msg.param.get(Param::Arg4) {
                         headers.push(Header::new("Secure-Join-Group".into(), id.into()));
                     };
+                    if step != "vg-request" && step != "vc-request" {
+                        headers.push(Header::new(
+                            "Auto-Submitted".to_string(),
+                            "auto-replied".to_string(),
+                        ));
+                    }
                 }
             }
             SystemMessage::ChatProtectionEnabled => {


### PR DESCRIPTION
I.e. to all messages except "v{c,g}-request" as they sent out on a QR code scanning which is a manual action and "vg-member-added" as formally this message is auto-submitted, but the member addition is a result of an explicit user action. Otherwise it would be strange to have the Auto-Submitted header in "member-added" messages of verified groups only.

Together with #5755 this will move appropriate outgoing SecureJoin messages to the mvbox regardless of the `mvbox_move` setting.