### PR TITLE
build: do not disable "vendored" feature in the workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,8 +162,8 @@ async-channel = "2.3.1"
 base64 = "0.22"
 chrono = { version = "0.4.38", default-features = false }
 deltachat-contact-tools = { path = "deltachat-contact-tools" }
-deltachat-jsonrpc = { path = "deltachat-jsonrpc", default-features = false }
-deltachat = { path = ".", default-features = false }
+deltachat-jsonrpc = { path = "deltachat-jsonrpc" }
+deltachat = { path = "." }
 futures = "0.3.30"
 futures-lite = "2.3.0"
 libc = "0.2"


### PR DESCRIPTION
This fixes `nix build .#python-docs`