### PR TITLE
refactor: remove param_addr_urlencoded argument from get_autoconfig()

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -507,7 +507,7 @@ async fn get_autoconfig(
         &format!(
             "https://autoconfig.{param_domain}/mail/config-v1.1.xml?emailaddress={param_addr_urlencoded}"
         ),
-        param,
+        &param.addr,
     )
     .await
     {
@@ -522,7 +522,7 @@ async fn get_autoconfig(
             "https://{}/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress={}",
             &param_domain, &param_addr_urlencoded
         ),
-        param,
+        &param.addr,
     )
     .await
     {
@@ -558,7 +558,7 @@ async fn get_autoconfig(
     if let Ok(res) = moz_autoconfigure(
         ctx,
         &format!("https://autoconfig.thunderbird.net/v1.1/{}", &param_domain),
-        param,
+        &param.addr,
     )
     .await
     {

--- a/src/configure/auto_mozilla.rs
+++ b/src/configure/auto_mozilla.rs
@@ -9,7 +9,6 @@ use quick_xml::events::{BytesStart, Event};
 
 use super::{Error, ServerParams};
 use crate::context::Context;
-use crate::login_param::LoginParam;
 use crate::net::read_url;
 use crate::provider::{Protocol, Socket};
 
@@ -257,11 +256,11 @@ fn parse_serverparams(in_emailaddr: &str, xml_raw: &str) -> Result<Vec<ServerPar
 pub(crate) async fn moz_autoconfigure(
     context: &Context,
     url: &str,
-    param_in: &LoginParam,
+    addr: &str,
 ) -> Result<Vec<ServerParams>, Error> {
     let xml_raw = read_url(context, url).await?;
 
-    let res = parse_serverparams(&param_in.addr, &xml_raw);
+    let res = parse_serverparams(addr, &xml_raw);
     if let Err(err) = &res {
         warn!(
             context,


### PR DESCRIPTION
It can be calculated inside the function.