### PR TITLE
ci: update EmbarkStudios/cargo-deny-action action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           show-progress: false
-      - uses: EmbarkStudios/cargo-deny-action@v1
+      - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           arguments: --all-features --workspace
           command: check


### PR DESCRIPTION
v1 is not going to be updated to cargo-deny 0.16.0 because of breaking changes in cargo-deny.