### PR TITLE
feat: allow using OAuth 2 with SOCKS5

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -274,14 +274,7 @@ async fn configure(ctx: &Context, param: &mut LoginParam) -> Result<()> {
         } else {
             // Try receiving autoconfig
             info!(ctx, "no offline autoconfig found");
-            param_autoconfig = if socks5_enabled {
-                // Currently we can't do http requests through socks5, to not leak
-                // the ip, just don't do online autoconfig
-                info!(ctx, "socks5 enabled, skipping autoconfig");
-                None
-            } else {
-                get_autoconfig(ctx, param, &param_domain).await
-            }
+            param_autoconfig = get_autoconfig(ctx, param, &param_domain).await;
         }
     } else {
         param_autoconfig = None;


### PR DESCRIPTION
SOCKS5 for HTTP requests is supported since
fa198c3b5e5e543f9ac6d78a495bc2250da8c2d9
(PR <https://github.com/deltachat/deltachat-core-rust/pull/4017>)