### PR TITLE
build: use --locked with `cargo install`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ $ curl https://sh.rustup.rs -sSf | sh
 Compile and run Delta Chat Core command line utility, using `cargo`:
 
 ```
-$ cargo run -p deltachat-repl -- ~/deltachat-db
+$ cargo run --locked -p deltachat-repl -- ~/deltachat-db
 ```
 where ~/deltachat-db is the database file. Delta Chat will create it if it does not exist.
 
 Optionally, install `deltachat-repl` binary with
 ```
-$ cargo install --path deltachat-repl/
+$ cargo install --locked --path deltachat-repl/
 ```
 and run as
 ```

--- a/scripts/make-rpc-testenv.sh
+++ b/scripts/make-rpc-testenv.sh
@@ -3,4 +3,4 @@ set -euo pipefail
 
 tox -c deltachat-rpc-client -e py --devenv venv
 venv/bin/pip install --upgrade pip
-cargo install --path deltachat-rpc-server/ --root "$PWD/venv" --debug
+cargo install --locked --path deltachat-rpc-server/ --root "$PWD/venv" --debug

--- a/scripts/run-rpc-test.sh
+++ b/scripts/run-rpc-test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-cargo install --path deltachat-rpc-server/ --root "$PWD/venv" --debug
+cargo install --locked --path deltachat-rpc-server/ --root "$PWD/venv" --debug
 PATH="$PWD/venv/bin:$PATH" tox -c deltachat-rpc-client


### PR DESCRIPTION
`cargo install` ignores lockfile by default.
Without lockfile current build fails
due to iroh-net 0.21.0 depending on `derive_more` 1.0.0-beta.6 but failing to compile with `derive_more` 1.0.0.-beta.7. This particular error will be fixed by upgrading to iroh 0.22.0, but using lockfile will avoid similar problems in the future.