### PR TITLE
fix: Still send MDNs from bots by default

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1769,7 +1769,7 @@ pub async fn markseen_msgs(context: &Context, msg_ids: Vec<MsgId>) -> Result<()>
             if curr_blocked == Blocked::Not
                 && curr_param.get_bool(Param::WantsMdn).unwrap_or_default()
                 && curr_param.get_cmd() == SystemMessage::Unknown
-                && context.mdns_enabled().await?
+                && context.should_send_mdns().await?
             {
                 context
                     .sql

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -186,7 +186,7 @@ impl MimeFactory {
 
             if !msg.is_system_message()
                 && msg.param.get_int(Param::Reaction).unwrap_or_default() == 0
-                && context.mdns_enabled().await?
+                && context.should_request_mdns().await?
             {
                 req_mdn = true;
             }

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -631,7 +631,7 @@ async fn send_mdn_rfc724_mid(
 
 /// Tries to send a single MDN. Returns true if more MDNs should be sent.
 async fn send_mdn(context: &Context, smtp: &mut Smtp) -> Result<bool> {
-    if !context.mdns_enabled().await? {
+    if !context.should_send_mdns().await? {
         context.sql.execute("DELETE FROM smtp_mdns", []).await?;
         return Ok(false);
     }


### PR DESCRIPTION
Fixup for 5ce44ade1. It is good that read receipts are sent by bots to see the bot received the message. Thanks to @adbenitez for pointing this out.