### PR TITLE
fix: default to strict TLS checks if not configured

### DIFF
--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -3,6 +3,7 @@ import concurrent.futures
 import json
 import logging
 import os
+import socket
 import subprocess
 import time
 from unittest.mock import MagicMock
@@ -68,6 +69,18 @@ def test_configure_starttls(acfactory) -> None:
     account.set_config("send_security", "2")
     account.configure()
     assert account.is_configured()
+
+
+def test_configure_ip(acfactory) -> None:
+    account = acfactory.new_preconfigured_account()
+
+    domain = account.get_config("addr").rsplit("@")[-1]
+    ip_address = socket.gethostbyname(domain)
+
+    # This should fail TLS check.
+    account.set_config("mail_server", ip_address)
+    with pytest.raises(JsonRpcError):
+        account.configure()
 
 
 def test_account(acfactory) -> None:

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -265,9 +265,7 @@ impl LoginParam {
             | CertificateChecks::AcceptInvalidCertificates2 => Some(false),
         };
         let provider_strict_tls = self.provider.map(|provider| provider.opt.strict_tls);
-        user_strict_tls
-            .or(provider_strict_tls)
-            .unwrap_or(self.socks5_config.is_some())
+        user_strict_tls.or(provider_strict_tls).unwrap_or(true)
     }
 }
 


### PR DESCRIPTION
If user has not set any settings manually
and provider is not configured,
default to strict TLS checks.

Bug was introduced in <https://github.com/deltachat/deltachat-core-rust/pull/5854>
(commit 6b4532a08e36d0a39aa24a2e94eb222d7f90a936)
and affects released core 1.142.4 and 1.142.5.

The problem only affects accounts configured using these core versions with provider not in the provider database or when using advanced settings.