### PR TITLE
fix: Only include one From: header in securejoin messages

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -731,17 +731,13 @@ impl MimeFactory {
                     protected_headers.push(header.clone());
                 }
 
-                if is_encrypted && verified || is_securejoin_message {
-                    unprotected_headers.push(
-                        Header::new_with_value(
-                            header.name,
-                            vec![Address::new_mailbox(self.from_addr.clone())],
-                        )
-                        .unwrap(),
-                    );
-                } else {
-                    unprotected_headers.push(header);
-                }
+                unprotected_headers.push(
+                    Header::new_with_value(
+                        header.name,
+                        vec![Address::new_mailbox(self.from_addr.clone())],
+                    )
+                    .unwrap(),
+                );
             } else if header_name == "to" {
                 protected_headers.push(header.clone());
                 if is_encrypted {

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -843,6 +843,7 @@ mod tests {
         );
 
         let sent = bob.pop_sent_msg().await;
+        assert!(!sent.payload.contains("Bob Examplenet"));
         assert_eq!(sent.recipient(), EmailAddress::new(alice_addr).unwrap());
         let msg = alice.parse_msg(&sent).await;
         assert!(!msg.was_encrypted());
@@ -860,6 +861,7 @@ mod tests {
         );
 
         let sent = alice.pop_sent_msg().await;
+        assert!(!sent.payload.contains("Alice Exampleorg"));
         let msg = bob.parse_msg(&sent).await;
         assert!(msg.was_encrypted());
         assert_eq!(

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -2,7 +2,7 @@
 //!
 //! This private module is only compiled for test runs.
 #![allow(clippy::indexing_slicing)]
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::fmt::Write;
 use std::ops::{Deref, DerefMut};
 use std::panic;
@@ -478,24 +478,32 @@ impl TestContext {
             .await
             .expect("failed to update message state");
 
-        // Check that we are sending exactly one From, Subject, Date, To, Message-ID, and MIME-Version header.
-        // This is to test for a regression where Delta Chat would sometimes send multiple From headers.
-        let payload_headers: Vec<_> = payload.split("\r\n\r\n").next().unwrap().lines().collect();
+        let payload_headers = payload.split("\r\n\r\n").next().unwrap().lines();
+        let payload_header_names: Vec<_> = payload_headers
+            .map(|h| h.split(':').next().unwrap())
+            .collect();
+
+        // Check that we are sending exactly one From, Subject, Date, To, Message-ID, and MIME-Version header:
         for header in &[
-            "From: ",
-            "Subject: ",
-            "Date: ",
-            "To: ",
+            "From",
+            "Subject",
+            "Date",
+            "To",
             "Message-ID",
-            "MIME-Version: ",
+            "MIME-Version",
         ] {
             assert_eq!(
-                payload_headers
-                    .iter()
-                    .filter(|s| s.starts_with(header))
-                    .count(),
+                payload_header_names.iter().filter(|h| *h == header).count(),
                 1,
                 "This sent email should contain the header {header} exactly 1 time:\n{payload}"
+            );
+        }
+        // Check that we aren't sending any header twice:
+        let mut hash_set = HashSet::new();
+        for header_name in payload_header_names {
+            assert!(
+                hash_set.insert(header_name),
+                "This sent email shouldn't contain the header {header_name} multiple times:\n{payload}"
             );
         }
 

--- a/src/tests/verified_chats.rs
+++ b/src/tests/verified_chats.rs
@@ -881,7 +881,7 @@ async fn test_verified_member_added_reordering() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_no_unencrypted_name_if_verified() -> Result<()> {
+async fn test_no_unencrypted_name_if_encrypted() -> Result<()> {
     let mut tcm = TestContextManager::new();
     for verified in [false, true] {
         let alice = tcm.alice().await;
@@ -898,7 +898,7 @@ async fn test_no_unencrypted_name_if_verified() -> Result<()> {
         let chat_id = bob.create_chat(&alice).await.id;
         let msg = &bob.send_text(chat_id, "hi").await;
 
-        assert_eq!(msg.payload.contains("Bob Smith"), !verified);
+        assert_eq!(msg.payload.contains("Bob Smith"), false);
         assert!(msg.payload.contains("BEGIN PGP MESSAGE"));
 
         let msg = alice.recv_msg(msg).await;


### PR DESCRIPTION
This fixes the bug that sometimes made QR scans fail.

The problem was:

When sorting headers into unprotected/hidden/protected, the From: header was added twice for all messages: Once into unprotected_headers and once into protected_headers. For messages that are `is_encrypted && verified || is_securejoin_message`, the display name is removed before pushing it into unprotected_headers.

Later, duplicate headers are removed from unprotected_headers right before prepending unprotected_headers to the message. But since the unencrypted From: header got modified a bit when removing the display name, it's not exactly the same anymore, so it's not removed from unprotected_headers and consequently added again.