### PR TITLE
Replace reqwest with hyper to parallelize HTTP connection attempts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,12 +379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-waker"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
-
-[[package]]
 name = "attohttpc"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,7 +409,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1267,6 +1261,7 @@ dependencies = [
  "async_zip",
  "base64 0.22.1",
  "brotli",
+ "bytes",
  "chrono",
  "criterion",
  "deltachat-contact-tools",
@@ -1282,7 +1277,10 @@ dependencies = [
  "futures-lite 2.3.0",
  "hex",
  "hickory-resolver",
+ "http-body-util",
  "humansize",
+ "hyper 1.4.1",
+ "hyper-util",
  "image",
  "iroh-gossip",
  "iroh-net",
@@ -1307,12 +1305,12 @@ dependencies = [
  "rand 0.8.5",
  "ratelimit",
  "regex",
- "reqwest",
  "rusqlite",
  "rust-hsluv",
  "sanitize-filename",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sha-1",
  "smallvec",
  "strum",
@@ -2413,25 +2411,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http 1.1.0",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2627,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2689,7 +2668,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2705,14 +2684,13 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.5",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
@@ -2732,7 +2710,7 @@ checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "hyper-util",
  "rustls 0.23.10",
  "rustls-pki-types",
@@ -2743,33 +2721,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.2.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3015,7 +2977,7 @@ dependencies = [
  "anyhow",
  "erased_set",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "hyper-util",
  "once_cell",
  "prometheus-client",
@@ -3052,7 +3014,7 @@ dependencies = [
  "hostname",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "hyper-util",
  "igd-next",
  "iroh-base",
@@ -3480,7 +3442,7 @@ dependencies = [
  "netlink-packet-route",
  "netlink-sys",
  "once_cell",
- "system-configuration 0.6.0",
+ "system-configuration",
  "windows-sys 0.52.0",
 ]
 
@@ -4789,22 +4751,18 @@ checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.5",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.2.0",
+ "hyper 1.4.1",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4816,9 +4774,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.0",
- "system-configuration 0.5.1",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.0",
  "tower-service",
  "url",
@@ -5712,34 +5668,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
 dependencies = [
  "bitflags 2.6.0",
  "core-foundation",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -5936,16 +5871,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.72",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ async-smtp = { version = "0.9", default-features = false, features = ["runtime-t
 async_zip = { version = "0.0.12", default-features = false, features = ["deflate", "fs"] }
 base64 = { workspace = true }
 brotli = { version = "6", default-features=false, features = ["std"] }
+bytes = "1"
 chrono = { workspace = true, features = ["alloc", "clock", "std"] }
 email = { git = "https://github.com/deltachat/rust-email", branch = "master" }
 encoded-words = { git = "https://github.com/async-email/encoded-words", branch = "master" }
@@ -57,7 +58,10 @@ futures = { workspace = true }
 futures-lite = { workspace = true }
 hex = "0.4.0"
 hickory-resolver = "0.24"
+http-body-util = "0.1.2"
 humansize = "2"
+hyper = "1"
+hyper-util = "0.1.7"
 image = { version = "0.25.1", default-features=false, features = ["gif", "jpeg", "ico", "png", "pnm", "webp", "bmp"] }
 iroh-net = { version = "0.23.0", default-features = false }
 iroh-gossip = { version = "0.23.0", default-features = false, features = ["net"] }
@@ -78,11 +82,11 @@ quick-xml = "0.36"
 quoted_printable = "0.5"
 rand = { workspace = true }
 regex = { workspace = true }
-reqwest = { version = "0.12.5", features = ["json"] }
 rusqlite = { workspace = true, features = ["sqlcipher"] }
 rust-hsluv = "0.1"
 sanitize-filename = { workspace = true }
 serde_json = { workspace = true }
+serde_urlencoded = "0.7.1"
 serde = { workspace = true, features = ["derive"] }
 sha-1 = "0.10"
 smallvec = "1.13.2"
@@ -193,8 +197,7 @@ default = ["vendored"]
 internals = []
 vendored = [
   "async-native-tls/vendored",
-  "rusqlite/bundled-sqlcipher-vendored-openssl",
-  "reqwest/native-tls-vendored"
+  "rusqlite/bundled-sqlcipher-vendored-openssl"
 ]
 
 [lints.rust]

--- a/deny.toml
+++ b/deny.toml
@@ -60,8 +60,6 @@ skip = [
      { name = "sync_wrapper", version = "0.1.2" },
      { name = "synstructure", version = "0.12.6" },
      { name = "syn", version = "1.0.109" },
-     { name = "system-configuration-sys", version = "0.5.0" },
-     { name = "system-configuration", version = "0.5.1" },
      { name = "time", version = "<0.3" },
      { name = "tokio-rustls", version = "0.24.1" },
      { name = "toml_edit", version = "0.21.1" },

--- a/src/net.rs
+++ b/src/net.rs
@@ -29,13 +29,6 @@ use tls::wrap_tls;
 /// This constant should be more than the largest expected RTT.
 pub(crate) const TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Transaction timeout, e.g. for a GET or POST request
-/// together with all connection attempts.
-///
-/// This is the worst case time user has to wait on a very slow network
-/// after clicking a button and before getting an error message.
-pub(crate) const TRANSACTION_TIMEOUT: Duration = Duration::from_secs(300);
-
 /// TTL for caches in seconds.
 pub(crate) const CACHE_TTL: u64 = 30 * 24 * 60 * 60;
 

--- a/src/push.rs
+++ b/src/push.rs
@@ -61,16 +61,13 @@ impl PushSubscriber {
             return Ok(());
         };
 
-        let load_cache = true;
-        let response = http::get_client(context, load_cache)
-            .await?
-            .post("https://notifications.delta.chat/register")
-            .body(format!("{{\"token\":\"{token}\"}}"))
-            .send()
-            .await?;
-
-        let response_status = response.status();
-        if response_status.is_success() {
+        if http::post_string(
+            context,
+            "https://notifications.delta.chat/register",
+            format!("{{\"token\":\"{token}\"}}"),
+        )
+        .await?
+        {
             state.heartbeat_subscribed = true;
         }
         Ok(())


### PR DESCRIPTION
Based on #5927

This PR replaces usage of `reqwest` and `hyper-util` with custom connection establishment code so it is done in the same way as for IMAP and SMTP connection. This way we control all HTTP, IMAP and SMTP connection establishment and schedule connection attempts to resolved IP addresses in the same way for all 3 protocols.

Only HTTP/1 is used, there is no attempt to use HTTP/2.