### PR TITLE
docs: document that bcc_self is enabled by default

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -422,8 +422,8 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  * - `mdns_enabled` = 0=do not send or request read receipts,
  *                    1=send and request read receipts
  *                    default=send and request read receipts, only send but not reuqest if `bot` is set
- * - `bcc_self`     = 0=do not send a copy of outgoing messages to self (default),
- *                    1=send a copy of outgoing messages to self.
+ * - `bcc_self`     = 0=do not send a copy of outgoing messages to self,
+ *                    1=send a copy of outgoing messages to self (default).
  *                    Sending messages to self is needed for a proper multi-account setup,
  *                    however, on the other hand, may lead to unwanted notifications in non-delta clients.
  * - `sentbox_watch`= 1=watch `Sent`-folder for changes,


### PR DESCRIPTION
bcc_self has been enabled by default
since core version 1.95.0
by merging
PR <https://github.com/deltachat/deltachat-core-rust/pull/3612>.

However deltachat.h documentation
still incorrectly said that bcc_self is disabled by default.