### PR TITLE
feat(securejoin): ignore invalid *-request-with-auth messages silently

### DIFF
--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -650,7 +650,8 @@ def test_withdraw_securejoin_qr(acfactory):
     logging.info("Bob scanned withdrawn QR code")
     while True:
         event = alice.wait_for_event()
-        if event.kind == EventType.MSGS_CHANGED and event.chat_id != 0:
+        if (
+            event.kind == EventType.WARNING
+            and "Ignoring vg-request-with-auth message because of invalid auth code." in event.msg
+        ):
             break
-    snapshot = alice.get_message_by_id(event.msg_id).get_snapshot()
-    assert snapshot.text == "Cannot establish guaranteed end-to-end encryption with {}".format(bob.get_config("addr"))


### PR DESCRIPTION
There are multiple reasons why `*-request-wih-auth` may be invalid. For example, Bob may have scanned a QR code that has already been withdrawn by Alice. AUTH code may also be not synchronized to one of Alice's devices because sync message was lost. In these cases Alice should not receive an info message each time Bob tries to scan such QR code and auth message is ignored.

Fixes #5932