### PR TITLE
fix: use default server list for providers that don't have one

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -11,7 +11,7 @@
 
 mod auto_mozilla;
 mod auto_outlook;
-mod server_params;
+pub(crate) mod server_params;
 
 use anyhow::{bail, ensure, Context as _, Result};
 use auto_mozilla::moz_autoconfigure;

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -1,6 +1,6 @@
 //! [Provider database](https://providers.delta.chat/) module.
 
-mod data;
+pub(crate) mod data;
 
 use anyhow::Result;
 use deltachat_contact_tools::EmailAddress;


### PR DESCRIPTION
There are providers in the provider database
that do not have servers specified.
For such providers default list should be tried
just like when configuring unknown providers.

Closes #5937