### PR TITLE
fix: Save QR code token regardless of whether the group exists (#5954)

### DIFF
--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -71,11 +71,11 @@ def test_qr_securejoin(acfactory, protect, tmp_path):
     alice2 = acfactory.get_unconfigured_account()
     alice2.import_backup(files[0])
 
-    logging.info("Alice creates a verified group")
-    alice_chat = alice.create_group("Verified group", protect=protect)
+    logging.info("Alice creates a group")
+    alice_chat = alice.create_group("Group", protect=protect)
     assert alice_chat.get_basic_snapshot().is_protected == protect
 
-    logging.info("Bob joins verified group")
+    logging.info("Bob joins the group")
     qr_code = alice_chat.get_qr_code()
     bob.secure_join(qr_code)
 
@@ -113,7 +113,7 @@ def test_qr_securejoin(acfactory, protect, tmp_path):
     assert alice2_contact_bob_snapshot.is_verified
 
     # The QR code token is synced, so alice2 must be able to handle join requests.
-    logging.info("Fiona joins verified group via alice2")
+    logging.info("Fiona joins the group via alice2")
     alice.stop_io()
     fiona.secure_join(qr_code)
     alice2.wait_for_securejoin_inviter_success()

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use lettre_email::PartBuilder;
 use serde::{Deserialize, Serialize};
 
-use crate::chat::{self, Chat, ChatId};
+use crate::chat::{self, ChatId};
 use crate::config::Config;
 use crate::constants::Blocked;
 use crate::contact::ContactId;
@@ -117,36 +117,22 @@ impl Context {
         Ok(())
     }
 
-    /// Adds most recent qr-code tokens for a given chat to the list of items to be synced.
-    /// If device synchronization is disabled,
+    /// Adds most recent qr-code tokens for the given group or self-contact to the list of items to
+    /// be synced. If device synchronization is disabled,
     /// no tokens exist or the chat is unpromoted, the function does nothing.
     /// The caller should perform `SchedulerState::interrupt_smtp()` on its own to trigger sending.
-    pub(crate) async fn sync_qr_code_tokens(&self, chat_id: Option<ChatId>) -> Result<()> {
+    pub(crate) async fn sync_qr_code_tokens(&self, grpid: Option<&str>) -> Result<()> {
         if !self.should_send_sync_msgs().await? {
             return Ok(());
         }
-
         if let (Some(invitenumber), Some(auth)) = (
-            token::lookup(self, Namespace::InviteNumber, chat_id).await?,
-            token::lookup(self, Namespace::Auth, chat_id).await?,
+            token::lookup(self, Namespace::InviteNumber, grpid).await?,
+            token::lookup(self, Namespace::Auth, grpid).await?,
         ) {
-            let grpid = if let Some(chat_id) = chat_id {
-                let chat = Chat::load_from_db(self, chat_id).await?;
-                if !chat.is_promoted() {
-                    info!(
-                        self,
-                        "group '{}' not yet promoted, do not sync tokens yet.", chat.grpid
-                    );
-                    return Ok(());
-                }
-                Some(chat.grpid)
-            } else {
-                None
-            };
             self.add_sync_item(SyncData::AddQrToken(QrTokenData {
                 invitenumber,
                 auth,
-                grpid,
+                grpid: grpid.map(|s| s.to_string()),
             }))
             .await?;
         }
@@ -296,21 +282,9 @@ impl Context {
     }
 
     async fn add_qr_token(&self, token: &QrTokenData) -> Result<()> {
-        let chat_id = if let Some(grpid) = &token.grpid {
-            if let Some((chat_id, _, _)) = chat::get_chat_id_by_grpid(self, grpid).await? {
-                Some(chat_id)
-            } else {
-                warn!(
-                    self,
-                    "Ignoring token for nonexistent/deleted group '{}'.", grpid
-                );
-                return Ok(());
-            }
-        } else {
-            None
-        };
-        token::save(self, Namespace::InviteNumber, chat_id, &token.invitenumber).await?;
-        token::save(self, Namespace::Auth, chat_id, &token.auth).await?;
+        let grpid = token.grpid.as_deref();
+        token::save(self, Namespace::InviteNumber, grpid, &token.invitenumber).await?;
+        token::save(self, Namespace::Auth, grpid, &token.auth).await?;
         Ok(())
     }
 
@@ -328,11 +302,11 @@ mod tests {
     use anyhow::bail;
 
     use super::*;
-    use crate::chat::ProtectionStatus;
+    use crate::chat::{remove_contact_from_chat, Chat, ProtectionStatus};
     use crate::chatlist::Chatlist;
     use crate::contact::{Contact, Origin};
     use crate::securejoin::get_securejoin_qr;
-    use crate::test_utils::{TestContext, TestContextManager};
+    use crate::test_utils::{self, TestContext, TestContextManager};
     use crate::tools::SystemTime;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -634,20 +608,25 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_unpromoted_group_no_qr_sync() -> Result<()> {
+    async fn test_unpromoted_group_qr_sync() -> Result<()> {
         let mut tcm = TestContextManager::new();
         let alice = &tcm.alice().await;
         alice.set_config_bool(Config::SyncMsgs, true).await?;
         let alice_chatid =
             chat::create_group_chat(alice, ProtectionStatus::Protected, "the chat").await?;
         let qr = get_securejoin_qr(alice, Some(alice_chatid)).await?;
-        let msg_id = alice.send_sync_msg().await?;
-        assert!(msg_id.is_none());
+
+        // alice2 syncs the QR code token.
+        let alice2 = &tcm.alice().await;
+        alice2.set_config_bool(Config::SyncMsgs, true).await?;
+        test_utils::sync(alice, alice2).await;
 
         let bob = &tcm.bob().await;
         tcm.exec_securejoin_qr(bob, alice, &qr).await;
         let msg_id = alice.send_sync_msg().await?;
-        // The group becomes promoted when Bob joins, so the QR code token is synced.
+        // Core <= v1.143 doesn't sync QR code tokens immediately, so current Core does that when a
+        // group is promoted for compatibility (because the group could be created by older Core).
+        // TODO: assert!(msg_id.is_none());
         assert!(msg_id.is_some());
         let sent = alice.pop_sent_msg().await;
         let msg = alice.parse_msg(&sent).await;
@@ -658,11 +637,22 @@ mod tests {
             unreachable!();
         };
 
+        // Remove Bob because alice2 doesn't have their key.
+        let alice_bob_id = alice.add_or_lookup_contact(bob).await.id;
+        remove_contact_from_chat(alice, alice_chatid, alice_bob_id).await?;
+        alice.pop_sent_msg().await;
+        let sent = alice
+            .send_text(alice_chatid, "Promoting group to another device")
+            .await;
+        alice2.recv_msg(&sent).await;
+
         let fiona = &tcm.fiona().await;
-        tcm.exec_securejoin_qr(fiona, alice, &qr).await;
-        let msg_id = alice.send_sync_msg().await?;
-        // The QR code token was already synced before.
-        assert!(msg_id.is_none());
+        tcm.exec_securejoin_qr(fiona, alice2, &qr).await;
+        let msg = fiona.get_last_msg().await;
+        assert_eq!(
+            msg.text,
+            "Member Me (fiona@example.net) added by alice@example.org."
+        );
         Ok(())
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -7,7 +7,6 @@
 use anyhow::Result;
 use deltachat_derive::{FromSql, ToSql};
 
-use crate::chat::ChatId;
 use crate::context::Context;
 use crate::tools::{create_id, time};
 
@@ -27,34 +26,22 @@ pub enum Namespace {
 pub async fn save(
     context: &Context,
     namespace: Namespace,
-    foreign_id: Option<ChatId>,
+    foreign_key: Option<&str>,
     token: &str,
 ) -> Result<()> {
-    match foreign_id {
-        Some(foreign_id) => context
-            .sql
-            .execute(
-                "INSERT INTO tokens (namespc, foreign_id, token, timestamp) VALUES (?, ?, ?, ?);",
-                (namespace, foreign_id, token, time()),
-            )
-            .await?,
-        None => {
-            context
-                .sql
-                .execute(
-                    "INSERT INTO tokens (namespc, token, timestamp) VALUES (?, ?, ?);",
-                    (namespace, token, time()),
-                )
-                .await?
-        }
-    };
-
+    context
+        .sql
+        .execute(
+            "INSERT INTO tokens (namespc, foreign_key, token, timestamp) VALUES (?, ?, ?, ?)",
+            (namespace, foreign_key.unwrap_or(""), token, time()),
+        )
+        .await?;
     Ok(())
 }
 
-/// Lookup most recently created token for a namespace/chat combination.
+/// Looks up most recently created token for a namespace / foreign key combination.
 ///
-/// As there may be more than one valid token for a chat-id,
+/// As there may be more than one such valid token,
 /// (eg. when a qr code token is withdrawn, recreated and revived later),
 /// use lookup() for qr-code creation only;
 /// do not use lookup() to check for token validity.
@@ -63,43 +50,28 @@ pub async fn save(
 pub async fn lookup(
     context: &Context,
     namespace: Namespace,
-    chat: Option<ChatId>,
+    foreign_key: Option<&str>,
 ) -> Result<Option<String>> {
-    let token = match chat {
-        Some(chat_id) => {
-            context
-                .sql
-                .query_get_value(
-                    "SELECT token FROM tokens WHERE namespc=? AND foreign_id=? ORDER BY timestamp DESC LIMIT 1;",
-                    (namespace, chat_id),
-                )
-                .await?
-        }
-        // foreign_id is declared as `INTEGER DEFAULT 0` in the schema.
-        None => {
-            context
-                .sql
-                .query_get_value(
-                    "SELECT token FROM tokens WHERE namespc=? AND foreign_id=0 ORDER BY timestamp DESC LIMIT 1;",
-                    (namespace,),
-                )
-                .await?
-        }
-    };
-    Ok(token)
+    context
+        .sql
+        .query_get_value(
+            "SELECT token FROM tokens WHERE namespc=? AND foreign_key=? ORDER BY timestamp DESC LIMIT 1",
+            (namespace, foreign_key.unwrap_or("")),
+        )
+        .await
 }
 
 pub async fn lookup_or_new(
     context: &Context,
     namespace: Namespace,
-    foreign_id: Option<ChatId>,
+    foreign_key: Option<&str>,
 ) -> Result<String> {
-    if let Some(token) = lookup(context, namespace, foreign_id).await? {
+    if let Some(token) = lookup(context, namespace, foreign_key).await? {
         return Ok(token);
     }
 
     let token = create_id();
-    save(context, namespace, foreign_id, &token).await?;
+    save(context, namespace, foreign_key, &token).await?;
     Ok(token)
 }
 
@@ -114,23 +86,22 @@ pub async fn exists(context: &Context, namespace: Namespace, token: &str) -> Res
     Ok(exists)
 }
 
-/// Looks up ChatId by auth token.
+/// Looks up foreign key by auth token.
 ///
 /// Returns None if auth token is not valid.
-/// Returns zero/unset ChatId if the token corresponds to "setup contact" rather than group join.
-pub async fn auth_chat_id(context: &Context, token: &str) -> Result<Option<ChatId>> {
-    let chat_id: Option<ChatId> = context
+/// Returns an empty string if the token corresponds to "setup contact" rather than group join.
+pub async fn auth_foreign_key(context: &Context, token: &str) -> Result<Option<String>> {
+    context
         .sql
         .query_row_optional(
-            "SELECT foreign_id FROM tokens WHERE namespc=? AND token=?",
+            "SELECT foreign_key FROM tokens WHERE namespc=? AND token=?",
             (Namespace::Auth, token),
             |row| {
-                let chat_id: ChatId = row.get(0)?;
-                Ok(chat_id)
+                let foreign_key: String = row.get(0)?;
+                Ok(foreign_key)
             },
         )
-        .await?;
-    Ok(chat_id)
+        .await
 }
 
 pub async fn delete(context: &Context, namespace: Namespace, token: &str) -> Result<()> {


### PR DESCRIPTION
Groups promotion to other devices and QR code tokens synchronisation are not synchronised processes, so there are reasons why a QR code token may arrive earlier than the first group message:
- We are going to upload sync messages via IMAP while group messages are sent by SMTP.
- If sync messages go to the mvbox, they can be fetched earlier than group messages from Inbox.

Fix #5954 

TODO(done): Test. I think that `test_securejoin.py:test_qr_securejoin()` may be left unmodified, it's very unlikely that the `alice2` device won't receive the QR code token by the moment Fiona joins (moreover, Alice doesn't have the mvbox in this test). But a new test checking that QR code tokens are saved if arrive earlier than first group messages is needed. EDIT: `sync::test_unpromoted_group_qr_sync()` tests this now.