### PR TITLE
fix: Set Config::NotifyAboutWrongPw before saving configuration (#5896)

### DIFF
--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -2209,6 +2209,19 @@ def test_configure_error_msgs_wrong_pw(acfactory):
     # Password is wrong so it definitely has to say something about "password"
     assert "password" in ev.data2
 
+    ac1.stop_io()
+    ac1.set_config("mail_pw", "abc")  # Wrong mail pw
+    ac1.configure()
+    while True:
+        ev = ac1._evtracker.get_matching("DC_EVENT_CONFIGURE_PROGRESS")
+        print(f"Configuration progress: {ev.data1}")
+        if ev.data1 == 0:
+            break
+    assert "password" in ev.data2
+    # Account will continue to work with the old password, so if it becomes wrong, a notification
+    # must be shown.
+    assert ac1.get_config("notify_about_wrong_pw") == "1"
+
 
 def test_configure_error_msgs_invalid_server(acfactory):
     ac2 = acfactory.get_unconfigured_account()


### PR DESCRIPTION
Fix #5896 