### PR TITLE
feat: Don't SMTP-send messages to self-chat if BccSelf is disabled

### DIFF
--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -620,7 +620,7 @@ def test_long_group_name(acfactory, lp):
 
 
 def test_send_self_message(acfactory, lp):
-    ac1 = acfactory.new_online_configuring_account(mvbox_move=True)
+    ac1 = acfactory.new_online_configuring_account(mvbox_move=True, bcc_self=True)
     acfactory.bring_accounts_online()
     lp.sec("ac1: create self chat")
     chat = ac1.get_self_contact().create_chat()

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -143,7 +143,9 @@ impl MimeFactory {
         let mut req_mdn = false;
 
         if chat.is_self_talk() {
-            recipients.push((from_displayname.to_string(), from_addr.to_string()));
+            if msg.param.get_cmd() == SystemMessage::AutocryptSetupMessage {
+                recipients.push((from_displayname.to_string(), from_addr.to_string()));
+            }
         } else if chat.is_mailing_list() {
             let list_post = chat
                 .param

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -2108,6 +2108,19 @@ async fn test_no_unencrypted_name_in_self_chat() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_no_smtp_job_for_self_chat() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let bob = &tcm.bob().await;
+    bob.set_config_bool(Config::BccSelf, false).await?;
+    let chat_id = bob.get_self_chat().await.id;
+    let mut msg = Message::new(Viewtype::Text);
+    msg.text = "Happy birthday to me".to_string();
+    chat::send_msg(bob, chat_id, &mut msg).await?;
+    assert!(bob.pop_sent_msg_opt(Duration::ZERO).await.is_none());
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_outgoing_classic_mail_creates_chat() {
     let alice = TestContext::new_alice().await;
 


### PR DESCRIPTION
`chat::create_send_msg_jobs()` already handles `Config::BccSelf` as needed, so i have no idea why `MimeFactory` adds the From address to recipients for the self-chat. Well, the self-chat is special because of sync messages, but they aren't sent if `BccSelf` is disabled anyway. This change unifies the logic for the self-chat and groups only containing `SELF`.

DONE: test.