### PR TITLE
refactor: do not wrap shadowsocks::ProxyClientStream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,7 +1315,6 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "pgp",
- "pin-project",
  "pretty_assertions",
  "proptest",
  "qrcodegen",
@@ -5385,9 +5384,9 @@ dependencies = [
 
 [[package]]
 name = "shadowsocks"
-version = "1.20.2"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06b6af20f0f009894644c9fb149ce6244c69b0a264ffcf7a53cbb3dd4883e4a3"
+checksum = "5ecb3780dfbc654de9383758015b9bb95c6e32fecace36ebded09d67e854d130"
 dependencies = [
  "aes",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,6 @@ once_cell = { workspace = true }
 parking_lot = "0.12"
 percent-encoding = "2.3"
 pgp = { version = "0.13.2", default-features = false }
-pin-project = "1"
 qrcodegen = "1.7.0"
 quick-xml = "0.36"
 quoted_printable = "0.5"
@@ -90,7 +89,7 @@ serde_json = { workspace = true }
 serde_urlencoded = "0.7.1"
 serde = { workspace = true, features = ["derive"] }
 sha-1 = "0.10"
-shadowsocks = { version = "1.20.2", default-features = false, features = ["aead-cipher-2022"] }
+shadowsocks = { version = "1.21.0", default-features = false, features = ["aead-cipher-2022"] }
 smallvec = "1.13.2"
 strum = "0.26"
 strum_macros = "0.26"

--- a/src/net/session.rs
+++ b/src/net/session.rs
@@ -1,4 +1,3 @@
-use crate::net::proxy::ShadowsocksStream;
 use async_native_tls::TlsStream;
 use fast_socks5::client::Socks5Stream;
 use std::pin::Pin;
@@ -45,9 +44,9 @@ impl<T: SessionStream> SessionStream for Socks5Stream<T> {
         self.get_socket_mut().set_read_timeout(timeout)
     }
 }
-impl<T: SessionStream> SessionStream for ShadowsocksStream<T> {
+impl<T: SessionStream> SessionStream for shadowsocks::ProxyClientStream<T> {
     fn set_read_timeout(&mut self, timeout: Option<Duration>) {
-        self.stream.get_mut().set_read_timeout(timeout)
+        self.get_mut().set_read_timeout(timeout)
     }
 }
 


### PR DESCRIPTION
Updated `shadowsocks` implements `Debug` for the type, so there is no need to wrap it.