### PR TITLE
chore(cargo): update lazy_static to 1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,7 +2094,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -3181,11 +3181,11 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
@@ -4812,7 +4812,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.12",
  "libc",
- "spin 0.9.8",
+ "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -5384,7 +5384,7 @@ dependencies = [
  "serde_urlencoded",
  "shadowsocks-crypto",
  "socket2",
- "spin 0.9.8",
+ "spin",
  "thiserror",
  "tokio",
  "tokio-tfo",
@@ -5500,12 +5500,6 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"

--- a/deny.toml
+++ b/deny.toml
@@ -49,7 +49,6 @@ skip = [
      { name = "rustls-pemfile", version = "1.0.4" },
      { name = "rustls", version = "0.21.11" },
      { name = "rustls-webpki", version = "0.101.7" },
-     { name = "spin", version = "<0.9.6" },
      { name = "sync_wrapper", version = "0.1.2" },
      { name = "synstructure", version = "0.12.6" },
      { name = "syn", version = "1.0.109" },


### PR DESCRIPTION
This removes duplicate `spin` dependency.