### PR TITLE
feat(smtp): more verbose SMTP connection establishment errors

### DIFF
--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -142,7 +142,7 @@ impl Smtp {
             {
                 Ok(transport) => transport,
                 Err(err) => {
-                    warn!(context, "SMTP failed to connect: {err:#}.");
+                    warn!(context, "SMTP failed to connect and authenticate: {err:#}.");
                     continue;
                 }
             };


### PR DESCRIPTION
The greeting is now always read manually,
even for STARTTLS connections,
so the errors returned on failure to read form the stream
are the same regardless of the connection type.
