### PR TITLE
fix(query_row_optional): do not treat rows with NULL as missing rows

### DIFF
--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -640,7 +640,7 @@ pub struct MessageInfo {
     error: Option<String>,
     rfc724_mid: String,
     server_urls: Vec<String>,
-    hop_info: Option<String>,
+    hop_info: String,
 }
 
 impl MessageInfo {

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -201,7 +201,8 @@ impl MimeFactory {
         let (in_reply_to, references) = context
             .sql
             .query_row(
-                "SELECT mime_in_reply_to, mime_references FROM msgs WHERE id=?",
+                "SELECT mime_in_reply_to, IFNULL(mime_references, '')
+                 FROM msgs WHERE id=?",
                 (msg.id,),
                 |row| {
                     let in_reply_to: String = row.get(0)?;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -558,15 +558,13 @@ impl Sql {
         self.call(move |conn| match conn.query_row(sql.as_ref(), params, f) {
             Ok(res) => Ok(Some(res)),
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(rusqlite::Error::InvalidColumnType(_, _, rusqlite::types::Type::Null)) => Ok(None),
             Err(err) => Err(err.into()),
         })
         .await
     }
 
     /// Executes a query which is expected to return one row and one
-    /// column. If the query does not return a value or returns SQL
-    /// `NULL`, returns `Ok(None)`.
+    /// column. If the query does not return any rows, returns `Ok(None)`.
     pub async fn query_get_value<T>(
         &self,
         query: &str,


### PR DESCRIPTION
Instead of treating NULL type error
as absence of the row,
handle NULL values with SQL.
Previously we sometimes
accidentally treated a single column
being NULL as the lack of the whole row.

Fixes #5994 
