### PR TITLE
feat: More context for the "Cannot establish guaranteed..." info message

### DIFF
--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -696,7 +696,10 @@ async fn could_not_establish_secure_connection(
     details: &str,
 ) -> Result<()> {
     let contact = Contact::get_by_id(context, contact_id).await?;
-    let msg = stock_str::contact_not_verified(context, &contact).await;
+    let mut msg = stock_str::contact_not_verified(context, &contact).await;
+    msg += " (";
+    msg += details;
+    msg += ")";
     chat::add_info_msg(context, chat_id, &msg, time()).await?;
     warn!(
         context,

--- a/src/securejoin/bob.rs
+++ b/src/securejoin/bob.rs
@@ -47,7 +47,7 @@ pub(super) async fn start_protocol(context: &Context, invite: QrInvite) -> Resul
         BobState::start_protocol(context, invite.clone(), chat_id).await?;
     for state in aborted_states {
         error!(context, "Aborting previously unfinished QR Join process.");
-        state.notify_aborted(context, "new QR scanned").await?;
+        state.notify_aborted(context, "New QR code scanned").await?;
         state.emit_progress(context, JoinerProgress::Error);
     }
     if matches!(stage, BobHandshakeStage::RequestWithAuthSent) {
@@ -194,7 +194,10 @@ impl BobState {
     /// This creates an info message in the chat being joined.
     async fn notify_aborted(&self, context: &Context, why: &str) -> Result<()> {
         let contact = Contact::get_by_id(context, self.invite().contact_id()).await?;
-        let msg = stock_str::contact_not_verified(context, &contact).await;
+        let mut msg = stock_str::contact_not_verified(context, &contact).await;
+        msg += " (";
+        msg += why;
+        msg += ")";
         let chat_id = self.joining_chat_id(context).await?;
         chat::add_info_msg(context, chat_id, &msg, time()).await?;
         warn!(


### PR DESCRIPTION
The "Cannot establish guaranteed end-to-end encryption with ..." info message can have lots of causes, and it happened twice to us now that it took us some time to figure out which one it is.

So, include some more detail in the info message by simply adding the non-translated error message in parantheses.

If we want to put in some more effort for nicer error messages, we could:
- Introduce one new translated string "Cannot establish guaranteed end-to-end encryption with …. Cause: %2$s" or similar (and remove the old stock string)
- And/Or: Introduce new translated strings for all the possible errors
- And/Or: Maybe reword it in order to account better for the case that the chat already is marked as g-e2ee, or use a different wording (because if the chat is marked as g-e2ee then it might be nice to notify the user that something may have gone wrong, but it's still working, just that maybe the other side doesn't have us verified now)

![Screenshot_20241003-222245](https://github.com/user-attachments/assets/c064c82e-01ac-4bac-ab11-3c9ac9db5298)

