### PR TITLE
feat: smooth progress bar for backup export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1315,6 +1315,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "pgp",
+ "pin-project",
  "pretty_assertions",
  "proptest",
  "qrcodegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ once_cell = { workspace = true }
 parking_lot = "0.12"
 percent-encoding = "2.3"
 pgp = { version = "0.13.2", default-features = false }
+pin-project = "1"
 qrcodegen = "1.7.0"
 quick-xml = "0.36"
 quoted_printable = "0.5"

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -666,10 +666,6 @@ impl<'a> BlobDirContents<'a> {
     pub(crate) fn iter(&self) -> BlobDirIter<'_> {
         BlobDirIter::new(self.context, self.inner.iter())
     }
-
-    pub(crate) fn len(&self) -> usize {
-        self.inner.len()
-    }
 }
 
 /// A iterator over all the [`BlobObject`]s in the blobdir.

--- a/src/imex/transfer.rs
+++ b/src/imex/transfer.rs
@@ -191,7 +191,7 @@ impl BackupProvider {
         context.emit_event(EventType::ImexProgress(10));
         send_stream.write_all(&file_size.to_be_bytes()).await?;
 
-        export_backup_stream(&context, &dbfile, blobdir, send_stream)
+        export_backup_stream(&context, &dbfile, blobdir, send_stream, file_size)
             .await
             .context("Failed to write backup into QUIC stream")?;
         info!(context, "Finished writing backup into QUIC stream.");


### PR DESCRIPTION
This makes progress bar move on every `poll_write` call instead of per file, so even if the database file is large, many events are emitted during its transfer.

Based on #6027 