### PR TITLE
fix: Readd tokens.foreign_id column (#6038)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,12 @@ If column is already declared without `NOT NULL`, use `IFNULL` function to provi
 Use `HAVING COUNT(*) > 0` clause
 to [prevent aggregate functions such as `MIN` and `MAX` from returning `NULL`](https://stackoverflow.com/questions/66527856/aggregate-functions-max-etc-return-null-instead-of-no-rows).
 
+Don't delete unused columns too early, but maybe after several months/releases, unused columns are
+still used by older versions, so deleting them breaks downgrading the core or importing a backup in
+an older version. Also don't change the column type, consider adding a new column with another name
+instead. Finally, never change column semantics, this is especially dangerous because the `STRICT`
+keyword doesn't help here.
+
 ### Commit messages
 
 Commit messages follow the [Conventional Commits] notation.

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -1037,6 +1037,15 @@ CREATE INDEX msgs_status_updates_index2 ON msgs_status_updates (uid);
         .await?;
     }
 
+    inc_and_check(&mut migration_version, 122)?;
+    if dbversion < migration_version {
+        sql.execute_migration(
+            "ALTER TABLE tokens ADD COLUMN foreign_id INTEGER NOT NULL DEFAULT 0",
+            migration_version,
+        )
+        .await?;
+    }
+
     let new_version = sql
         .get_raw_config_int(VERSION_CFG)
         .await?


### PR DESCRIPTION
Otherwise backups exported from the current core and imported in versions < 1.144.0 have QR codes not working. The breaking change which removed the column is 5a6efdff44b1d374ea0752ac394423ba258c134b.

Fix #6038 