### PR TITLE
test(test_qr_setup_contact_svg): stop testing for no display name

### DIFF
--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -44,13 +44,6 @@ def test_qr_setup_contact_svg(acfactory) -> None:
 
     _qr_code, svg = alice.get_qr_code_svg()
 
-    # Test that email address is in SVG
-    # when we have no display name.
-    # Check only the domain name, because
-    # long address may be split over multiple lines
-    # and not matched.
-    assert domain in svg
-
     alice.set_config("displayname", "Alice")
 
     # Test that display name is used


### PR DESCRIPTION
It is impossible to set no display name anyway
in Delta Chat Android at least
because we don't want email addresses
in the UI.

This test does not work with long domains
that may get wrapped, so better remove it
instead of trying to prevent wrapping of domains.

Closes #6046