### PR TITLE
docs: fix `too_long_first_doc_paragraph` clippy lint

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -179,7 +179,9 @@ pub const DC_DESIRED_TEXT_LEN: usize = DC_DESIRED_TEXT_LINE_LEN * DC_DESIRED_TEX
 // and may be set together with the username, password etc.
 // via dc_set_config() using the key "server_flags".
 
-/// Force OAuth2 authorization. This flag does not skip automatic configuration.
+/// Force OAuth2 authorization.
+///
+/// This flag does not skip automatic configuration.
 /// Before calling configure() with DC_LP_AUTH_OAUTH2 set,
 /// the user has to confirm access at the URL returned by dc_get_oauth2_url().
 pub const DC_LP_AUTH_OAUTH2: i32 = 0x2;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1915,6 +1915,7 @@ pub async fn get_request_msg_cnt(context: &Context) -> usize {
 
 /// Estimates the number of messages that will be deleted
 /// by the options `delete_device_after` or `delete_server_after`.
+///
 /// This is typically used to show the estimated impact to the user
 /// before actually enabling deletion of old messages.
 ///

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -25,6 +25,7 @@ pub const QUOTA_ERROR_THRESHOLD_PERCENTAGE: u64 = 95;
 
 /// if quota is below this value (again),
 /// QuotaExceeding is cleared.
+///
 /// This value should be a bit below QUOTA_WARN_THRESHOLD_PERCENTAGE to
 /// avoid jittering and lots of warnings when quota is exactly at the warning threshold.
 ///


### PR DESCRIPTION
This lint is enabled for beta and nightly Rust.