### PR TITLE
test(test_aeap_flow_verified): wait for "member added" before sending messages

### DIFF
--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -467,6 +467,7 @@ def test_aeap_flow_verified(acfactory):
     logging.info("ac2: start QR-code based join-group protocol")
     ac2.secure_join(qr_code)
     ac1.wait_for_securejoin_inviter_success()
+    ac2.wait_for_securejoin_joiner_success()
 
     logging.info("sending first message")
     msg_out = chat.send_text("old address").get_snapshot()


### PR DESCRIPTION
Otherwise instead of "old address"
ac2 may receive "member added",
resulting in this failure:
```
>       assert msg_in_1.text == msg_out.text
E       AssertionError: assert 'Member Me (c...hat.computer.' == 'old address'
E         - old address
E         + Member Me (ci-hfpxxe@***) added by ci-8e7mkr@***.
```