### PR TITLE
feat: add more context to `send_msg` errors

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -1946,9 +1946,13 @@ impl CommandApi {
 
     async fn send_msg(&self, account_id: u32, chat_id: u32, data: MessageData) -> Result<u32> {
         let ctx = self.get_context(account_id).await?;
-        let mut message = data.create_message(&ctx).await?;
+        let mut message = data
+            .create_message(&ctx)
+            .await
+            .context("Failed to create message")?;
         let msg_id = chat::send_msg(&ctx, ChatId::new(chat_id), &mut message)
-            .await?
+            .await
+            .context("Failed to send created message")?
             .to_u32();
         Ok(msg_id)
     }

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -605,16 +605,13 @@ impl MessageData {
             message.set_location(latitude, longitude);
         }
         if let Some(id) = self.quoted_message_id {
+            let quoted_message = Message::load_from_db(context, MsgId::new(id))
+                .await
+                .context("Failed to load quoted message")?;
             message
-                .set_quote(
-                    context,
-                    Some(
-                        &Message::load_from_db(context, MsgId::new(id))
-                            .await
-                            .context("message to quote could not be loaded")?,
-                    ),
-                )
-                .await?;
+                .set_quote(context, Some(&quoted_message))
+                .await
+                .context("Failed to set quote")?;
         } else if let Some(text) = self.quoted_text {
             let protect = false;
             message.set_quote_text(Some((text, protect)));

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2941,7 +2941,10 @@ async fn prepare_send_msg(
         );
         message::update_msg_state(context, msg.id, MessageState::OutPending).await?;
     }
-    create_send_msg_jobs(context, msg).await
+    let row_ids = create_send_msg_jobs(context, msg)
+        .await
+        .context("Failed to create send jobs")?;
+    Ok(row_ids)
 }
 
 /// Constructs jobs for sending a message and inserts them into the appropriate table.


### PR DESCRIPTION
Attempt to debug #6066
With these changes we will at least get more context next time it fails.