### PR TITLE
test: Message from old setup preserves contact verification, but breaks 1:1 protection

### DIFF
--- a/test-data/golden/verified_chats_message_from_old_dc_setup
+++ b/test-data/golden/verified_chats_message_from_old_dc_setup
@@ -1,0 +1,7 @@
+Single#Chat#10: bob@example.net [bob@example.net] 
+--------------------------------------------------------------------------------
+Msg#10: info (Contact#Contact#Info): Messages are guaranteed to be end-to-end encrypted from now on. [NOTICED][INFO 🛡️]
+Msg#11🔒:  (Contact#Contact#10): Now i have it! [FRESH]
+Msg#12: info (Contact#Contact#Info): bob@example.net sent a message from another device. [NOTICED][INFO 🛡️❌]
+Msg#13:  (Contact#Contact#10): Soon i'll have a new device [FRESH]
+--------------------------------------------------------------------------------


### PR DESCRIPTION
If a message from an old contact's setup is received, the outdated Autocrypt header isn't applied, so the contact verification preserves. But the chat protection breaks because the old message is sorted to the bottom as it mustn't be sorted over the protection info message (which is `InNoticed` moreover). Would be nice to preserve the chat protection too e.g. add a "protection broken" message, then the old message and then a new "protection enabled" message, but let's record the current behaviour first.