### PR TITLE
fix: Resolve warning about default-features, and make it possible to disable vendoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ add_custom_command(
         PREFIX=${CMAKE_INSTALL_PREFIX}
         LIBDIR=${CMAKE_INSTALL_FULL_LIBDIR}
         INCLUDEDIR=${CMAKE_INSTALL_FULL_INCLUDEDIR}
-	${CARGO} build --target-dir=${CMAKE_BINARY_DIR}/target --release --no-default-features --features jsonrpc
+	${CARGO} build --target-dir=${CMAKE_BINARY_DIR}/target --release --features jsonrpc
 	WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/deltachat-ffi
 )
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,8 +169,8 @@ async-channel = "2.3.1"
 base64 = "0.22"
 chrono = { version = "0.4.38", default-features = false }
 deltachat-contact-tools = { path = "deltachat-contact-tools" }
-deltachat-jsonrpc = { path = "deltachat-jsonrpc" }
-deltachat = { path = "." }
+deltachat-jsonrpc = { path = "deltachat-jsonrpc", default-features = false }
+deltachat = { path = ".", default-features = false }
 futures = "0.3.30"
 futures-lite = "2.3.0"
 libc = "0.2"


### PR DESCRIPTION
On main, when running `cargo build`, the following warning is emitted:

> warning: /home/jonathan/deltachat-android/jni/deltachat-core-rust/deltachat-ffi/Cargo.toml: `default-features` is ignored for deltachat, since `default-features` was not specified for `workspace.dependencies.deltachat`, this could become a hard error in the future

This is because when referring to a workspace dependency, it's not possible to remove features, it's only possible to add features, so that the `vendored` feature was always enabled with no possibility to disable it.

This PR restores the wanted behavior of enabling vendoring by default with the possibility to disable it with "default-features = false".

It fixes `nix build .#python-docs` by not passing
`--no-default-features` when building deltachat with nix.