### PR TITLE
feat: internal profile names

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -522,6 +522,8 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    In contrast to `dc_set_chat_mute_duration()`,
  *                    fresh message and badge counters are not changed by this setting,
  *                    but should be tuned down where appropriate.
+ * - `private_tag`  = Optional tag as "Work", "Family".
+ *                    Meant to help profile owner to differ between profiles with similar names.
  * - `ui.*`         = All keys prefixed by `ui.` can be used by the user-interfaces for system-specific purposes.
  *                    The prefix should be followed by the system and maybe subsystem,
  *                    e.g. `ui.desktop.foo`, `ui.desktop.linux.bar`, `ui.android.foo`, `ui.dc40.bar`, `ui.bot.simplebot.baz`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -321,6 +321,10 @@ pub enum Config {
     /// True if account is muted.
     IsMuted,
 
+    /// Optional tag as "Work", "Family".
+    /// Meant to help profile owner to differ between profiles with similar names.
+    PrivateTag,
+
     /// All secondary self addresses separated by spaces
     /// (`addr1@example.org addr2@example.org addr3@example.org`)
     SecondaryAddrs,

--- a/src/context.rs
+++ b/src/context.rs
@@ -857,6 +857,12 @@ impl Context {
             "is_muted",
             self.get_config_bool(Config::IsMuted).await?.to_string(),
         );
+        res.insert(
+            "private_tag",
+            self.get_config(Config::PrivateTag)
+                .await?
+                .unwrap_or_else(|| "<unset>".to_string()),
+        );
 
         if let Some(metadata) = &*self.metadata.read().await {
             if let Some(comment) = &metadata.comment {


### PR DESCRIPTION
this PR allows setting a "private tag" for a profile, see https://github.com/deltachat/deltachat-android/pull/3373 for a possible UI.

currently, the core does not do anything with the tag (so, it could also be a ui.-config option), however, this may change in the future - it might bet synced, and become also otherwise useful in core. also, having this in core is better documentation-wise, as otherwise each UI easily does its own things :)

