### PR TITLE
feat: allow sending realtime messages up to 128 KB in size

### DIFF
--- a/deltachat-rpc-client/tests/test_iroh_webxdc.py
+++ b/deltachat-rpc-client/tests/test_iroh_webxdc.py
@@ -7,6 +7,7 @@ If you want to debug iroh at rust-trace/log level set
     RUST_LOG=iroh_net=trace,iroh_gossip=trace
 """
 
+import os
 import sys
 import threading
 import time
@@ -107,13 +108,15 @@ def test_realtime_sequentially(acfactory, path_to_webxdc):
     assert snapshot.text == "ping2"
 
     log("sending realtime data ac1 -> ac2")
-    ac1_webxdc_msg.send_webxdc_realtime_data(b"foo")
+    # Test that 128 KB of data can be sent in a single message.
+    data = os.urandom(128000)
+    ac1_webxdc_msg.send_webxdc_realtime_data(data)
 
     log("ac2: waiting for realtime data")
     while 1:
         event = ac2.wait_for_event()
         if event.kind == EventType.WEBXDC_REALTIME_DATA:
-            assert event.data == list(b"foo")
+            assert event.data == list(data)
             break
 
 

--- a/src/peer_channels.rs
+++ b/src/peer_channels.rs
@@ -259,7 +259,14 @@ impl Context {
 
         // create gossip
         let my_addr = endpoint.node_addr().await?;
-        let gossip = Gossip::from_endpoint(endpoint.clone(), Default::default(), &my_addr.info);
+        let gossip_config = iroh_gossip::proto::topic::Config {
+            // Allow messages up to 128 KB in size.
+            // We set the limit to 128 KiB to account for internal overhead,
+            // but only guarantee 128 KB of payload to WebXDC developers.
+            max_message_size: 128 * 1024,
+            ..Default::default()
+        };
+        let gossip = Gossip::from_endpoint(endpoint.clone(), gossip_config, &my_addr.info);
 
         // spawn endpoint loop that forwards incoming connections to the gossiper
         let context = self.clone();


### PR DESCRIPTION
Previous default value was 4 KiB.

Closes #5674 