### PR TITLE
fix: do not wait for connections in maybe_add_gossip_peers()

### DIFF
--- a/src/peer_channels.rs
+++ b/src/peer_channels.rs
@@ -143,9 +143,10 @@ impl Iroh {
                 self.endpoint.add_node_addr(peer.clone())?;
             }
 
-            self.gossip
-                .join(topic, peers.into_iter().map(|peer| peer.node_id).collect())
-                .await?;
+            self.gossip.join_with_opts(
+                topic,
+                JoinOptions::with_bootstrap(peers.into_iter().map(|peer| peer.node_id)),
+            );
         }
         Ok(())
     }


### PR DESCRIPTION
join() method of Gossip [1]
waits for at least one connection
and this is not what we want
because it may block receive_imf()
forever if no connection arrives.

[1] https://docs.rs/iroh-gossip/0.25.0/iroh_gossip/net/struct.Gossip.html#method.join

Closes #6108