### PR TITLE
fix: Auto-restore 1:1 chat protection if contact is only forward verified

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3743,10 +3743,10 @@ pub(crate) async fn add_contact_to_chat_ex(
         }
     } else {
         // else continue and send status mail
-        if chat.is_protected() && !contact.is_verified(context).await? {
+        if chat.is_protected() && !contact.is_forward_verified(context).await? {
             error!(
                 context,
-                "Cannot add non-bidirectionally verified contact {contact_id} to protected chat {chat_id}."
+                "Cannot add non-forward verified contact {contact_id} to protected chat {chat_id}."
             );
             return Ok(false);
         }

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1011,7 +1011,7 @@ async fn add_parts(
                             && peerstate.prefer_encrypt == EncryptPreference::Mutual
                             // Check that the contact still has the Autocrypt key same as the
                             // verified key, see also `Peerstate::is_using_verified_key()`.
-                            && contact.is_verified(context).await?;
+                            && contact.is_forward_verified(context).await?;
                     }
                 }
             }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1172,27 +1172,40 @@ fn print_logevent(logevent: &LogEvent) {
 }
 
 /// Saves the other account's public key as verified
-/// and peerstate as backwards verified.
-pub(crate) async fn mark_as_verified(this: &TestContext, other: &TestContext) {
+/// and peerstate as backwards verified / not verified.
+pub(crate) async fn mark_as_verified_ex(
+    this: &TestContext,
+    other: &TestContext,
+    last_seen: i64,
+    backward: bool,
+) {
     let mut peerstate = Peerstate::from_header(
         &EncryptHelper::new(other).await.unwrap().get_aheader(),
-        // We have to give 0 as the time, not the current time:
-        // The time is going to be saved in peerstate.last_seen.
-        // The code in `peerstate.rs` then compares `if message_time > self.last_seen`,
-        // and many similar checks in peerstate.rs, and doesn't allow changes otherwise.
-        // Giving the current time would mean that message_time == peerstate.last_seen,
-        // so changes would not be allowed.
-        // This might lead to flaky tests.
-        0,
+        last_seen,
     );
 
     peerstate.verified_key.clone_from(&peerstate.public_key);
     peerstate
         .verified_key_fingerprint
         .clone_from(&peerstate.public_key_fingerprint);
-    peerstate.backward_verified_key_id = Some(this.get_config_i64(Config::KeyId).await.unwrap());
-
+    peerstate.backward_verified_key_id = match backward {
+        true => Some(this.get_config_i64(Config::KeyId).await.unwrap()),
+        false => None,
+    };
     peerstate.save_to_db(&this.sql).await.unwrap();
+}
+
+/// Saves the other account's public key as verified
+/// and peerstate as backwards verified.
+pub(crate) async fn mark_as_verified(this: &TestContext, other: &TestContext) {
+    // We have to give 0 as the time, not the current time: The time is going to be saved in
+    // peerstate.last_seen. The code in `peerstate.rs` then compares `if message_time >
+    // self.last_seen`, and many similar checks in peerstate.rs, and doesn't allow changes
+    // otherwise. Giving the current time would mean that message_time == peerstate.last_seen, so
+    // changes would not be allowed. This might lead to flaky tests.
+    let last_seen = 0;
+    let backward = true;
+    mark_as_verified_ex(this, other, last_seen, backward).await
 }
 
 /// Pops a sync message from alice0 and receives it on alice1. Should be used after an action on


### PR DESCRIPTION
See commit messages.

The second commit isn't that important, i just think all additional checks related to usability should be in UIs, so i can remove it if there are any objections.