### PR TITLE
fix: Prevent accidental wrong-password-notifications

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -416,35 +416,38 @@ impl Imap {
                     let imap_user = lp.user.to_owned();
                     let message = stock_str::cannot_login(context, &imap_user).await;
 
-                    let err_str = err.to_string();
                     warn!(context, "IMAP failed to login: {err:#}.");
                     first_error.get_or_insert(format_err!("{message} ({err:#})"));
 
+                    // If it looks like the password is wrong, send a notification:
                     let _lock = context.wrong_pw_warning_mutex.lock().await;
-                    if !configuring
-                        && self.login_failed_once
-                        && err_str.to_lowercase().contains("authentication")
-                        && context.get_config_bool(Config::NotifyAboutWrongPw).await?
-                    {
-                        let mut msg = Message::new_text(message);
-                        if let Err(e) = chat::add_device_msg_with_importance(
-                            context,
-                            None,
-                            Some(&mut msg),
-                            true,
-                        )
-                        .await
+                    if err.to_string().to_lowercase().contains("authentication") {
+                        if self.login_failed_once
+                            && !configuring
+                            && context.get_config_bool(Config::NotifyAboutWrongPw).await?
                         {
-                            warn!(context, "Failed to add device message: {e:#}.");
+                            let mut msg = Message::new_text(message);
+                            if let Err(e) = chat::add_device_msg_with_importance(
+                                context,
+                                None,
+                                Some(&mut msg),
+                                true,
+                            )
+                            .await
+                            {
+                                warn!(context, "Failed to add device message: {e:#}.");
+                            } else {
+                                context
+                                    .set_config_internal(Config::NotifyAboutWrongPw, None)
+                                    .await
+                                    .log_err(context)
+                                    .ok();
+                            }
                         } else {
-                            context
-                                .set_config_internal(Config::NotifyAboutWrongPw, None)
-                                .await
-                                .log_err(context)
-                                .ok();
+                            self.login_failed_once = true;
                         }
                     } else {
-                        self.login_failed_once = true;
+                        self.login_failed_once = false;
                     }
                 }
             }


### PR DESCRIPTION
Over the past years, it happend two times that a user came to me worried about a false-positive "Cannot login as ***. Please check if the e-mail address and the password are correct." message.

I'm not sure why this happened, but I think we should make the logic for showing this notification stricter:
- Before: The notification is shown if connection fails two times in a row, and the second error contains the word "authentication".
- Now: The notification is shown if the connection fails two times in a row, and _both_ error messages contain the word "authentication".

The second commit just renames `login_failed_once` to `authentication_failed_once` in order to reflect this change.