### PR TITLE
api: Add Message::new_text()

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -2118,8 +2118,7 @@ impl CommandApi {
     ) -> Result<u32> {
         let ctx = self.get_context(account_id).await?;
 
-        let mut msg = Message::new(Viewtype::Text);
-        msg.set_text(text);
+        let mut msg = Message::new_text(text);
 
         let message_id = deltachat::chat::send_msg(&ctx, ChatId::new(chat_id), &mut msg).await?;
         Ok(message_id.to_u32())

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -1004,8 +1004,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             ensure!(sel_chat.is_some(), "No chat selected.");
 
             if !arg1.is_empty() {
-                let mut draft = Message::new(Viewtype::Text);
-                draft.set_text(arg1.to_string());
+                let mut draft = Message::new_text(arg1.to_string());
                 sel_chat
                     .as_ref()
                     .unwrap()
@@ -1028,8 +1027,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                 !arg1.is_empty(),
                 "Please specify text to add as device message."
             );
-            let mut msg = Message::new(Viewtype::Text);
-            msg.set_text(arg1.to_string());
+            let mut msg = Message::new_text(arg1.to_string());
             chat::add_device_msg(&context, None, Some(&mut msg)).await?;
         }
         "listmedia" => {

--- a/src/message.rs
+++ b/src/message.rs
@@ -491,6 +491,15 @@ impl Message {
         }
     }
 
+    /// Creates a new message with Viewtype::Text.
+    pub fn new_text(text: String) -> Self {
+        Message {
+            viewtype: Viewtype::Text,
+            text,
+            ..Default::default()
+        }
+    }
+
     /// Loads message with given ID from the database.
     ///
     /// Returns an error if the message does not exist.


### PR DESCRIPTION
This adds a function to `Message`:

```rust
    pub fn new_text(text: String) -> Self {
        Message {
            viewtype: Viewtype::Text,
            text,
            ..Default::default()
        }
    }
```

I keep expecting that a function like this must exist and being surprised that it doesn't.

Open question is whether it should be `pub` or `pub(crate)` - I made it `pub` for now because it may be useful for others and we currently we aren't thinking about the Rust API that much, anyway, but I can make it `pub(crate)`, too (then it can't be used in deltachat-jsonrpc and deltachat-repl).

I replaced some usages of Message::new(Viewtype::Text), but not all yet, I'm going to do this in a follow-up, which will remove another around 65 LOC.