### PR TITLE
chore: Silence another rust-analyzer false-positive

### DIFF
--- a/deltachat-jsonrpc/src/api/types/events.rs
+++ b/deltachat-jsonrpc/src/api/types/events.rs
@@ -409,6 +409,9 @@ impl From<CoreEventType> for EventType {
             },
             CoreEventType::ChatlistChanged => ChatlistChanged,
             CoreEventType::EventChannelOverflow { n } => EventChannelOverflow { n },
+            #[allow(unreachable_patterns)]
+            #[cfg(test)]
+            _ => unreachable!("This is just to silence a rust_analyzer false-positive"),
         }
     }
 }


### PR DESCRIPTION
Follow-up to #6077. Not sure why this error didn't show up in my rust-analyzer until now.