### PR TITLE
feat: Enable Webxdc realtime by default

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -530,8 +530,8 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    These keys go to backups and allow easy per-account settings when using @ref dc_accounts_t,
  *                    however, are not handled by the core otherwise.
  * - `webxdc_realtime_enabled` = Whether the realtime APIs should be enabled.
- *                               0 = WebXDC realtime API is disabled and behaves as noop (default).
- *                               1 = WebXDC realtime API is enabled.
+ *                               0 = WebXDC realtime API is disabled and behaves as noop.
+ *                               1 = WebXDC realtime API is enabled (default).
  *
  * If you want to retrieve a value, use dc_get_config().
  *

--- a/src/config.rs
+++ b/src/config.rs
@@ -433,6 +433,7 @@ pub enum Config {
     WebxdcIntegration,
 
     /// Enable webxdc realtime features.
+    #[strum(props(default = "1"))]
     WebxdcRealtimeEnabled,
 }
 

--- a/src/peer_channels.rs
+++ b/src/peer_channels.rs
@@ -590,17 +590,6 @@ mod tests {
         let alice = &mut tcm.alice().await;
         let bob = &mut tcm.bob().await;
 
-        bob.ctx
-            .set_config_bool(Config::WebxdcRealtimeEnabled, true)
-            .await
-            .unwrap();
-
-        alice
-            .ctx
-            .set_config_bool(Config::WebxdcRealtimeEnabled, true)
-            .await
-            .unwrap();
-
         // Alice sends webxdc to bob
         let alice_chat = alice.create_chat(bob).await;
         let mut instance = Message::new(Viewtype::File);
@@ -738,17 +727,6 @@ mod tests {
         let mut tcm = TestContextManager::new();
         let alice = &mut tcm.alice().await;
         let bob = &mut tcm.bob().await;
-
-        bob.ctx
-            .set_config_bool(Config::WebxdcRealtimeEnabled, true)
-            .await
-            .unwrap();
-
-        alice
-            .ctx
-            .set_config_bool(Config::WebxdcRealtimeEnabled, true)
-            .await
-            .unwrap();
 
         assert!(alice
             .get_config_bool(Config::WebxdcRealtimeEnabled)
@@ -907,17 +885,6 @@ mod tests {
         let alice = &mut tcm.alice().await;
         let bob = &mut tcm.bob().await;
 
-        bob.ctx
-            .set_config_bool(Config::WebxdcRealtimeEnabled, true)
-            .await
-            .unwrap();
-
-        alice
-            .ctx
-            .set_config_bool(Config::WebxdcRealtimeEnabled, true)
-            .await
-            .unwrap();
-
         // Alice sends webxdc to bob
         let alice_chat = alice.create_chat(bob).await;
         let mut instance = Message::new(Viewtype::File);
@@ -985,6 +952,11 @@ mod tests {
     async fn test_peer_channels_disabled() {
         let mut tcm = TestContextManager::new();
         let alice = &mut tcm.alice().await;
+
+        alice
+            .set_config_bool(Config::WebxdcRealtimeEnabled, false)
+            .await
+            .unwrap();
 
         // creates iroh endpoint as side effect
         send_webxdc_realtime_advertisement(alice, MsgId::new(1))


### PR DESCRIPTION
Mainly after discussions between @hpk42, @r10s, and @adbenitez.

Todo for the UIs:
- Move the option from experimental to a normal advanced setting.

Considerations:
- if someone ants to get your IP address, they can just send you a link to some server where they can look into the log files
  - So, opening a Webxdc is similar to sending a link
- Your chat partner will have to modify their DC app or monitor network traffic to actually see your IP address

Open questions:
- Should this PR wait until all the UIs moved the option from "experimental" to a normal advanced setting?

Future possibilities:
- Add a button the UI "set all settings to be maximally secure" or similar that disables this and other settings