### PR TITLE
fix: building of npm package @deltachat/jsonrpc-client

### DIFF
--- a/deltachat-jsonrpc/typescript/package.json
+++ b/deltachat-jsonrpc/typescript/package.json
@@ -9,6 +9,7 @@
     "@types/chai": "^4.2.21",
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^9.0.0",
+    "@types/node": "^18.19.60",
     "@types/ws": "^7.2.4",
     "c8": "^7.10.0",
     "chai": "^4.3.4",


### PR DESCRIPTION
typescript complained about different implementations of AbortSignal. I think it makes sense to reduce dependencies in the future by splitting of the websocket transport into a dedicated npm package.
