### PR TITLE
fix: concat ndns

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -2253,7 +2253,7 @@ async fn handle_ndn(
         set_msg_failed(
             context,
             &mut message,
-            prev_error.as_ref().unwrap_or(&err_msg),
+            prev_error.as_ref().unwrap_or(err_msg),
         )
         .await?;
         if first {

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -2246,15 +2246,14 @@ async fn handle_ndn(
     for msg in msgs {
         let (msg_id, chat_id, chat_type) = msg?;
         let mut message = Message::load_from_db(context, msg_id).await?;
-        let prev_error = message
+        let aggregated_error = message
             .error
             .as_ref()
-            .map(|err| format!("{}\n{}", err, err_msg));
-        println!("prev error: {:?}", prev_error);
+            .map(|err| format!("{}\n\n{}", err, err_msg));
         set_msg_failed(
             context,
             &mut message,
-            prev_error.as_ref().unwrap_or(err_msg),
+            aggregated_error.as_ref().unwrap_or(err_msg),
         )
         .await?;
         if first {

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -2240,12 +2240,22 @@ async fn handle_ndn(
     } else {
         "Delivery to at least one recipient failed.".to_string()
     };
+    let err_msg = &error;
 
     let mut first = true;
     for msg in msgs {
         let (msg_id, chat_id, chat_type) = msg?;
         let mut message = Message::load_from_db(context, msg_id).await?;
-        set_msg_failed(context, &mut message, &error).await?;
+        let prev_error = message
+            .error
+            .as_ref()
+            .map(|err| format!("{}\n{}", err, err_msg));
+        set_msg_failed(
+            context,
+            &mut message,
+            prev_error.as_ref().unwrap_or(&err_msg),
+        )
+        .await?;
         if first {
             // Add only one info msg for all failed messages
             ndn_maybe_add_info_msg(context, failed, chat_id, chat_type).await?;

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -2250,6 +2250,7 @@ async fn handle_ndn(
             .error
             .as_ref()
             .map(|err| format!("{}\n{}", err, err_msg));
+        println!("prev error: {:?}", prev_error);
         set_msg_failed(
             context,
             &mut message,

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -927,7 +927,7 @@ async fn test_concat_multiple_ndns() -> Result<()> {
     receive_imf(&t, raw.as_bytes(), false).await?;
     let msg = Message::load_from_db(&t, msg_id).await?;
 
-    assert_eq!(msg.error(), Some([err.clone(), err].join("\n")));
+    assert_eq!(msg.error(), Some([err.clone(), err].join("\n\n")));
     Ok(())
 }
 

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -821,6 +821,7 @@ async fn test_resend_after_ndn() -> Result<()> {
         "To: hcksocnsofoejx@five.chat\n\
         From: alice@testrun.org\n\
         Date: Today, 2 January 2024 00:00:00 -300\n\
+        Subject: hi\n\
         Message-ID: Mr.A7pTA5IgrUA.q4bP41vAJOp@testrun.org\n\
         \n\
         hi"
@@ -880,6 +881,54 @@ async fn test_parse_ndn_group_msg() -> Result<()> {
         stock_str::failed_sending_to(&t, "assidhfaaspocwaeofi@gmail.com").await
     );
     assert_eq!(last_msg.from_id, ContactId::INFO);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_concat_multiple_ndns() -> Result<()> {
+    let t = TestContext::new().await;
+    t.configure_addr("alice@posteo.org").await;
+    let mid = "1234@mail.gmail.com";
+    receive_imf(
+        &t,
+        b"Received: (Postfix, from userid 1000); Mon, 4 Dec 2006 14:51:39 +0100 (CET)\n\
+                 From: alice@posteo.org\n\
+                 To: hanerthaertidiuea@gmx.de\n\
+                 Subject: foo\n\
+                 Message-ID: <1234@mail.gmail.com>\n\
+                 Chat-Version: 1.0\n\
+                 Chat-Disposition-Notification-To: alice@example.org\n\
+                 Date: Sun, 22 Mar 2020 22:37:57 +0000\n\
+                 \n\
+                 hello\n",
+        false,
+    )
+    .await?;
+
+    let chats = Chatlist::try_load(&t, 0, None, None).await?;
+    let msg_id = chats.get_msg_id(0)?.unwrap();
+
+    let raw = include_str!("../../test-data/message/posteo_ndn.eml");
+    let raw = raw.replace(
+        "Message-ID: <04422840-f884-3e37-5778-8192fe22d8e1@posteo.de>",
+        &format!("Message-ID: <{}>", mid),
+    );
+    receive_imf(&t, raw.as_bytes(), false).await?;
+
+    let msg = Message::load_from_db(&t, msg_id).await?;
+
+    let err = "Undelivered Mail Returned to Sender – This is the mail system at host mout01.posteo.de.\n\nI'm sorry to have to inform you that your message could not\nbe delivered to one or more recipients. It's attached below.\n\nFor further assistance, please send mail to postmaster.\n\nIf you do so, please include this problem report. You can\ndelete your own text from the attached returned message.\n\n                   The mail system\n\n<hanerthaertidiuea@gmx.de>: host mx01.emig.gmx.net[212.227.17.5] said: 550\n    Requested action not taken: mailbox unavailable (in reply to RCPT TO\n    command)".to_string();
+    assert_eq!(msg.error(), Some(err.clone()));
+    assert_eq!(msg.state, MessageState::OutFailed);
+
+    let raw = raw.replace(
+        "Message-Id: <20200609184422.DCB6B1200DD@mout01.posteo.de>",
+        "Message-Id: <next@mout01.posteo.de>",
+    );
+    receive_imf(&t, raw.as_bytes(), false).await?;
+    let msg = Message::load_from_db(&t, msg_id).await?;
+
+    assert_eq!(msg.error(), Some([err.clone(), err].join("\n")));
     Ok(())
 }
 

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -821,7 +821,6 @@ async fn test_resend_after_ndn() -> Result<()> {
         "To: hcksocnsofoejx@five.chat\n\
         From: alice@testrun.org\n\
         Date: Today, 2 January 2024 00:00:00 -300\n\
-        Subject: hi\n\
         Message-ID: Mr.A7pTA5IgrUA.q4bP41vAJOp@testrun.org\n\
         \n\
         hi"


### PR DESCRIPTION
close #2338

Concat error messages when receiving new ndns.
This PR adds a newline followed by the new NDN error to the error text. Maybe we should use something more prominent like 
```
-----------------------------------------------------------------------
```
or more newlines, but I'm not sure. This maybe has to be tested on a real device to see what works best.