### PR TITLE
prefer long options in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,8 +14,8 @@ For example, to release version 1.116.0 of the core, do the following steps.
 5. Commit the changes as `chore(release): prepare for 1.116.0`.
    Optionally, use a separate branch like `prep-1.116.0` for this commit and open a PR for review.
 
-6. Tag the release: `git tag -a v1.116.0`.
+6. Tag the release: `git tag --annotate v1.116.0`.
 
 7. Push the release tag: `git push origin v1.116.0`.
 
-8. Create a GitHub release: `gh release create v1.116.0 -n ''`.
+8. Create a GitHub release: `gh release create v1.116.0 --notes ''`.


### PR DESCRIPTION
using long options make things less mystical, it is clearer what happens.

(apart from that i also disallowed `git -a` on my machine in general, as `git commit -a` is considered harmful. as my approach to disallow that is a bit greedy and disallows `-a` just for any git commands, this is the only place where i regularly struggle :)
