### PR TITLE
fix: always exit fake IDLE after at most 60 seconds

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -655,9 +655,7 @@ async fn fetch_idle(
             ctx,
             "IMAP session does not support IDLE, going to fake idle."
         );
-        connection
-            .fake_idle(ctx, &mut session, watch_folder, folder_meaning)
-            .await?;
+        connection.fake_idle(ctx, watch_folder).await?;
         return Ok(session);
     }
 
@@ -669,9 +667,7 @@ async fn fetch_idle(
         .unwrap_or_default()
     {
         info!(ctx, "IMAP IDLE is disabled, going to fake idle.");
-        connection
-            .fake_idle(ctx, &mut session, watch_folder, folder_meaning)
-            .await?;
+        connection.fake_idle(ctx, watch_folder).await?;
         return Ok(session);
     }
 


### PR DESCRIPTION
Do not call `fetch_new_messages`,
always exit and let the IMAP loop
prepare the connection properly and run all pending tasks.