### PR TITLE
feat: add support for locked/encrypted accounts to jsonrpc api

### DIFF
--- a/deltachat-jsonrpc/src/api/types/account.rs
+++ b/deltachat-jsonrpc/src/api/types/account.rs
@@ -23,10 +23,15 @@ pub enum Account {
     },
     #[serde(rename_all = "camelCase")]
     Unconfigured { id: u32 },
+    #[serde(rename_all = "camelCase")]
+    Locked { id: u32 },
 }
 
 impl Account {
     pub async fn from_context(ctx: &deltachat::context::Context, id: u32) -> Result<Self> {
+        if !ctx.is_open().await {
+            return Ok(Account::Locked { id });
+        }
         if ctx.is_configured().await? {
             let display_name = ctx.get_config(Config::Displayname).await?;
             let addr = ctx.get_config(Config::Addr).await?;


### PR DESCRIPTION
api!: jsonrpc new variant of `Account` enum: `Account::Locked`.


TODO:
- [X] `Account::Locked` type
- [ ] when #6118 is merged add event and test upon unlocking/opening
- [ ] Add missing encryption apis to jsonrpc/api.rs
