### PR TITLE
feat: experimental header protection for Autocrypt

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -506,6 +506,11 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                    to not mess up with non-delivery-reports or read-receipts.
  *                    0=no limit (default).
  *                    Changes affect future messages only.
+ * - `protect_autocrypt` = Enable Header Protection for Autocrypt header.
+ *                    This is an experimental option not compatible to other MUAs
+ *                    and older Delta Chat versions.
+ *                    1 = enable.
+ *                    0 = disable (default).
  * - `gossip_period` = How often to gossip Autocrypt keys in chats with multiple recipients, in
  *                    seconds. 2 days by default.
  *                    This is not supposed to be changed by UIs and only used for testing.

--- a/src/authres.rs
+++ b/src/authres.rs
@@ -520,8 +520,13 @@ Authentication-Results: dkim=";
         handle_authres(&t, &mail, "invalid@rom.com").await.unwrap();
     }
 
+    // Test that Autocrypt works with mailing list.
+    //
+    // Previous versions of Delta Chat ignored Autocrypt based on the List-Post header.
+    // This is not needed: comparing of the From address to Autocrypt header address is enough.
+    // If the mailing list is not rewriting the From header, Autocrypt should be applied.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_autocrypt_in_mailinglist_ignored() -> Result<()> {
+    async fn test_autocrypt_in_mailinglist_not_ignored() -> Result<()> {
         let mut tcm = TestContextManager::new();
         let alice = tcm.alice().await;
         let bob = tcm.bob().await;
@@ -533,28 +538,18 @@ Authentication-Results: dkim=";
             .insert_str(0, "List-Post: <mailto:deltachat-community.example.net>\n");
         bob.recv_msg(&sent).await;
         let peerstate = Peerstate::from_addr(&bob, "alice@example.org").await?;
-        assert!(peerstate.is_none());
-
-        // Do the same without the mailing list header, this time the peerstate should be accepted
-        let sent = alice
-            .send_text(alice_bob_chat.id, "hellooo without mailing list")
-            .await;
-        bob.recv_msg(&sent).await;
-        let peerstate = Peerstate::from_addr(&bob, "alice@example.org").await?;
         assert!(peerstate.is_some());
 
-        // This also means that Bob can now write encrypted to Alice:
+        // Bob can now write encrypted to Alice:
         let mut sent = bob
             .send_text(bob_alice_chat.id, "hellooo in the mailinglist again")
             .await;
         assert!(sent.load_from_db().await.get_showpadlock());
 
-        // But if Bob writes to a mailing list, Alice doesn't show a padlock
-        // since she can't verify the signature without accepting Bob's key:
         sent.payload
             .insert_str(0, "List-Post: <mailto:deltachat-community.example.net>\n");
         let rcvd = alice.recv_msg(&sent).await;
-        assert!(!rcvd.get_showpadlock());
+        assert!(rcvd.get_showpadlock());
         assert_eq!(&rcvd.text, "hellooo in the mailinglist again");
 
         Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -396,6 +396,12 @@ pub enum Config {
     /// Make all outgoing messages with Autocrypt header "multipart/signed".
     SignUnencrypted,
 
+    /// Enable header protection for `Autocrypt` header.
+    ///
+    /// This is an experimental setting not compatible to other MUAs
+    /// and older Delta Chat versions (core version <= v1.149.0).
+    ProtectAutocrypt,
+
     /// Let the core save all events to the database.
     /// This value is used internally to remember the MsgId of the logging xdc
     #[strum(props(default = "0"))]

--- a/src/context.rs
+++ b/src/context.rs
@@ -991,6 +991,12 @@ impl Context {
                 .to_string(),
         );
         res.insert(
+            "protect_autocrypt",
+            self.get_config_int(Config::ProtectAutocrypt)
+                .await?
+                .to_string(),
+        );
+        res.insert(
             "debug_logging",
             self.get_config_int(Config::DebugLogging).await?.to_string(),
         );

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -743,7 +743,9 @@ impl MimeFactory {
                 hidden_headers.push(header);
             } else if header_name == "chat-user-avatar" {
                 hidden_headers.push(header);
-            } else if header_name == "autocrypt" {
+            } else if header_name == "autocrypt"
+                && !context.get_config_bool(Config::ProtectAutocrypt).await?
+            {
                 unprotected_headers.push(header.clone());
             } else if header_name == "from" {
                 // Unencrypted securejoin messages should _not_ include the display name:


### PR DESCRIPTION
This change adds support for receiving
Autocrypt header in the protected part of encrypted message.

Autocrypt header is now also allowed in mailing lists.
Previously Autocrypt header was rejected when
List-Post header was present,
but the check for the address being equal to the From: address
is sufficient.

New experimental `protect_autocrypt` config is disabled
by default because Delta Chat with reception
support should be released first on all platforms.

Closes #6171 