### PR TITLE
feat: handle 1:1 messages with differing from addr as alias

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -3239,7 +3239,13 @@ Until the false-positive is fixed:
             "bob@example.net sent a message from another device."
         );
 
-        let msg = tcm.send_recv(alice, bob, "Unencrypted").await;
+        let msg = tcm
+            .send_recv(
+                alice,
+                bob,
+                "[This message is not encrypted. See 'Info' for more details]",
+            )
+            .await;
         assert_eq!(msg.get_showpadlock(), false);
 
         Ok(())

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -842,7 +842,6 @@ async fn add_parts(
             }
         }
 
-        // Lookup or create adhoc group chat.
         if chat_id.is_none() {
             if let Some((new_chat_id, new_chat_id_blocked)) = lookup_chat_or_create_adhoc_group(
                 context,


### PR DESCRIPTION
This PR adds alias handling to 1:1 chats. If a message is received that only has self as to-address and references a MID that we know and is a 1:1 chat, it should go into that chat, even when the sender has a different email. In this case we could overwrite the sender address (from_id) or only set `OverrideSenderDisplayname`. This is still open for discussion. 

close #2509