### PR TITLE
feat: do not copy Chat-Version header into unprotected part

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1019,7 +1019,6 @@ impl MimeFactory {
                     | "in-reply-to"
                     | "references"
                     | "auto-submitted"
-                    | "chat-version"
                     | "autocrypt-setup-message" => {
                         unprotected_headers.push(header.clone());
                     }


### PR DESCRIPTION
Chat-Version is used sometimes by Sieve filters to move messages to DeltaChat folder:
https://github.com/mailcow/mailcow-dockerized/blob/37beed6ad93f259b97cad41877982bce95295629/data/conf/dovecot/global_sieve_before
This probably prevents notifications to MUAs that don't watch DeltaChat folder but watch Inbox folder.

There are however disadvantages to exposing Chat-Version:
1. Spam filters may not like this header and it is difficult or impossible to tell if `Chat-Version` plays role in rejecting the message or delivering it into Spam folder. If there is no such header visible to the spam filter, this possibility can be ruled out.
2. Replies to chat messages may have no `Chat-Version` but have to be moved anyway.
3. User may have no control over the Sieve filter, but it comes preconfigured in mailcow, so it is not possible to disable on the client.

This is an experimental PR, I just want to see if CI fails.

There is a problem with prefetching of Chat-Version. Normally we want to download messages only once they reach their destination, but if Chat-Version is hidden we don't know that we want to move the message to DeltaChat folder yet. This also applies to replies to chat messages that are not chat messages themselves.