### PR TITLE
fix: Clear draft when leaving a group or when Self is removed.

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2317,6 +2317,9 @@ async fn apply_group_changes(
         }
 
         if new_members != chat_contacts {
+            if !new_members.contains(&ContactId::SELF) {
+                chat_id.set_draft(context, None).await?; // Clear draft since Self was removed from the group.
+            }
             chat::update_chat_contacts_table(context, chat_id, &new_members).await?;
             chat_contacts = new_members;
             send_event_chat_modified = true;


### PR DESCRIPTION
Fix #6175.

This is not a very bad bug (even WhatsApp has the same bug, and WhatsApp rarely has any bugs at all!), so I think it's fine not to add regression tests, but I can add some if you want.

I did test that it works on an Android phone. Clearing the draft when a different device leaves the group or when Self is removed from the group works.

What doesn't work is clearing the draft when leaving a group from this device, because after leaving, the UI still has the draft in the now-hidden input bar, and calls set_draft() when the user leaves the activity, re-adding the draft. We could fix this by loading the chat in do_set_draft(), calling, `is_self_in_chat()`, and not setting the draft if self isn't in the chat. This is two extra database calls everytime the user leaves a group and goes back to the chat list - not a big deal, but I'm nonetheless not sure it's worth it for this super arcane bug. What do you think?