### PR TITLE
fix: Only add "member added/removed" messages if they actually do that (#5992)

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -5371,7 +5371,7 @@ mod tests {
 
         // Eventually, first removal message arrives.
         // This has no effect.
-        bob.recv_msg(&remove1).await;
+        bob.recv_msg_trash(&remove1).await;
         assert_eq!(get_chat_contacts(&bob, bob_chat_id).await?.len(), 2);
         Ok(())
     }

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -4185,9 +4185,8 @@ async fn test_recreate_contact_list_on_missing_message() -> Result<()> {
     // readd fiona
     add_contact_to_chat(&alice, chat_id, alice_fiona).await?;
 
-    alice.recv_msg(&remove_msg).await;
-
     // delayed removal of fiona shouldn't remove her
+    alice.recv_msg_trash(&remove_msg).await;
     assert_eq!(get_chat_contacts(&alice, chat_id).await?.len(), 4);
 
     Ok(())
@@ -4944,6 +4943,32 @@ async fn test_unarchive_on_member_removal() -> Result<()> {
     let bob_chat = Chat::load_from_db(bob, bob_chat_id).await?;
     assert_eq!(bob_chat.get_visibility(), ChatVisibility::Normal);
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_no_op_member_added_is_trash() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = &tcm.alice().await;
+    let bob = &tcm.bob().await;
+    let alice_chat_id = alice
+        .create_group_with_members(ProtectionStatus::Unprotected, "foos", &[bob])
+        .await;
+    send_text_msg(alice, alice_chat_id, "populate".to_string()).await?;
+    let msg = alice.pop_sent_msg().await;
+    bob.recv_msg(&msg).await;
+    let bob_chat_id = bob.get_last_msg().await.chat_id;
+    bob_chat_id.accept(bob).await?;
+
+    let fiona_id = Contact::create(alice, "", "fiona@example.net").await?;
+    add_contact_to_chat(alice, alice_chat_id, fiona_id).await?;
+    let msg = alice.pop_sent_msg().await;
+
+    let fiona_id = Contact::create(bob, "", "fiona@example.net").await?;
+    add_contact_to_chat(bob, bob_chat_id, fiona_id).await?;
+    bob.recv_msg_trash(&msg).await;
+    let contacts = get_chat_contacts(bob, bob_chat_id).await?;
+    assert_eq!(contacts.len(), 3);
     Ok(())
 }
 


### PR DESCRIPTION
There were many cases in which "member added/removed" messages were added to chats even if they actually do nothing because a member is already added or removed. But primarily this fixes a scenario when Alice has several devices and shares an invite link somewhere, and both their devices handle the SecureJoin and issue `ChatGroupMemberAdded` messages so all other members see a duplicated group member addition.

Fix #5992 