### PR TITLE
test: remove all calls to print() from deltachat-rpc-client tests

### DIFF
--- a/deltachat-rpc-client/tests/test_iroh_webxdc.py
+++ b/deltachat-rpc-client/tests/test_iroh_webxdc.py
@@ -7,8 +7,8 @@ If you want to debug iroh at rust-trace/log level set
     RUST_LOG=iroh_net=trace,iroh_gossip=trace
 """
 
+import logging
 import os
-import sys
 import threading
 import time
 
@@ -25,9 +25,7 @@ def path_to_webxdc(request):
 
 
 def log(msg):
-    print()
-    print("*" * 80 + "\n" + msg + "\n", file=sys.stderr)
-    print()
+    logging.info(msg)
 
 
 def setup_realtime_webxdc(ac1, ac2, path_to_webxdc):

--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -57,8 +57,8 @@ def test_acfactory(acfactory) -> None:
             if event.progress == 1000:  # Success
                 break
         else:
-            print(event)
-    print("Successful configuration")
+            logging.info(event)
+    logging.info("Successful configuration")
 
 
 def test_configure_starttls(acfactory) -> None:


### PR DESCRIPTION
They frequently fail in CI with `OSError: [Errno 9] Bad file descriptor`.

Closes #6082