### PR TITLE
feat: add location streaming failure response code

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2521,7 +2521,9 @@ pub unsafe extern "C" fn dc_is_sending_locations_to_chat(
     };
 
     block_on(async {
-        location::is_sending_locations_to_chat(ctx, chat_id).await.map(|res| res as u8)
+        location::is_sending_locations_to_chat(ctx, chat_id)
+            .await
+            .map(|res| res as u8)
     })
     .unwrap_or_log_default(ctx, "Failed dc_is_sending_locations_to_chat()") as libc::c_int
 }

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2520,8 +2520,10 @@ pub unsafe extern "C" fn dc_is_sending_locations_to_chat(
         Some(ChatId::new(chat_id))
     };
 
-    block_on(location::is_sending_locations_to_chat(ctx, chat_id))
-        .unwrap_or_log_default(ctx, "Failed dc_is_sending_locations_to_chat()") as libc::c_int
+    block_on(async {
+        location::is_sending_locations_to_chat(ctx, chat_id).await.map(|res| res as u8)
+    })
+    .unwrap_or_log_default(ctx, "Failed dc_is_sending_locations_to_chat()") as libc::c_int
 }
 
 #[no_mangle]

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -629,7 +629,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                     );
                 }
             }
-            if location::is_sending_locations_to_chat(&context, None).await? {
+            if location::is_sending_locations_to_chat(&context, None).await? != location::LocationSendingStatus::Disabled {
                 println!("Location streaming enabled.");
             }
             println!("{cnt} chats");
@@ -841,7 +841,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             }
 
             println!(
-                "Location streaming: {}",
+                "Location streaming: {:?}",
                 location::is_sending_locations_to_chat(
                     &context,
                     Some(sel_chat.as_ref().unwrap().get_id())

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -629,7 +629,9 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                     );
                 }
             }
-            if location::is_sending_locations_to_chat(&context, None).await? != location::LocationSendingStatus::Disabled {
+            if location::is_sending_locations_to_chat(&context, None).await?
+                != location::LocationSendingStatus::Disabled
+            {
                 println!("Location streaming enabled.");
             }
             println!("{cnt} chats");

--- a/src/location.rs
+++ b/src/location.rs
@@ -90,10 +90,10 @@ pub struct Kml {
 /// Location streaming status for one chat.
 #[derive(Debug, PartialEq, Eq)]
 pub enum LocationSendingStatus {
-    /// Location streaming is enabled.
-    Enabled = 0,
     /// Location streaming is disabled.
-    Disabled = 1,
+    Disabled = 0,
+    /// Location streaming is enabled.
+    Enabled = 1,
     /// Location streaming is enabled but (currently) not possible.
     Failure = 2,
 }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -20,7 +20,7 @@ use crate::e2ee::EncryptHelper;
 use crate::ephemeral::Timer as EphemeralTimer;
 use crate::headerdef::HeaderDef;
 use crate::html::new_html_mimepart;
-use crate::location;
+use crate::location::{self, LocationSendingStatus};
 use crate::message::{self, Message, MsgId, Viewtype};
 use crate::mimeparser::SystemMessage;
 use crate::param::Param;
@@ -1372,7 +1372,9 @@ impl MimeFactory {
             parts.push(msg_kml_part);
         }
 
-        if location::is_sending_locations_to_chat(context, Some(msg.chat_id)).await? {
+        if location::is_sending_locations_to_chat(context, Some(msg.chat_id)).await?
+            != LocationSendingStatus::Disabled
+        {
             if let Some(part) = self.get_location_kml_part(context).await? {
                 parts.push(part);
             }


### PR DESCRIPTION
Before this PR, `is_sending_location_to_chat` returned a boolean when location streaming was enabled or disabled for a chat. It now returns an enum value representing enabled, disabled and failure states where failure says that its enabled but (currently) not possible. This should not break cffi because 0 is still disabled, 1 enabled and new code 2 (failure) is handled similar to 1.

close #5547