### PR TITLE
fix: line-before-quote may be up to 120 character long.

### DIFF
--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -298,7 +298,7 @@ fn is_quoted_headline(buf: &str) -> bool {
     - Currently, we simply check if the last character is a ':'.
     - Checking for the existence of an email address may fail (headlines may show the user's name instead of the address) */
 
-    buf.len() <= 80 && buf.ends_with(':')
+    buf.len() <= 120 && buf.ends_with(':')
 }
 
 fn is_plain_quote(buf: &str) -> bool {

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -404,6 +404,28 @@ mod tests {
     }
 
     #[test]
+    fn test_is_quoted_headline() {
+        assert!(is_quoted_headline("On 2024-08-28, Bob wrote:"));
+        assert!(is_quoted_headline("Am 11. November 2024 schrieb Alice:"));
+        assert!(is_quoted_headline("Anonymous Longer Name a écrit:"));
+        assert!(is_quoted_headline("There is not really a pattern wrote:"));
+        assert!(is_quoted_headline(
+            "On Mon, 3 Jan, 2022 at 8:34 PM \"Anonymous Longer Name\" <anonymous-longer-name@example.com> wrote:"
+        ));
+        assert!(!is_quoted_headline(
+            "How are you? I just want to say that this line does not belong to the quote!"
+        ));
+        assert!(!is_quoted_headline(
+            "No quote headline as not ending with a colon"
+        ));
+        assert!(!is_quoted_headline(
+            "Even though this ends with a colon, \
+            this is no quote-headline as just too long for most cases of date+name+address. \
+            it's all heuristics only, it is expected to go wrong sometimes. there is always the 'Show full message' button:"
+        ));
+    }
+
+    #[test]
     fn test_remove_top_quote() {
         let (lines, top_quote) = remove_top_quote(&["> first", "> second"], true);
         assert!(lines.is_empty());


### PR DESCRIPTION
with this PR,  up to 120 characters for the line-before-quite are allowed. 80 characters are a bit limited in practise ...

```
On Mon, 3 Jan, 2022 at 8:34 PM "Anonymous The Mighty" <anonymous@example.com> wrote:
```

... already breaks the limit. it is good to allow up to 40 additional characters for name + email address.

closes #2958

allowing any length, however, may catch too much,
as the line could also be a normal paragraph with important content, so 120 characters seems reasonable.

the idea of adding more complexity here would probably lead only to, well more complexity - things can anyways go wrong -
and, we have the "show full message..." button for exactly that purpose, so that the user can access everything as original.

so, if things go wrong sometimes,
this is expected and fine.