### PR TITLE
fix: Auto-restore 1:1 chat protection if contact is only forward verified

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1010,7 +1010,7 @@ async fn add_parts(
                             && peerstate.prefer_encrypt == EncryptPreference::Mutual
                             // Check that the contact still has the Autocrypt key same as the
                             // verified key, see also `Peerstate::is_using_verified_key()`.
-                            && contact.is_verified(context).await?;
+                            && contact.is_forward_verified(context).await?;
                     }
                 }
             }

--- a/src/tests/verified_chats.rs
+++ b/src/tests/verified_chats.rs
@@ -11,8 +11,10 @@ use crate::mimefactory::MimeFactory;
 use crate::mimeparser::SystemMessage;
 use crate::receive_imf::receive_imf;
 use crate::stock_str;
-use crate::test_utils::{get_chat_msg, mark_as_verified, TestContext, TestContextManager};
-use crate::tools::SystemTime;
+use crate::test_utils::{
+    get_chat_msg, mark_as_verified, mark_as_verified_ex, TestContext, TestContextManager,
+};
+use crate::tools::{time, SystemTime};
 use crate::{e2ee, message};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -754,11 +756,16 @@ async fn test_message_from_old_dc_setup() -> Result<()> {
     tcm.send_recv(bob, alice, "Now i have it!").await;
     assert_verified(alice, bob, ProtectionStatus::Protected).await;
 
+    // Forward verification should be sufficient to keep the chat protected.
+    let backward = false;
+    mark_as_verified_ex(alice, bob, time() - 1, backward).await;
+
     let msg = alice.recv_msg(&sent_old).await;
     assert!(!msg.get_showpadlock());
     let contact = alice.add_or_lookup_contact(bob).await;
     // The outdated Bob's Autocrypt header isn't applied, so the verification preserves.
-    assert!(contact.is_verified(alice).await.unwrap());
+    assert!(contact.is_forward_verified(alice).await.unwrap());
+    assert!(!contact.is_verified(alice).await.unwrap());
     let chat = alice.get_chat(bob).await;
     assert!(chat.is_protected());
     assert_eq!(chat.is_protection_broken(), false);


### PR DESCRIPTION
Follow-up to 3f1dfef0e779a01f81198967ee8396771736d840. Forward verification is sufficient to have the 1:1 chat protected, backwards verification is needed to add the contact to verified groups.

Unlike the closed #6116, this doesn't change behaviour for adding contacts to verified groups.