### PR TITLE
tune down io-not-started info in connectivity-html

### DIFF
--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -318,10 +318,6 @@ impl Context {
                     .yellow {
                         background-color: #fdc625;
                     }
-                    .not-started-error {
-                        font-size: 2em;
-                        color: red;
-                    }
                 </style>
             </head>
             <body>"#
@@ -341,7 +337,10 @@ impl Context {
                 sched.smtp.state.connectivity.clone(),
             ),
             _ => {
-                ret += "<div class=\"not-started-error\">Error: IO Not Started</div><p>Please report this issue to the app developer.</p>\n</body></html>\n";
+                ret += &format!(
+                    "<h3>{}</h3>\n</body></html>\n",
+                    stock_str::not_connected(self).await
+                );
                 return Ok(ret);
             }
         };


### PR DESCRIPTION
due to async processing,
it may happen `getConnectivityHtml()` is called from UI before `startIO()` is actually called.

eg. on iOS, we may delay `startIo()` [if another process is still processing a PUSH notification](https://github.com/deltachat/deltachat-ios/pull/2393) - when during this time, the connectivity view is opened, it is weird if a big error "CONTACT THE DEVELOPERS!11!!!" is shown :) (i have seen that also on desktop, but i cannot reproduce that there, maybe some races, maybe fixed meanwhile)

just showing "Not Connected" seems to be nicer in that case, this is even localised - and also correct (that IO is not started does not matter from the view of the user - and devs can still see the reasons as the view does not has folders listed)

also, there is not really a function is_connected(), iirc for $reasons, as this turned out to be flacky, so it is not even easy to check the state before calling `getConnectivityHtml()`

it is not worth in doing too much special, we are talking about rare situaton, also, the connectivity view gets updated some moments later anyways.

before / after:

<img width=300  src=https://github.com/user-attachments/assets/1147afb1-c0a6-443e-a9de-649a1cdd2b90>
<img width=300 src=https://github.com/user-attachments/assets/835e0cf7-e689-42f3-8be2-564e2a2f9938>

