### PR TITLE
Build Jsonrpc-server for darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -363,6 +363,8 @@
           mkRustPackages "x86_64-linux" //
           mkRustPackages "armv7l-linux" //
           mkRustPackages "armv6l-linux" //
+          mkRustPackages "x86_64-darwin" //
+          mkRustPackages "aarch64-darwin" //
           mkAndroidPackages "armeabi-v7a" //
           mkAndroidPackages "arm64-v8a" //
           mkAndroidPackages "x86" //

--- a/flake.nix
+++ b/flake.nix
@@ -244,7 +244,7 @@
               rustc = toolchain;
             };
           in
-          naersk-lib.buildPackage rec {
+          naersk-lib.buildPackage {
             pname = packageName;
             cargoBuildOptions = x: x ++ [ "--package" packageName ];
             version = manifest.version;
@@ -255,16 +255,6 @@
             ];
             auditable = false; # Avoid cargo-auditable failures.
             doCheck = false; # Disable test as it requires network access.
-
-            CARGO_BUILD_TARGET = rustTarget;
-            TARGET_CC = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
-            CARGO_BUILD_RUSTFLAGS = [
-              "-C"
-              "linker=${TARGET_CC}"
-            ];
-
-            CC = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
-            LD = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
           };
 
         androidAttrs = {


### PR DESCRIPTION
This PR adds  x84_64-darwin and aarch-darwin as packages to flake.nix 

This depends on https://github.com/deltachat/deltachat-core-rust/pull/6203, we should merge it first so I can rebase and we get an easy diff for this one.

close #6095