### PR TITLE
docs: scanned proxies are added and normalized

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -2541,6 +2541,8 @@ void            dc_stop_ongoing_process      (dc_context_t* context);
  * - DC_QR_PROXY with dc_lot_t::text1=address:
  *   ask the user if they want to use the given proxy.
  *   if so, call dc_set_config_from_qr() and restart I/O.
+ *   On success, dc_get_config(context, "proxy_url")
+ *   will contain the new proxy in normalized form as the first element.
  *
  * - DC_QR_ADDR with dc_lot_t::id=Contact ID:
  *   e-mail address scanned, optionally, a draft message could be set in


### PR DESCRIPTION
there was a bug on iOS before (https://github.com/deltachat/deltachat-ios/pull/2397)
that assumed that the proxy needs to be added to the proxy list additionally, also the normalization was unexpected.