### PR TITLE
Fix: Dont overwrite equal drafts

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -929,7 +929,7 @@ impl ChatId {
                                 .param
                                 .get_blob(Param::File, context, !msg.is_increation())
                                 .await?
-                                .context("no file stored in params")?;
+                                .context("No file stored in params")?;
                             let old_blob = old_draft
                                 .param
                                 .get_blob(Param::File, context, false)

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -922,10 +922,8 @@ impl ChatId {
                     && old_draft.chat_id == self
                     && old_draft.state == MessageState::OutDraft
                 {
-                    return context
-                        .sql
-                        .transaction(|transaction| {
-                            let affected_rows = transaction.execute(
+                    let affected_rows = context
+                        .sql.execute(
                                 "UPDATE msgs
                                 SET timestamp=?1,type=?2,txt=?3,txt_normalized=?4,param=?5,mime_in_reply_to=?6
                                 WHERE id=?7
@@ -943,14 +941,12 @@ impl ChatId {
                                     msg.in_reply_to.as_deref().unwrap_or_default(),
                                     msg.id,
                                 ),
-                            )?;
-                            if affected_rows > 0 {
-                                Ok(true)
-                            } else {
-                                Ok(false)
-                            }
-                        })
-                        .await;
+                            ).await?;
+                    if affected_rows > 0 {
+                        return Ok(true);
+                    } else {
+                        return Ok(false);
+                    }
                 }
             }
         }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -7724,6 +7724,7 @@ mod tests {
         let self_chat = alice.get_self_chat().await.id;
         self_chat.set_draft(&alice, Some(&mut msg)).await.unwrap();
         let draft1 = self_chat.get_draft(&alice).await?.unwrap();
+        tokio::time::sleep(Duration::from_millis(800)).await;
         self_chat.set_draft(&alice, Some(&mut msg)).await.unwrap();
         let draft2 = self_chat.get_draft(&alice).await?.unwrap();
         assert_eq!(draft1.timestamp_sort, draft2.timestamp_sort);

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -942,11 +942,7 @@ impl ChatId {
                                     msg.id,
                                 ),
                             ).await?;
-                    if affected_rows > 0 {
-                        return Ok(true);
-                    } else {
-                        return Ok(false);
-                    }
+                    return Ok(affected_rows > 0);
                 }
             }
         }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -934,7 +934,7 @@ impl ChatId {
                                 .param
                                 .get_blob(Param::File, context, false)
                                 .await?
-                                .context("no file stored in params")?;
+                                .context("No file stored in params")?;
                             if blob == old_blob {
                                 return Ok(false);
                             }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -927,14 +927,15 @@ impl ChatId {
                         .transaction(|transaction| {
                             let affected_rows = transaction.execute(
                                 "UPDATE msgs
-                                SET type=?1,txt=?2,txt_normalized=?3,param=?4,mime_in_reply_to=?5
-                                WHERE id=? 
-                                AND (type <> ?1 
-                                    OR txt <> ?2 
-                                    OR txt_normalized <> ?3 
-                                    OR param <> ?4 
-                                    OR mime_in_reply_to <> ?5);",
+                                SET timestamp=?1,type=?2,txt=?3,txt_normalized=?4,param=?5,mime_in_reply_to=?6
+                                WHERE id=?7
+                                AND (type <> ?2 
+                                    OR txt <> ?3 
+                                    OR txt_normalized <> ?4
+                                    OR param <> ?5
+                                    OR mime_in_reply_to <> ?6);",
                                 (
+                                    time(),
                                     msg.viewtype,
                                     &msg.text,
                                     message::normalize_text(&msg.text),
@@ -944,10 +945,6 @@ impl ChatId {
                                 ),
                             )?;
                             if affected_rows > 0 {
-                                transaction.execute(
-                                    "UPDATE msgs SET timestamp=? WHERE id=?;",
-                                    (time(), msg.id),
-                                )?;
                                 Ok(true)
                             } else {
                                 Ok(false)

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -7724,7 +7724,7 @@ mod tests {
         let self_chat = alice.get_self_chat().await.id;
         self_chat.set_draft(&alice, Some(&mut msg)).await.unwrap();
         let draft1 = self_chat.get_draft(&alice).await?.unwrap();
-        tokio::time::sleep(Duration::from_millis(800)).await;
+        SystemTime::shift(Duration::from_secs(1)).await;
         self_chat.set_draft(&alice, Some(&mut msg)).await.unwrap();
         let draft2 = self_chat.get_draft(&alice).await?.unwrap();
         assert_eq!(draft1.timestamp_sort, draft2.timestamp_sort);

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -7715,4 +7715,18 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_do_not_overwrite_draft() -> Result<()> {
+        let mut tcm = TestContextManager::new();
+        let alice = tcm.alice().await;
+        let mut msg = Message::new_text("This is a draft message".to_string());
+        let self_chat = alice.get_self_chat().await.id;
+        self_chat.set_draft(&alice, Some(&mut msg)).await.unwrap();
+        let draft1 = self_chat.get_draft(&alice).await?.unwrap();
+        self_chat.set_draft(&alice, Some(&mut msg)).await.unwrap();
+        let draft2 = self_chat.get_draft(&alice).await?.unwrap();
+        assert_eq!(draft1.timestamp_sort, draft2.timestamp_sort);
+        Ok(())
+    }
 }


### PR DESCRIPTION
This PR prevents overwriting drafts when the text and file are the same. 

close #6211