### PR TITLE
Use i.delta.chat in qr codes

### DIFF
--- a/python/tests/test_3_offline.py
+++ b/python/tests/test_3_offline.py
@@ -705,7 +705,7 @@ class TestOfflineChat:
         ac1 = acfactory.get_pseudo_configured_account()
         ac2 = acfactory.get_pseudo_configured_account()
         qr = ac1.get_setup_contact_qr()
-        assert qr.startswith("OPENPGP4FPR:")
+        assert qr.startswith("https://i.delta.chat")
         res = ac2.check_qr(qr)
         assert res.is_ask_verifycontact()
         assert not res.is_ask_verifygroup()

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -104,7 +104,7 @@ pub async fn get_securejoin_qr(context: &Context, group: Option<ChatId>) -> Resu
             context.scheduler.interrupt_inbox().await;
         }
         format!(
-            "OPENPGP4FPR:{}#a={}&g={}&x={}&i={}&s={}",
+            "https://i.delta.chat/#{}&a={}&g={}&x={}&i={}&s={}",
             fingerprint.hex(),
             self_addr_urlencoded,
             &group_name_urlencoded,
@@ -119,7 +119,7 @@ pub async fn get_securejoin_qr(context: &Context, group: Option<ChatId>) -> Resu
             context.scheduler.interrupt_inbox().await;
         }
         format!(
-            "OPENPGP4FPR:{}#a={}&n={}&i={}&s={}",
+            "https://i.delta.chat/#{}&a={}&n={}&i={}&s={}",
             fingerprint.hex(),
             self_addr_urlencoded,
             self_name_urlencoded,


### PR DESCRIPTION
As discussed in #5467 we want to use `i.delta.chat` in QR codes in favor of `OPENPGP4FPR:` scheme. This PR does the replacement in `get_securejoin_qr` which is used in `get_securejoin_qr_svg`.

close #5467