### PR TITLE
feat: Clear config cache in start_io()

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -472,6 +472,14 @@ impl Context {
             // Allow at least 1 message every second + a burst of 3.
             *lock = Ratelimit::new(Duration::new(3, 0), 3.0);
         }
+
+        // The next line is mainly for iOS:
+        // iOS starts a separate process for receiving notifications and if the user concurrently
+        // starts the app, the UI process opens the database but waits with calling start_io()
+        // until the notifications process finishes.
+        // Now, some configs may have changed, so, we need to invalidate the cache.
+        self.sql.config_cache.write().await.clear();
+
         self.scheduler.start(self.clone()).await;
     }
 


### PR DESCRIPTION
This is needed for iOS, see comment in the code. An alternative would be to add an API `invalidate_config_cache()` or to do nothing and just assume that things will be fine.

We _could_ mention this in the doc comment of `start_io()`, but right now this PR does not, since it's only important for one platform.