### PR TITLE
feat: webxdc deeplink

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4517,6 +4517,26 @@ int             dc_msg_get_info_type          (const dc_msg_t* msg);
 #define         DC_INFO_INVALID_UNENCRYPTED_MAIL  13
 #define         DC_INFO_WEBXDC_INFO_MESSAGE       32
 
+
+/**
+ * Get deeplink attached to an info message.
+ * The info message need to be of type DC_INFO_WEBXDC_INFO_MESSAGE.
+ *
+ * Typically, this is used to start the corresponding webxdc directly or indirectly
+ * and passing the deeplink to `window.webxdc.deeplink` in JS land.
+ *
+ * @memberof dc_context_t
+ * @param context The context object.
+ * @param info_msg_id The info message object.
+ *     Not: the webxdc instance.
+ * @return The deeplink that can be passed to `window.webxdc.deeplink` in JS land.
+ *     The content of the deeplink is a full status update and its semantic is defined by the app.
+ *     Returns NULL if there is no deeplink attached to the info message and on errors.
+ *
+ */
+char*           dc_msg_get_webxdc_deeplink    (const dc_msg_t* msg);
+
+
 /**
  * Check if a message is still in creation. A message is in creation between
  * the calls to dc_prepare_msg() and dc_send_msg().

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -3682,6 +3682,31 @@ pub unsafe extern "C" fn dc_msg_get_info_type(msg: *mut dc_msg_t) -> libc::c_int
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_msg_get_webxdc_deeplink(msg: *mut dc_msg_t) -> *mut libc::c_char {
+    if msg.is_null() {
+        eprintln!("ignoring careless call to dc_msg_get_webxdc_deeplink()");
+        return "".strdup();
+    }
+
+    let ffi_msg = &*msg;
+    let ctx = &*ffi_msg.context;
+    let res = block_on(async move {
+        ffi_msg
+            .message
+            .get_webxdc_deeplink(ctx)
+            .await
+            .context("failed to get deeplink")
+            .log_err(ctx)
+            .unwrap_or(None)
+    });
+
+    match res {
+        Some(str) => str.strdup(),
+        None => ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_msg_is_increation(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_is_increation()");


### PR DESCRIPTION
this might not be merged in this form, idea is to have a setSystemListener() that received clicked deeplinks as well as information about rate limits

closes #6219 

<details>
<summary>docs</summary>

```

`window.webxdc.deeplink`

If the app was started
by **tapping an info message** or a **notification**,
this property contains the update object as given to [`sendUpdate()`].

If the app was started otherwise,
this property is `undefined`.

This can be useful eg. in an editor
to not only add an info message as "Alice edited the text"
but also highlight a diff on opening.
Or directly jump to the calendar entry added.

Note, that while you will always receive the update object
by [`setUpdateListener()`],
it is not guaranteed that you see the same update object ever as `window.webxdc.deeplink`
(user may just not tap them).
On the other hand, you may get the same deeplink several times on different starts in random order
(user may tap them several times).

In practise, you will often only use an ID or sth. like that from the payload.

You can think of `window.webxdc.deeplink`
as the [argv or args] entry point in other programming languages.


[`sendUpdate()`]: ./sendUpdate.html
[`setUpdateListener()`]: ./setUpdateListener.md
[argv or args]: https://en.wikipedia.org/wiki/Entry_point
```
</details>