### PR TITLE
api: deprecate webxdc `descr` parameter

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1161,8 +1161,7 @@ uint32_t dc_send_videochat_invitation (dc_context_t* context, uint32_t chat_id);
  *     - `document`: optional document name. shown eg. in title bar.
  *     - `summary`: optional summary. shown beside app icon.
  *     - `notify`: optional array of other users `selfAddr` to be notified e.g. by a sound about `info` or `summary`.
- * @param descr The user-visible description of JSON data,
- *     in case of a chess game, e.g. the move.
+ * @param descr Deprecated, set to NULL
  * @return 1=success, 0=error
  */
 int dc_send_webxdc_status_update (dc_context_t* context, uint32_t msg_id, const char* json, const char* descr);

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1065,7 +1065,7 @@ pub unsafe extern "C" fn dc_send_webxdc_status_update(
     context: *mut dc_context_t,
     msg_id: u32,
     json: *const libc::c_char,
-    _unused: *const libc::c_char,
+    _descr: *const libc::c_char,
 ) -> libc::c_int {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_send_webxdc_status_update()");

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1065,7 +1065,7 @@ pub unsafe extern "C" fn dc_send_webxdc_status_update(
     context: *mut dc_context_t,
     msg_id: u32,
     json: *const libc::c_char,
-    descr: *const libc::c_char,
+    _unused: *const libc::c_char,
 ) -> libc::c_int {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_send_webxdc_status_update()");
@@ -1073,14 +1073,10 @@ pub unsafe extern "C" fn dc_send_webxdc_status_update(
     }
     let ctx = &*context;
 
-    block_on(ctx.send_webxdc_status_update(
-        MsgId::new(msg_id),
-        &to_string_lossy(json),
-        &to_string_lossy(descr),
-    ))
-    .context("Failed to send webxdc update")
-    .log_err(ctx)
-    .is_ok() as libc::c_int
+    block_on(ctx.send_webxdc_status_update(MsgId::new(msg_id), &to_string_lossy(json)))
+        .context("Failed to send webxdc update")
+        .log_err(ctx)
+        .is_ok() as libc::c_int
 }
 
 #[no_mangle]

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -1767,7 +1767,7 @@ impl CommandApi {
         account_id: u32,
         instance_msg_id: u32,
         update_str: String,
-        _unused: String,
+        _descr: String,
     ) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
         ctx.send_webxdc_status_update(MsgId::new(instance_msg_id), &update_str)

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -1767,10 +1767,10 @@ impl CommandApi {
         account_id: u32,
         instance_msg_id: u32,
         update_str: String,
-        description: String,
+        _unused: String,
     ) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
-        ctx.send_webxdc_status_update(MsgId::new(instance_msg_id), &update_str, &description)
+        ctx.send_webxdc_status_update(MsgId::new(instance_msg_id), &update_str)
             .await
     }
 

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -969,9 +969,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                 "Arguments <msg-id> <json status update> expected"
             );
             let msg_id = MsgId::new(arg1.parse()?);
-            context
-                .send_webxdc_status_update(msg_id, arg2, "this is a webxdc status update")
-                .await?;
+            context.send_webxdc_status_update(msg_id, arg2).await?;
         }
         "videochat" => {
             ensure!(sel_chat.is_some(), "No chat selected.");

--- a/src/download.rs
+++ b/src/download.rs
@@ -440,7 +440,7 @@ mod tests {
         let _sent1 = alice.send_msg(chat_id, &mut instance).await;
 
         alice
-            .send_webxdc_status_update(instance.id, r#"{"payload":7}"#, "d")
+            .send_webxdc_status_update(instance.id, r#"{"payload":7}"#)
             .await?;
         alice.flush_status_updates().await?;
         let sent2 = alice.pop_sent_msg().await;

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -547,10 +547,10 @@ impl Context {
 
         if send_now {
             self.sql.insert(
-                "INSERT INTO smtp_status_updates (msg_id, first_serial, last_serial, descr) VALUES(?, ?, ?, ?)
+                "INSERT INTO smtp_status_updates (msg_id, first_serial, last_serial, descr) VALUES(?, ?, ?, '')
                  ON CONFLICT(msg_id)
-                 DO UPDATE SET last_serial=excluded.last_serial, descr=excluded.descr",
-                (instance.id, status_update_serial, status_update_serial, BODY_DESCR),
+                 DO UPDATE SET last_serial=excluded.last_serial",
+                (instance.id, status_update_serial, status_update_serial),
             ).await.context("Failed to insert webxdc update into SMTP queue")?;
             self.scheduler.interrupt_smtp().await;
         }

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -57,7 +57,7 @@ pub const WEBXDC_SUFFIX: &str = "xdc";
 const WEBXDC_DEFAULT_ICON: &str = "__webxdc__/default-icon.png";
 
 /// Text shown to classic e-mail users in the visible e-mail body.
-const BODY_DESCR: &str = "Status Update";
+const BODY_DESCR: &str = "Webxdc Status Update";
 
 /// Raw information read from manifest.toml
 #[derive(Debug, Deserialize, Default)]

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -13,7 +13,7 @@
 //! - `msg_id` - ID of the message in the `msgs` table
 //! - `first_serial` - serial number of the first status update to send
 //! - `last_serial` - serial number of the last status update to send
-//! - `descr` - text to send along with the updates
+//! - `descr` - not used, set to empty string
 
 mod integration;
 mod maps_integration;

--- a/src/webxdc/maps_integration.rs
+++ b/src/webxdc/maps_integration.rs
@@ -205,7 +205,6 @@ mod tests {
         t.send_webxdc_status_update(
             integration_id,
             r#"{"payload": {"action": "pos", "lat": 11.0, "lng": 12.0, "label": "poi #1"}}"#,
-            "descr",
         )
         .await?;
         t.evtracker
@@ -239,7 +238,6 @@ mod tests {
         t.send_webxdc_status_update(
             integration_id,
             r#"{"payload": {"action": "pos", "lat": 22.0, "lng": 23.0, "label": "poi #2"}}"#,
-            "descr",
         )
         .await?;
         let updates = t


### PR DESCRIPTION
this PR removes most usages of the `descr` parameter.

- to avoid noise in different branches etc. (as annoying on similar, at a first glance simple changes), i left the external API stable

- also, the effort to do a database migration seems to be over the top, so the column is left and set to empty strings on future updates - maybe we can recycle the column at some point ;)

closes #6245 