### PR TITLE
add webxdc limits api

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4203,6 +4203,10 @@ char*             dc_msg_get_webxdc_blob      (const dc_msg_t* msg, const char* 
  *   currently, this is only true for encrypted Webxdc's in the self chat
  *   that have requested internet access in the manifest.
  * - self_addr: address to be used for `window.webxdc.selfAddr` in JS land.
+ * - send_update_interval: Milliseconds to wait before calling `sendUpdate()` again since the last call.
+ *   Should be exposed to `webxdc.sendUpdateInterval` in JS land.
+ * - send_update_max_size: Maximum number of bytes accepted for a serialized update object.
++    Should be exposed to `webxdc.sendUpdateMaxSize` in JS land.
  *
  * @memberof dc_msg_t
  * @param msg The webxdc instance.

--- a/deltachat-jsonrpc/src/api/types/webxdc.rs
+++ b/deltachat-jsonrpc/src/api/types/webxdc.rs
@@ -37,6 +37,12 @@ pub struct WebxdcMessageInfo {
     internet_access: bool,
     /// Address to be used for `window.webxdc.selfAddr` in JS land.
     self_addr: String,
+    /// Milliseconds to wait before calling `sendUpdate()` again since the last call.
+    /// Should be exposed to `window.sendUpdateInterval` in JS land.
+    send_update_interval: usize,
+    /// Maximum number of bytes accepted for a serialized update object.
+    /// Should be exposed to `window.sendUpdateMaxSize` in JS land.
+    send_update_max_size: usize,
 }
 
 impl WebxdcMessageInfo {
@@ -53,6 +59,8 @@ impl WebxdcMessageInfo {
             source_code_url,
             internet_access,
             self_addr,
+            send_update_interval,
+            send_update_max_size,
         } = message.get_webxdc_info(context).await?;
 
         Ok(Self {
@@ -63,6 +71,8 @@ impl WebxdcMessageInfo {
             source_code_url: maybe_empty_string_to_option(source_code_url),
             internet_access,
             self_addr,
+            send_update_interval,
+            send_update_max_size,
         })
     }
 }

--- a/deltachat-ratelimit/src/lib.rs
+++ b/deltachat-ratelimit/src/lib.rs
@@ -90,6 +90,11 @@ impl Ratelimit {
     pub fn until_can_send(&self) -> Duration {
         self.until_can_send_at(SystemTime::now())
     }
+
+    /// Returns minimum possible update interval in milliseconds.
+    pub fn update_interval(&self) -> usize {
+        (self.window.as_millis() as f64 / self.quota) as usize
+    }
 }
 
 #[cfg(test)]
@@ -102,6 +107,7 @@ mod tests {
 
         let mut ratelimit = Ratelimit::new_at(Duration::new(60, 0), 3.0, now);
         assert!(ratelimit.can_send_at(now));
+        assert_eq!(ratelimit.update_interval(), 20_000);
 
         // Send burst of 3 messages.
         ratelimit.send_at(now);

--- a/deltachat-rpc-client/tests/test_webxdc.py
+++ b/deltachat-rpc-client/tests/test_webxdc.py
@@ -25,6 +25,8 @@ def test_webxdc(acfactory) -> None:
         "sourceCodeUrl": None,
         "summary": None,
         "selfAddr": webxdc_info["selfAddr"],
+        "sendUpdateInterval": 1000,
+        "sendUpdateMaxSize": 18874368,
     }
 
     status_updates = message.get_webxdc_status_updates()


### PR DESCRIPTION
this PR implements the spec of https://github.com/webxdc/website/pull/91/files 

`sendUpdateInterval` interval is then 1,000 milliseconds for chatmail and 10,000 ms otherwise.

`sendUpdateMaxSize` is about 18 mb unconditionally

closes https://github.com/deltachat/deltachat-core-rust/issues/6220 , once merged, we should create PR/issues for Android/iOS (desktop already has an issue-draft for missing things)