### PR TITLE
feat: add href to IncomingWebxdcNotify event

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5901,15 +5901,26 @@ int dc_event_get_data2_int(dc_event_t* event);
 
 /**
  * Get data associated with an event object.
- * The meaning of the data depends on the event ID
- * returned as @ref DC_EVENT constants by dc_event_get_id().
- * See also dc_event_get_data1_int() and dc_event_get_data2_int().
+ * The meaning of the data depends on the event ID returned as @ref DC_EVENT constants.
  *
  * @memberof dc_event_t
  * @param event Event object as returned from dc_get_next_event().
- * @return "data2" as a string or NULL.
- *     the meaning depends on the event type associated with this event.
- *     Once you're done with the string, you have to unref it using dc_unref_str().
+ * @return "data1" string or NULL.
+ *     The meaning depends on the event type associated with this event.
+ *     Must be freed using dc_str_unref().
+ */
+char* dc_event_get_data1_str(dc_event_t* event);
+
+
+/**
+ * Get data associated with an event object.
+ * The meaning of the data depends on the event ID returned as @ref DC_EVENT constants.
+ *
+ * @memberof dc_event_t
+ * @param event Event object as returned from dc_get_next_event().
+ * @return "data2" string or NULL.
+ *     The meaning depends on the event type associated with this event.
+ *     Must be freed using dc_str_unref().
  */
 char* dc_event_get_data2_str(dc_event_t* event);
 
@@ -6111,7 +6122,9 @@ void dc_event_unref(dc_event_t* event);
 /**
  * A webxdc wants an info message or a changed summary to be notified.
  *
- * @param data1 contact_id ID of the contact sending.
+ * @param data1 (int) contact_id ID _and_ (char*) href.
+ *      - dc_event_get_data1_int() returns contact_id of the sending contact.
+ *      - dc_event_get_data1_str() returns the href as set to `update.href`.
  * @param data2 (int) msg_id _and_ (char*) text_to_notify.
  *      - dc_event_get_data2_int() returns the msg_id,
  *        referring to the webxdc-info-message, if there is any.

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -710,6 +710,27 @@ pub unsafe extern "C" fn dc_event_get_data2_int(event: *mut dc_event_t) -> libc:
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_event_get_data1_str(event: *mut dc_event_t) -> *mut libc::c_char {
+    if event.is_null() {
+        eprintln!("ignoring careless call to dc_event_get_data1_str()");
+        return ptr::null_mut();
+    }
+
+    let event = &(*event).typ;
+
+    match event {
+        EventType::IncomingWebxdcNotify { href, .. } => {
+            if let Some(href) = href {
+                href.to_c_string().unwrap_or_default().into_raw()
+            } else {
+                ptr::null_mut()
+            }
+        }
+        _ => ptr::null_mut(),
+    }
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_event_get_data2_str(event: *mut dc_event_t) -> *mut libc::c_char {
     if event.is_null() {
         eprintln!("ignoring careless call to dc_event_get_data2_str()");

--- a/deltachat-jsonrpc/src/api/types/events.rs
+++ b/deltachat-jsonrpc/src/api/types/events.rs
@@ -112,6 +112,7 @@ pub enum EventType {
         contact_id: u32,
         msg_id: u32,
         text: String,
+        href: Option<String>,
     },
 
     /// There is a fresh message. Typically, the user will show an notification
@@ -345,10 +346,12 @@ impl From<CoreEventType> for EventType {
                 contact_id,
                 msg_id,
                 text,
+                href,
             } => IncomingWebxdcNotify {
                 contact_id: contact_id.to_u32(),
                 msg_id: msg_id.to_u32(),
                 text,
+                href,
             },
             CoreEventType::IncomingMsg { chat_id, msg_id } => IncomingMsg {
                 chat_id: chat_id.to_u32(),

--- a/src/events/payload.rs
+++ b/src/events/payload.rs
@@ -117,6 +117,9 @@ pub enum EventType {
 
         /// Text to notify.
         text: String,
+
+        /// Link assigned to this notification, if any.
+        href: Option<String>,
     },
 
     /// There is a fresh message. Typically, the user will show an notification

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -393,7 +393,7 @@ impl Context {
                     .await?;
                 }
 
-                if let Some(href) = status_update_item.href {
+                if let Some(ref href) = status_update_item.href {
                     let mut notify_msg = Message::load_from_db(self, notify_msg_id).await?;
                     notify_msg.param.set(Param::Arg, href);
                     notify_msg.update_param(self).await?;
@@ -421,12 +421,14 @@ impl Context {
                         contact_id: from_id,
                         msg_id: notify_msg_id,
                         text: notify_text.clone(),
+                        href: status_update_item.href,
                     });
                 } else if let Some(notify_text) = notify_list.get("*") {
                     self.emit_event(EventType::IncomingWebxdcNotify {
                         contact_id: from_id,
                         msg_id: notify_msg_id,
                         text: notify_text.clone(),
+                        href: status_update_item.href,
                     });
                 }
             }


### PR DESCRIPTION
this PR adds the `href` from `update.href` to the IncomingWebxdcNotify event (DC_EVENT_INCOMING_WEBXDC_NOTIFY in cffi)

purpose is to add a "Start" button to the notifications that allow starting the app immediately with the given href