### PR TITLE
chore: Beta clippy suggestions

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -671,7 +671,7 @@ impl MimeMessage {
             && self
                 .parts
                 .get(1)
-                .map_or(false, |filepart| match filepart.typ {
+                .is_some_and(|filepart| match filepart.typ {
                     Viewtype::Image
                     | Viewtype::Gif
                     | Viewtype::Sticker

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -887,13 +887,11 @@ pub async fn remove_unused_files(context: &Context) -> Result<()> {
                         }
                         unreferenced_count += 1;
                         let recently_created =
-                            stats.created().map_or(false, |t| t > keep_files_newer_than);
-                        let recently_modified = stats
-                            .modified()
-                            .map_or(false, |t| t > keep_files_newer_than);
-                        let recently_accessed = stats
-                            .accessed()
-                            .map_or(false, |t| t > keep_files_newer_than);
+                            stats.created().is_ok_and(|t| t > keep_files_newer_than);
+                        let recently_modified =
+                            stats.modified().is_ok_and(|t| t > keep_files_newer_than);
+                        let recently_accessed =
+                            stats.accessed().is_ok_and(|t| t > keep_files_newer_than);
 
                         if p == blobdir
                             && (recently_created || recently_modified || recently_accessed)


### PR DESCRIPTION
Already apply rust beta (1.84) clippy suggestions now, before they let CI fail in 6 weeks.

The newly used functions are available since 1.70, our MSRV is 1.77, so we can use them.