### PR TITLE
fix: replace connectivity state "Connected" with "Preparing"

### DIFF
--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1899,7 +1899,7 @@ def test_connectivity(acfactory, lp):
 
     ac1.start_io()
     ac1._evtracker.wait_for_connectivity(dc.const.DC_CONNECTIVITY_CONNECTING)
-    ac1._evtracker.wait_for_connectivity_change(dc.const.DC_CONNECTIVITY_CONNECTING, dc.const.DC_CONNECTIVITY_CONNECTED)
+    ac1._evtracker.wait_for_connectivity_change(dc.const.DC_CONNECTIVITY_CONNECTING, dc.const.DC_CONNECTIVITY_WORKING)
 
     lp.sec(
         "Test that after calling start_io(), maybe_network() and waiting for `all_work_done()`, "

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -407,7 +407,7 @@ impl Imap {
                         "IMAP-LOGIN as {}",
                         lp.user
                     )));
-                    self.connectivity.set_connected(context).await;
+                    self.connectivity.set_preparing(context).await;
                     info!(context, "Successfully logged into IMAP server");
                     return Ok(session);
                 }


### PR DESCRIPTION
This better reflects that this state means
we just connected and there may me work to do.
This state is converted to `DC_CONNECTIVITY_WORKING`
instead of `DC_CONNECTIVITY_CONNECTED` state now.

Before this change when IMAP connected
to the server, it switched
from DC_CONNECTIVITY_NOT_CONNECTED
to DC_CONNECTIVITY_CONNECTING,
then to DC_CONNECTIVITY_CONNECTED (actually preparing)
then to DC_CONNECTIVITY_WORKING
and then to DC_CONNECTIVITY_CONNECTED again (actually idle).

On fast connections this resulted in flickering "Connected"
string in the status bar right before "Updating..."
and on slow connections this "Connected" state
before "Updating..." lasted for a while
leaving the user to wonder if there are no new messages
or if Delta Chat will still switch to "Updating..."
before going into "Connected" state again.
