### PR TITLE
test: fix cargo check for receive_emails benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,10 @@ jobs:
         run: cargo fmt --all -- --check
       - name: Run clippy
         run: scripts/clippy.sh
-      - name: Check
+      - name: Check with all features
         run: cargo check --workspace --all-targets --all-features
+      - name: Check with only default features
+        run: cargo check --all-targets
 
   npm_constants:
     name: Check if node constants are up to date

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,7 @@ harness = false
 
 [[bench]]
 name = "receive_emails"
+required-features = ["internals"]
 harness = false
 
 [[bench]]


### PR DESCRIPTION
Replaces https://github.com/deltachat/deltachat-core-rust/pull/6272

The only `cargo` invocation that would have caught this is `cargo --all-features` (without `--workspace`) because `--workspace` means that `deltachat-repl` is also compiled, which will enable the `internals` feature for the whole workspace. So, this is what I added to CI in the first commit.

The second commit fixes the problem.