### PR TITLE
test: Fix panic in `receive_emails` benchmark

### DIFF
--- a/benches/receive_emails.rs
+++ b/benches/receive_emails.rs
@@ -12,18 +12,18 @@ use deltachat::{
 };
 use tempfile::tempdir;
 
-async fn recv_all_emails(context: Context) -> Context {
+async fn recv_all_emails(context: Context, iteration: u32) -> Context {
     for i in 0..100 {
         let imf_raw = format!(
             "Subject: Benchmark
-Message-ID: Mr.OssSYnOFkhR.{i}@testrun.org
+Message-ID: Mr.{iteration}.{i}@testrun.org
 Date: Sat, 07 Dec 2019 19:00:27 +0000
 To: alice@example.com
 From: sender@testrun.org
 Chat-Version: 1.0
 Chat-Disposition-Notification-To: sender@testrun.org
 Chat-User-Avatar: 0
-In-Reply-To: Mr.OssSYnOFkhR.{i_dec}@testrun.org
+In-Reply-To: Mr.{iteration}.{i_dec}@testrun.org
 MIME-Version: 1.0
 
 Content-Type: text/plain; charset=utf-8; format=flowed; delsp=no
@@ -41,11 +41,11 @@ Hello {i}",
 
 /// Receive 100 emails that remove charlie@example.com and add
 /// him back
-async fn recv_groupmembership_emails(context: Context) -> Context {
+async fn recv_groupmembership_emails(context: Context, iteration: u32) -> Context {
     for i in 0..50 {
         let imf_raw = format!(
             "Subject: Benchmark
-Message-ID: Gr.OssSYnOFkhR.{i}@testrun.org
+Message-ID: Gr.{iteration}.ADD.{i}@testrun.org
 Date: Sat, 07 Dec 2019 19:00:27 +0000
 To: alice@example.com, b@example.com, c@example.com, d@example.com, e@example.com, f@example.com
 From: sender@testrun.org
@@ -53,13 +53,12 @@ Chat-Version: 1.0
 Chat-Disposition-Notification-To: sender@testrun.org
 Chat-User-Avatar: 0
 Chat-Group-Member-Added: charlie@example.com
-In-Reply-To: Gr.OssSYnOFkhR.{i_dec}@testrun.org
+In-Reply-To: Gr.{iteration}.REMOVE.{i_dec}@testrun.org
 MIME-Version: 1.0
 
 Content-Type: text/plain; charset=utf-8; format=flowed; delsp=no
 
 Hello {i}",
-            i = i,
             i_dec = i - 1,
         );
         receive_imf(&context, black_box(imf_raw.as_bytes()), false)
@@ -68,7 +67,7 @@ Hello {i}",
 
         let imf_raw = format!(
             "Subject: Benchmark
-Message-ID: Gr.OssSYnOFkhR.{i}@testrun.org
+Message-ID: Gr.{iteration}.REMOVE.{i}@testrun.org
 Date: Sat, 07 Dec 2019 19:00:27 +0000
 To: alice@example.com, b@example.com, c@example.com, d@example.com, e@example.com, f@example.com
 From: sender@testrun.org
@@ -76,14 +75,12 @@ Chat-Version: 1.0
 Chat-Disposition-Notification-To: sender@testrun.org
 Chat-User-Avatar: 0
 Chat-Group-Member-Removed: charlie@example.com
-In-Reply-To: Gr.OssSYnOFkhR.{i_dec}@testrun.org
+In-Reply-To: Gr.{iteration}.ADD.{i}@testrun.org
 MIME-Version: 1.0
 
 Content-Type: text/plain; charset=utf-8; format=flowed; delsp=no
 
-Hello {i}",
-            i = i,
-            i_dec = i - 1,
+Hello {i}"
         );
         receive_imf(&context, black_box(imf_raw.as_bytes()), false)
             .await
@@ -129,11 +126,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     group.bench_function("Receive 100 simple text msgs", |b| {
         let rt = tokio::runtime::Runtime::new().unwrap();
         let context = rt.block_on(create_context());
+        let mut i = 0;
 
         b.to_async(&rt).iter(|| {
             let ctx = context.clone();
+            i += 1;
             async move {
-                recv_all_emails(black_box(ctx)).await;
+                recv_all_emails(black_box(ctx), i).await;
             }
         });
     });
@@ -142,11 +141,13 @@ fn criterion_benchmark(c: &mut Criterion) {
         |b| {
             let rt = tokio::runtime::Runtime::new().unwrap();
             let context = rt.block_on(create_context());
+            let mut i = 0;
 
             b.to_async(&rt).iter(|| {
                 let ctx = context.clone();
+                i += 1;
                 async move {
-                    recv_groupmembership_emails(black_box(ctx)).await;
+                    recv_groupmembership_emails(black_box(ctx), i).await;
                 }
             });
         },


### PR DESCRIPTION
The benchmark function (e.g. `recv_all_emails()`) is executed multiple times on the same context. During the second iteration, all the emails were already in the database, so, receiving them again failed.

This PR fixes that by passing in a second `iteration` counter that is different for every invocation of the benchmark function.