### PR TITLE
api!: remove dc_all_work_done()

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -722,12 +722,6 @@ char*           dc_get_connectivity_html     (dc_context_t* context);
 int              dc_get_push_state           (dc_context_t* context);
 
 
-/**
- * Only used by the python tests.
- */
-int             dc_all_work_done             (dc_context_t* context);
-
-
 // connect
 
 /**

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -414,16 +414,6 @@ pub unsafe extern "C" fn dc_get_push_state(context: *const dc_context_t) -> libc
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn dc_all_work_done(context: *mut dc_context_t) -> libc::c_int {
-    if context.is_null() {
-        eprintln!("ignoring careless call to dc_all_work_done()");
-        return 0;
-    }
-    let ctx = &*context;
-    block_on(async move { ctx.all_work_done().await as libc::c_int })
-}
-
-#[no_mangle]
 pub unsafe extern "C" fn dc_get_oauth2_url(
     context: *mut dc_context_t,
     addr: *const libc::c_char,

--- a/python/src/deltachat/account.py
+++ b/python/src/deltachat/account.py
@@ -671,9 +671,6 @@ class Account:
     def get_connectivity_html(self) -> str:
         return from_dc_charpointer(lib.dc_get_connectivity_html(self._dc_context))
 
-    def all_work_done(self):
-        return lib.dc_all_work_done(self._dc_context)
-
     def start_io(self):
         """start this account's IO scheduling (Rust-core async scheduler).
 

--- a/python/src/deltachat/events.py
+++ b/python/src/deltachat/events.py
@@ -158,12 +158,6 @@ class FFIEventTracker:
 
             self.get_matching("DC_EVENT_CONNECTIVITY_CHANGED")
 
-    def wait_for_all_work_done(self):
-        while True:
-            if self.account.all_work_done():
-                return
-            self.get_matching("DC_EVENT_CONNECTIVITY_CHANGED")
-
     def ensure_event_not_queued(self, event_name_regex):
         __tracebackhide__ = True
         rex = re.compile(f"(?:{event_name_regex}).*")

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -80,7 +80,7 @@ impl DetailedConnectivity {
             DetailedConnectivity::Uninitialized => Some(Connectivity::NotConnected),
             DetailedConnectivity::Connecting => Some(Connectivity::Connecting),
             DetailedConnectivity::Working => Some(Connectivity::Working),
-            DetailedConnectivity::InterruptingIdle => Some(Connectivity::Connected),
+            DetailedConnectivity::InterruptingIdle => Some(Connectivity::Working),
 
             // At this point IMAP has just connected,
             // but does not know yet if there are messages to download.
@@ -201,7 +201,7 @@ impl ConnectivityStore {
 }
 
 /// Set all folder states to InterruptingIdle in case they were `Idle` before.
-/// Called during `dc_maybe_network()` to make sure that `dc_all_work_done()`
+/// Called during `dc_maybe_network()` to make sure that `all_work_done()`
 /// returns false immediately after `dc_maybe_network()`.
 pub(crate) async fn idle_interrupted(inbox: ConnectivityStore, oboxes: Vec<ConnectivityStore>) {
     let mut connectivity_lock = inbox.0.lock().await;


### PR DESCRIPTION
Also cleaned up test_connectivity()
which tested that state does not flicker to WORKING when there are no messages to be fetched.
The state is expected to flicker to WORKING
when checking for new messages,
so the tests were outdated since
change 3b0b2379b89dab583759dc51d2d8352182745fe4