### PR TITLE
Fix HTML display of multipart messages with truncated parts (#4462)

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -105,14 +105,12 @@ pub(crate) struct MimeMessage {
     /// received.
     pub(crate) footer: Option<String>,
 
-    // if this flag is set, the parts/text/etc. are just close to the original mime-message;
-    // clients should offer a way to view the original message in this case
+    /// If set, this is a modified MIME message; clients should offer a way to view the original
+    /// MIME message in this case.
     pub is_mime_modified: bool,
 
-    /// The decrypted, raw mime structure.
-    ///
-    /// This is non-empty iff `is_mime_modified` and the message was actually encrypted. It is used
-    /// for e.g. late-parsing HTML.
+    /// Decrypted, raw MIME structure. Nonempty iff `is_mime_modified` and the message was actually
+    /// encrypted.
     pub decoded_data: Vec<u8>,
 
     /// Hop info for debugging.

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -3834,30 +3834,51 @@ async fn test_big_forwarded_with_big_attachment() -> Result<()> {
     let raw = include_bytes!("../../test-data/message/big_forwarded_with_big_attachment.eml");
     let rcvd = receive_imf(t, raw, false).await?.unwrap();
     assert_eq!(rcvd.msg_ids.len(), 3);
+
     let msg = Message::load_from_db(t, rcvd.msg_ids[0]).await?;
     assert_eq!(msg.get_viewtype(), Viewtype::Text);
     assert_eq!(msg.get_text(), "Hello!");
-    // Wrong: the second bubble's text is truncated, but "Show Full Message..." is going to be shown
-    // in the first message bubble in the UIs.
-    assert_eq!(
-        msg.id
-            .get_html(t)
-            .await?
-            .unwrap()
-            .matches("Hello!")
-            .count(),
-        1
-    );
-    let msg = Message::load_from_db(t, rcvd.msg_ids[1]).await?;
-    assert_eq!(msg.get_viewtype(), Viewtype::Text);
-    assert!(msg.get_text().starts_with("this text with 42 chars is just repeated."));
-    assert!(msg.get_text().ends_with("[...]"));
-    // Wrong: the text is truncated, but it's not possible to see the full text in HTML.
-    assert!(!msg.has_html());
-    let msg = Message::load_from_db(t, rcvd.msg_ids[2]).await?;
-    assert_eq!(msg.get_viewtype(), Viewtype::File);
     assert!(!msg.has_html());
 
+    let msg = Message::load_from_db(t, rcvd.msg_ids[1]).await?;
+    assert_eq!(msg.get_viewtype(), Viewtype::Text);
+    assert!(msg
+        .get_text()
+        .starts_with("this text with 42 chars is just repeated."));
+    assert!(msg.get_text().ends_with("[...]"));
+    assert!(!msg.has_html());
+
+    let msg = Message::load_from_db(t, rcvd.msg_ids[2]).await?;
+    assert_eq!(msg.get_viewtype(), Viewtype::File);
+    assert!(msg.has_html());
+    let html = msg.id.get_html(t).await?.unwrap();
+    let tail = html
+        .split_once("Hello!")
+        .unwrap()
+        .1
+        .split_once("From: AAA")
+        .unwrap()
+        .1
+        .split_once("aaa@example.org")
+        .unwrap()
+        .1
+        .split_once("To: Alice")
+        .unwrap()
+        .1
+        .split_once("alice@example.org")
+        .unwrap()
+        .1
+        .split_once("Subject: Some subject")
+        .unwrap()
+        .1
+        .split_once("Date: Fri, 2 Jun 2023 12:29:17 +0000")
+        .unwrap()
+        .1;
+    assert_eq!(
+        tail.matches("this text with 42 chars is just repeated.")
+            .count(),
+        128
+    );
     Ok(())
 }
 

--- a/test-data/message/big_forwarded_with_big_attachment.eml
+++ b/test-data/message/big_forwarded_with_big_attachment.eml
@@ -1,0 +1,305 @@
+From: Alice <alice@example.org>
+To: Bob <bob@example.net>
+Date: Fri, 2 Jun 2023 13:29:17 +0000
+Message-ID: <foobar1@localhost>
+Content-Type: multipart/mixed; boundary="zRs3OquGy6eU58KF"
+
+
+--zRs3OquGy6eU58KF
+Content-Type: text/plain; charset=us-ascii
+Content-Disposition: inline
+
+Hello!
+
+--zRs3OquGy6eU58KF
+Content-Type: message/rfc822
+Content-Disposition: inline
+
+From: AAA <aaa@example.org>
+To: Alice <alice@example.org>
+Subject: Some subject
+Date: Fri, 2 Jun 2023 12:29:17 +0000
+Message-ID: <foobar@localhost>
+In-Reply-To: <barbaz@localhost>
+Content-Type: multipart/mixed;
+	boundary="_innerboundary_"
+MIME-Version: 1.0
+
+--_innerboundary_
+Content-Type: text/plain; charset="us-ascii"
+Content-Transfer-Encoding: quoted-printable
+
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+
+--=20
+
+Kind regards,
+
+Bob
+
+--_innerboundary_
+Content-Type: text/plain; name="deltachat-log.txt"
+Content-Description: deltachat-log.txt
+Content-Disposition: attachment; filename="deltachat-log.txt";
+	size=55254; creation-date="Fri, 02 Jun 2023 11:33:49 GMT";
+	modification-date="Fri, 02 Jun 2023 12:29:17 GMT"
+
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+this text with 42 chars is just repeated.
+
+--_innerboundary_--
+
+--zRs3OquGy6eU58KF--


### PR DESCRIPTION
Fix #4462
See commit messages. I suggest to fix this somehow to avoid huge refactoring. Not sure, but maybe it's even good that we have the full decrypted message structure in `mime_headers`.