### PR TITLE
fix: Emit MsgsNoticed on receipt of an IMAP-seen message

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -614,6 +614,9 @@ pub(crate) async fn receive_imf_inner(
             chat_id.emit_msg_event(context, *msg_id, mime_parser.incoming && fresh);
         }
     }
+    if received_msg.state == MessageState::InSeen {
+        context.emit_event(EventType::MsgsNoticed(chat_id));
+    }
     context.new_msgs_notify.notify_one();
 
     mime_parser

--- a/src/receive_imf/tests.rs
+++ b/src/receive_imf/tests.rs
@@ -270,6 +270,31 @@ async fn test_adhoc_groups_merge() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_msgs_noticed_on_seen_msg() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = &tcm.alice().await;
+    let seen = true;
+    let rcvd_msg = receive_imf(
+        alice,
+        b"From: bob@example.net\n\
+        To: alice@example.org\n\
+        Message-ID: <3333@example.net>\n\
+        Date: Sun, 22 Mar 2020 22:37:57 +0000\n\
+        \n\
+        This is a seen message.\n",
+        seen,
+    )
+    .await?
+    .unwrap();
+    let ev = alice
+        .evtracker
+        .get_matching(|e| matches!(e, EventType::MsgsNoticed { .. }))
+        .await;
+    assert_eq!(ev, EventType::MsgsNoticed(rcvd_msg.chat_id));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_read_receipt_and_unarchive() -> Result<()> {
     // create alice's account
     let t = TestContext::new_alice().await;


### PR DESCRIPTION
`imap::Session::sync_seen_flags()` emits `MsgsNoticed` for existing messages seen on other devices, so `receive_imf` should do the same when it receives a seen message. Otherwise a multi-device user may see a new message notification on device A, just swipe it, then see another new message notification and mark it as read, and when their device B goes online, it will show a notification for the first message, and it won't be removed because `MsgsNoticed` isn't emitted. I have checked this with my DC Android and Desktop. With this fix the notification should be removed at least.

EDIT: The fix doesn't help DC Desktop not show a notification for the first message. I didn't check Android though. Anyway, `MsgsNoticed` was missing obviously.