### PR TITLE
fix: Never change Viewtype::Sticker to Image if file has non-image extension (#6352)

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -5393,6 +5393,8 @@ int64_t         dc_lot_get_timestamp     (const dc_lot_t* lot);
 
 /**
  * Message containing a sticker, similar to image.
+ * NB: When sending, the message viewtype may be changed to `Image` by some heuristics like checking
+ * for transparent pixels.
  * If possible, the UI should display the image without borders in a transparent way.
  * A click on a sticker will offer to install the sticker set in some future.
  */

--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -273,6 +273,9 @@ pub enum MessageViewtype {
     Gif,
 
     /// Message containing a sticker, similar to image.
+    /// NB: When sending, the message viewtype may be changed to `Image` by some heuristics like
+    /// checking for transparent pixels. Use `Message::force_sticker()` to disable them.
+    ///
     /// If possible, the ui should display the image without borders in a transparent way.
     /// A click on a sticker will offer to install the sticker set in some future.
     Sticker,

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -1455,4 +1455,23 @@ mod tests {
         check_image_size(file_saved, width, height);
         Ok(())
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_send_gif_as_sticker() -> Result<()> {
+        let bytes = include_bytes!("../test-data/image/image100x50.gif");
+        let alice = &TestContext::new_alice().await;
+        let file = alice.get_blobdir().join("file").with_extension("gif");
+        fs::write(&file, &bytes)
+            .await
+            .context("failed to write file")?;
+        let mut msg = Message::new(Viewtype::Sticker);
+        msg.set_file(file.to_str().unwrap(), None);
+        let chat = alice.get_self_chat().await;
+        let sent = alice.send_msg(chat.id, &mut msg).await;
+        let msg = Message::load_from_db(alice, sent.sender_msg_id).await?;
+        // Message::force_sticker() wasn't used, still Viewtype::Sticker is preserved because of the
+        // extension.
+        assert_eq!(msg.get_viewtype(), Viewtype::Sticker);
+        Ok(())
+    }
 }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2688,7 +2688,10 @@ async fn prepare_msg_blob(context: &Context, msg: &mut Message) -> Result<()> {
             .with_context(|| format!("attachment missing for message of type #{}", msg.viewtype))?;
         let send_as_is = msg.viewtype == Viewtype::File;
 
-        if msg.viewtype == Viewtype::File || msg.viewtype == Viewtype::Image {
+        if msg.viewtype == Viewtype::File
+            || msg.viewtype == Viewtype::Image
+            || msg.viewtype == Viewtype::Sticker && !msg.param.exists(Param::ForceSticker)
+        {
             // Correct the type, take care not to correct already very special
             // formats as GIF or VOICE.
             //
@@ -2697,7 +2700,12 @@ async fn prepare_msg_blob(context: &Context, msg: &mut Message) -> Result<()> {
             // - from FILE/IMAGE to GIF */
             if let Some((better_type, _)) = message::guess_msgtype_from_suffix(&blob.to_abs_path())
             {
-                if better_type != Viewtype::Webxdc
+                if msg.viewtype == Viewtype::Sticker {
+                    if better_type != Viewtype::Image {
+                        // UIs don't want conversions of `Sticker` to anything other than `Image`.
+                        msg.param.set_int(Param::ForceSticker, 1);
+                    }
+                } else if better_type != Viewtype::Webxdc
                     || context
                         .ensure_sendable_webxdc_file(&blob.to_abs_path())
                         .await

--- a/src/message.rs
+++ b/src/message.rs
@@ -2094,6 +2094,9 @@ pub enum Viewtype {
     Gif = 21,
 
     /// Message containing a sticker, similar to image.
+    /// NB: When sending, the message viewtype may be changed to `Image` by some heuristics like
+    /// checking for transparent pixels. Use `Message::force_sticker()` to disable them.
+    ///
     /// If possible, the ui should display the image without borders in a transparent way.
     /// A click on a sticker will offer to install the sticker set in some future.
     Sticker = 23,


### PR DESCRIPTION
Fix #6352 