### PR TITLE
refactor: Remove marknoticed_chat_if_older_than()

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3231,19 +3231,6 @@ pub async fn get_chat_msgs_ex(
     Ok(items)
 }
 
-pub(crate) async fn marknoticed_chat_if_older_than(
-    context: &Context,
-    chat_id: ChatId,
-    timestamp: i64,
-) -> Result<()> {
-    if let Some(chat_timestamp) = chat_id.get_timestamp(context).await? {
-        if timestamp > chat_timestamp {
-            marknoticed_chat(context, chat_id).await?;
-        }
-    }
-    Ok(())
-}
-
 /// Marks all messages in the chat as noticed.
 /// If the given chat-id is the archive-link, marks all messages in all archived chats as noticed.
 pub async fn marknoticed_chat(context: &Context, chat_id: ChatId) -> Result<()> {

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1690,11 +1690,6 @@ RETURNING id
         "Message has {icnt} parts and is assigned to chat #{chat_id}."
     );
 
-    // new outgoing message from another device marks the chat as noticed.
-    if !mime_parser.incoming && !chat_id.is_special() {
-        chat::marknoticed_chat_if_older_than(context, chat_id, sort_timestamp).await?;
-    }
-
     if !is_mdn {
         let mut chat = Chat::load_from_db(context, chat_id).await?;
 


### PR DESCRIPTION
It was called from `receive_imf` when an outgoing message is received. But `Imap::fetch_new_messages()` already calls `chat::mark_old_messages_as_noticed()` which does the job better (per-message).