### PR TITLE
fix: Don't treat location-only and sync messages as bot ones (#6357)

### DIFF
--- a/src/location.rs
+++ b/src/location.rs
@@ -1127,6 +1127,10 @@ Content-Disposition: attachment; filename="location.kml"
         assert_eq!(get_range(alice, None, None, 0, 0).await?.len(), 1);
         assert_eq!(get_range(bob, None, None, 0, 0).await?.len(), 1);
 
+        // Location-only messages are "auto-generated", but they mustn't make the contact a bot.
+        let contact = bob.add_or_lookup_contact(alice).await;
+        assert!(!contact.is_bot());
+
         // Day later Bob removes location.
         SystemTime::shift(Duration::from_secs(86400));
         delete_expired(alice, time()).await?;

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -570,7 +570,12 @@ impl MimeMessage {
             },
         };
 
-        if parser.mdn_reports.is_empty() && parser.webxdc_status_update.is_none() {
+        let is_location_only = parser.location_kml.is_some() && parser.parts.is_empty();
+        if parser.mdn_reports.is_empty()
+            && !is_location_only
+            && parser.sync_items.is_none()
+            && parser.webxdc_status_update.is_none()
+        {
             let is_bot =
                 parser.headers.get("auto-submitted") == Some(&"auto-generated".to_string());
             parser.is_bot = Some(is_bot);

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -566,6 +566,10 @@ mod tests {
         assert!(token::exists(&alice2, token::Namespace::Auth, "testtoken").await?);
         assert_eq!(Chatlist::try_load(&alice2, 0, None, None).await?.len(), 0);
 
+        // Sync messages are "auto-generated", but they mustn't make the self-contact a bot.
+        let self_contact = alice2.add_or_lookup_contact(&alice2).await;
+        assert!(!self_contact.is_bot());
+
         // the same sync message sent to bob must not be executed
         let bob = TestContext::new_bob().await;
         bob.recv_msg(&sent_msg).await;


### PR DESCRIPTION
Fix #6357 