### PR TITLE
test: fix `test_logged_ac_process_ffi_failure` flakiness

### DIFF
--- a/python/tests/test_4_lowlevel.py
+++ b/python/tests/test_4_lowlevel.py
@@ -212,8 +212,13 @@ def test_logged_ac_process_ffi_failure(acfactory):
             0 / 0
 
     cap = Queue()
-    ac1.log = cap.put
+
+    # Make sure the next attempt to log an event fails.
     ac1.add_account_plugin(FailPlugin())
+
+    # Start capturing events.
+    ac1.log = cap.put
+
     # cause any event eg contact added/changed
     ac1.create_contact("something@example.org")
     res = cap.get(timeout=10)


### PR DESCRIPTION
This test keeps failing on macOS CI,
capturing events like `DC_EVENT_ACCOUNTS_ITEM_CHANGED` before FailPlugin is setup.
These CI runners likely get less resources
because there is a limited number of them,
and this triggers this race condition.

Race is fixed by setting up fail plugin
before starting to capture events.