### PR TITLE
New group consistency algorithm

### DIFF
--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -144,7 +144,7 @@ impl Chatlist {
                                   ORDER BY timestamp DESC, id DESC LIMIT 1)
                  WHERE c.id>9
                    AND c.blocked!=1
-                   AND c.id IN(SELECT chat_id FROM chats_contacts WHERE contact_id=?2)
+                   AND c.id IN(SELECT chat_id FROM chats_contacts WHERE contact_id=?2 AND add_timestamp >= remove_timestamp)
                  GROUP BY c.id
                  ORDER BY c.archived=?3 DESC, IFNULL(m.timestamp,c.created_timestamp) DESC, m.id DESC;",
                 (MessageState::OutDraft, query_contact_id, ChatVisibility::Pinned),
@@ -261,7 +261,7 @@ impl Chatlist {
                      WHERE c.id>9 AND c.id!=?
                        AND c.blocked=0
                        AND NOT c.archived=?
-                       AND (c.type!=? OR c.id IN(SELECT chat_id FROM chats_contacts WHERE contact_id=?))
+                       AND (c.type!=? OR c.id IN(SELECT chat_id FROM chats_contacts WHERE contact_id=? AND add_timestamp >= remove_timestamp))
                      GROUP BY c.id
                      ORDER BY c.id=? DESC, c.archived=? DESC, IFNULL(m.timestamp,c.created_timestamp) DESC, m.id DESC;",
                     (

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -114,7 +114,8 @@ impl ContactId {
                  SET gossiped_timestamp=0
                  WHERE EXISTS (SELECT 1 FROM chats_contacts
                                WHERE chats_contacts.chat_id=chats.id
-                               AND chats_contacts.contact_id=?)",
+                               AND chats_contacts.contact_id=?
+                               AND chats_contacts.add_timestamp >= chats_contacts.remove_timestamp)",
                 (self,),
             )
             .await?;

--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -65,6 +65,15 @@ pub enum HeaderDef {
     ChatGroupMemberAdded,
     ChatContent,
 
+    /// Past members of the group.
+    ChatGroupPastMembers,
+
+    /// Space-separated timestamps of member addition
+    /// for members listed in the `To` field
+    /// followed by timestamps of member removal
+    /// for members listed in the `Chat-Group-Past-Members` field.
+    ChatGroupMemberTimestamps,
+
     /// Duration of the attached media file.
     ChatDuration,
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -183,6 +183,8 @@ pub enum Param {
     GroupNameTimestamp = b'g',
 
     /// For Chats: timestamp of member list update.
+    ///
+    /// Deprecated 2025-01-07.
     MemberListTimestamp = b'k',
 
     /// For Webxdc Message Instances: Current document name

--- a/src/securejoin/bob.rs
+++ b/src/securejoin/bob.rs
@@ -59,8 +59,13 @@ pub(super) async fn start_protocol(context: &Context, invite: QrInvite) -> Resul
             // only become usable once the protocol is finished.
             let group_chat_id = state.joining_chat_id(context).await?;
             if !is_contact_in_chat(context, group_chat_id, invite.contact_id()).await? {
-                chat::add_to_chat_contacts_table(context, group_chat_id, &[invite.contact_id()])
-                    .await?;
+                chat::add_to_chat_contacts_table(
+                    context,
+                    time(),
+                    group_chat_id,
+                    &[invite.contact_id()],
+                )
+                .await?;
             }
             let msg = stock_str::secure_join_started(context, invite.contact_id()).await;
             chat::add_info_msg(context, group_chat_id, &msg, time()).await?;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -41,6 +41,7 @@ use crate::pgp::KeyPair;
 use crate::receive_imf::receive_imf;
 use crate::securejoin::{get_securejoin_qr, join_securejoin};
 use crate::stock_str::StockStrings;
+use crate::tools::time;
 
 #[allow(non_upper_case_globals)]
 pub const AVATAR_900x900_BYTES: &[u8] = include_bytes!("../test-data/image/avatar900x900.png");
@@ -880,7 +881,7 @@ impl TestContext {
             let contact = self.add_or_lookup_contact(member).await;
             to_add.push(contact.id);
         }
-        add_to_chat_contacts_table(self, chat_id, &to_add)
+        add_to_chat_contacts_table(self, time(), chat_id, &to_add)
             .await
             .unwrap();
 

--- a/test-data/golden/chat_test_msg_with_implicit_member_add
+++ b/test-data/golden/chat_test_msg_with_implicit_member_add
@@ -1,9 +1,0 @@
-Group#Chat#10: Group chat [3 member(s)] 
---------------------------------------------------------------------------------
-Msg#10:  (Contact#Contact#11): I created a group [FRESH]
-Msg#11:  (Contact#Contact#11): Member Fiona (fiona@example.net) added by alice@example.org. [FRESH][INFO]
-Msg#12: Me (Contact#Contact#Self): You removed member Fiona (fiona@example.net). [INFO] √
-Msg#13:  (Contact#Contact#11): Welcome, Fiona! [FRESH]
-Msg#14: info (Contact#Contact#Info): Member Fiona (fiona@example.net) added. [NOTICED][INFO]
-Msg#15:  (Contact#Contact#11): Welcome back, Fiona! [FRESH]
---------------------------------------------------------------------------------

--- a/test-data/golden/chat_test_parallel_member_remove
+++ b/test-data/golden/chat_test_parallel_member_remove
@@ -1,8 +1,7 @@
-Group#Chat#10: Group chat [4 member(s)] 
+Group#Chat#10: Group chat [3 member(s)] 
 --------------------------------------------------------------------------------
 Msg#10:  (Contact#Contact#10): Hi! I created a group. [FRESH]
 Msg#11: Me (Contact#Contact#Self): You left the group. [INFO] √
 Msg#12:  (Contact#Contact#10): Member claire@example.net added by alice@example.org. [FRESH][INFO]
-Msg#13: info (Contact#Contact#Info): Member Me (bob@example.net) added. [NOTICED][INFO]
-Msg#14:  (Contact#Contact#10): What a silence! [FRESH]
+Msg#13:  (Contact#Contact#10): What a silence! [FRESH]
 --------------------------------------------------------------------------------

--- a/test-data/golden/receive_imf_delayed_removal_is_ignored
+++ b/test-data/golden/receive_imf_delayed_removal_is_ignored
@@ -5,4 +5,5 @@ Msg#11: info (Contact#Contact#Info): Member blue@example.net added. [NOTICED][IN
 Msg#12: info (Contact#Contact#Info): Member fiona (fiona@example.net) removed. [NOTICED][INFO]
 Msg#13: bob (Contact#Contact#11): Member orange@example.net added by bob (bob@example.net). [FRESH][INFO]
 Msg#14: Me (Contact#Contact#Self): You added member fiona (fiona@example.net). [INFO] o
+Msg#15: bob (Contact#Contact#11): Member fiona (fiona@example.net) removed by bob (bob@example.net). [FRESH][INFO]
 --------------------------------------------------------------------------------

--- a/test-data/golden/receive_imf_recreate_member_list_on_missing_add_of_self
+++ b/test-data/golden/receive_imf_recreate_member_list_on_missing_add_of_self
@@ -1,9 +1,0 @@
-Group#Chat#10: Group [2 member(s)] 
---------------------------------------------------------------------------------
-Msg#10: info (Contact#Contact#Info): Member Me (bob@example.net) added. [NOTICED][INFO]
-Msg#11:  (Contact#Contact#10): second message [FRESH]
-Msg#12🔒: Me (Contact#Contact#Self): You left the group. [INFO] √
-Msg#13:  (Contact#Contact#10): 4th message [FRESH]
-Msg#14: info (Contact#Contact#Info): Member Me (bob@example.net) added. [NOTICED][INFO]
-Msg#15:  (Contact#Contact#10): 6th message [FRESH]
---------------------------------------------------------------------------------


### PR DESCRIPTION
This implements the basic group consistency algorithm described in #6401

It is already ready for review because all the tests pass. Removing tombstones after 60 days and a test for it will be another PR. Important note about handling inactive groups to avoid-readding members if someone restores old backup is at https://github.com/deltachat/deltachat-core-rust/issues/6401#issuecomment-2575938346

There are some attempts to workaround the case when "member added" (
0a0e7156e001e4fd9ba99c12d3484ccce82aa2c0) or "member removed" (1855f84fe0f48f79a51dd1be09a9978e36ef189a) messages fail to be sent. I am removing them here, going to update `add_timestamp` or `remove_timestamp` locally and then do an attempt to send the message out. If the message is not sent because of missing peerstate or because the app is killed, this is the same as having the network lose the message. Especially in the case of removing multiple members by making multiple parallel JSON-RPC or FFI calls it seems better to update the timestamp locally and then send out local state than sending out multiple "member removed" messages which each remove one member but not all the others, not sure if it even worked properly in case the bot or the UI requests multiple member removal in parallel.