### PR TITLE
fix: Don't emit MsgsNoticed when a message was seen on IMAP

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1284,7 +1284,6 @@ impl Session {
             context.on_archived_chats_maybe_noticed();
         }
         for updated_chat_id in updated_chat_ids {
-            context.emit_event(EventType::MsgsNoticed(updated_chat_id));
             chatlist_events::emit_chatlist_item_changed(context, updated_chat_id);
         }
 


### PR DESCRIPTION
`receive_imf` doesn't emit `MsgsNoticed` on receipt of an IMAP-seen message, so the code was inconsistent. The easiest fix is to not emit `MsgsNoticed` when a message was seen on another device, we don't want to emit `MsgsNoticed` if not all messages are seen, otherwise that removes useful notifications from UIs and may lead to missing messages. Checking that all previous chat messages are at least `InNoticed` looks complicated, let's not do this for now.

EDIT: This is a replacement of #6351.
EDIT: This approach is wrong because we don't have other events that remove notifications for messages seen on other devices, see https://github.com/deltachat/deltachat-core-rust/pull/6351#issuecomment-2576171447 for more info. Closing the PR.