### PR TITLE
fix: Emit MsgsNoticed on receipt of an IMAP-seen message

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1284,6 +1284,9 @@ impl Session {
             context.on_archived_chats_maybe_noticed();
         }
         for updated_chat_id in updated_chat_ids {
+            // NB: There are no other events that remove notifications at least for messages seen on
+            // other devices, so while we may also remove useful notifications for newer messages,
+            // we have no other choice.
             context.emit_event(EventType::MsgsNoticed(updated_chat_id));
             chatlist_events::emit_chatlist_item_changed(context, updated_chat_id);
         }

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -614,6 +614,9 @@ pub(crate) async fn receive_imf_inner(
             chat_id.emit_msg_event(context, *msg_id, mime_parser.incoming && fresh);
         }
     }
+    if !chat_id.is_trash() && received_msg.state == MessageState::InSeen {
+        context.emit_event(EventType::MsgsNoticed(chat_id));
+    }
     context.new_msgs_notify.notify_one();
 
     mime_parser


### PR DESCRIPTION
See commit messages.

Let's continue the discussion here, this is a reply to https://github.com/deltachat/deltachat-core-rust/pull/6351#issuecomment-2575304115.
> FTR, if we have an actual user value for emitting MsgsNoticed on receipt of an IMAP-seen message, and test that MsgsNoticed is not emitted for every reaction and mdn, then I'm not against it.

Removed emitting `MsgsNoticed` for the trash chat (added a check) and added such tests, though the test on receiving a seen reaction is apparently going to be broken by #6213 because reactions will be assigned to the actual chat, not to the trash. But i don't see a problem here, reactions just become hidden messages and if a reaction is seen, that's a result of an explicit user action and also means that the user has noticed notifications for earlier messages.