### PR TITLE
refactor: Chat::why_cant_send: Check more severe conditions first

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1654,15 +1654,17 @@ impl Chat {
     pub(crate) async fn why_cant_send(&self, context: &Context) -> Result<Option<CantSendReason>> {
         use CantSendReason::*;
 
+        // NB: "Can't send" conditions should be checked in the order of their severity; the
+        // returned result may be handled and the message sent under certain conditions.
         // NB: Don't forget to update Chatlist::try_load() when changing this function!
         let reason = if self.id.is_special() {
             Some(SpecialChat)
         } else if self.is_device_talk() {
             Some(DeviceChat)
-        } else if self.is_contact_request() {
-            Some(ContactRequest)
         } else if self.is_protection_broken() {
             Some(ProtectionBroken)
+        } else if self.is_contact_request() {
+            Some(ContactRequest)
         } else if self.is_mailing_list() && self.get_mailinglist_addr().is_none_or_empty() {
             Some(ReadOnlyMailingList)
         } else if !self.is_self_in_chat(context).await? {


### PR DESCRIPTION
"Can't send" conditions should be checked in the order of their severity; the returned result may be handled and the message sent under certain conditions.

I'm not sure if a broken protection may intersect with the case of contact request, but the former looks a more severe condition. Otherwise this change is mostly to add a comment about the order of checks.