### PR TITLE
Experiment: Webxdc: add virtual directory for fetching avatars and group memberlist

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -1829,6 +1829,20 @@ impl CommandApi {
         WebxdcMessageInfo::get_for_message(&ctx, MsgId::new(instance_msg_id)).await
     }
 
+    /// Returns webxdc memberlist, each member is a tuple (private user id, display_name)
+    /// Only includes members that have a known public key in the database
+    async fn get_webxdc_memberlist(
+        &self,
+        account_id: u32,
+        instance_msg_id: u32,
+    ) -> Result<Vec<(String, String)>> {
+        let ctx = self.get_context(account_id).await?;
+        Message::load_from_db(&ctx, MsgId::new(instance_msg_id))
+            .await?
+            .get_webxdc_memberlist(&ctx)
+            .await
+    }
+
     /// Get href from a WebxdcInfoMessage which might include a hash holding
     /// information about a specific position or state in a webxdc app (optional)
     async fn get_webxdc_href(

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1376,6 +1376,18 @@ impl Contact {
         &self.addr
     }
 
+    /// Get display name. This is the name as defined by the contact himself,
+    /// modified by the user or, if both are unset, an empty string.
+    pub fn get_display_name_without_email(&self) -> String {
+        if !self.name.is_empty() {
+            return self.name.clone();
+        }
+        if !self.authname.is_empty() {
+            return self.authname.clone();
+        }
+        String::new()
+    }
+
     /// Get a summary of authorized name and address.
     ///
     /// The returned string is either "Name (email@domain.com)" or just


### PR DESCRIPTION
There are still many open questions, this is just a prototype, see the comments in the code.
The most controversial thing is the member list, I needed it to make the avatars work, so I already exposed it. But we can also postpone the memberlist webxdc api and just do the avatar api for now.

The changes:
- adds a webxdc.getMemberList which returns the group members for which we have public keys (because the webxdc user id is based on public key + webxdc message rfc id)
  - The format is `[userid:string, displayName:string][]`
- adds a way to get user avatars over a virtual directory: `__webxdc__/avatar/<user_id>.jpg`
  - if the user has no profile picture this returns 404, we could think about returning a color image or text avatar, but we don't want to deal with text rendering in core, so I think it is fine like it is.B

user_id is basically the (self)addr

Desktop pr so you can test the changes - you can test avatars without it, only needed for memberlist api: (https://github.com/deltachat/deltachat-desktop/pull/4481)