### PR TITLE
build: switch to non-git version of encoded-words

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,7 +1832,7 @@ dependencies = [
 [[package]]
 name = "email"
 version = "0.0.20"
-source = "git+https://github.com/deltachat/rust-email?branch=master#5179cd68db44101ee3d3df7bfef96f014507352b"
+source = "git+https://github.com/deltachat/rust-email?branch=master#ba176ca31ae000203368eb9baacc7eb469fd7692"
 dependencies = [
  "base64 0.11.0",
  "chrono",
@@ -1852,7 +1852,8 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 [[package]]
 name = "encoded-words"
 version = "0.2.0"
-source = "git+https://github.com/async-email/encoded-words?branch=master#d55366b36f96e383f39c432aedce42ee8b43f796"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1693107e6084e2b9444d34a985697f56c8832d314924d5cfb1fb7793154bef"
 dependencies = [
  "base64 0.12.3",
  "charset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ brotli = { version = "7", default-features=false, features = ["std"] }
 bytes = "1"
 chrono = { workspace = true, features = ["alloc", "clock", "std"] }
 email = { git = "https://github.com/deltachat/rust-email", branch = "master" }
-encoded-words = { git = "https://github.com/async-email/encoded-words", branch = "master" }
+encoded-words = "0.2"
 escaper = "0.1"
 fast-socks5 = "0.10"
 fd-lock = "4"

--- a/deny.toml
+++ b/deny.toml
@@ -97,6 +97,5 @@ license-files = [
 [sources.allow-org]
 # Organisations which we allow git sources from.
 github = [
-       "async-email",
        "deltachat",
 ]


### PR DESCRIPTION
The only difference is that it is uploaded to crates.io

I also updated our rust-email repo: https://github.com/deltachat/rust-email/commit/ba176ca31ae000203368eb9baacc7eb469fd7692