### PR TITLE
feat: add IncomingReaction.chat_id

### DIFF
--- a/deltachat-jsonrpc/src/api/types/events.rs
+++ b/deltachat-jsonrpc/src/api/types/events.rs
@@ -101,6 +101,7 @@ pub enum EventType {
     /// Incoming reaction, should be notified.
     #[serde(rename_all = "camelCase")]
     IncomingReaction {
+        chat_id: u32,
         contact_id: u32,
         msg_id: u32,
         reaction: String,
@@ -335,10 +336,12 @@ impl From<CoreEventType> for EventType {
                 contact_id: contact_id.to_u32(),
             },
             CoreEventType::IncomingReaction {
+                chat_id,
                 contact_id,
                 msg_id,
                 reaction,
             } => IncomingReaction {
+                chat_id: chat_id.to_u32(),
                 contact_id: contact_id.to_u32(),
                 msg_id: msg_id.to_u32(),
                 reaction: reaction.as_str().to_string(),

--- a/src/events/payload.rs
+++ b/src/events/payload.rs
@@ -97,6 +97,9 @@ pub enum EventType {
 
     /// Reactions for the message changed.
     IncomingReaction {
+        /// ID of the chat which the message belongs to.
+        chat_id: ChatId,
+
         /// ID of the contact whose reaction set is changed.
         contact_id: ContactId,
 

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -285,6 +285,7 @@ pub(crate) async fn set_msg_reaction(
             && msg_id.get_state(context).await?.is_outgoing()
         {
             context.emit_event(EventType::IncomingReaction {
+                chat_id,
                 contact_id,
                 msg_id,
                 reaction,

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -583,6 +583,7 @@ Here's my footer -- bob@example.net"
 
     async fn expect_incoming_reactions_event(
         t: &TestContext,
+        expected_chat_id: ChatId,
         expected_msg_id: MsgId,
         expected_contact_id: ContactId,
         expected_reaction: &str,
@@ -600,10 +601,12 @@ Here's my footer -- bob@example.net"
             .await;
         match event {
             EventType::IncomingReaction {
+                chat_id
                 msg_id,
                 contact_id,
                 reaction,
             } => {
+                assert_eq!(chat_id, expected_chat_id);
                 assert_eq!(msg_id, expected_msg_id);
                 assert_eq!(contact_id, expected_contact_id);
                 assert_eq!(reaction, Reaction::from(expected_reaction));
@@ -678,7 +681,7 @@ Here's my footer -- bob@example.net"
         assert_eq!(bob_reaction.as_str(), "👍");
         expect_reactions_changed_event(&alice, chat_alice.id, alice_msg.sender_msg_id, *bob_id)
             .await?;
-        expect_incoming_reactions_event(&alice, alice_msg.sender_msg_id, *bob_id, "👍").await?;
+        expect_incoming_reactions_event(&alice, chat_alice.id, alice_msg.sender_msg_id, *bob_id, "👍").await?;
         expect_no_unwanted_events(&alice).await;
 
         // Alice reacts to own message.
@@ -721,7 +724,7 @@ Here's my footer -- bob@example.net"
         send_reaction(&bob, bob_msg1.id, "👍").await?;
         let bob_send_reaction = bob.pop_sent_msg().await;
         alice.recv_msg_trash(&bob_send_reaction).await;
-        expect_incoming_reactions_event(&alice, alice_msg1.sender_msg_id, alice_bob_id, "👍")
+        expect_incoming_reactions_event(&alice, alice_chat.id, alice_msg1.sender_msg_id, alice_bob_id, "👍")
             .await?;
         expect_no_unwanted_events(&alice).await;
 

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -601,7 +601,7 @@ Here's my footer -- bob@example.net"
             .await;
         match event {
             EventType::IncomingReaction {
-                chat_id
+                chat_id,
                 msg_id,
                 contact_id,
                 reaction,

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -681,7 +681,14 @@ Here's my footer -- bob@example.net"
         assert_eq!(bob_reaction.as_str(), "👍");
         expect_reactions_changed_event(&alice, chat_alice.id, alice_msg.sender_msg_id, *bob_id)
             .await?;
-        expect_incoming_reactions_event(&alice, chat_alice.id, alice_msg.sender_msg_id, *bob_id, "👍").await?;
+        expect_incoming_reactions_event(
+            &alice,
+            chat_alice.id,
+            alice_msg.sender_msg_id,
+            *bob_id,
+            "👍",
+        )
+        .await?;
         expect_no_unwanted_events(&alice).await;
 
         // Alice reacts to own message.
@@ -724,8 +731,14 @@ Here's my footer -- bob@example.net"
         send_reaction(&bob, bob_msg1.id, "👍").await?;
         let bob_send_reaction = bob.pop_sent_msg().await;
         alice.recv_msg_trash(&bob_send_reaction).await;
-        expect_incoming_reactions_event(&alice, alice_chat.id, alice_msg1.sender_msg_id, alice_bob_id, "👍")
-            .await?;
+        expect_incoming_reactions_event(
+            &alice,
+            alice_chat.id,
+            alice_msg1.sender_msg_id,
+            alice_bob_id,
+            "👍",
+        )
+        .await?;
         expect_no_unwanted_events(&alice).await;
 
         let chatlist = Chatlist::try_load(&bob, 0, None, None).await?;


### PR DESCRIPTION
For the same reasons as mentioned in #6356 and to streamline the "Incoming" Event API. (all have a chat_id)

If this makes sense from core architecure perspective has to be decided. Of course it is possible to fetch the chatId by fetching the Message but that is true for all the other events too.