### PR TITLE
feat: Deduplicate in more places

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -4752,6 +4752,7 @@ void            dc_msg_set_override_sender_name(dc_msg_t* msg, const char* name)
  * @param file If the message object is used in dc_send_msg() later,
  *     this must be the full path of the image file to send.
  * @param filemime The MIME type of the file. NULL if you don't know or don't care.
+ * @deprecated 2025-01-21 Use dc_msg_set_file_and_deduplicate instead
  */
 void            dc_msg_set_file               (dc_msg_t* msg, const char* file, const char* filemime);
 

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -939,7 +939,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             } else {
                 Viewtype::File
             });
-            msg.set_file(arg1, None);
+            msg.set_file_and_deduplicate(&context, Path::new(arg1), None, None)?;
             msg.set_text(arg2.to_string());
             chat::send_msg(&context, sel_chat.as_ref().unwrap().get_id(), &mut msg).await?;
         }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2461,7 +2461,8 @@ pub(crate) async fn update_saved_messages_icon(context: &Context) -> Result<()> 
         ChatIdBlocked::lookup_by_contact(context, ContactId::SELF).await?
     {
         let icon = include_bytes!("../assets/icon-saved-messages.png");
-        let blob = BlobObject::create(context, "icon-saved-messages.png", icon).await?;
+        let blob =
+            BlobObject::create_and_deduplicate_from_bytes(context, icon, "saved-messages.png")?;
         let icon = blob.as_name().to_string();
 
         let mut chat = Chat::load_from_db(context, chat_id).await?;
@@ -2476,7 +2477,7 @@ pub(crate) async fn update_device_icon(context: &Context) -> Result<()> {
         ChatIdBlocked::lookup_by_contact(context, ContactId::DEVICE).await?
     {
         let icon = include_bytes!("../assets/icon-device.png");
-        let blob = BlobObject::create(context, "icon-device.png", icon).await?;
+        let blob = BlobObject::create_and_deduplicate_from_bytes(context, icon, "device.png")?;
         let icon = blob.as_name().to_string();
 
         let mut chat = Chat::load_from_db(context, chat_id).await?;
@@ -2496,7 +2497,7 @@ pub(crate) async fn get_broadcast_icon(context: &Context) -> Result<String> {
     }
 
     let icon = include_bytes!("../assets/icon-broadcast.png");
-    let blob = BlobObject::create(context, "icon-broadcast.png", icon).await?;
+    let blob = BlobObject::create_and_deduplicate_from_bytes(context, icon, "broadcast.png")?;
     let icon = blob.as_name().to_string();
     context
         .sql
@@ -2511,7 +2512,7 @@ pub(crate) async fn get_archive_icon(context: &Context) -> Result<String> {
     }
 
     let icon = include_bytes!("../assets/icon-archive.png");
-    let blob = BlobObject::create(context, "icon-archive.png", icon).await?;
+    let blob = BlobObject::create_and_deduplicate_from_bytes(context, icon, "archive.png")?;
     let icon = blob.as_name().to_string();
     context
         .sql

--- a/src/config.rs
+++ b/src/config.rs
@@ -686,7 +686,7 @@ impl Context {
         let value = match key {
             Config::Selfavatar if value.is_empty() => None,
             Config::Selfavatar => {
-                config_value = BlobObject::store_from_base64(self, value, "avatar").await?;
+                config_value = BlobObject::store_from_base64(self, value)?;
                 Some(config_value.as_str())
             }
             _ => Some(value),
@@ -1143,6 +1143,8 @@ mod tests {
         Ok(())
     }
 
+    const SAVED_MESSAGES_DEDUPLICATED_FILE: &str = "969142cb84015bc135767bc2370934a.png";
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_sync() -> Result<()> {
         let alice0 = TestContext::new_alice().await;
@@ -1217,7 +1219,7 @@ mod tests {
         let self_chat_avatar_path = self_chat.get_profile_image(&alice0).await?.unwrap();
         assert_eq!(
             self_chat_avatar_path,
-            alice0.get_blobdir().join("icon-saved-messages.png")
+            alice0.get_blobdir().join(SAVED_MESSAGES_DEDUPLICATED_FILE)
         );
         assert!(alice1
             .get_config(Config::Selfavatar)

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -345,7 +345,7 @@ async fn import_vcard_contact(context: &Context, contact: &VcardContact) -> Resu
         return Ok(id);
     }
     let path = match &contact.profile_image {
-        Some(image) => match BlobObject::store_from_base64(context, image, "avatar").await {
+        Some(image) => match BlobObject::store_from_base64(context, image) {
             Err(e) => {
                 warn!(
                     context,

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -13,7 +13,7 @@ use crate::context::Context;
 use crate::net::proxy::ProxyConfig;
 use crate::net::session::SessionStream;
 use crate::net::tls::wrap_rustls;
-use crate::tools::{create_id, time};
+use crate::tools::time;
 
 /// HTTP(S) GET response.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -119,12 +119,8 @@ fn http_url_cache_timestamps(url: &str, mimetype: Option<&str>) -> (i64, i64) {
 
 /// Places the binary into HTTP cache.
 async fn http_cache_put(context: &Context, url: &str, response: &Response) -> Result<()> {
-    let blob = BlobObject::create(
-        context,
-        &format!("http_cache_{}", create_id()),
-        response.blob.as_slice(),
-    )
-    .await?;
+    let blob =
+        BlobObject::create_and_deduplicate_from_bytes(context, response.blob.as_slice(), "")?;
 
     let (expires, stale) = http_url_cache_timestamps(url, response.mimetype.as_deref());
     context

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -1415,9 +1415,10 @@ impl Context {
         // add welcome-messages. by the label, this is done only once,
         // if the user has deleted the message or the chat, it is not added again.
         let image = include_bytes!("../assets/welcome-image.jpg");
-        let blob = BlobObject::create(self, "welcome-image.jpg", image).await?;
+        let blob = BlobObject::create_and_deduplicate_from_bytes(self, image, "welcome.jpg")?;
         let mut msg = Message::new(Viewtype::Image);
         msg.param.set(Param::File, blob.as_name());
+        msg.param.set(Param::Filename, "welcome-image.jpg");
         chat::add_device_msg(self, Some("core-welcome-image"), Some(&mut msg)).await?;
 
         let mut msg = Message::new_text(welcome_message(self).await);


### PR DESCRIPTION
Deduplicate:
- In the REPL
- In `store_from_base64()`, which writes avatars received in headers
- In a few tests
- The saved messages, broadcast, device, archive icons
- The autocrypt setup message

1-2 more PRs, and we can get rid of `BlobObject::create`, `sanitise_name()`, and some others