### PR TITLE
refactor: Remove BlobObject::create(), use create_and_deduplicate_from_bytes() instead

### DIFF
--- a/src/blob.rs
+++ b/src/blob.rs
@@ -104,10 +104,8 @@ impl<'a> BlobObject<'a> {
             return Err(err).context("failed to copy file");
         }
 
-        // workaround a bug in async-std
-        // (the executor does not handle blocking operation in Drop correctly,
-        // see <https://github.com/async-rs/async-std/issues/900>)
-        let _ = dst_file.flush().await;
+        // Ensure that all buffered bytes are written
+        dst_file.flush().await?;
 
         let blob = BlobObject {
             blobdir: context.get_blobdir(),

--- a/src/message.rs
+++ b/src/message.rs
@@ -1114,7 +1114,7 @@ impl Message {
                 .unwrap_or_else(|| "unknown_file".to_string())
         };
 
-        let blob = BlobObject::create_and_deduplicate(context, file, &name)?;
+        let blob = BlobObject::create_and_deduplicate(context, file, Path::new(&name))?;
         self.param.set(Param::File, blob.as_name());
 
         self.param.set(Param::Filename, name);


### PR DESCRIPTION
Part of #6332 