### PR TITLE
fix: use non-empty `To:` field for "saved messages"

### DIFF
--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -752,6 +752,16 @@ async fn test_self_talk() -> Result<()> {
     assert!(msg.get_showpadlock());
 
     let sent_msg = t.pop_sent_msg().await;
+    let payload = sent_msg.payload();
+    // Make sure the `To` field contains the address and not
+    // "undisclosed recipients".
+    // Otherwise Delta Chat core <1.153.0 assigns the message
+    // to the trash chat.
+    assert_eq!(
+        payload.match_indices("To: <alice@example.org>\r\n").count(),
+        1
+    );
+
     let t2 = TestContext::new_alice().await;
     t2.recv_msg(&sent_msg).await;
     let chat = &t2.get_self_chat().await;

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -186,8 +186,8 @@ impl MimeFactory {
         if chat.is_self_talk() {
             if msg.param.get_cmd() == SystemMessage::AutocryptSetupMessage {
                 recipients.push(from_addr.to_string());
-                to.push((from_displayname.to_string(), from_addr.to_string()));
             }
+            to.push((from_displayname.to_string(), from_addr.to_string()));
         } else if chat.is_mailing_list() {
             let list_post = chat
                 .param


### PR DESCRIPTION
Fixes #6468