### PR TITLE
feat: Mark reactions as IMAP-seen in marknoticed_chat(), second try

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,10 @@ name = "get_chat_msgs"
 harness = false
 
 [[bench]]
+name = "marknoticed_chat"
+harness = false
+
+[[bench]]
 name = "get_chatlist"
 harness = false
 

--- a/benches/get_chat_msgs.rs
+++ b/benches/get_chat_msgs.rs
@@ -7,6 +7,7 @@ use deltachat::chatlist::Chatlist;
 use deltachat::context::Context;
 use deltachat::stock_str::StockStrings;
 use deltachat::Events;
+use tempfile::tempdir;
 
 async fn get_chat_msgs_benchmark(dbfile: &Path, chats: &[ChatId]) {
     let id = 100;
@@ -16,6 +17,17 @@ async fn get_chat_msgs_benchmark(dbfile: &Path, chats: &[ChatId]) {
 
     for c in chats.iter().take(10) {
         black_box(chat::get_chat_msgs(&context, *c).await.ok());
+    }
+}
+
+async fn marknoticed_chat_benchmark(dbfile: &Path, chats: &[ChatId]) {
+    let id = 100;
+    let context = Context::new(dbfile, id, Events::new(), StockStrings::new())
+        .await
+        .unwrap();
+
+    for c in chats.iter().take(20) {
+        black_box(chat::marknoticed_chat(&context, *c).await.unwrap());
     }
 }
 
@@ -34,9 +46,19 @@ fn criterion_benchmark(c: &mut Criterion) {
             (0..len).map(|i| chatlist.get_chat_id(i).unwrap()).collect()
         });
 
-        c.bench_function("chat::get_chat_msgs (load messages from 10 chats)", |b| {
+        // c.bench_function("chat::get_chat_msgs (load messages from 10 chats)", |b| {
+        //     b.to_async(&rt)
+        //         .iter(|| get_chat_msgs_benchmark(black_box(path.as_ref()), black_box(&chats)))
+        // });
+
+        c.bench_function("chat::marknoticed_chat (mark 10 chats as noticed)", |b| {
+            let dir = tempdir().unwrap();
+            let dir = dir.path();
+            let new_db = dir.join("dc.db");
+            std::fs::copy(&path, &new_db).unwrap();
+
             b.to_async(&rt)
-                .iter(|| get_chat_msgs_benchmark(black_box(path.as_ref()), black_box(&chats)))
+                .iter(|| marknoticed_chat_benchmark(black_box(new_db.as_ref()), black_box(&chats)))
         });
     } else {
         println!("env var not set: DELTACHAT_BENCHMARK_DATABASE");

--- a/benches/marknoticed_chat.rs
+++ b/benches/marknoticed_chat.rs
@@ -1,0 +1,94 @@
+#![recursion_limit = "256"]
+use std::path::Path;
+
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use deltachat::chat::{self, ChatId};
+use deltachat::chatlist::Chatlist;
+use deltachat::context::Context;
+use deltachat::stock_str::StockStrings;
+use deltachat::Events;
+use futures_lite::future::block_on;
+use tempfile::tempdir;
+
+async fn marknoticed_chat_benchmark(context: &Context, chats: &[ChatId]) {
+    for c in chats.iter().take(20) {
+        chat::marknoticed_chat(context, *c).await.unwrap();
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    // To enable this benchmark, set `DELTACHAT_BENCHMARK_DATABASE` to some large database with many
+    // messages, such as your primary account.
+    if let Ok(path) = std::env::var("DELTACHAT_BENCHMARK_DATABASE") {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+
+        let chats: Vec<_> = rt.block_on(async {
+            let context = Context::new(Path::new(&path), 100, Events::new(), StockStrings::new())
+                .await
+                .unwrap();
+            let chatlist = Chatlist::try_load(&context, 0, None, None).await.unwrap();
+            let len = chatlist.len();
+            (1..len).map(|i| chatlist.get_chat_id(i).unwrap()).collect()
+        });
+
+        // This mainly tests the performance of marknoticed_chat()
+        // when nothing has to be done
+        c.bench_function(
+            "chat::marknoticed_chat (mark 20 chats as noticed repeatedly)",
+            |b| {
+                let dir = tempdir().unwrap();
+                let dir = dir.path();
+                let new_db = dir.join("dc.db");
+                std::fs::copy(&path, &new_db).unwrap();
+
+                let context = block_on(async {
+                    Context::new(Path::new(&new_db), 100, Events::new(), StockStrings::new())
+                        .await
+                        .unwrap()
+                });
+
+                b.to_async(&rt)
+                    .iter(|| marknoticed_chat_benchmark(&context, black_box(&chats)))
+            },
+        );
+
+        // If the first 20 chats contain fresh messages or reactions,
+        // this tests the performance of marking them as noticed.
+        c.bench_function(
+            "chat::marknoticed_chat (mark 20 chats as noticed, resetting after every iteration)",
+            |b| {
+                b.to_async(&rt).iter_batched(
+                    || {
+                        let dir = tempdir().unwrap();
+                        let new_db = dir.path().join("dc.db");
+                        std::fs::copy(&path, &new_db).unwrap();
+
+                        let context = block_on(async {
+                            Context::new(
+                                Path::new(&new_db),
+                                100,
+                                Events::new(),
+                                StockStrings::new(),
+                            )
+                            .await
+                            .unwrap()
+                        });
+                        (dir, context)
+                    },
+                    |(_dir, context)| {
+                        let chats = &chats;
+                        async move {
+                            marknoticed_chat_benchmark(black_box(&context), black_box(chats)).await
+                        }
+                    },
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    } else {
+        println!("env var not set: DELTACHAT_BENCHMARK_DATABASE");
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -287,6 +287,43 @@ def test_message(acfactory) -> None:
     assert reactions == snapshot.reactions
 
 
+def test_reaction_seen_on_another_dev(acfactory, tmp_path) -> None:
+    alice, bob = acfactory.get_online_accounts(2)
+    alice.export_backup(tmp_path)
+    files = list(tmp_path.glob("*.tar"))
+    alice2 = acfactory.get_unconfigured_account()
+    alice2.import_backup(files[0])
+    alice2.start_io()
+
+    bob_addr = bob.get_config("addr")
+    alice_contact_bob = alice.create_contact(bob_addr, "Bob")
+    alice_chat_bob = alice_contact_bob.create_chat()
+    alice_chat_bob.send_text("Hello!")
+
+    event = bob.wait_for_incoming_msg_event()
+    msg_id = event.msg_id
+
+    message = bob.get_message_by_id(msg_id)
+    snapshot = message.get_snapshot()
+    snapshot.chat.accept()
+    message.send_reaction("😎")
+    for a in [alice, alice2]:
+        while True:
+            event = a.wait_for_event()
+            if event.kind == EventType.INCOMING_REACTION:
+                break
+
+    alice_chat_bob.mark_noticed()
+    while True:
+        event = alice2.wait_for_event()
+        if event.kind == EventType.MSGS_NOTICED:
+            chat_id = event.chat_id
+            break
+    alice2_contact_bob = alice2.get_contact_by_addr(bob_addr)
+    alice2_chat_bob = alice2_contact_bob.create_chat()
+    assert chat_id == alice2_chat_bob.id
+
+
 def test_is_bot(acfactory) -> None:
     """Test that we can recognize messages submitted by bots."""
     alice, bob = acfactory.get_online_accounts(2)

--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -313,6 +313,7 @@ def test_reaction_seen_on_another_dev(acfactory, tmp_path) -> None:
             if event.kind == EventType.INCOMING_REACTION:
                 break
 
+    alice2.clear_all_events()
     alice_chat_bob.mark_noticed()
     while True:
         event = alice2.wait_for_event()

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3349,7 +3349,7 @@ pub async fn marknoticed_chat(context: &Context, chat_id: ChatId) -> Result<()> 
                     WHERE state=?
                       AND hidden=1
                       AND chat_id=?
-                    ORDER BY id DESC LIMIT 100", // LIMIT to 100 in order to avoid blocking the UI too long, usually there will be less than 100 messages anyway
+                    ORDER BY id LIMIT 100", // LIMIT to 100 in order to avoid blocking the UI too long, usually there will be less than 100 messages anyway
                 (MessageState::InFresh, chat_id), // No need to check for InNoticed messages, because reactions are never InNoticed
                 |row| {
                     let msg_id: MsgId = row.get(0)?;

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3350,7 +3350,7 @@ pub async fn marknoticed_chat(context: &Context, chat_id: ChatId) -> Result<()> 
                       AND hidden=1
                       AND chat_id=?
                     ORDER BY id DESC LIMIT 100", // LIMIT to 100 in order to avoid blocking the UI too long, usually there will be less than 100 messages anyway
-                (MessageState::InNoticed, chat_id),
+                (MessageState::InFresh, chat_id), // No need to check for InNoticed messages, because reactions are never InNoticed
                 |row| {
                     let msg_id: MsgId = row.get(0)?;
                     let rfc724_mid: String = row.get(1)?;

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -398,7 +398,7 @@ mod tests {
     use deltachat_contact_tools::ContactAddress;
 
     use super::*;
-    use crate::chat::{forward_msgs, get_chat_msgs, send_text_msg};
+    use crate::chat::{forward_msgs, get_chat_msgs, marknoticed_chat, send_text_msg};
     use crate::chatlist::Chatlist;
     use crate::config::Config;
     use crate::contact::{Contact, Origin};
@@ -667,7 +667,8 @@ Here's my footer -- bob@example.net"
         assert_eq!(get_chat_msgs(&bob, bob_msg.chat_id).await?.len(), 2);
 
         let bob_reaction_msg = bob.pop_sent_msg().await;
-        alice.recv_msg_trash(&bob_reaction_msg).await;
+        let alice_reaction_msg = alice.recv_msg_hidden(&bob_reaction_msg).await;
+        assert_eq!(alice_reaction_msg.state, MessageState::InNoticed);
         assert_eq!(get_chat_msgs(&alice, chat_alice.id).await?.len(), 2);
 
         let reactions = get_msg_reactions(&alice, alice_msg.sender_msg_id).await?;
@@ -690,6 +691,20 @@ Here's my footer -- bob@example.net"
         )
         .await?;
         expect_no_unwanted_events(&alice).await;
+
+        marknoticed_chat(&alice, chat_alice.id).await?;
+        assert_eq!(
+            alice_reaction_msg.id.get_state(&alice).await?,
+            MessageState::InSeen
+        );
+        // Reactions don't request MDNs.
+        assert_eq!(
+            alice
+                .sql
+                .count("SELECT COUNT(*) FROM smtp_mdns", ())
+                .await?,
+            0
+        );
 
         // Alice reacts to own message.
         send_reaction(&alice, alice_msg.sender_msg_id, "👍 😀")
@@ -730,7 +745,7 @@ Here's my footer -- bob@example.net"
         bob_msg1.chat_id.accept(&bob).await?;
         send_reaction(&bob, bob_msg1.id, "👍").await?;
         let bob_send_reaction = bob.pop_sent_msg().await;
-        alice.recv_msg_trash(&bob_send_reaction).await;
+        alice.recv_msg_hidden(&bob_send_reaction).await;
         expect_incoming_reactions_event(
             &alice,
             alice_chat.id,
@@ -899,7 +914,7 @@ Here's my footer -- bob@example.net"
         let bob_reaction_msg = bob.pop_sent_msg().await;
 
         // Alice receives a reaction.
-        alice.recv_msg_trash(&bob_reaction_msg).await;
+        alice.recv_msg_hidden(&bob_reaction_msg).await;
 
         let reactions = get_msg_reactions(&alice, alice_msg_id).await?;
         assert_eq!(reactions.to_string(), "👍1");
@@ -951,7 +966,7 @@ Here's my footer -- bob@example.net"
         {
             send_reaction(&alice2, alice2_msg.id, "👍").await?;
             let msg = alice2.pop_sent_msg().await;
-            alice1.recv_msg_trash(&msg).await;
+            alice1.recv_msg_hidden(&msg).await;
         }
 
         // Check that the status is still the same.
@@ -973,7 +988,7 @@ Here's my footer -- bob@example.net"
         let alice1_msg = alice1.recv_msg(&alice0.pop_sent_msg().await).await;
 
         send_reaction(&alice0, alice0_msg_id, "👀").await?;
-        alice1.recv_msg_trash(&alice0.pop_sent_msg().await).await;
+        alice1.recv_msg_hidden(&alice0.pop_sent_msg().await).await;
 
         expect_reactions_changed_event(&alice0, chat_id, alice0_msg_id, ContactId::SELF).await?;
         expect_reactions_changed_event(&alice1, alice1_msg.chat_id, alice1_msg.id, ContactId::SELF)

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -623,7 +623,9 @@ Here's my footer -- bob@example.net"
             .get_matching_opt(t, |evt| {
                 matches!(
                     evt,
-                    EventType::IncomingReaction { .. } | EventType::IncomingMsg { .. }
+                    EventType::IncomingReaction { .. }
+                        | EventType::IncomingMsg { .. }
+                        | EventType::MsgsChanged { .. }
                 )
             })
             .await;
@@ -668,7 +670,7 @@ Here's my footer -- bob@example.net"
 
         let bob_reaction_msg = bob.pop_sent_msg().await;
         let alice_reaction_msg = alice.recv_msg_hidden(&bob_reaction_msg).await;
-        assert_eq!(alice_reaction_msg.state, MessageState::InNoticed);
+        assert_eq!(alice_reaction_msg.state, MessageState::InFresh);
         assert_eq!(get_chat_msgs(&alice, chat_alice.id).await?.len(), 2);
 
         let reactions = get_msg_reactions(&alice, alice_msg.sender_msg_id).await?;

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -624,9 +624,11 @@ pub(crate) async fn receive_imf_inner(
         }
     }
 
-    if let Some(replace_chat_id) = replace_chat_id {
+    if received_msg.hidden {
+        // No need to emit an event about the changed message
+    } else if let Some(replace_chat_id) = replace_chat_id {
         context.emit_msgs_changed_without_msg_id(replace_chat_id);
-    } else if !chat_id.is_trash() && !received_msg.hidden {
+    } else if !chat_id.is_trash() {
         let fresh = received_msg.state == MessageState::InFresh;
         for msg_id in &received_msg.msg_ids {
             chat_id.emit_msg_event(context, *msg_id, mime_parser.incoming && fresh);
@@ -1600,8 +1602,8 @@ RETURNING id
                     replace_msg_id,
                     rfc724_mid_orig,
                     if trash { DC_CHAT_ID_TRASH } else { chat_id },
-                    if trash || hidden { ContactId::UNDEFINED } else { from_id },
-                    if trash || hidden { ContactId::UNDEFINED } else { to_id },
+                    if trash { ContactId::UNDEFINED } else { from_id },
+                    if trash { ContactId::UNDEFINED } else { to_id },
                     sort_timestamp,
                     mime_parser.timestamp_sent,
                     mime_parser.timestamp_rcvd,

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -607,6 +607,19 @@ impl TestContext {
         msg
     }
 
+    /// Receive a message using the `receive_imf()` pipeline. Panics if it's not hidden.
+    pub async fn recv_msg_hidden(&self, msg: &SentMessage<'_>) -> Message {
+        let received = self
+            .recv_msg_opt(msg)
+            .await
+            .expect("receive_imf() seems not to have added a new message to the db");
+        let msg = Message::load_from_db(self, *received.msg_ids.last().unwrap())
+            .await
+            .unwrap();
+        assert!(msg.hidden);
+        msg
+    }
+
     /// Receive a message using the `receive_imf()` pipeline. This is similar
     /// to `recv_msg()`, but doesn't assume that the message is shown in the chat.
     pub async fn recv_msg_opt(


### PR DESCRIPTION
This is a more minimal alternative to https://github.com/deltachat/deltachat-core-rust/pull/6213, trying to keep things simpler.

Close https://github.com/deltachat/deltachat-core-rust/issues/6210.

Also, this adds a benchmark.