### PR TITLE
feat: improve logging around IMAP IDLE

### DIFF
--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1983,7 +1983,7 @@ def test_fetch_deleted_msg(acfactory, lp):
         if ev.name == "DC_EVENT_MSGS_CHANGED":
             pytest.fail("A deleted message was shown to the user")
 
-        if ev.name == "DC_EVENT_INFO" and "INBOX: Idle entering wait-on-remote state" in ev.data2:
+        if ev.name == "DC_EVENT_INFO" and 'IDLE entering wait-on-remote state in folder "INBOX".' in ev.data2:
             break  # DC is done with reading messages
 
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -671,7 +671,10 @@ async fn fetch_idle(
         return Ok(session);
     }
 
-    info!(ctx, "IMAP session supports IDLE, using it.");
+    info!(
+        ctx,
+        "IMAP session in folder {watch_folder:?} supports IDLE, using it."
+    );
     let session = session
         .idle(
             ctx,


### PR DESCRIPTION
This will hopefully make it easier to debug https://github.com/deltachat/deltachat-core-rust/issues/6477 because currently the folder name is not always logged and it is difficult to figure out whether it is INBOX or DeltaChat loop that got stuck.