### PR TITLE
fix: store device token in IMAP METADATA on each connection

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -455,6 +455,13 @@ pub enum Config {
     /// If it has not changed, we do not store
     /// the device token again.
     DeviceToken,
+
+    /// Device token encrypted with OpenPGP.
+    ///
+    /// We store encrypted token next to `device_token`
+    /// to avoid encrypting it differently and
+    /// storing the same token multiple times on the server.
+    EncryptedDeviceToken,
 }
 
 impl Config {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1778,6 +1778,7 @@ mod tests {
             "key_id",
             "webxdc_integration",
             "device_token",
+            "encrypted_device_token",
         ];
         let t = TestContext::new().await;
         let info = t.get_info().await.unwrap();


### PR DESCRIPTION
APNS tokens never expire unless
the user uninstalls the application.
Because of this in most cases
the token remains valid forever
and chatmail server never removes the token
even if it is unencrypted
or the user has removed Delta Chat profile
from the device but not the whole application.

We want to modify chatmail servers
to remember the last time the token was stored
and remove them after some time.
Before we do this, we need to modify
the client to store the device token
each time so the server knows which tokens are used and can update their timestamps.