### PR TITLE
test: make sure DCBACKUP2 compatibility does not break again

### DIFF
--- a/src/qr.rs
+++ b/src/qr.rs
@@ -1854,4 +1854,17 @@ mod tests {
 
         Ok(())
     }
+
+    /// Ensure that `DCBACKUP2` QR code does not fail to deserialize
+    /// because iroh changes the format of `NodeAddr`
+    /// as happened between iroh 0.29 and iroh 0.30 before.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_decode_backup() -> Result<()> {
+        let ctx = TestContext::new().await;
+
+        let qr = check_qr(&ctx, r#"DCBACKUP2:TWSv6ZjDPa5eoxkocj7xMi8r&{"node_id":"9afc1ea5b4f543e5cdd7b7a21cd26aee7c0b1e1c2af26790896fbd8932a06e1e","relay_url":null,"direct_addresses":["192.168.1.10:12345"]}"#).await?;
+        assert!(matches!(qr, Qr::Backup2 { .. }));
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
QR code format changed because `NodeAddr` serialization changed between iroh 0.29.0 and iroh 0.30.0.
We have already released iroh 0.30.0,
so the test at least makes change we don't break compatibility again.

Closes https://github.com/deltachat/deltachat-core-rust/issues/6518