### PR TITLE
fix: do not include CRLF before MIME boundary in the part body

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3596,9 +3596,9 @@ checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 
 [[package]]
 name = "mailparse"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da03d5980411a724e8aaf7b61a7b5e386ec55a7fb49ee3d0ff79efc7e5e7c7e"
+checksum = "cdd4a624f609f8ea7366324724b7ff41cb0f982eb665a54ac825bc1c0efc07a3"
 dependencies = [
  "charset",
  "data-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ iroh = { version = "0.32", default-features = false }
 kamadak-exif = "0.6.1"
 lettre_email = { git = "https://github.com/deltachat/lettre", branch = "master" }
 libc = { workspace = true }
-mailparse = "0.15"
+mailparse = "0.16"
 mime = "0.3.17"
 num_cpus = "1.16"
 num-derive = "0.4"

--- a/src/html.rs
+++ b/src/html.rs
@@ -371,7 +371,6 @@ and will be wrapped as usual.<br/>
 mime-modified should not be set set as there is no html and no special stuff;<br/>
 although not being a delta-message.<br/>
 test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x27; :)<br/>
-<br/>
 </body></html>
 "#
         );
@@ -405,7 +404,6 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
             r##"<html>
   <p>mime-modified <b>set</b>; simplify is always regarded as lossy.</p>
 </html>
-
 "##
         );
     }
@@ -422,7 +420,6 @@ test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x
     this is <b>html</b>
   </p>
 </html>
-
 "##
         );
     }

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -379,13 +379,6 @@ pub fn pk_validate(
 
     let standalone_signature = StandaloneSignature::from_armor_single(Cursor::new(signature))?.0;
 
-    // Remove trailing CRLF before the delimiter.
-    // According to RFC 3156 it is considered to be part of the MIME delimiter for the purpose of
-    // OpenPGP signature calculation.
-    let content = content
-        .get(..content.len().saturating_sub(2))
-        .context("index is out of range")?;
-
     for pkey in public_keys_for_validation {
         if standalone_signature.verify(pkey, content).is_ok() {
             let fp = pkey.dc_fingerprint();


### PR DESCRIPTION
This change adds a test and updates mailparse from 0.15.0 to 0.16.0.
mailparse 0.16.0 includes a fix for the bug
that resulted in CRLF being included at the end of the body.
Workaround for the bug in the `pk_validate` function is also removed.

This fixes the problem https://github.com/staktrace/mailparse/issues/127
This PR is required for https://github.com/deltachat/deltachat-core-rust/pull/6492