### PR TITLE
fix: accept QR codes with 'broken' JSON

### DIFF
--- a/src/qr.rs
+++ b/src/qr.rs
@@ -22,6 +22,7 @@ use crate::message::Message;
 use crate::net::http::post_empty;
 use crate::net::proxy::{ProxyConfig, DEFAULT_SOCKS_PORT};
 use crate::peerstate::Peerstate;
+use crate::securejoin::fix_add_second_device_qr;
 use crate::token;
 use crate::tools::validate_id;
 
@@ -290,7 +291,8 @@ pub async fn check_qr(context: &Context, qr: &str) -> Result<Qr> {
     } else if qr.starts_with(SHADOWSOCKS_SCHEME) {
         decode_shadowsocks_proxy(qr)?
     } else if starts_with_ignore_case(qr, DCBACKUP2_SCHEME) {
-        decode_backup2(qr)?
+        let qr_fixed = fix_add_second_device_qr(qr);
+        decode_backup2(&qr_fixed)?
     } else if qr.starts_with(MAILTO_SCHEME) {
         decode_mailto(context, qr).await?
     } else if qr.starts_with(SMTP_SCHEME) {


### PR DESCRIPTION
this converts old QR codes to the new format, in an hacky, but simple way, see #6518 for more details and for code snippet

i tested in https://github.com/deltachat/deltachat-ios/pull/2595 that this actually fixes the problem, and there is no deeper issue with changed chashes or so - seemed not to be the case, at least, with this hack, core accepts QR codes from the released 1.52-and-before series

this hack gives user time to update, it can be removed after some months (we can also remove the old BACKUP qr code alltogether then)