### PR TITLE
fix: do not allow to edit html messages

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3141,6 +3141,7 @@ pub async fn send_edit_request(context: &Context, msg_id: MsgId, new_text: Strin
         "Can edit only own messages"
     );
     ensure!(!original_msg.is_info(), "Cannot edit info messages");
+    ensure!(!original_msg.has_html(), "Cannot edit HTML messages");
     ensure!(
         original_msg.viewtype != Viewtype::VideochatInvitation,
         "Cannot edit videochat invitations"

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3722,7 +3722,7 @@ async fn test_cannot_edit_html() -> Result<()> {
     msg.set_html(Some("<b>html</b> text".to_string()));
     send_msg(alice, chat.id, &mut msg).await.unwrap();
     assert!(msg.has_html());
-    assert!(send_edit_request(&alice, msg.id, "foo".to_string())
+    assert!(send_edit_request(alice, msg.id, "foo".to_string())
         .await
         .is_err());
 

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3710,3 +3710,21 @@ async fn test_receive_edit_request_after_removal() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_cannot_edit_html() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = &tcm.alice().await;
+    let bob = &tcm.bob().await;
+    let chat = alice.create_chat(bob).await;
+
+    let mut msg = Message::new_text("plain text".to_string());
+    msg.set_html(Some("<b>html</b> text".to_string()));
+    send_msg(alice, chat.id, &mut msg).await.unwrap();
+    assert!(msg.has_html());
+    assert!(send_edit_request(&alice, msg.id, "foo".to_string())
+        .await
+        .is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
closes https://github.com/deltachat/deltachat-core-rust/issues/6561