### PR TITLE
fix: make it impossible to overwrite default key

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/account.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/account.py
@@ -359,3 +359,7 @@ class Account:
         """Import keys."""
         passphrase = ""  # Importing passphrase-protected keys is currently not supported.
         self._rpc.import_self_keys(self.id, str(path), passphrase)
+
+    def initiate_autocrypt_key_transfer(self) -> None:
+        """Send Autocrypt Setup Message."""
+        return self._rpc.initiate_autocrypt_key_transfer(self.id)

--- a/deltachat-rpc-client/src/deltachat_rpc_client/message.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/message.py
@@ -52,6 +52,9 @@ class Message:
         """Mark the message as seen."""
         self._rpc.markseen_msgs(self.account.id, [self.id])
 
+    def continue_autocrypt_key_transfer(self, setup_code: str) -> None:
+        self._rpc.continue_autocrypt_key_transfer(self.account.id, self.id, setup_code)
+
     def send_webxdc_status_update(self, update: Union[dict, str], description: str) -> None:
         """Send a webxdc status update. This message must be a webxdc."""
         if not isinstance(update, str):

--- a/deltachat-rpc-client/tests/test_key_transfer.py
+++ b/deltachat-rpc-client/tests/test_key_transfer.py
@@ -1,0 +1,50 @@
+import pytest
+
+from deltachat_rpc_client import EventType
+from deltachat_rpc_client.rpc import JsonRpcError
+
+
+def wait_for_autocrypt_setup_message(account):
+    while True:
+        event = account.wait_for_event()
+        if event.kind == EventType.MSGS_CHANGED and event.msg_id != 0:
+            msg_id = event.msg_id
+            msg = account.get_message_by_id(msg_id)
+            if msg.get_snapshot().is_setupmessage:
+                return msg
+
+
+def test_autocrypt_setup_message_key_transfer(acfactory):
+    alice1 = acfactory.get_online_account()
+
+    alice2 = acfactory.get_unconfigured_account()
+    alice2.set_config("addr", alice1.get_config("addr"))
+    alice2.set_config("mail_pw", alice1.get_config("mail_pw"))
+    alice2.configure()
+
+    setup_code = alice1.initiate_autocrypt_key_transfer()
+    msg = wait_for_autocrypt_setup_message(alice2)
+
+    # Test that entering wrong code returns an error.
+    with pytest.raises(JsonRpcError):
+        msg.continue_autocrypt_key_transfer("7037-0673-6287-3013-4095-7956-5617-6806-6756")
+
+    msg.continue_autocrypt_key_transfer(setup_code)
+
+
+def test_ac_setup_message_twice(acfactory):
+    alice1 = acfactory.get_online_account()
+    alice2 = acfactory.get_unconfigured_account()
+    alice2.set_config("addr", alice1.get_config("addr"))
+    alice2.set_config("mail_pw", alice1.get_config("mail_pw"))
+    alice2.configure()
+
+    # Send the first Autocrypt Setup Message and ignore it.
+    _setup_code = alice1.initiate_autocrypt_key_transfer()
+    wait_for_autocrypt_setup_message(alice2)
+
+    # Send the second Autocrypt Setup Message and import it.
+    setup_code = alice1.initiate_autocrypt_key_transfer()
+    msg = wait_for_autocrypt_setup_message(alice2)
+
+    msg.continue_autocrypt_key_transfer(setup_code)

--- a/python/src/deltachat/message.py
+++ b/python/src/deltachat/message.py
@@ -215,7 +215,7 @@ class Message:
         """extract key and use it as primary key for this account."""
         res = lib.dc_continue_key_transfer(self.account._dc_context, self.id, as_dc_charpointer(setup_code))
         if res == 0:
-            raise ValueError("could not decrypt")
+            raise ValueError("Importing the key from Autocrypt Setup Message failed")
 
     @props.with_doc
     def time_sent(self):

--- a/python/tests/test_0_complex_or_slow.py
+++ b/python/tests/test_0_complex_or_slow.py
@@ -510,6 +510,7 @@ def test_see_new_verified_member_after_going_online(acfactory, tmp_path, lp):
     """
     ac1, ac2 = acfactory.get_online_accounts(2)
     ac2_addr = ac2.get_config("addr")
+    acfactory.remove_preconfigured_keys()
     ac1_offl = acfactory.new_online_configuring_account(cloned_from=ac1)
     for ac in [ac1, ac1_offl]:
         ac.set_config("bcc_self", "1")
@@ -560,6 +561,7 @@ def test_use_new_verified_group_after_going_online(acfactory, data, tmp_path, lp
       missing, cannot encrypt".
     """
     ac1, ac2 = acfactory.get_online_accounts(2)
+    acfactory.remove_preconfigured_keys()
     ac2_offl = acfactory.new_online_configuring_account(cloned_from=ac2)
     for ac in [ac2, ac2_offl]:
         ac.set_config("bcc_self", "1")
@@ -615,6 +617,7 @@ def test_verified_group_vs_delete_server_after(acfactory, tmp_path, lp):
     - Now the seconds device has all members verified.
     """
     ac1, ac2 = acfactory.get_online_accounts(2)
+    acfactory.remove_preconfigured_keys()
     ac2_offl = acfactory.new_online_configuring_account(cloned_from=ac2)
     for ac in [ac2, ac2_offl]:
         ac.set_config("bcc_self", "1")

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -38,7 +38,7 @@ use crate::provider::{Protocol, Socket, UsernamePattern};
 use crate::smtp::Smtp;
 use crate::sync::Sync::*;
 use crate::tools::time;
-use crate::{chat, e2ee, provider};
+use crate::{chat, provider};
 use crate::{stock_str, EventType};
 use deltachat_contact_tools::addr_cmp;
 
@@ -472,9 +472,6 @@ async fn configure(ctx: &Context, param: &EnteredLoginParam) -> Result<Configure
         .await?;
 
     progress!(ctx, 920);
-
-    e2ee::ensure_secret_key_exists(ctx).await?;
-    info!(ctx, "key generation completed");
 
     ctx.set_config_internal(Config::FetchedExistingMsgs, config::from_bool(false))
         .await?;

--- a/src/receive_imf/receive_imf_tests.rs
+++ b/src/receive_imf/receive_imf_tests.rs
@@ -4705,8 +4705,10 @@ async fn test_outgoing_msg_forgery() -> Result<()> {
     // We need Bob only to encrypt the forged message to Alice's key, actually Bob doesn't
     // participate in the scenario.
     let bob = &TestContext::new().await;
+    assert_eq!(crate::key::load_self_secret_keyring(bob).await?.len(), 0);
     bob.configure_addr("bob@example.net").await;
     imex(bob, ImexMode::ImportSelfKeys, export_dir.path(), None).await?;
+    assert_eq!(crate::key::load_self_secret_keyring(bob).await?.len(), 1);
     let malice = &TestContext::new().await;
     malice.configure_addr(alice_addr).await;
 
@@ -4714,6 +4716,7 @@ async fn test_outgoing_msg_forgery() -> Result<()> {
         .send_recv_accept(bob, malice, "hi from bob")
         .await
         .chat_id;
+    assert_eq!(crate::key::load_self_secret_keyring(bob).await?.len(), 1);
 
     let sent_msg = malice.send_text(malice_chat_id, "hi from malice").await;
     let msg = alice.recv_msg(&sent_msg).await;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -33,7 +33,7 @@ use crate::contact::{Contact, ContactId, Modifier, Origin};
 use crate::context::Context;
 use crate::e2ee::EncryptHelper;
 use crate::events::{Event, EventEmitter, EventType, Events};
-use crate::key::{self, DcKey, KeyPairUse};
+use crate::key::{self, DcKey};
 use crate::message::{update_msg_state, Message, MessageState, MsgId, Viewtype};
 use crate::mimeparser::{MimeMessage, SystemMessage};
 use crate::peerstate::Peerstate;
@@ -271,7 +271,7 @@ impl TestContextBuilder {
 
             let test_context = TestContext::new_internal(Some(name), self.log_sink).await;
             test_context.configure_addr(&addr).await;
-            key::store_self_keypair(&test_context, &key_pair, KeyPairUse::Default)
+            key::store_self_keypair(&test_context, &key_pair)
                 .await
                 .expect("Failed to save key");
             test_context


### PR DESCRIPTION
Replacing default key
when a profile is already part of
verified groups results in
`[The message was sent with non-verified encryption. See 'Info' for more details]` messages for other users.

It is still possible
to import the default key before
Delta Chat generates the key.