### PR TITLE
feat: Don't send a notification when a group member left

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/account.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/account.py
@@ -301,6 +301,13 @@ class Account:
             if event.kind == EventType.INCOMING_MSG:
                 return event
 
+    def wait_for_msgs_changed_event(self):
+        """Wait for messages changed event and return it."""
+        while True:
+            event = self.wait_for_event()
+            if event.kind == EventType.MSGS_CHANGED:
+                return event
+
     def wait_for_incoming_msg(self):
         """Wait for incoming message and return it.
 

--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -653,6 +653,8 @@ def test_withdraw_securejoin_qr(acfactory):
     bob_chat = bob.secure_join(qr_code)
     bob.wait_for_securejoin_joiner_success()
 
+    alice.clear_all_events()
+
     snapshot = bob.get_message_by_id(bob.wait_for_incoming_msg_event().msg_id).get_snapshot()
     assert snapshot.text == "Member Me ({}) added by {}.".format(bob.get_config("addr"), alice.get_config("addr"))
     assert snapshot.chat.get_basic_snapshot().is_protected

--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -658,7 +658,7 @@ def test_withdraw_securejoin_qr(acfactory):
     assert snapshot.chat.get_basic_snapshot().is_protected
     bob_chat.leave()
 
-    snapshot = alice.get_message_by_id(alice.wait_for_incoming_msg_event().msg_id).get_snapshot()
+    snapshot = alice.get_message_by_id(alice.wait_for_msgs_changed_event().msg_id).get_snapshot()
     assert snapshot.text == "Group left by {}.".format(bob.get_config("addr"))
 
     logging.info("Alice withdraws QR code.")

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1480,6 +1480,14 @@ impl ChatId {
             Result::<()>::Ok(())
         });
     }
+
+    pub(crate) async fn get_created_timestamp(&self, context: &Context) -> Result<i64> {
+        Ok(context
+            .sql
+            .query_get_value("SELECT created_timestamp FROM chats WHERE id=?;", (self,))
+            .await?
+            .unwrap_or(0))
+    }
 }
 
 impl std::fmt::Display for ChatId {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1048,10 +1048,10 @@ impl ChatId {
         Ok(count)
     }
 
-    pub(crate) async fn get_created_timestamp(self, context: &Context) -> Result<i64> {
+    pub(crate) async fn created_timestamp(self, context: &Context) -> Result<i64> {
         Ok(context
             .sql
-            .query_get_value("SELECT created_timestamp FROM chats WHERE id=?;", (self,))
+            .query_get_value("SELECT created_timestamp FROM chats WHERE id=?", (self,))
             .await?
             .unwrap_or(0))
     }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1409,21 +1409,7 @@ impl ChatId {
         let mut sort_timestamp = cmp::min(message_timestamp, smeared_time(context));
 
         let last_msg_time: Option<i64> = if always_sort_to_bottom {
-            // get newest message for this chat
-
-            // Let hidden messages also be ordered with protection messages because hidden messages
-            // also can be or not be verified, so let's preserve this information -- even it's not
-            // used currently, it can be useful in the future versions.
-            context
-                .sql
-                .query_get_value(
-                    "SELECT MAX(timestamp)
-                     FROM msgs
-                     WHERE chat_id=? AND state!=?
-                     HAVING COUNT(*) > 0",
-                    (self, MessageState::OutDraft),
-                )
-                .await?
+            self.get_last_msg_timestamp(context).await?
         } else if received {
             // Received messages shouldn't mingle with just sent ones and appear somewhere in the
             // middle of the chat, so we go after the newest non fresh message.
@@ -1469,6 +1455,31 @@ impl ChatId {
         Ok(sort_timestamp)
     }
 
+    pub(crate) async fn get_last_msg_timestamp(self, context: &Context) -> Result<Option<i64>> {
+        // Let hidden messages also be ordered with protection messages because hidden messages
+        // also can be or not be verified, so let's preserve this information -- even it's not
+        // used currently, it can be useful in the future versions.
+
+        context
+            .sql
+            .query_get_value(
+                "SELECT MAX(timestamp)
+                FROM msgs
+                WHERE chat_id=? AND state!=?
+                HAVING COUNT(*) > 0",
+                (self, MessageState::OutDraft),
+            )
+            .await
+    }
+
+    pub(crate) async fn get_created_timestamp(self, context: &Context) -> Result<i64> {
+        Ok(context
+            .sql
+            .query_get_value("SELECT created_timestamp FROM chats WHERE id=?;", (self,))
+            .await?
+            .unwrap_or(0))
+    }
+
     /// Spawns a task checking after a timeout whether the SecureJoin has finished for the 1:1 chat
     /// and otherwise notifying the user accordingly.
     pub(crate) fn spawn_securejoin_wait(self, context: &Context, timeout: u64) {
@@ -1479,14 +1490,6 @@ impl ChatId {
             chat.check_securejoin_wait(&context, 0).await?;
             Result::<()>::Ok(())
         });
-    }
-
-    pub(crate) async fn get_created_timestamp(&self, context: &Context) -> Result<i64> {
-        Ok(context
-            .sql
-            .query_get_value("SELECT created_timestamp FROM chats WHERE id=?;", (self,))
-            .await?
-            .unwrap_or(0))
     }
 }
 

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -720,6 +720,9 @@ async fn test_leave_group() -> Result<()> {
         .get_matching(|ev| match ev {
             EventType::Test => true,
             EventType::IncomingMsg { .. } => panic!("'Group left' message should be silent"),
+            EventType::MsgsNoticed(..) => {
+                panic!("'Group left' message shouldn't clear notifications")
+            }
             _ => false,
         })
         .await;

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -699,17 +699,20 @@ async fn test_leave_group() -> Result<()> {
     // that the 'Group left' message didn't trigger IncomingMsg:
     alice.evtracker.clear_events();
 
+    // Shift the time so that we can later check the 'Group left' message's timestamp:
+    SystemTime::shift(Duration::from_secs(60));
+
     // Bob leaves the group.
     let bob_chat_id = bob_msg.chat_id;
     bob_chat_id.accept(&bob).await?;
     remove_contact_from_chat(&bob, bob_chat_id, ContactId::SELF).await?;
 
     let leave_msg = bob.pop_sent_msg().await;
-    let rcvd = alice.recv_msg(&leave_msg).await;
+    let rcvd_leave_msg = alice.recv_msg(&leave_msg).await;
 
     assert_eq!(get_chat_contacts(&alice, alice_chat_id).await?.len(), 1);
 
-    assert_eq!(rcvd.state, MessageState::InSeen);
+    assert_eq!(rcvd_leave_msg.state, MessageState::InSeen);
 
     alice.emit_event(EventType::Test);
     alice
@@ -720,6 +723,13 @@ async fn test_leave_group() -> Result<()> {
             _ => false,
         })
         .await;
+
+    // The 'Group left' message timestamp should be the same as the previous message in the chat
+    // so that the chat is not popped up in the chatlist:
+    assert_eq!(
+        sent_msg.load_from_db().await.timestamp_sort,
+        rcvd_leave_msg.timestamp_sort
+    );
 
     Ok(())
 }

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -676,14 +676,7 @@ impl Peerstate {
                 let lastmsg = Message::load_from_db(context, *msg_id).await?;
                 lastmsg.timestamp_sort
             } else {
-                context
-                    .sql
-                    .query_get_value(
-                        "SELECT created_timestamp FROM chats WHERE id=?;",
-                        (chat_id,),
-                    )
-                    .await?
-                    .unwrap_or(0)
+                chat_id.get_created_timestamp(context).await?
             };
 
             if let PeerstateChange::Aeap(new_addr) = &change {

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -676,7 +676,7 @@ impl Peerstate {
                 let lastmsg = Message::load_from_db(context, *msg_id).await?;
                 lastmsg.timestamp_sort
             } else {
-                chat_id.get_created_timestamp(context).await?
+                chat_id.created_timestamp(context).await?
             };
 
             if let PeerstateChange::Aeap(new_addr) = &change {

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1825,7 +1825,7 @@ async fn tweak_sort_timestamp(
     // set the timestamp to be no more than the same as last message
     // so that the chat is not sorted to the top of the chatlist.
     if silent {
-        let last_msg_timestamp = if let Some(t) = chat_id.get_last_msg_timestamp(context).await? {
+        let last_msg_timestamp = if let Some(t) = chat_id.get_timestamp(context).await? {
             t
         } else {
             chat_id.get_created_timestamp(context).await?

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1396,22 +1396,14 @@ async fn add_parts(
         }
     }
 
-    // Ensure replies to messages are sorted after the parent message.
-    //
-    // This is useful in a case where sender clocks are not
-    // synchronized and parent message has a Date: header with a
-    // timestamp higher than reply timestamp.
-    //
-    // This does not help if parent message arrives later than the
-    // reply.
-    let parent_timestamp = mime_parser.get_parent_timestamp(context).await?;
-    let sort_timestamp = if group_changes.silent {
-        get_last_msg_timestamp(context, chat_id).await?
-    } else {
-        parent_timestamp.map_or(sort_timestamp, |parent_timestamp| {
-            std::cmp::max(sort_timestamp, parent_timestamp)
-        })
-    };
+    let sort_timestamp = tweak_sort_timestamp(
+        context,
+        mime_parser,
+        group_changes.silent,
+        chat_id,
+        sort_timestamp,
+    )
+    .await?;
 
     // if the mime-headers should be saved, find out its size
     // (the mime-header ends with an empty line)
@@ -1809,24 +1801,38 @@ RETURNING id
     })
 }
 
-async fn get_last_msg_timestamp(context: &Context, chat_id: ChatId) -> Result<i64> {
-    let last_msg_timestamp = context
-        .sql
-        .query_get_value(
-            "SELECT id
-FROM msgs
-WHERE chat_id=?
-AND hidden=0
-ORDER BY timestamp DESC, id DESC LIMIT 1",
-            (chat_id,),
-        )
-        .await?;
+async fn tweak_sort_timestamp(
+    context: &Context,
+    mime_parser: &mut MimeMessage,
+    silent: bool,
+    chat_id: ChatId,
+    sort_timestamp: i64,
+) -> Result<i64> {
+    // Ensure replies to messages are sorted after the parent message.
+    //
+    // This is useful in a case where sender clocks are not
+    // synchronized and parent message has a Date: header with a
+    // timestamp higher than reply timestamp.
+    //
+    // This does not help if parent message arrives later than the
+    // reply.
+    let parent_timestamp = mime_parser.get_parent_timestamp(context).await?;
+    let mut sort_timestamp = parent_timestamp.map_or(sort_timestamp, |parent_timestamp| {
+        std::cmp::max(sort_timestamp, parent_timestamp)
+    });
 
-    Ok(if let Some(t) = last_msg_timestamp {
-        t
-    } else {
-        chat_id.get_created_timestamp(context).await?
-    })
+    // If the message should be silent,
+    // set the timestamp to be no more than the same as last message
+    // so that the chat is not sorted to the top of the chatlist.
+    if silent {
+        let last_msg_timestamp = if let Some(t) = chat_id.get_last_msg_timestamp(context).await? {
+            t
+        } else {
+            chat_id.get_created_timestamp(context).await?
+        };
+        sort_timestamp = std::cmp::min(sort_timestamp, last_msg_timestamp);
+    }
+    Ok(sort_timestamp)
 }
 
 /// Saves attached locations to the database.


### PR DESCRIPTION
When there is a broken group (which might happen with multi-transport), people want to leave it.

The problem is that every "Group left" message notifies all other members and pops up the chat, so that other members also want to leave the group.

This PR makes it so that "Group left" messages don't create a notification, don't cause a number-in-a-cirle badge counter on the chat, and don't sort up the chat in the chatlist.

If a group is deleted, then the group won't pop up when someone leaves it; this worked fine already before this PR, and there also is a test for it.