### PR TITLE
fix: update mailparse to 0.16.1 to fix panic when parsing a message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3451,9 +3451,9 @@ source = "git+https://github.com/stalwartlabs/mail-builder?branch=main#b86e558d5
 
 [[package]]
 name = "mailparse"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd4a624f609f8ea7366324724b7ff41cb0f982eb665a54ac825bc1c0efc07a3"
+checksum = "60819a97ddcb831a5614eb3b0174f3620e793e97e09195a395bfa948fd68ed2f"
 dependencies = [
  "charset",
  "data-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ iroh = { version = "0.32", default-features = false }
 kamadak-exif = "0.6.1"
 libc = { workspace = true }
 mail-builder = { git = "https://github.com/stalwartlabs/mail-builder", branch = "main", default-features = false }
-mailparse = "0.16"
+mailparse = "0.16.1"
 mime = "0.3.17"
 num_cpus = "1.16"
 num-derive = "0.4"

--- a/src/mimeparser/mimeparser_tests.rs
+++ b/src/mimeparser/mimeparser_tests.rs
@@ -312,6 +312,19 @@ fn test_mailparse_content_type() {
     );
 }
 
+/// Test to reproduce
+/// <https://github.com/staktrace/mailparse/issues/130>.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mailparse_0_16_0_panic() {
+    let context = TestContext::new_alice().await;
+    let raw = include_bytes!("../../test-data/message/mailparse-0.16.0-panic.eml");
+
+    // There should be an error, but no panic.
+    assert!(MimeMessage::from_bytes(&context.ctx, &raw[..], None)
+        .await
+        .is_err());
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_parse_first_addr() {
     let context = TestContext::new().await;

--- a/test-data/message/mailparse-0.16.0-panic.eml
+++ b/test-data/message/mailparse-0.16.0-panic.eml
@@ -1,0 +1,3 @@
+Content-Type: multipart/mixed; boundary="foobar"
+
+--foobar--


### PR DESCRIPTION
Fixes #6581 