### PR TITLE
fix: upgrade native-tls from 0.2.13 to 0.2.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3593,9 +3593,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",


### PR DESCRIPTION
Fixes #6590 

This fixes the problem introduced by upgrading native-tls from 0.2.11 to 0.2.13 that prevented using OpenSSL on Android.