### PR TITLE
build: use mailbuilder from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3446,8 +3446,9 @@ checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 
 [[package]]
 name = "mail-builder"
-version = "0.4.1"
-source = "git+https://github.com/stalwartlabs/mail-builder?branch=main#b86e558d54d43c1c1991fbda84109268815abcac"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5666db60ccc742381c715c8daf303e60d266f1d1c8b123ab3fe78b590edaf564"
 
 [[package]]
 name = "mailparse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ iroh-gossip = { version = "0.32", default-features = false, features = ["net"] }
 iroh = { version = "0.32", default-features = false }
 kamadak-exif = "0.6.1"
 libc = { workspace = true }
-mail-builder = { git = "https://github.com/stalwartlabs/mail-builder", branch = "main", default-features = false }
+mail-builder = { version = "0.4.2", default-features = false }
 mailparse = "0.16.1"
 mime = "0.3.17"
 num_cpus = "1.16"

--- a/deny.toml
+++ b/deny.toml
@@ -92,9 +92,3 @@ expression = "MIT AND ISC AND OpenSSL"
 license-files = [
       { path = "LICENSE", hash = 0xbd0eed23 },
 ]
-
-[sources.allow-org]
-# Organisations which we allow git sources from.
-github = [
-       "stalwartlabs",
-]


### PR DESCRIPTION
This gets rid of the last git dependency.