### PR TITLE
api(deltachat-rpc-client): make it possible to clone accounts

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/account.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/account.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Optional, Union
 from warnings import warn
 
@@ -37,6 +39,16 @@ class Account:
     def remove(self) -> None:
         """Remove the account."""
         self._rpc.remove_account(self.id)
+
+    def clone(self) -> "Account":
+        """Clone given account."""
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            self.export_backup(tmp_path)
+            files = list(tmp_path.glob("*.tar"))
+            new_account = self.manager.add_account()
+            new_account.import_backup(files[0])
+            return new_account
 
     def start_io(self) -> None:
         """Start the account I/O."""

--- a/deltachat-rpc-client/tests/test_chatlist_events.py
+++ b/deltachat-rpc-client/tests/test_chatlist_events.py
@@ -157,11 +157,7 @@ def get_multi_account_test_setup(acfactory: ACFactory) -> [Account, Account, Acc
 
     bob.wait_for_incoming_msg_event()
 
-    alice_second_device: Account = acfactory.get_unconfigured_account()
-
-    alice._rpc.provide_backup.future(alice.id)
-    backup_code = alice._rpc.get_backup_qr(alice.id)
-    alice_second_device._rpc.get_backup(alice_second_device.id, backup_code)
+    alice_second_device = alice.clone()
     alice_second_device.start_io()
     alice.clear_all_events()
     alice_second_device.clear_all_events()

--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -60,15 +60,12 @@ def test_qr_setup_contact_svg(acfactory) -> None:
 
 
 @pytest.mark.parametrize("protect", [True, False])
-def test_qr_securejoin(acfactory, protect, tmp_path):
+def test_qr_securejoin(acfactory, protect):
     alice, bob, fiona = acfactory.get_online_accounts(3)
 
     # Setup second device for Alice
     # to test observing securejoin protocol.
-    alice.export_backup(tmp_path)
-    files = list(tmp_path.glob("*.tar"))
-    alice2 = acfactory.get_unconfigured_account()
-    alice2.import_backup(files[0])
+    alice2 = alice.clone()
 
     logging.info("Alice creates a group")
     alice_chat = alice.create_group("Group", protect=protect)

--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -287,12 +287,9 @@ def test_message(acfactory) -> None:
     assert reactions == snapshot.reactions
 
 
-def test_reaction_seen_on_another_dev(acfactory, tmp_path) -> None:
+def test_reaction_seen_on_another_dev(acfactory) -> None:
     alice, bob = acfactory.get_online_accounts(2)
-    alice.export_backup(tmp_path)
-    files = list(tmp_path.glob("*.tar"))
-    alice2 = acfactory.get_unconfigured_account()
-    alice2.import_backup(files[0])
+    alice2 = alice.clone()
     alice2.start_io()
 
     bob_addr = bob.get_config("addr")
@@ -661,7 +658,7 @@ def test_download_limit_chat_assignment(acfactory, tmp_path, n_accounts):
             assert snapshot.chat == bob_chat_alice
 
 
-def test_markseen_contact_request(acfactory, tmp_path):
+def test_markseen_contact_request(acfactory):
     """
     Test that seen status is synchronized for contact request messages
     even though read receipt is not sent.
@@ -669,10 +666,7 @@ def test_markseen_contact_request(acfactory, tmp_path):
     alice, bob = acfactory.get_online_accounts(2)
 
     # Bob sets up a second device.
-    bob.export_backup(tmp_path)
-    files = list(tmp_path.glob("*.tar"))
-    bob2 = acfactory.get_unconfigured_account()
-    bob2.import_backup(files[0])
+    bob2 = bob.clone()
     bob2.start_io()
 
     alice_chat_bob = alice.create_chat(bob)


### PR DESCRIPTION
This is mostly to make tests cleaner. I also want to move some legacy python tests into deltachat-rpc-client, this is going to be useful.