### PR TITLE
build(deltachat-rpc-client): move development dependencies from tox.ini to pyproject.toml

### DIFF
--- a/deltachat-rpc-client/pyproject.toml
+++ b/deltachat-rpc-client/pyproject.toml
@@ -70,3 +70,11 @@ line-length = 120
 
 [tool.isort]
 profile = "black"
+
+[dependency-groups]
+dev = [
+    "imap-tools",
+    "pytest",
+    "pytest-timeout",
+    "pytest-xdist",
+]

--- a/deltachat-rpc-client/tox.ini
+++ b/deltachat-rpc-client/tox.ini
@@ -12,11 +12,8 @@ setenv =
     RUST_MIN_STACK=8388608
 passenv =
     CHATMAIL_DOMAIN
-deps =
-    pytest
-    pytest-timeout
-    pytest-xdist
-    imap-tools
+dependency_groups =
+    dev
 
 [testenv:lint]
 skipsdist = True


### PR DESCRIPTION
`dev` dependency group is supported by [`uv`](https://docs.astral.sh/uv/) out of the box, so `uv sync` creates a `.venv` with all dev dependencies installed unless you explicitly pass `--no-dev` argument.

`tox` supports dependency groups since https://github.com/tox-dev/tox/pull/3409

This does not change anything for `scripts/make-rpc-testenv.sh` and `tox` users.