### PR TITLE
fix: update async-compression to 0.4.21 to fix IMAP COMPRESS getting stuck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.18"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+checksum = "c0cf008e5e1a9e9e22a7d3c9a4992e21a350290069e36d8fb72304ed17e8f2d2"
 dependencies = [
  "flate2",
  "futures-core",


### PR DESCRIPTION
async-compression 0.4.21 fixes a bug in the encoder where it did not flush all the internal state sometimes, resulting in IMAP APPEND command timing out
waiting for response when uploading large sync messages.

See <https://github.com/Nullus157/async-compression/pull/333> for details.

Closes #6656