### PR TITLE
build: remove encoded-words dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,12 +510,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
@@ -1397,7 +1391,6 @@ dependencies = [
  "deltachat-contact-tools",
  "deltachat-time",
  "deltachat_derive",
- "encoded-words",
  "escaper",
  "fast-socks5",
  "fd-lock",
@@ -1893,21 +1886,6 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
-
-[[package]]
-name = "encoded-words"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1693107e6084e2b9444d34a985697f56c8832d314924d5cfb1fb7793154bef"
-dependencies = [
- "base64 0.12.3",
- "charset",
- "encoding_rs",
- "hex",
- "lazy_static",
- "regex",
- "thiserror 1.0.69",
-]
 
 [[package]]
 name = "encoding_rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ brotli = { version = "7", default-features=false, features = ["std"] }
 bytes = "1"
 chrono = { workspace = true, features = ["alloc", "clock", "std"] }
 data-encoding = "2.7.0"
-encoded-words = "0.2"
 escaper = "0.1"
 fast-socks5 = "0.10"
 fd-lock = "4"

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -713,12 +713,11 @@ impl MimeFactory {
 
         if let Loaded::Message { chat, .. } = &self.loaded {
             if chat.typ == Chattype::Broadcast {
-                let encoded_chat_name = encode_words(&chat.name);
                 headers.push((
                     "List-ID",
-                    mail_builder::headers::raw::Raw::new(format!(
-                        "{encoded_chat_name} <{}>",
-                        chat.grpid
+                    mail_builder::headers::text::Text::new(format!(
+                        "{} <{}>",
+                        chat.name, chat.grpid
                     ))
                     .into(),
                 ));
@@ -1746,14 +1745,6 @@ fn render_rfc724_mid(rfc724_mid: &str) -> String {
     } else {
         format!("<{rfc724_mid}>")
     }
-}
-
-/* ******************************************************************************
- * Encode/decode header words, RFC 2047
- ******************************************************************************/
-
-fn encode_words(word: &str) -> String {
-    encoded_words::encode(word, None, encoded_words::EncodingFlag::Shortest, None)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
mail-builder is doing its own encoding.