### PR TITLE
feat(securejoin): do not create 1:1 chat on Alice's side until vc-request-with-auth

### DIFF
--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -334,12 +334,6 @@ pub(crate) async fn handle_securejoin_handshake(
 
             inviter_progress(context, contact_id, 300);
 
-            // for setup-contact, make Alice's one-to-one chat with Bob visible
-            // (secure-join-information are shown in the group chat)
-            if !join_vg {
-                ChatId::create_for_contact(context, contact_id).await?;
-            }
-
             // Alice -> Bob
             send_alice_handshake_msg(
                 context,
@@ -435,6 +429,11 @@ pub(crate) async fn handle_securejoin_handshake(
             }
             contact_id.regossip_keys(context).await?;
             ContactId::scaleup_origin(context, &[contact_id], Origin::SecurejoinInvited).await?;
+            // for setup-contact, make Alice's one-to-one chat with Bob visible
+            // (secure-join-information are shown in the group chat)
+            if !join_vg {
+                ChatId::create_for_contact(context, contact_id).await?;
+            }
             info!(context, "Auth verified.",);
             context.emit_event(EventType::ContactsChanged(Some(contact_id)));
             inviter_progress(context, contact_id, 600);

--- a/src/securejoin/securejoin_tests.rs
+++ b/src/securejoin/securejoin_tests.rs
@@ -129,7 +129,7 @@ async fn test_setup_contact_ex(case: SetupContactCase) {
             .await
             .unwrap()
             .len(),
-        1
+        0
     );
 
     let sent = alice.pop_sent_msg().await;


### PR DESCRIPTION
vc-request is an unencrypted message
that Bob sends when he does not have Alice's key.
It also does not contain
Bob's avatar and name,
so the contact has only the email address
at this point and it is too early
to show it.