### PR TITLE
fix: do not fail to send the message if some keys are missing

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1732,6 +1732,10 @@ pub async fn delete_msgs_ex(
             !delete_for_all || msg.from_id == ContactId::SELF,
             "Can delete only own messages for others"
         );
+        ensure!(
+            !delete_for_all || msg.get_showpadlock(),
+            "Cannot request deletion of unencrypted message for others"
+        );
 
         modified_chat_ids.insert(msg.chat_id);
         deleted_rfc724_mid.push(msg.rfc724_mid.clone());

--- a/src/receive_imf/receive_imf_tests.rs
+++ b/src/receive_imf/receive_imf_tests.rs
@@ -4924,11 +4924,10 @@ async fn test_protected_group_add_remove_member_missing_key() -> Result<()> {
     let fiona_addr = fiona.get_config(Config::Addr).await?.unwrap();
     mark_as_verified(alice, fiona).await;
     let alice_fiona_id = alice.add_or_lookup_contact(fiona).await.id;
-    assert!(add_contact_to_chat(alice, group_id, alice_fiona_id)
-        .await
-        .is_err());
-    // Sending the message failed,
-    // but member is added to the chat locally already.
+    add_contact_to_chat(alice, group_id, alice_fiona_id).await?;
+
+    // The message is not sent to Bob,
+    // but member is added to the chat locally anyway.
     assert!(is_contact_in_chat(alice, group_id, alice_fiona_id).await?);
     let msg = alice.get_last_msg_in(group_id).await;
     assert!(msg.is_info());
@@ -4936,10 +4935,6 @@ async fn test_protected_group_add_remove_member_missing_key() -> Result<()> {
         msg.get_text(),
         stock_str::msg_add_member_local(alice, &fiona_addr, ContactId::SELF).await
     );
-
-    // Now the chat has a message "You added member fiona@example.net. [INFO] !!" (with error) that
-    // may be confusing, but if the error is displayed in UIs, it's more or less ok. This is not a
-    // normal scenario anyway.
 
     remove_contact_from_chat(alice, group_id, alice_bob_id).await?;
     assert!(!is_contact_in_chat(alice, group_id, alice_bob_id).await?);
@@ -4949,7 +4944,6 @@ async fn test_protected_group_add_remove_member_missing_key() -> Result<()> {
         msg.get_text(),
         stock_str::msg_del_member_local(alice, &bob_addr, ContactId::SELF,).await
     );
-    assert!(msg.error().is_some());
     Ok(())
 }
 


### PR DESCRIPTION
There is no error displayed. We could call `set_msg_failed()`, but the error will be immediately removed because the message is "delivered" to the SMTP server. Maybe it is actually not that bad that there is no warning about the missing key, because it usually happens in large group chats with users frequently joining anyway and a few missing messages until the new user writes something are not a big problem.

Closes #6525 