### PR TITLE
test: use encryption in more Rust tests

### DIFF
--- a/test-data/golden/receive_imf_delayed_removal_is_ignored
+++ b/test-data/golden/receive_imf_delayed_removal_is_ignored
@@ -1,9 +1,9 @@
 Group#Chat#10: Group [5 member(s)] 
 --------------------------------------------------------------------------------
-Msg#10: Me (Contact#Contact#Self): populate  √
+Msg#10🔒: Me (Contact#Contact#Self): populate  √
 Msg#11: info (Contact#Contact#Info): Member blue@example.net added. [NOTICED][INFO]
-Msg#12: info (Contact#Contact#Info): Member fiona (fiona@example.net) removed. [NOTICED][INFO]
-Msg#13: bob (Contact#Contact#11): Member orange@example.net added by bob (bob@example.net). [FRESH][INFO]
-Msg#14: Me (Contact#Contact#Self): You added member fiona (fiona@example.net). [INFO] o
-Msg#15: bob (Contact#Contact#11): Member fiona (fiona@example.net) removed by bob (bob@example.net). [FRESH][INFO]
+Msg#12: info (Contact#Contact#Info): Member fiona@example.net removed. [NOTICED][INFO]
+Msg#13:  (Contact#Contact#10): Member orange@example.net added by bob@example.net. [FRESH][INFO]
+Msg#14: Me (Contact#Contact#Self): You added member fiona@example.net. [INFO] o
+Msg#15🔒:  (Contact#Contact#10): Member fiona@example.net removed by bob@example.net. [FRESH][INFO]
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This fixes more tests that break if we encrypt all chats with chat ID, but not all yet.