### PR TITLE
test: use encryption in all JSON-RPC online tests

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
@@ -79,7 +79,7 @@ class ACFactory:
     ) -> Message:
         if not from_account:
             from_account = (self.get_online_accounts(1))[0]
-        to_contact = from_account.create_contact(to_account.get_config("addr"))
+        to_contact = from_account.create_contact(to_account)
         if group:
             to_chat = from_account.create_group(group)
             to_chat.add_contact(to_contact)

--- a/deltachat-rpc-client/tests/test_vcard.py
+++ b/deltachat-rpc-client/tests/test_vcard.py
@@ -1,8 +1,7 @@
 def test_vcard(acfactory) -> None:
     alice, bob = acfactory.get_online_accounts(2)
 
-    bob_addr = bob.get_config("addr")
-    alice_contact_bob = alice.create_contact(bob_addr, "Bob")
+    alice_contact_bob = alice.create_contact(bob, "Bob")
     alice_contact_charlie = alice.create_contact("charlie@example.org", "Charlie")
 
     alice_chat_bob = alice_contact_bob.create_chat()

--- a/deltachat-rpc-client/tests/test_webxdc.py
+++ b/deltachat-rpc-client/tests/test_webxdc.py
@@ -1,8 +1,7 @@
 def test_webxdc(acfactory) -> None:
     alice, bob = acfactory.get_online_accounts(2)
 
-    bob_addr = bob.get_config("addr")
-    alice_contact_bob = alice.create_contact(bob_addr, "Bob")
+    alice_contact_bob = alice.create_contact(bob, "Bob")
     alice_chat_bob = alice_contact_bob.create_chat()
     alice_chat_bob.send_message(text="Let's play chess!", file="../test-data/webxdc/chess.xdc")
 
@@ -45,8 +44,7 @@ def test_webxdc(acfactory) -> None:
 def test_webxdc_insert_lots_of_updates(acfactory) -> None:
     alice, bob = acfactory.get_online_accounts(2)
 
-    bob_addr = bob.get_config("addr")
-    alice_contact_bob = alice.create_contact(bob_addr, "Bob")
+    alice_contact_bob = alice.create_contact(bob, "Bob")
     alice_chat_bob = alice_contact_bob.create_chat()
     message = alice_chat_bob.send_message(text="Let's play chess!", file="../test-data/webxdc/chess.xdc")
 


### PR DESCRIPTION
This makes all JSON-RPC tests pass against the server that requires encryption.