### PR TITLE
Remove fetch_existing_msgs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -182,12 +182,6 @@ pub enum Config {
     #[strum(props(default = "0"))] // also change MediaQuality.default() on changes
     MediaQuality,
 
-    /// If set to "1", on the first time `start_io()` is called after configuring,
-    /// the newest existing messages are fetched.
-    /// Existing recipients are added to the contact database regardless of this setting.
-    #[strum(props(default = "0"))]
-    FetchExistingMsgs,
-
     /// If set to "1", then existing messages are considered to be already fetched.
     /// This flag is reset after successful configuration.
     #[strum(props(default = "1"))]
@@ -707,7 +701,6 @@ impl Context {
             | Config::SentboxWatch
             | Config::MvboxMove
             | Config::OnlyFetchMvbox
-            | Config::FetchExistingMsgs
             | Config::DeleteToTrash
             | Config::Configured
             | Config::Bot

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -178,9 +178,6 @@ pub const DC_LP_AUTH_NORMAL: i32 = 0x4;
 /// if none of these flags are set, the default is chosen
 pub const DC_LP_AUTH_FLAGS: i32 = DC_LP_AUTH_OAUTH2 | DC_LP_AUTH_NORMAL;
 
-/// How many existing messages shall be fetched after configuration.
-pub(crate) const DC_FETCH_EXISTING_MSGS_COUNT: i64 = 100;
-
 // max. weight of images to send w/o recoding
 pub const BALANCED_IMAGE_BYTES: usize = 500_000;
 pub const WORSE_IMAGE_BYTES: usize = 130_000;

--- a/src/context.rs
+++ b/src/context.rs
@@ -904,12 +904,6 @@ impl Context {
 
         res.insert("secondary_addrs", secondary_addrs);
         res.insert(
-            "fetch_existing_msgs",
-            self.get_config_int(Config::FetchExistingMsgs)
-                .await?
-                .to_string(),
-        );
-        res.insert(
             "fetched_existing_msgs",
             self.get_config_bool(Config::FetchedExistingMsgs)
                 .await?

--- a/src/download.rs
+++ b/src/download.rs
@@ -220,7 +220,6 @@ impl Session {
                 vec![uid],
                 &uid_message_ids,
                 false,
-                false,
             )
             .await?;
         if last_uid.is_none() {
@@ -369,7 +368,6 @@ mod tests {
             header.as_bytes(),
             false,
             Some(100000),
-            false,
         )
         .await?;
         let msg = t.get_last_msg().await;
@@ -385,7 +383,6 @@ mod tests {
             format!("{header}\n\n100k text...").as_bytes(),
             false,
             None,
-            false,
         )
         .await?;
         let msg = t.get_last_msg().await;
@@ -420,7 +417,6 @@ mod tests {
                     Content-Type: text/plain",
             false,
             Some(100000),
-            false,
         )
         .await?;
         assert_eq!(
@@ -457,7 +453,6 @@ mod tests {
             sent2.payload().as_bytes(),
             false,
             Some(sent2.payload().len() as u32),
-            false,
         )
         .await?;
         let msg = bob.get_last_msg().await;
@@ -473,7 +468,6 @@ mod tests {
             sent2.payload().as_bytes(),
             false,
             None,
-            false,
         )
         .await?;
         assert_eq!(get_chat_msgs(&bob, chat_id).await?.len(), 0);
@@ -517,15 +511,7 @@ mod tests {
             ";
 
         // not downloading the mdn results in an placeholder
-        receive_imf_from_inbox(
-            &bob,
-            "bar@example.org",
-            raw,
-            false,
-            Some(raw.len() as u32),
-            false,
-        )
-        .await?;
+        receive_imf_from_inbox(&bob, "bar@example.org", raw, false, Some(raw.len() as u32)).await?;
         let msg = bob.get_last_msg().await;
         let chat_id = msg.chat_id;
         assert_eq!(get_chat_msgs(&bob, chat_id).await?.len(), 1);
@@ -533,7 +519,7 @@ mod tests {
 
         // downloading the mdn afterwards expands to nothing and deletes the placeholder directly
         // (usually mdn are too small for not being downloaded directly)
-        receive_imf_from_inbox(&bob, "bar@example.org", raw, false, None, false).await?;
+        receive_imf_from_inbox(&bob, "bar@example.org", raw, false, None).await?;
         assert_eq!(get_chat_msgs(&bob, chat_id).await?.len(), 0);
         assert!(Message::load_from_db_optional(&bob, msg.id)
             .await?

--- a/src/imap/session.rs
+++ b/src/imap/session.rs
@@ -1,4 +1,3 @@
-use std::cmp;
 use std::collections::BTreeMap;
 use std::ops::{Deref, DerefMut};
 
@@ -7,7 +6,6 @@ use async_imap::types::Mailbox;
 use async_imap::Session as ImapSession;
 use futures::TryStreamExt;
 
-use crate::constants::DC_FETCH_EXISTING_MSGS_COUNT;
 use crate::imap::capabilities::Capabilities;
 use crate::net::session::SessionStream;
 
@@ -138,35 +136,6 @@ impl Session {
                 if msg_uid >= uid_next {
                     msgs.insert((msg.internal_date(), msg_uid), msg);
                 }
-            }
-        }
-
-        Ok(msgs.into_iter().map(|((_, uid), msg)| (uid, msg)).collect())
-    }
-
-    /// Like prefetch(), but not for new messages but existing ones (the DC_FETCH_EXISTING_MSGS_COUNT newest messages)
-    pub(crate) async fn prefetch_existing_msgs(
-        &mut self,
-    ) -> Result<Vec<(u32, async_imap::types::Fetch)>> {
-        let exists: i64 = {
-            let mailbox = self.selected_mailbox.as_ref().context("no mailbox")?;
-            mailbox.exists.into()
-        };
-
-        // Fetch last DC_FETCH_EXISTING_MSGS_COUNT (100) messages.
-        // Sequence numbers are sequential. If there are 1000 messages in the inbox,
-        // we can fetch the sequence numbers 900-1000 and get the last 100 messages.
-        let first = cmp::max(1, exists - DC_FETCH_EXISTING_MSGS_COUNT + 1);
-        let set = format!("{first}:{exists}");
-        let mut list = self
-            .fetch(&set, PREFETCH_FLAGS)
-            .await
-            .context("IMAP Could not fetch")?;
-
-        let mut msgs = BTreeMap::new();
-        while let Some(msg) = list.try_next().await? {
-            if let Some(msg_uid) = msg.uid {
-                msgs.insert((msg.internal_date(), msg_uid), msg);
             }
         }
 

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -900,7 +900,6 @@ Here's my footer -- bob@example.net"
             msg_header.as_bytes(),
             false,
             Some(100000),
-            false,
         )
         .await?
         .unwrap();
@@ -931,7 +930,6 @@ Here's my footer -- bob@example.net"
             msg_full.as_bytes(),
             false,
             None,
-            false,
         )
         .await?;
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -98,12 +98,11 @@ pub async fn receive_imf(
                 head.as_bytes(),
                 seen,
                 Some(imf_raw.len().try_into()?),
-                false,
             )
             .await;
         }
     }
-    receive_imf_from_inbox(context, &rfc724_mid, imf_raw, seen, None, false).await
+    receive_imf_from_inbox(context, &rfc724_mid, imf_raw, seen, None).await
 }
 
 /// Emulates reception of a message from "INBOX".
@@ -116,7 +115,6 @@ pub(crate) async fn receive_imf_from_inbox(
     imf_raw: &[u8],
     seen: bool,
     is_partial_download: Option<u32>,
-    fetching_existing_messages: bool,
 ) -> Result<Option<ReceivedMsg>> {
     receive_imf_inner(
         context,
@@ -127,7 +125,6 @@ pub(crate) async fn receive_imf_from_inbox(
         imf_raw,
         seen,
         is_partial_download,
-        fetching_existing_messages,
     )
     .await
 }
@@ -171,7 +168,6 @@ pub(crate) async fn receive_imf_inner(
     imf_raw: &[u8],
     seen: bool,
     is_partial_download: Option<u32>,
-    fetching_existing_messages: bool,
 ) -> Result<Option<ReceivedMsg>> {
     if std::env::var(crate::DCC_MIME_DEBUG).is_ok() {
         info!(
@@ -444,7 +440,6 @@ pub(crate) async fn receive_imf_inner(
             seen,
             is_partial_download,
             replace_msg_id,
-            fetching_existing_messages,
             prevent_rename,
             verified_encryption,
         )
@@ -718,13 +713,10 @@ async fn add_parts(
     seen: bool,
     is_partial_download: Option<u32>,
     mut replace_msg_id: Option<MsgId>,
-    fetching_existing_messages: bool,
     prevent_rename: bool,
     verified_encryption: VerifiedEncryption,
 ) -> Result<ReceivedMsg> {
     let is_bot = context.get_config_bool(Config::Bot).await?;
-    // Bots handle existing messages the same way as new ones.
-    let fetching_existing_messages = fetching_existing_messages && !is_bot;
     let rfc724_mid_orig = &mime_parser
         .get_rfc724_mid()
         .unwrap_or(rfc724_mid.to_string());
@@ -1043,11 +1035,7 @@ async fn add_parts(
             }
         }
 
-        state = if seen
-            || fetching_existing_messages
-            || is_mdn
-            || chat_id_blocked == Blocked::Yes
-            || group_changes.silent
+        state = if seen || is_mdn || chat_id_blocked == Blocked::Yes || group_changes.silent
         // No check for `hidden` because only reactions are such and they should be `InFresh`.
         {
             MessageState::InSeen
@@ -1114,7 +1102,7 @@ async fn add_parts(
             }
         }
 
-        if mime_parser.decrypting_failed && !fetching_existing_messages {
+        if mime_parser.decrypting_failed {
             if chat_id.is_none() {
                 chat_id = Some(DC_CHAT_ID_TRASH);
             } else {
@@ -1238,12 +1226,6 @@ async fn add_parts(
                 chat.id.unblock_ex(context, Nosync).await?;
             }
         }
-    }
-
-    if fetching_existing_messages && mime_parser.decrypting_failed {
-        chat_id = Some(DC_CHAT_ID_TRASH);
-        // We are only gathering old messages on first start. We do not want to add loads of non-decryptable messages to the chats.
-        info!(context, "Existing non-decipherable message (TRASH).");
     }
 
     if mime_parser.webxdc_status_update.is_some() && mime_parser.parts.len() == 1 {
@@ -1508,7 +1490,7 @@ async fn add_parts(
     while let Some(part) = parts.next() {
         if part.is_reaction {
             let reaction_str = simplify::remove_footers(part.msg.as_str());
-            let is_incoming_fresh = mime_parser.incoming && !seen && !fetching_existing_messages;
+            let is_incoming_fresh = mime_parser.incoming && !seen;
             set_msg_reaction(
                 context,
                 mime_in_reply_to,

--- a/src/receive_imf/receive_imf_tests.rs
+++ b/src/receive_imf/receive_imf_tests.rs
@@ -3467,46 +3467,6 @@ async fn test_send_as_bot() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_bot_recv_existing_msg() -> Result<()> {
-    let mut tcm = TestContextManager::new();
-    let bob = &tcm.bob().await;
-    bob.set_config(Config::Bot, Some("1")).await.unwrap();
-    bob.set_config(Config::FetchExistingMsgs, Some("1"))
-        .await
-        .unwrap();
-    let fetching_existing_messages = true;
-    let msg = receive_imf_from_inbox(
-        bob,
-        "first@example.org",
-        b"From: Alice <alice@example.org>\n\
-          To: Bob <bob@example.net>\n\
-          Chat-Version: 1.0\n\
-          Message-ID: <first@example.org>\n\
-          Date: Sun, 14 Nov 2021 00:10:00 +0000\n\
-          Content-Type: text/plain\n\
-          \n\
-          hello\n",
-        false,
-        None,
-        fetching_existing_messages,
-    )
-    .await?
-    .unwrap();
-    let msg = Message::load_from_db(bob, msg.msg_ids[0]).await?;
-    assert_eq!(msg.state, MessageState::InFresh);
-    let event = bob
-        .evtracker
-        .get_matching(|ev| matches!(ev, EventType::IncomingMsg { .. }))
-        .await;
-    let EventType::IncomingMsg { chat_id, msg_id } = event else {
-        unreachable!();
-    };
-    assert_eq!(chat_id, msg.chat_id);
-    assert_eq!(msg_id, msg.id);
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_wrong_date_in_imf_section() {
     let mut tcm = TestContextManager::new();
     let alice = &tcm.alice().await;
@@ -4812,7 +4772,6 @@ Content-Type: text/plain
 Chat-Group-Member-Added: charlie@example.com",
         false,
         Some(100000),
-        false,
     )
     .await?
     .context("no received message")?;
@@ -4850,7 +4809,6 @@ Content-Type: text/plain
 Chat-Group-Member-Added: charlie@example.com",
         false,
         None,
-        false,
     )
     .await?
     .context("no received message")?;

--- a/src/webxdc/webxdc_tests.rs
+++ b/src/webxdc/webxdc_tests.rs
@@ -339,7 +339,6 @@ async fn test_webxdc_update_for_not_downloaded_instance() -> Result<()> {
         sent1.payload().as_bytes(),
         false,
         Some(70790),
-        false,
     )
     .await?;
     let bob_instance = bob.get_last_msg().await;
@@ -354,7 +353,6 @@ async fn test_webxdc_update_for_not_downloaded_instance() -> Result<()> {
         sent1.payload().as_bytes(),
         false,
         None,
-        false,
     )
     .await?
     .unwrap();


### PR DESCRIPTION
This setting is currently unused and cannot work with encrypted messages without importing the key. It is also impossible to test with chatmail servers without uploading unencrypted messages via IMAP to bypass filtermail. Instead of trying to make the test work or keeping the setting without the tests, I'm removing the setting in this PR.