### PR TITLE
api!: Remove unused config smtp_certificate_checks, deprecate old server configs

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -409,8 +409,7 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  * - `server_flags` = IMAP-/SMTP-flags as a combination of @ref DC_LP flags, guessed if left out
  * - `proxy_enabled` = Proxy enabled. Disabled by default.
  * - `proxy_url` = Proxy URL. May contain multiple URLs separated by newline, but only the first one is used.
- * - `imap_certificate_checks` = how to check IMAP certificates, one of the @ref DC_CERTCK flags, defaults to #DC_CERTCK_AUTO (0)
- * - `smtp_certificate_checks` = deprecated option, should be set to the same value as `imap_certificate_checks` but ignored by the new core
+ * - `imap_certificate_checks` = how to check IMAP and SMTP certificates, one of the @ref DC_CERTCK flags, defaults to #DC_CERTCK_AUTO (0)
  * - `displayname`  = Own name to use when sending messages. MUAs are allowed to spread this way e.g. using CC, defaults to empty
  * - `selfstatus`   = Own status to display, e.g. in e-mail footers, defaults to empty
  * - `selfavatar`   = File containing avatar. Will immediately be copied to the 
@@ -5804,7 +5803,7 @@ int64_t         dc_lot_get_timestamp     (const dc_lot_t* lot);
  * These constants configure TLS certificate checks for IMAP and SMTP connections.
  *
  * These constants are set via dc_set_config()
- * using keys "imap_certificate_checks" and "smtp_certificate_checks".
+ * using key "imap_certificate_checks".
  *
  * @addtogroup DC_CERTCK
  * @{

--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -390,26 +390,9 @@ char*           dc_get_blobdir               (const dc_context_t* context);
 /**
  * Configure the context. The configuration is handled by key=value pairs as:
  *
- * - `addr`         = Email address to use for configuration.
- *                    If dc_configure() fails this is not the email address actually in use.
- *                    Use `configured_addr` to find out the email address actually in use.
- * - `configured_addr` = Email address actually in use.
+ * - `configured_addr` = Email address in use.
  *                    Unless for testing, do not set this value using dc_set_config().
  *                    Instead, set `addr` and call dc_configure().
- * - `mail_server`  = IMAP-server, guessed if left out
- * - `mail_user`    = IMAP-username, guessed if left out
- * - `mail_pw`      = IMAP-password (always needed)
- * - `mail_port`    = IMAP-port, guessed if left out
- * - `mail_security`= IMAP-socket, one of @ref DC_SOCKET, defaults to #DC_SOCKET_AUTO
- * - `send_server`  = SMTP-server, guessed if left out
- * - `send_user`    = SMTP-user, guessed if left out
- * - `send_pw`      = SMTP-password, guessed if left out
- * - `send_port`    = SMTP-port, guessed if left out
- * - `send_security`= SMTP-socket, one of @ref DC_SOCKET, defaults to #DC_SOCKET_AUTO
- * - `server_flags` = IMAP-/SMTP-flags as a combination of @ref DC_LP flags, guessed if left out
- * - `proxy_enabled` = Proxy enabled. Disabled by default.
- * - `proxy_url` = Proxy URL. May contain multiple URLs separated by newline, but only the first one is used.
- * - `imap_certificate_checks` = how to check IMAP and SMTP certificates, one of the @ref DC_CERTCK flags, defaults to #DC_CERTCK_AUTO (0)
  * - `displayname`  = Own name to use when sending messages. MUAs are allowed to spread this way e.g. using CC, defaults to empty
  * - `selfstatus`   = Own status to display, e.g. in e-mail footers, defaults to empty
  * - `selfavatar`   = File containing avatar. Will immediately be copied to the 
@@ -512,6 +495,27 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  *                       1 = Contacts (default, does not include contact requests),
  *                       2 = Nobody (calls never result in a notification).
  *
+ * Also, there are configs that are only needed
+ * if you want to use the deprecated dc_configure() API, such as:
+ *
+ * - `addr`         = Email address to use for configuration.
+ *                    If dc_configure() fails this is not the email address actually in use.
+ *                    Use `configured_addr` to find out the email address actually in use.
+ * - `mail_server`  = IMAP-server, guessed if left out
+ * - `mail_user`    = IMAP-username, guessed if left out
+ * - `mail_pw`      = IMAP-password (always needed)
+ * - `mail_port`    = IMAP-port, guessed if left out
+ * - `mail_security`= IMAP-socket, one of @ref DC_SOCKET, defaults to #DC_SOCKET_AUTO
+ * - `send_server`  = SMTP-server, guessed if left out
+ * - `send_user`    = SMTP-user, guessed if left out
+ * - `send_pw`      = SMTP-password, guessed if left out
+ * - `send_port`    = SMTP-port, guessed if left out
+ * - `send_security`= SMTP-socket, one of @ref DC_SOCKET, defaults to #DC_SOCKET_AUTO
+ * - `server_flags` = IMAP-/SMTP-flags as a combination of @ref DC_LP flags, guessed if left out
+ * - `proxy_enabled` = Proxy enabled. Disabled by default.
+ * - `proxy_url` = Proxy URL. May contain multiple URLs separated by newline, but only the first one is used.
+ * - `imap_certificate_checks` = how to check IMAP and SMTP certificates, one of the @ref DC_CERTCK flags, defaults to #DC_CERTCK_AUTO (0)
+
  * If you want to retrieve a value, use dc_get_config().
  *
  * @memberof dc_context_t
@@ -698,6 +702,12 @@ int              dc_get_push_state           (dc_context_t* context);
 
 /**
  * Configure a context.
+ *
+ * This way of configuring a context is deprecated,
+ * and does not allow to configure multiple transports.
+ * If you can, use the JSON-RPC API (../deltachat-jsonrpc/src/api.rs)
+ * `add_or_update_transport()`/`addOrUpdateTransport()` instead.
+ *
  * During configuration IO must not be started,
  * if needed stop IO using dc_accounts_stop_io() or dc_stop_io() first.
  * If the context is already configured,

--- a/deltachat-jsonrpc/src/lib.rs
+++ b/deltachat-jsonrpc/src/lib.rs
@@ -85,7 +85,7 @@ mod tests {
             assert_eq!(result, response.to_owned());
         }
         {
-            let request = r#"{"jsonrpc":"2.0","method":"batch_set_config","id":2,"params":[1,{"addr":"","mail_user":"","mail_pw":"","mail_server":"","mail_port":"","mail_security":"","imap_certificate_checks":"","send_user":"","send_pw":"","send_server":"","send_port":"","send_security":"","smtp_certificate_checks":""}]}"#;
+            let request = r#"{"jsonrpc":"2.0","method":"batch_set_config","id":2,"params":[1,{"addr":"","mail_user":"","mail_pw":"","mail_server":"","mail_port":"","mail_security":"","imap_certificate_checks":"","send_user":"","send_pw":"","send_server":"","send_port":"","send_security":""}]}"#;
             let response = r#"{"jsonrpc":"2.0","id":2,"result":null}"#;
             session.handle_incoming(request).await;
             let result = receiver.recv().await?;

--- a/python/src/deltachat/testplugin.py
+++ b/python/src/deltachat/testplugin.py
@@ -433,7 +433,6 @@ class ACFactory:
         if self.pytestconfig.getoption("--strict-tls"):
             # Enable strict certificate checks for online accounts
             configdict["imap_certificate_checks"] = str(const.DC_CERTCK_STRICT)
-            configdict["smtp_certificate_checks"] = str(const.DC_CERTCK_STRICT)
 
         assert "addr" in configdict and "mail_pw" in configdict
         return configdict
@@ -505,7 +504,6 @@ class ACFactory:
                 "addr": cloned_from.get_config("addr"),
                 "mail_pw": cloned_from.get_config("mail_pw"),
                 "imap_certificate_checks": cloned_from.get_config("imap_certificate_checks"),
-                "smtp_certificate_checks": cloned_from.get_config("smtp_certificate_checks"),
             }
         configdict.update(kwargs)
         ac = self._get_cached_account(addr=configdict["addr"]) if cache else None

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,45 +42,85 @@ use crate::{constants, stats};
 )]
 #[strum(serialize_all = "snake_case")]
 pub enum Config {
+    /// Deprecated(2026-04).
+    /// Use ConfiguredAddr, [`crate::login_param::EnteredLoginParam`],
+    /// or add_transport{from_qr}()/list_transports() instead.
+    ///
     /// Email address, used in the `From:` field.
     Addr,
 
+    /// Deprecated(2026-04).
+    /// Use EnteredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// IMAP server hostname.
     MailServer,
 
+    /// Deprecated(2026-04).
+    /// Use EnteredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// IMAP server username.
     MailUser,
 
+    /// Deprecated(2026-04).
+    /// Use EnteredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// IMAP server password.
     MailPw,
 
+    /// Deprecated(2026-04).
+    /// Use EnteredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// IMAP server port.
     MailPort,
 
+    /// Deprecated(2026-04).
+    /// Use EnteredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// IMAP server security (e.g. TLS, STARTTLS).
     MailSecurity,
 
+    /// Deprecated(2026-04).
+    /// Use EnteredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// How to check TLS certificates.
     ///
     /// "IMAP" in the name is for compatibility,
     /// this actually applies to both IMAP and SMTP connections.
     ImapCertificateChecks,
 
+    /// Deprecated(2026-04).
+    /// Use EnteredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// SMTP server hostname.
     SendServer,
 
+    /// Deprecated(2026-04).
+    /// Use EnteredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// SMTP server username.
     SendUser,
 
+    /// Deprecated(2026-04).
+    /// Use EnteredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// SMTP server password.
     SendPw,
 
+    /// Deprecated(2026-04).
+    /// Use EnteredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// SMTP server port.
     SendPort,
 
+    /// Deprecated(2026-04).
+    /// Use EnteredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// SMTP server security (e.g. TLS, STARTTLS).
     SendSecurity,
 
+    /// Deprecated(2026-04).
+    /// Use EnteredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// Whether to use OAuth 2.
     ///
     /// Historically contained other bitflags, which are now deprecated.
@@ -180,32 +220,47 @@ pub enum Config {
     /// The primary email address.
     ConfiguredAddr,
 
+    /// Deprecated(2026-04).
+    /// Use ConfiguredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// List of configured IMAP servers as a JSON array.
     ConfiguredImapServers,
 
+    /// Deprecated(2026-04).
+    /// Use ConfiguredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// Configured IMAP server hostname.
     ///
     /// This is replaced by `configured_imap_servers` for new configurations.
     ConfiguredMailServer,
 
-    /// Configured IMAP server port.
+    /// Deprecated(2026-04).
+    /// Use ConfiguredLoginParam and add_transport{from_qr}()/list_transports() instead.
     ///
-    /// This is replaced by `configured_imap_servers` for new configurations.
+    /// Configured IMAP server port.
     ConfiguredMailPort,
 
-    /// Configured IMAP server security (e.g. TLS, STARTTLS).
+    /// Deprecated(2026-04).
+    /// Use ConfiguredLoginParam and add_transport{from_qr}()/list_transports() instead.
     ///
-    /// This is replaced by `configured_imap_servers` for new configurations.
+    /// Configured IMAP server security (e.g. TLS, STARTTLS).
     ConfiguredMailSecurity,
 
-    /// Configured IMAP server username.
+    /// Deprecated(2026-04).
+    /// Use ConfiguredLoginParam and add_transport{from_qr}()/list_transports() instead.
     ///
-    /// This is set if user has configured username manually.
+    /// Configured IMAP server username.
     ConfiguredMailUser,
 
+    /// Deprecated(2026-04).
+    /// Use ConfiguredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// Configured IMAP server password.
     ConfiguredMailPw,
 
+    /// Deprecated(2026-04).
+    /// Use ConfiguredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// Configured TLS certificate checks.
     /// This option is saved on successful configuration
     /// and should not be modified manually.
@@ -214,32 +269,53 @@ pub enum Config {
     /// but has "IMAP" in the name for backwards compatibility.
     ConfiguredImapCertificateChecks,
 
+    /// Deprecated(2026-04).
+    /// Use ConfiguredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// List of configured SMTP servers as a JSON array.
     ConfiguredSmtpServers,
 
+    /// Deprecated(2026-04).
+    /// Use ConfiguredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// Configured SMTP server hostname.
     ///
     /// This is replaced by `configured_smtp_servers` for new configurations.
     ConfiguredSendServer,
 
+    /// Deprecated(2026-04).
+    /// Use ConfiguredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// Configured SMTP server port.
     ///
     /// This is replaced by `configured_smtp_servers` for new configurations.
     ConfiguredSendPort,
 
+    /// Deprecated(2026-04).
+    /// Use ConfiguredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// Configured SMTP server security (e.g. TLS, STARTTLS).
     ///
     /// This is replaced by `configured_smtp_servers` for new configurations.
     ConfiguredSendSecurity,
 
+    /// Deprecated(2026-04).
+    /// Use ConfiguredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// Configured SMTP server username.
     ///
     /// This is set if user has configured username manually.
     ConfiguredSendUser,
 
+    /// Deprecated(2026-04).
+    /// Use ConfiguredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// Configured SMTP server password.
     ConfiguredSendPw,
 
+    /// Deprecated(2026-04).
+    /// Use ConfiguredLoginParam and add_transport{from_qr}()/list_transports() instead.
+    ///
     /// Whether OAuth 2 is used with configured provider.
     ConfiguredServerFlags,
 
@@ -252,6 +328,9 @@ pub enum Config {
     /// ID of the configured provider from the provider database.
     ConfiguredProvider,
 
+    /// Deprecated(2026-04).
+    /// Use [`Context::is_configured()`] instead.
+    ///
     /// True if account is configured.
     Configured,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,11 +81,6 @@ pub enum Config {
     /// SMTP server security (e.g. TLS, STARTTLS).
     SendSecurity,
 
-    /// Deprecated option for backwards compatibility.
-    ///
-    /// Certificate checks for SMTP are actually controlled by `imap_certificate_checks` config.
-    SmtpCertificateChecks,
-
     /// Whether to use OAuth 2.
     ///
     /// Historically contained other bitflags, which are now deprecated.
@@ -244,11 +239,6 @@ pub enum Config {
 
     /// Configured SMTP server password.
     ConfiguredSendPw,
-
-    /// Deprecated, stored for backwards compatibility.
-    ///
-    /// ConfiguredImapCertificateChecks is actually used.
-    ConfiguredSmtpCertificateChecks,
 
     /// Whether OAuth 2 is used with configured provider.
     ConfiguredServerFlags,

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -76,7 +76,7 @@ impl Context {
     /// Deprecated since 2025-02; use `add_transport_from_qr()`
     /// or `add_or_update_transport()` instead.
     pub async fn configure(&self) -> Result<()> {
-        let mut param = EnteredLoginParam::load(self).await?;
+        let mut param = EnteredLoginParam::load_legacy(self).await?;
 
         self.add_transport_inner(&mut param).await
     }
@@ -150,7 +150,7 @@ impl Context {
             progress!(self, 0, Some(error_msg.clone()));
             bail!(error_msg);
         } else {
-            param.save(self).await?;
+            param.save_legacy(self).await?;
             progress!(self, 1000);
         }
 

--- a/src/context/context_tests.rs
+++ b/src/context/context_tests.rs
@@ -284,7 +284,6 @@ async fn test_get_info_completeness() {
         "send_security",
         "server_flags",
         "skip_start_messages",
-        "smtp_certificate_checks",
         "proxy_url",      // May contain passwords, don't leak it to the logs.
         "socks5_enabled", // SOCKS5 options are deprecated.
         "socks5_host",

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -138,10 +138,11 @@ pub struct EnteredLoginParam {
 }
 
 impl EnteredLoginParam {
-    /// Loads entered account settings.
+    /// Loads entered account settings
+    /// that were set by the deprecated `configured_*` configs.
     ///
-    /// This is a legacy API for loading from separate config parameters.
-    pub(crate) async fn load(context: &Context) -> Result<Self> {
+    /// This is only needed by tests and clients using the old CFFI API.
+    pub(crate) async fn load_legacy(context: &Context) -> Result<Self> {
         let addr = context
             .get_config(Config::Addr)
             .await?
@@ -241,7 +242,10 @@ impl EnteredLoginParam {
 
     /// Saves entered account settings,
     /// so that they can be prefilled if the user wants to configure the server again.
-    pub(crate) async fn save(&self, context: &Context) -> Result<()> {
+    ///
+    /// This is needed in case a UI is not yet updated, and still uses `get_config("mail_pw")` etc.
+    /// in order to prefill the entered account settings.
+    pub(crate) async fn save_legacy(&self, context: &Context) -> Result<()> {
         context.set_config(Config::Addr, Some(&self.addr)).await?;
 
         context
@@ -364,7 +368,7 @@ mod tests {
             .await?;
         t.set_config(Config::MailPw, Some("foobarbaz")).await?;
 
-        let param = EnteredLoginParam::load(t).await?;
+        let param = EnteredLoginParam::load_legacy(t).await?;
         assert_eq!(param.addr, "alice@example.org");
         assert_eq!(
             param.certificate_checks,
@@ -373,13 +377,13 @@ mod tests {
 
         t.set_config(Config::ImapCertificateChecks, Some("1"))
             .await?;
-        let param = EnteredLoginParam::load(t).await?;
+        let param = EnteredLoginParam::load_legacy(t).await?;
         assert_eq!(param.certificate_checks, EnteredCertificateChecks::Strict);
 
         // Fail to load invalid settings, but do not panic.
         t.set_config(Config::ImapCertificateChecks, Some("999"))
             .await?;
-        assert!(EnteredLoginParam::load(t).await.is_err());
+        assert!(EnteredLoginParam::load_legacy(t).await.is_err());
 
         Ok(())
     }
@@ -407,7 +411,7 @@ mod tests {
             certificate_checks: Default::default(),
             oauth2: false,
         };
-        param.save(&t).await?;
+        param.save_legacy(&t).await?;
         assert_eq!(
             t.get_config(Config::Addr).await?.unwrap(),
             "alice@example.org"
@@ -416,7 +420,7 @@ mod tests {
         assert_eq!(t.get_config(Config::SendPw).await?, None);
         assert_eq!(t.get_config_int(Config::SendPort).await?, 2947);
 
-        assert_eq!(EnteredLoginParam::load(&t).await?, param);
+        assert_eq!(EnteredLoginParam::load_legacy(&t).await?, param);
 
         Ok(())
     }

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -178,7 +178,7 @@ impl EnteredLoginParam {
         // The setting is named `imap_certificate_checks`
         // for backwards compatibility,
         // but now it is a global setting applied to all protocols,
-        // while `smtp_certificate_checks` is ignored.
+        // while `smtp_certificate_checks` has been removed.
         let certificate_checks = if let Some(certificate_checks) = context
             .get_config_parsed::<i32>(Config::ImapCertificateChecks)
             .await?

--- a/src/qr/qr_tests.rs
+++ b/src/qr/qr_tests.rs
@@ -709,7 +709,7 @@ async fn test_decode_dclogin_advanced_options() -> Result<()> {
     assert_eq!(param.smtp.security, Socket::Plain);
 
     // `sc` option is actually ignored and `ic` is used instead
-    // because `smtp_certificate_checks` is deprecated.
+    // because `smtp_certificate_checks` has been removed.
     assert_eq!(param.certificate_checks, EnteredCertificateChecks::Strict);
 
     Ok(())

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -1919,7 +1919,7 @@ CREATE INDEX gossip_timestamp_index ON gossip_timestamp (chat_id, fingerprint);
 
     inc_and_check(&mut migration_version, 131)?;
     if dbversion < migration_version {
-        let entered_param = EnteredLoginParam::load(context).await?;
+        let entered_param = EnteredLoginParam::load_legacy(context).await?;
         let configured_param = ConfiguredLoginParam::load_legacy(context).await?;
 
         sql.execute_migration_transaction(

--- a/src/transport/transport_tests.rs
+++ b/src/transport/transport_tests.rs
@@ -118,8 +118,6 @@ async fn test_posteo_alias() -> Result<()> {
     t.set_config(Config::ConfiguredSendUser, Some(user)).await?;
     t.set_config(Config::ConfiguredSendPw, Some("foobarbaz"))
         .await?;
-    t.set_config(Config::ConfiguredSmtpCertificateChecks, Some("1"))
-        .await?; // Strict
     t.set_config(Config::ConfiguredServerFlags, Some("0"))
         .await?;
 
@@ -207,8 +205,6 @@ async fn test_empty_server_list_legacy() -> Result<()> {
         .await?; // Strict
     t.set_config(Config::ConfiguredSendPw, Some("foobarbaz"))
         .await?;
-    t.set_config(Config::ConfiguredSmtpCertificateChecks, Some("1"))
-        .await?; // Strict
     t.set_config(Config::ConfiguredServerFlags, Some("0"))
         .await?;
 


### PR DESCRIPTION
This deprecates the old configs Config::Addr, Config::MailPw, etc. which were used to pass login data to core
and the Config::Configured* configs which were replaced by the `add_or_update_transport()` and `list_transports()` APIs.

`smtp_certificate_checks` was not used by anything, so I removed it instead of deprecating.

These are the transport-related configs that are left now:
- MvboxMove, OnlyFetchMvbox - will be removed by https://github.com/chatmail/core/pull/7780
- ConfiguredInboxFolder, ConfiguredMvboxFolder - at least the latter will also be removed by https://github.com/chatmail/core/pull/7780/
- ConfiguredProvider
- IsChatmail
- AuthservIdCandidates - this one we can just remove in a follow-up PR