### PR TITLE
fix: try_many_times: retry 5 times instead of 60

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -888,7 +888,7 @@ impl Config {
     }
 }
 
-/// Spend up to 1 minute trying to do the operation.
+/// Try the operation 5 times, waiting 1 second between retries.
 ///
 /// Even if Delta Chat itself does not hold the file lock,
 /// there may be other processes such as antivirus,
@@ -907,7 +907,7 @@ where
         counter += 1;
 
         if let Err(err) = f().await {
-            if counter > 60 {
+            if counter >= 5 {
                 return Err(err);
             }
 


### PR DESCRIPTION
If 5 times is not enough, 60 will probably not be enough either.

This is mainly an attempt of improving the situation with
https://github.com/deltachat/deltachat-desktop/issues/3959.

The `remove_account` RPC call would make the RPC server
stop responding to all other requests,
which is basically equivalent to a one minute hang.

Additionally, `try_many_times` appears to be unnecessary after
https://github.com/chatmail/core/pull/5814#issuecomment-2257164502.
