### PR TITLE
build: enable async-native-tls/vendored feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,8 @@ yerpc = "0.6.4"
 default = ["vendored"]
 internals = []
 vendored = [
-  "rusqlite/bundled-sqlcipher-vendored-openssl"
+  "rusqlite/bundled-sqlcipher-vendored-openssl",
+  "async-native-tls/vendored"
 ]
 
 [lints.rust]


### PR DESCRIPTION
OpenSSL is vendored, but because of rusqlite feature transitively enabling vendoring feature.
This change makes vendoring explicit
even if we disable SQLCipher in the future.