### PR TITLE
api!: make logging macros private

### DIFF
--- a/benches/send_events.rs
+++ b/benches/send_events.rs
@@ -3,15 +3,15 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use deltachat::context::Context;
 use deltachat::stock_str::StockStrings;
-use deltachat::{info, Event, EventType, Events};
+use deltachat::{Event, EventType, Events};
 use tempfile::tempdir;
 
 async fn send_events_benchmark(context: &Context) {
     let emitter = context.get_event_emitter();
     for _i in 0..1_000_000 {
-        info!(context, "interesting event...");
+        context.emit_event(EventType::Info("interesting event...".to_string()));
     }
-    info!(context, "DONE");
+    context.emit_event(EventType::Info("DONE".to_string()));
 
     loop {
         match emitter.recv().await.unwrap() {

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -19,6 +19,7 @@ use deltachat::constants::DC_MSG_ID_DAYMARKER;
 use deltachat::contact::{may_be_valid_addr, Contact, ContactId, Origin};
 use deltachat::context::get_info;
 use deltachat::ephemeral::Timer;
+use deltachat::imex;
 use deltachat::location;
 use deltachat::message::get_msg_read_receipts;
 use deltachat::message::{
@@ -35,7 +36,6 @@ use deltachat::securejoin;
 use deltachat::stock_str::StockMessage;
 use deltachat::webxdc::StatusUpdateSerial;
 use deltachat::EventEmitter;
-use deltachat::{imex, info};
 use sanitize_filename::is_sanitized;
 use tokio::fs;
 use tokio::sync::{watch, Mutex, RwLock};
@@ -1919,12 +1919,10 @@ impl CommandApi {
         instance_msg_id: u32,
     ) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
-        let fut = send_webxdc_realtime_advertisement(&ctx, MsgId::new(instance_msg_id)).await?;
-        if let Some(fut) = fut {
-            tokio::spawn(async move {
-                fut.await.ok();
-                info!(ctx, "send_webxdc_realtime_advertisement done")
-            });
+        if let Some(fut) =
+            send_webxdc_realtime_advertisement(&ctx, MsgId::new(instance_msg_id)).await?
+        {
+            tokio::spawn(fut);
         }
         Ok(())
     }

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -120,7 +120,7 @@ async fn poke_spec(context: &Context, spec: Option<&str>) -> bool {
     } else {
         let rs = context.sql().get_raw_config("import_spec").await.unwrap();
         if rs.is_none() {
-            error!(context, "Import: No file or folder given.");
+            eprintln!("Import: No file or folder given.");
             return false;
         }
         real_spec = rs.unwrap();
@@ -149,7 +149,7 @@ async fn poke_spec(context: &Context, spec: Option<&str>) -> bool {
                 }
             }
         } else {
-            error!(context, "Import: Cannot open directory \"{}\".", &real_spec);
+            eprintln!("Import: Cannot open directory \"{}\".", &real_spec);
             return false;
         }
     }

--- a/deltachat-repl/src/main.rs
+++ b/deltachat-repl/src/main.rs
@@ -5,7 +5,6 @@
 //! Usage:  cargo run --example repl --release -- <databasefile>
 //! All further options can be set using the set-command (type ? for help).
 
-#[macro_use]
 extern crate deltachat;
 
 use std::borrow::Cow::{self, Borrowed, Owned};

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -18,6 +18,7 @@ use tokio::time::{sleep, Duration};
 
 use crate::context::{Context, ContextBuilder};
 use crate::events::{Event, EventEmitter, EventType, Events};
+use crate::log::{info, warn};
 use crate::push::PushSubscriber;
 use crate::stock_str::StockStrings;
 

--- a/src/blob.rs
+++ b/src/blob.rs
@@ -20,7 +20,7 @@ use crate::config::Config;
 use crate::constants::{self, MediaQuality};
 use crate::context::Context;
 use crate::events::EventType;
-use crate::log::LogExt;
+use crate::log::{error, info, warn, LogExt};
 use crate::tools::sanitize_filename;
 
 /// Represents a file in the blob directory.

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -34,7 +34,7 @@ use crate::download::DownloadState;
 use crate::ephemeral::{start_chat_ephemeral_timers, Timer as EphemeralTimer};
 use crate::events::EventType;
 use crate::location;
-use crate::log::LogExt;
+use crate::log::{error, info, warn, LogExt};
 use crate::message::{self, Message, MessageState, MsgId, Viewtype};
 use crate::mimefactory::MimeFactory;
 use crate::mimeparser::SystemMessage;

--- a/src/chatlist.rs
+++ b/src/chatlist.rs
@@ -10,6 +10,7 @@ use crate::constants::{
 };
 use crate::contact::{Contact, ContactId};
 use crate::context::Context;
+use crate::log::warn;
 use crate::message::{Message, MessageState, MsgId};
 use crate::param::{Param, Params};
 use crate::stock_str;

--- a/src/config.rs
+++ b/src/config.rs
@@ -17,7 +17,7 @@ use crate::configure::EnteredLoginParam;
 use crate::constants;
 use crate::context::Context;
 use crate::events::EventType;
-use crate::log::LogExt;
+use crate::log::{info, LogExt};
 use crate::login_param::ConfiguredLoginParam;
 use crate::mimefactory::RECOMMENDED_FILE_SIZE;
 use crate::provider::{get_provider_by_id, Provider};

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -27,7 +27,7 @@ use crate::config::{self, Config};
 use crate::constants::NON_ALPHANUMERIC_WITHOUT_DOT;
 use crate::context::Context;
 use crate::imap::Imap;
-use crate::log::LogExt;
+use crate::log::{info, warn, LogExt};
 pub use crate::login_param::EnteredLoginParam;
 use crate::login_param::{
     ConfiguredCertificateChecks, ConfiguredLoginParam, ConfiguredServerLoginParam,

--- a/src/configure/auto_mozilla.rs
+++ b/src/configure/auto_mozilla.rs
@@ -9,6 +9,7 @@ use quick_xml::events::{BytesStart, Event};
 
 use super::{Error, ServerParams};
 use crate::context::Context;
+use crate::log::warn;
 use crate::net::read_url;
 use crate::provider::{Protocol, Socket};
 

--- a/src/configure/auto_outlook.rs
+++ b/src/configure/auto_outlook.rs
@@ -9,6 +9,7 @@ use quick_xml::events::Event;
 
 use super::{Error, ServerParams};
 use crate::context::Context;
+use crate::log::warn;
 use crate::net::read_url;
 use crate::provider::{Protocol, Socket};
 

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -29,7 +29,7 @@ use crate::constants::{Blocked, Chattype, DC_GCL_ADD_SELF};
 use crate::context::Context;
 use crate::events::EventType;
 use crate::key::{load_self_public_key, DcKey, SignedPublicKey};
-use crate::log::LogExt;
+use crate::log::{info, warn, LogExt};
 use crate::message::MessageState;
 use crate::mimeparser::AvatarAction;
 use crate::param::{Param, Params};

--- a/src/context.rs
+++ b/src/context.rs
@@ -28,6 +28,7 @@ use crate::download::DownloadState;
 use crate::events::{Event, EventEmitter, EventType, Events};
 use crate::imap::{FolderMeaning, Imap, ServerMetadata};
 use crate::key::{load_self_public_key, load_self_secret_key, DcKey as _};
+use crate::log::{info, warn};
 use crate::login_param::{ConfiguredLoginParam, EnteredLoginParam};
 use crate::message::{self, Message, MessageState, MsgId};
 use crate::param::{Param, Params};

--- a/src/debug_logging.rs
+++ b/src/debug_logging.rs
@@ -3,6 +3,7 @@ use crate::chat::ChatId;
 use crate::config::Config;
 use crate::context::Context;
 use crate::events::EventType;
+use crate::log::{error, info};
 use crate::message::{Message, MsgId, Viewtype};
 use crate::param::Param;
 use crate::tools::time;

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -9,6 +9,7 @@ use mailparse::ParsedMail;
 use crate::aheader::Aheader;
 use crate::context::Context;
 use crate::key::{DcKey, Fingerprint, SignedPublicKey, SignedSecretKey};
+use crate::log::info;
 use crate::peerstate::Peerstate;
 use crate::pgp;
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::config::Config;
 use crate::context::Context;
 use crate::imap::session::Session;
+use crate::log::info;
 use crate::message::{Message, MsgId, Viewtype};
 use crate::mimeparser::{MimeMessage, Part};
 use crate::tools::time;

--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -11,6 +11,7 @@ use crate::aheader::{Aheader, EncryptPreference};
 use crate::config::Config;
 use crate::context::Context;
 use crate::key::{load_self_public_key, load_self_secret_key, SignedPublicKey};
+use crate::log::warn;
 use crate::peerstate::Peerstate;
 use crate::pgp;
 

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -81,7 +81,7 @@ use crate::context::Context;
 use crate::download::MIN_DELETE_SERVER_AFTER;
 use crate::events::EventType;
 use crate::location;
-use crate::log::LogExt;
+use crate::log::{error, info, warn, LogExt};
 use crate::message::{Message, MessageState, MsgId, Viewtype};
 use crate::mimeparser::SystemMessage;
 use crate::stock_str;

--- a/src/html.rs
+++ b/src/html.rs
@@ -16,6 +16,7 @@ use mime::Mime;
 
 use crate::context::Context;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
+use crate::log::warn;
 use crate::message::{self, Message, MsgId};
 use crate::mimeparser::parse_message_id;
 use crate::param::Param::SendHtml;

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -32,7 +32,7 @@ use crate::contact::{Contact, ContactId, Modifier, Origin};
 use crate::context::Context;
 use crate::events::EventType;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
-use crate::log::LogExt;
+use crate::log::{error, info, warn, LogExt};
 use crate::login_param::{
     prioritize_server_login_params, ConfiguredLoginParam, ConfiguredServerLoginParam,
 };

--- a/src/imap/client.rs
+++ b/src/imap/client.rs
@@ -8,6 +8,7 @@ use tokio::io::BufWriter;
 
 use super::capabilities::Capabilities;
 use crate::context::Context;
+use crate::log::{info, warn};
 use crate::login_param::{ConnectionCandidate, ConnectionSecurity};
 use crate::net::dns::{lookup_host_with_cache, update_connect_timestamp};
 use crate::net::proxy::ProxyConfig;

--- a/src/imap/idle.rs
+++ b/src/imap/idle.rs
@@ -8,6 +8,7 @@ use tokio::time::timeout;
 use super::session::Session;
 use super::Imap;
 use crate::context::Context;
+use crate::log::{info, warn};
 use crate::net::TIMEOUT;
 use crate::tools::{self, time_elapsed};
 

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -5,7 +5,7 @@ use anyhow::{Context as _, Result};
 use super::{get_folder_meaning_by_attrs, get_folder_meaning_by_name};
 use crate::config::Config;
 use crate::imap::{session::Session, Imap};
-use crate::log::LogExt;
+use crate::log::{info, LogExt};
 use crate::tools::{self, time_elapsed};
 use crate::{context::Context, imap::FolderMeaning};
 

--- a/src/imap/select_folder.rs
+++ b/src/imap/select_folder.rs
@@ -5,6 +5,7 @@ use anyhow::Context as _;
 use super::session::Session as ImapSession;
 use super::{get_uid_next, get_uidvalidity, set_modseq, set_uid_next, set_uidvalidity};
 use crate::context::Context;
+use crate::log::{info, warn};
 
 type Result<T> = std::result::Result<T, Error>;
 

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -20,7 +20,7 @@ use crate::context::Context;
 use crate::e2ee;
 use crate::events::EventType;
 use crate::key::{self, DcKey, DcSecretKey, SignedPublicKey, SignedSecretKey};
-use crate::log::LogExt;
+use crate::log::{error, info, warn, LogExt};
 use crate::pgp;
 use crate::qr::DCBACKUP_VERSION;
 use crate::sql;

--- a/src/imex/transfer.rs
+++ b/src/imex/transfer.rs
@@ -41,6 +41,7 @@ use tokio_util::sync::CancellationToken;
 use crate::chat::add_device_msg;
 use crate::context::Context;
 use crate::imex::BlobDirContents;
+use crate::log::{info, warn};
 use crate::message::Message;
 use crate::qr::Qr;
 use crate::stock_str::backup_transfer_msg_body;

--- a/src/key.rs
+++ b/src/key.rs
@@ -15,7 +15,7 @@ use rand::thread_rng;
 use tokio::runtime::Handle;
 
 use crate::context::Context;
-use crate::log::LogExt;
+use crate::log::{info, LogExt};
 use crate::pgp::KeyPair;
 use crate::tools::{self, time_elapsed};
 

--- a/src/location.rs
+++ b/src/location.rs
@@ -22,6 +22,7 @@ use crate::constants::DC_CHAT_ID_TRASH;
 use crate::contact::ContactId;
 use crate::context::Context;
 use crate::events::EventType;
+use crate::log::{info, warn};
 use crate::message::{Message, MsgId, Viewtype};
 use crate::mimeparser::SystemMessage;
 use crate::tools::{duration_to_str, time};

--- a/src/message.rs
+++ b/src/message.rs
@@ -26,6 +26,7 @@ use crate::ephemeral::{start_ephemeral_timers_msgids, Timer as EphemeralTimer};
 use crate::events::EventType;
 use crate::imap::markseen_on_imap_table;
 use crate::location::delete_poi_location;
+use crate::log::{error, info, warn};
 use crate::mimeparser::{parse_message_id, SystemMessage};
 use crate::param::{Param, Params};
 use crate::pgp::split_armored_data;

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -25,6 +25,7 @@ use crate::e2ee::EncryptHelper;
 use crate::ephemeral::Timer as EphemeralTimer;
 use crate::key::DcKey;
 use crate::location;
+use crate::log::{info, warn};
 use crate::message::{self, Message, MsgId, Viewtype};
 use crate::mimeparser::{is_hidden, SystemMessage};
 use crate::param::Param;
@@ -32,9 +33,9 @@ use crate::peer_channels::create_iroh_header;
 use crate::peerstate::Peerstate;
 use crate::simplify::escape_message_footer_marks;
 use crate::stock_str;
-use crate::tools::IsNoneOrEmpty;
 use crate::tools::{
     create_outgoing_rfc724_mid, create_smeared_timestamp, remove_subject_prefix, time,
+    IsNoneOrEmpty,
 };
 use crate::webxdc::StatusUpdateSerial;
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -29,14 +29,14 @@ use crate::dehtml::dehtml;
 use crate::events::EventType;
 use crate::headerdef::{HeaderDef, HeaderDefMap};
 use crate::key::{self, load_self_secret_keyring, DcKey, Fingerprint, SignedPublicKey};
+use crate::log::{error, info, warn};
 use crate::message::{self, get_vcard_summary, set_msg_failed, Message, MsgId, Viewtype};
 use crate::param::{Param, Params};
 use crate::peerstate::Peerstate;
 use crate::simplify::{simplify, SimplifiedText};
 use crate::sync::SyncItems;
-use crate::tools::time;
 use crate::tools::{
-    get_filemeta, parse_receive_headers, smeared_time, truncate_msg_text, validate_id,
+    get_filemeta, parse_receive_headers, smeared_time, time, truncate_msg_text, validate_id,
 };
 use crate::{chatlist_events, location, stock_str, tools};
 

--- a/src/net/dns.rs
+++ b/src/net/dns.rs
@@ -50,6 +50,7 @@ use tokio::time::timeout;
 
 use super::load_connection_timestamp;
 use crate::context::Context;
+use crate::log::{info, warn};
 use crate::tools::time;
 
 /// Inserts entry into DNS cache

--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -10,6 +10,7 @@ use tokio::fs;
 
 use crate::blob::BlobObject;
 use crate::context::Context;
+use crate::log::{info, warn};
 use crate::net::proxy::ProxyConfig;
 use crate::net::session::SessionStream;
 use crate::net::tls::wrap_rustls;

--- a/src/oauth2.rs
+++ b/src/oauth2.rs
@@ -7,6 +7,7 @@ use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use serde::Deserialize;
 
 use crate::context::Context;
+use crate::log::{info, warn};
 use crate::net::http::post_form;
 use crate::net::read_url_blob;
 use crate::provider;

--- a/src/peer_channels.rs
+++ b/src/peer_channels.rs
@@ -39,6 +39,7 @@ use url::Url;
 use crate::chat::send_msg;
 use crate::config::Config;
 use crate::context::Context;
+use crate::log::{info, warn};
 use crate::message::{Message, MsgId, Viewtype};
 use crate::mimeparser::SystemMessage;
 use crate::EventType;

--- a/src/peerstate.rs
+++ b/src/peerstate.rs
@@ -15,6 +15,7 @@ use crate::contact::{Contact, Origin};
 use crate::context::Context;
 use crate::events::EventType;
 use crate::key::{DcKey, Fingerprint, SignedPublicKey};
+use crate::log::{info, warn};
 use crate::message::Message;
 use crate::mimeparser::SystemMessage;
 use crate::sql::Sql;

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::config::Config;
 use crate::context::Context;
+use crate::log::warn;
 use crate::provider::data::{PROVIDER_DATA, PROVIDER_IDS};
 
 /// Provider status according to manual testing.

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -11,6 +11,7 @@ use crate::config::Config;
 use crate::context::Context;
 use crate::imap::scan_folders::get_watched_folders;
 use crate::imap::session::Session as ImapSession;
+use crate::log::warn;
 use crate::message::Message;
 use crate::tools::{self, time_elapsed};
 use crate::{stock_str, EventType};

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -26,6 +26,7 @@ use crate::chatlist_events;
 use crate::contact::ContactId;
 use crate::context::Context;
 use crate::events::EventType;
+use crate::log::info;
 use crate::message::{rfc724_mid_exists, Message, MsgId};
 use crate::param::Param;
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -26,6 +26,7 @@ use crate::headerdef::{HeaderDef, HeaderDefMap};
 use crate::imap::{markseen_on_imap_table, GENERATED_PREFIX};
 use crate::key::DcKey;
 use crate::log::LogExt;
+use crate::log::{info, warn};
 use crate::message::{
     self, rfc724_mid_exists, Message, MessageState, MessengerMessage, MsgId, Viewtype,
 };

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -21,7 +21,7 @@ use crate::ephemeral::{self, delete_expired_imap_messages};
 use crate::events::EventType;
 use crate::imap::{session::Session, FolderMeaning, Imap};
 use crate::location;
-use crate::log::LogExt;
+use crate::log::{error, info, warn, LogExt};
 use crate::message::MsgId;
 use crate::smtp::{send_smtp_messages, Smtp};
 use crate::sql;

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -8,6 +8,7 @@ use tokio::sync::Mutex;
 
 use crate::events::EventType;
 use crate::imap::{scan_folders::get_watched_folder_configs, FolderMeaning};
+use crate::log::info;
 use crate::quota::{QUOTA_ERROR_THRESHOLD_PERCENTAGE, QUOTA_WARN_THRESHOLD_PERCENTAGE};
 use crate::stock_str;
 use crate::{context::Context, log::LogExt};

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -14,6 +14,7 @@ use crate::e2ee::ensure_secret_key_exists;
 use crate::events::EventType;
 use crate::headerdef::HeaderDef;
 use crate::key::{load_self_public_key, DcKey, Fingerprint};
+use crate::log::{error, info, warn};
 use crate::message::{Message, Viewtype};
 use crate::mimeparser::{MimeMessage, SystemMessage};
 use crate::param::Param;

--- a/src/securejoin/bob.rs
+++ b/src/securejoin/bob.rs
@@ -10,6 +10,7 @@ use crate::contact::Origin;
 use crate::context::Context;
 use crate::events::EventType;
 use crate::key::{load_self_public_key, DcKey};
+use crate::log::info;
 use crate::message::{Message, Viewtype};
 use crate::mimeparser::{MimeMessage, SystemMessage};
 use crate::param::Param;

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -13,6 +13,7 @@ use crate::config::Config;
 use crate::contact::{Contact, ContactId};
 use crate::context::Context;
 use crate::events::EventType;
+use crate::log::{error, info, warn};
 use crate::login_param::prioritize_server_login_params;
 use crate::login_param::{ConfiguredLoginParam, ConfiguredServerLoginParam};
 use crate::message::Message;

--- a/src/smtp/connect.rs
+++ b/src/smtp/connect.rs
@@ -7,6 +7,7 @@ use async_smtp::{SmtpClient, SmtpTransport};
 use tokio::io::{AsyncBufRead, AsyncWrite, BufStream};
 
 use crate::context::Context;
+use crate::log::{info, warn};
 use crate::login_param::{ConnectionCandidate, ConnectionSecurity};
 use crate::net::dns::{lookup_host_with_cache, update_connect_timestamp};
 use crate::net::proxy::ProxyConfig;

--- a/src/smtp/send.rs
+++ b/src/smtp/send.rs
@@ -6,6 +6,7 @@ use super::Smtp;
 use crate::config::Config;
 use crate::context::Context;
 use crate::events::EventType;
+use crate::log::{info, warn};
 use crate::tools;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -16,7 +16,7 @@ use crate::debug_logging::set_debug_logging_xdc;
 use crate::ephemeral::start_ephemeral_timers;
 use crate::imex::BLOBS_BACKUP_NAME;
 use crate::location::delete_orphaned_poi_locations;
-use crate::log::LogExt;
+use crate::log::{error, info, warn, LogExt};
 use crate::message::{Message, MsgId};
 use crate::net::dns::prune_dns_cache;
 use crate::net::http::http_cache_cleanup;

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -9,6 +9,7 @@ use crate::configure::EnteredLoginParam;
 use crate::constants::ShowEmails;
 use crate::context::Context;
 use crate::imap;
+use crate::log::{info, warn};
 use crate::login_param::ConfiguredLoginParam;
 use crate::message::MsgId;
 use crate::provider::get_provider_by_domain;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -10,6 +10,7 @@ use crate::constants::Blocked;
 use crate::contact::ContactId;
 use crate::context::Context;
 use crate::log::LogExt;
+use crate::log::{info, warn};
 use crate::message::{Message, MsgId, Viewtype};
 use crate::mimeparser::SystemMessage;
 use crate::param::Param;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -33,6 +33,7 @@ use crate::context::Context;
 use crate::e2ee::EncryptHelper;
 use crate::events::{Event, EventEmitter, EventType, Events};
 use crate::key::{self, DcKey, DcSecretKey};
+use crate::log::warn;
 use crate::message::{update_msg_state, Message, MessageState, MsgId, Viewtype};
 use crate::mimeparser::{MimeMessage, SystemMessage};
 use crate::peerstate::Peerstate;

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -41,6 +41,7 @@ use crate::config::Config;
 use crate::constants::{self, DC_ELLIPSIS, DC_OUTDATED_WARNING_DAYS};
 use crate::context::Context;
 use crate::events::EventType;
+use crate::log::warn;
 use crate::message::{Message, Viewtype};
 use crate::stock_str;
 

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -40,13 +40,13 @@ use crate::contact::ContactId;
 use crate::context::Context;
 use crate::events::EventType;
 use crate::key::{load_self_public_key, DcKey};
+use crate::log::{info, warn};
 use crate::message::{Message, MessageState, MsgId, Viewtype};
 use crate::mimefactory::RECOMMENDED_FILE_SIZE;
 use crate::mimeparser::SystemMessage;
 use crate::param::Param;
 use crate::param::Params;
-use crate::tools::create_id;
-use crate::tools::{create_smeared_timestamp, get_abs_path};
+use crate::tools::{create_id, create_smeared_timestamp, get_abs_path};
 
 /// The current API version.
 /// If `min_api` in manifest.toml is set to a larger value,

--- a/src/webxdc/maps_integration.rs
+++ b/src/webxdc/maps_integration.rs
@@ -41,6 +41,7 @@ use crate::message::{Message, MsgId};
 use crate::chat::ChatId;
 use crate::color::color_int_to_hex_string;
 use crate::contact::{Contact, ContactId};
+use crate::log::warn;
 use crate::tools::time;
 use crate::webxdc::{StatusUpdateItem, StatusUpdateItemAndSerial, StatusUpdateSerial};
 use anyhow::Result;


### PR DESCRIPTION
This is a preparation for #6919. I want to add dependency on the `tracing` crate into logging macros, but then they cannot be used by crates that do not import `tracing` as well. Overall not exporting internal logging macros seems cleaner to me, it also discourages library users from logging their own logs into our event channel.