### PR TITLE
fix: Also migrate messages in PGP-contacts migration

### DIFF
--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -1,6 +1,5 @@
 //! Migrations module.
 
-use std::cmp::max;
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::time::Instant;


### PR DESCRIPTION
Previously, messages were not rewritten. This meant that all messages stayed with the old email-identified contact.
#6916 made it very obvious that all messages sent into a group before the PGP-contacts migration got the email avatar.

With this PR, all encrypted messages are rewritten to the PGP-contact identified by the current autocrypt key. It is not possible to find out which key was actually used to sign the message.

For me, this prints:

```
06-16 16:08:32.444 19307 19345 I DeltaChat: [accId=1] src/sql/migrations.rs:1820: Rewriting msgs for PGP contacts took 3.768890467s
06-16 16:08:41.825 19307 19345 I DeltaChat: [accId=1] src/sql/migrations.rs:1242: PGP contacts migration took 13.516607026s in total
```

which is slow, but the messages aren't actually the slowest part of it. We may want to try and show a spinner in the UI while the migration is being done, but let's first hear what others report as to how long this takes.