### PR TITLE
feat: increase DCBACKUP_VERSION with PGP-contacts

### DIFF
--- a/src/qr.rs
+++ b/src/qr.rs
@@ -41,7 +41,7 @@ pub(crate) const DCBACKUP_SCHEME_PREFIX: &str = "DCBACKUP";
 
 /// Version written to Backups and Backup-QR-Codes.
 /// Imports will fail when they have a larger version.
-pub(crate) const DCBACKUP_VERSION: i32 = 2;
+pub(crate) const DCBACKUP_VERSION: i32 = 3;
 
 /// Scanned QR code.
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
This way, we prevent users from running into problems when importing an old backup.

Note that this is not strictly necessary, but a decision of assuming that this is better for usability - importing a new backup into an old DC version would mostly work fine, but there would be weird bugs. E.g., after updating the imported profile to PGP-contacts, the migration wouldn't run a second time, so that all peerstate changes since the device was updated would get lost.

Desktop|Android
-|-
![image](https://github.com/user-attachments/assets/b9fc6f3a-f778-4e64-ad2c-393d5c756ded) | ![image](https://github.com/user-attachments/assets/65aceb7e-eeba-45e3-8f00-0c676a218f9d)

Not sure why Desktop shows a nice error message, while Android shows a cryptic "IMEX failed to complete", though for this release, it's too late to change this (except if we want to make a quick release before PGP-contacts, which improves the error message).

_Edit:_ It's because I used Add-second-device for Desktop, and import-file for Android. Would be nice to improve the error message when importing a backup, but this is out of scope for this PR. I created an issue: https://github.com/chatmail/core/issues/6930 This is not a blocker for the PGP-contacts release, because as I said, it's too late to change this except if we want to make another release before the PGP-contacts release.