### PR TITLE
feat: migrations: Use tools::Time to measure time for logging

### DIFF
--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use anyhow::{Context as _, Result, ensure};
 use deltachat_contact_tools::EmailAddress;
@@ -1237,13 +1237,13 @@ CREATE INDEX gossip_timestamp_index ON gossip_timestamp (chat_id, fingerprint);
 
     inc_and_check(&mut migration_version, 132)?;
     if dbversion < migration_version {
-        let start = Instant::now();
+        let start = Time::now();
         sql.execute_migration_transaction(|t| migrate_key_contacts(context, t), migration_version)
             .await?;
         info!(
             context,
             "key-contacts migration took {:?} in total.",
-            start.elapsed()
+            time_elapsed(&start),
         );
         // Schedule `msgs_to_key_contacts()`.
         context

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -14,7 +14,8 @@ use std::str::from_utf8;
 // `Instant` may use `libc::clock_gettime(CLOCK_MONOTONIC)`, e.g. on Android, and does not advance
 // while being in deep sleep mode, we use `SystemTime` instead, but add an alias for it to document
 // why `Instant` isn't used in those places. Also this can help to switch to another clock impl if
-// we find any.
+// we find any. Another reason is that `Instant` may reintroduce panics in the future versions:
+// https://doc.rust-lang.org/1.87.0/std/time/struct.Instant.html#method.elapsed.
 use std::time::Duration;
 pub use std::time::SystemTime as Time;
 #[cfg(not(test))]


### PR DESCRIPTION
There's a comment in `tools` that tells to use `tools::Time` instead of `Instant` because on Android the latter doesn't advance in the deep sleep mode. The only place except `migrations` where `Instant` is used is tests, but we don't run CI on Android. It's unlikely that Delta Chat goes to the deep sleep while executing migrations, but still possible, so let's use `tools::Time` as everywhere else.

Related Rust forum thread: https://users.rust-lang.org/t/std-now-with-android/41774