### PR TITLE
fix: remove display name from get_info()

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -774,13 +774,11 @@ impl Context {
 
     /// Returns information about the context as key-value pairs.
     pub async fn get_info(&self) -> Result<BTreeMap<&'static str, String>> {
-        let unset = "0";
         let l = EnteredLoginParam::load(self).await?;
         let l2 = ConfiguredLoginParam::load(self)
             .await?
             .map_or_else(|| "Not configured".to_string(), |param| param.to_string());
         let secondary_addrs = self.get_secondary_self_addrs().await?.join(", ");
-        let displayname = self.get_config(Config::Displayname).await?;
         let chats = get_chat_cnt(self).await?;
         let unblocked_msgs = message::get_unblocked_msg_cnt(self).await;
         let request_msgs = message::get_request_msg_cnt(self).await;
@@ -859,7 +857,6 @@ impl Context {
         );
         res.insert("journal_mode", journal_mode);
         res.insert("blobdir", self.get_blobdir().display().to_string());
-        res.insert("displayname", displayname.unwrap_or_else(|| unset.into()));
         res.insert(
             "selfavatar",
             self.get_config(Config::Selfavatar)

--- a/src/context/context_tests.rs
+++ b/src/context/context_tests.rs
@@ -310,6 +310,13 @@ async fn test_get_info_completeness() {
                 "'{key}' missing in get_info() output"
             );
         }
+
+        if skip_from_get_info.contains(&&*key) {
+            assert!(
+                !info.contains_key(&*key),
+                "'{key}' should not be in get_info() output"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
Display name is rarely needed for debugging,
so there is no need to include it in the logs.
Display name is even already listed in `skip_from_get_info`, but the test only allowed the values to be skipped without checking that they are always skipped.