### PR TITLE
feat: increase event channel size from 1000 to 10000

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -27,7 +27,7 @@ impl Default for Events {
 impl Events {
     /// Creates a new event channel.
     pub fn new() -> Self {
-        let (mut sender, _receiver) = async_broadcast::broadcast(1_000);
+        let (mut sender, _receiver) = async_broadcast::broadcast(10_000);
 
         // We only keep this receiver around
         // to prevent the channel from closing.


### PR DESCRIPTION
SQL migration to key contacts generates a lot of events, and they are dropped in desktop logs because it does not read the events fast enough.
This at least reduces the number of dropped messages.