### PR TITLE
fix: Update repl help and autocomplete to match implementation

### DIFF
--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -333,8 +333,6 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             _ => println!(
                 "==========================Database commands==\n\
                  info\n\
-                 open <file to open or create>\n\
-                 close\n\
                  set <configuration-key> [<value>]\n\
                  get <configuration-key>\n\
                  oauth2\n\
@@ -349,6 +347,8 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                  ==============================Chat commands==\n\
                  listchats [<query>]\n\
                  listarchived\n\
+                 start-realtime <msg-id>\n\
+                 send-realtime <msg-id> <data>\n\
                  chat [<chat-id>|0]\n\
                  createchat <contact-id>\n\
                  creategroup <name>\n\
@@ -364,6 +364,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                  dellocations\n\
                  getlocations [<contact-id>]\n\
                  send <text>\n\
+                 sendempty\n\
                  sendimage <file> [<text>]\n\
                  sendsticker <file> [<text>]\n\
                  sendfile <file> [<text>]\n\
@@ -382,7 +383,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                  unmute <chat-id>\n\
                  delchat <chat-id>\n\
                  accept <chat-id>\n\
-                 decline <chat-id>\n\
+                 blockchat <chat-id>\n\
                  ===========================Message commands==\n\
                  listmsgs <query>\n\
                  msginfo <msg-id>\n\
@@ -399,7 +400,6 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                  addcontact [<name>] <addr>\n\
                  contactinfo <contact-id>\n\
                  delcontact <contact-id>\n\
-                 cleanupcontacts\n\
                  block <contact-id>\n\
                  unblock <contact-id>\n\
                  listblocked\n\

--- a/deltachat-repl/src/main.rs
+++ b/deltachat-repl/src/main.rs
@@ -179,9 +179,11 @@ const DB_COMMANDS: [&str; 11] = [
     "housekeeping",
 ];
 
-const CHAT_COMMANDS: [&str; 36] = [
+const CHAT_COMMANDS: [&str; 39] = [
     "listchats",
     "listarchived",
+    "start-realtime",
+    "send-realtime",
     "chat",
     "createchat",
     "creategroup",
@@ -197,13 +199,16 @@ const CHAT_COMMANDS: [&str; 36] = [
     "dellocations",
     "getlocations",
     "send",
+    "sendempty",
     "sendimage",
+    "sendsticker",
     "sendfile",
     "sendhtml",
     "sendsyncmsg",
     "sendupdate",
     "videochat",
     "draft",
+    "devicemsg",
     "listmedia",
     "archive",
     "unarchive",
@@ -211,46 +216,46 @@ const CHAT_COMMANDS: [&str; 36] = [
     "unpin",
     "mute",
     "unmute",
-    "protect",
-    "unprotect",
     "delchat",
     "accept",
     "blockchat",
 ];
-const MESSAGE_COMMANDS: [&str; 9] = [
+const MESSAGE_COMMANDS: [&str; 10] = [
     "listmsgs",
     "msginfo",
+    "download",
+    "html",
     "listfresh",
     "forward",
     "resend",
     "markseen",
     "delmsg",
-    "download",
     "react",
 ];
-const CONTACT_COMMANDS: [&str; 8] = [
+const CONTACT_COMMANDS: [&str; 7] = [
     "listcontacts",
     "addcontact",
     "contactinfo",
     "delcontact",
-    "cleanupcontacts",
     "block",
     "unblock",
     "listblocked",
 ];
-const MISC_COMMANDS: [&str; 12] = [
+const MISC_COMMANDS: [&str; 14] = [
     "getqr",
     "getqrsvg",
     "getbadqr",
     "checkqr",
     "joinqr",
+    "setqr",
     "createqrsvg",
+    "providerinfo",
     "fileinfo",
+    "estimatedeletion",
     "clear",
     "exit",
     "quit",
     "help",
-    "estimatedeletion",
 ];
 
 impl Hinter for DcHelper {


### PR DESCRIPTION
- Added commands to help and/or autocomplete:
    - start-realtime (added in 31d7b4f9ce8fa3e0d8ed503eaadc802ad89cccab)
    - send-realtime (added in 31d7b4f9ce8fa3e0d8ed503eaadc802ad89cccab)
    - sendempty (added in 7c5070222157bc4c2611f3480de4e406f76dac60)
    - sendsticker (added in c616b65ce49e4966e878af2b447d67294644293a)
    - devicemsg (added in 89bb2d0ffeac0ed47c92c60d08dd7980cf8f23a4)
    - html (added in e2688f63556edb68f4585892f67e1bbe6eb7607f)
    - setqr (added in 8b4edc46a7ac31e276beb0922e87f0a7f17bc9f7 and 0f90d5038513cd62096cd696b86c2222f1dc019f)
    - providerinfo (added in 748e54d4c286e99fb267408cea979d25b3fb1717)
- Removed non-existent commands from help and/or autocomplete:
    - open (removed in afc9a3108011f68cc931eeff3b69536bbc3a1ace)
    - close (removed in afc9a3108011f68cc931eeff3b69536bbc3a1ace)
    - cleanupcontacts (removed in 227a61e16f1ce1afe2c19f3d141cf6e22571094b)
    - protect (removed in 9cd000c4f2afc223ea92dbb244c92dffb3effbff)
    - unprotect (removed in 9cd000c4f2afc223ea92dbb244c92dffb3effbff)
- Changed 'decline' to 'blockchat' in help.  This was added in commit 065b574d930789d8c63721226d57091499f1c51b; it looks like the name may have changed during development.
- Re-ordered autocomplete lists to match help.

fixes #6977