### PR TITLE
fix: Save msgs to key-contacts migration state and run migration periodically (#6956)

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -257,6 +257,9 @@ pub(crate) const ASM_BODY: &str = "This is the Autocrypt Setup Message \
     If you see this message in a chatmail client (Delta Chat, Arcane Chat, Delta Touch ...), \
     use \"Settings / Add Second Device\" instead.";
 
+/// Period between `sql::housekeeping()` runs.
+pub(crate) const HOUSEKEEPING_PERIOD: i64 = 24 * 60 * 60;
+
 #[cfg(test)]
 mod tests {
     use num_traits::FromPrimitive;

--- a/src/context.rs
+++ b/src/context.rs
@@ -1041,6 +1041,13 @@ impl Context {
                 .await?
                 .to_string(),
         );
+        res.insert(
+            "first_key_contacts_msg_id",
+            self.sql
+                .get_raw_config("first_key_contacts_msg_id")
+                .await?
+                .unwrap_or_default(),
+        );
 
         let elapsed = time_elapsed(&self.creation_time);
         res.insert("uptime", duration_to_str(elapsed));

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -15,6 +15,7 @@ use tokio_util::task::TaskTracker;
 
 use self::connectivity::ConnectivityStore;
 use crate::config::{self, Config};
+use crate::constants;
 use crate::contact::{ContactId, RecentlySeenLoop};
 use crate::context::Context;
 use crate::download::{DownloadState, download_msg};
@@ -497,7 +498,8 @@ async fn inbox_fetch_idle(ctx: &Context, imap: &mut Imap, mut session: Session) 
 
     match ctx.get_config_i64(Config::LastHousekeeping).await {
         Ok(last_housekeeping_time) => {
-            let next_housekeeping_time = last_housekeeping_time.saturating_add(60 * 60 * 24);
+            let next_housekeeping_time =
+                last_housekeeping_time.saturating_add(constants::HOUSEKEEPING_PERIOD);
             if next_housekeeping_time <= time() {
                 sql::housekeeping(ctx).await.log_err(ctx).ok();
             }

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -581,6 +581,12 @@ impl Sql {
         Ok(value)
     }
 
+    /// Removes the `key`'s value from the cache.
+    pub(crate) async fn uncache_raw_config(&self, key: &str) {
+        let mut lock = self.config_cache.write().await;
+        lock.remove(key);
+    }
+
     /// Sets configuration for the given key to 32-bit signed integer value.
     pub async fn set_raw_config_int(&self, key: &str, value: i32) -> Result<()> {
         self.set_raw_config(key, Some(&format!("{value}"))).await
@@ -722,6 +728,11 @@ pub async fn housekeeping(context: &Context) -> Result<()> {
     http_cache_cleanup(context)
         .await
         .context("Failed to cleanup HTTP cache")
+        .log_err(context)
+        .ok();
+    migrations::msgs_to_key_contacts(context)
+        .await
+        .context("migrations::msgs_to_key_contacts")
         .log_err(context)
         .ok();
 


### PR DESCRIPTION
See commit messages. This makes #6956 non-blocker at least. But i wonder if we need a background process to convert messages: if i replace `10_000` with `u64::MAX` (i.e. convert all messages), the migration only takes extra 800 ms for my database. Please test on your dbs, maybe mine isn't huge enough.

EDIT: Added a background process to `housekeeping()`. Fix #6956 