### PR TITLE
fix: Add query to post request for account creation

### DIFF
--- a/src/qr/qr_tests.rs
+++ b/src/qr/qr_tests.rs
@@ -911,15 +911,3 @@ async fn test_decode_backup() -> Result<()> {
 
     Ok(())
 }
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_import_acc() -> Result<()> {
-    let ctx = &TestContext::new().await;
-    set_account_from_qr(
-        ctx,
-        "dcaccount:https://mailadm.testrun.org/new_email?t=1s_7yjxykttyf7zhh3&n=1s",
-    )
-    .await?;
-
-    Ok(())
-}


### PR DESCRIPTION
This PR adds that the given request url is requested instead of only the path. This fixes the newly added test.
Testing: tried to to test it locally but because of nix, I cant run electron or tauri.. ._.


close #6988
