### PR TITLE
test: Tune down DELTACHAT_SAVE_TMP_DB hint

### DIFF
--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1082,8 +1082,6 @@ impl Drop for TestContext {
                             .join(format!("test-account-{}.db", self.name()));
                         tokio::fs::copy(from, &target).await.unwrap();
                         eprintln!("Copied database from {from:?} to {target:?}\n");
-                    } else {
-                        eprintln!("Hint: If you want to examine the database files, set environment variable DELTACHAT_SAVE_TMP_DB=1\n")
                     }
                 });
             }
@@ -1167,6 +1165,11 @@ impl Drop for InnerLogSink {
     fn drop(&mut self) {
         while let Ok(event) = self.events.try_recv() {
             print_logevent(&event);
+        }
+        if std::env::var("DELTACHAT_SAVE_TMP_DB").is_err() {
+            eprintln!(
+                "note: If you want to examine the database files, set environment variable DELTACHAT_SAVE_TMP_DB=1"
+            )
         }
     }
 }


### PR DESCRIPTION
Follow-up for https://github.com/chatmail/core/pull/6992

Since we're printing the hint to stderr now, rather than stdout (as per link2xt's suggestion), it was too noisy. Also, it was printed once for every test account rather than once per test.

Now, it integrates nicely with rust's hint to enable a backtrace:

```
  stderr ───

    thread 'chat::chat_tests::test_broadcasts_name_and_avatar' panicked at src/chat/chat_tests.rs:2757:5:
    assertion failed: `(left == right)`

    Diff < left / right > :
    <true
    >false


    note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
    note: If you want to examine the database files, set environment variable DELTACHAT_SAVE_TMP_DB=1

        FAIL [   0.265s] deltachat chat::chat_tests::test_broadcast
```