### PR TITLE
fix: update tokio-io-timeout to 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6073,9 +6073,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-io-timeout"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
 dependencies = [
  "pin-project-lite",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,7 +101,7 @@ strum_macros = "0.27"
 tagger = "4.3.4"
 textwrap = "0.16.2"
 thiserror = { workspace = true }
-tokio-io-timeout = "1.2.0"
+tokio-io-timeout = "1.2.1"
 tokio-rustls = { version = "0.26.2", default-features = false }
 tokio-stream = { version = "0.1.17", features = ["fs"] }
 tokio-tar = { version = "0.3" } # TODO: integrate tokio into async-tar


### PR DESCRIPTION
tokio-io-timeout 1.2.0 used previously
did not reset the timeout when returning
timeout error. This resulted
in infinite loop spamming
the log with messages that look like this and using 100% CPU:

    Read error on stream 192.168.1.20:993 after reading 9118 and writing 1036 bytes: timed out.
    Read error on stream 192.168.1.20:993 after reading 9118 and writing 1036 bytes: timed out.
    Read error on stream 192.168.1.20:993 after reading 9118 and writing 1036 bytes: timed out.
    Read error on stream 192.168.1.20:993 after reading 9118 and writing 1036 bytes: timed out.
    Read error on stream 192.168.1.20:993 after reading 9118 and writing 1036 bytes: timed out.
    Read error on stream 192.168.1.20:993 after reading 9118 and writing 1036 bytes: timed out.

Normally these messages should be separated by at least 1 minute timeout.

The reason for infinite loop is not figured out yet, but this change should at least fix 100% CPU usage.

See <https://github.com/sfackler/tokio-io-timeout/issues/13> for the bugreport and
<https://github.com/sfackler/tokio-io-timeout/pull/14> for the bugfix.