### PR TITLE
feat: Remove webxdc info messages together with webxdc

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1797,7 +1797,7 @@ pub async fn delete_msgs_ex(
 
         if msg.viewtype == Viewtype::Webxdc {
             let info_msgs = get_webxdc_info_messages(context, &msg).await?;
-            msg_ids_queue.extend(info_msgs.clone());
+            msg_ids_queue.extend(&info_msgs);
             msg_ids.extend(info_msgs);
         }
         modified_chat_ids.insert(msg.chat_id);

--- a/src/message.rs
+++ b/src/message.rs
@@ -1781,7 +1781,7 @@ pub async fn delete_msgs_ex(
     let mut modified_chat_ids = HashSet::new();
     let mut deleted_rfc724_mid = Vec::new();
     let mut res = Ok(());
-    let mut msg_ids_queue = VecDeque::from_iter(msg_ids.iter().cloned());
+    let mut msg_ids_queue = VecDeque::from_iter(msg_ids.iter().copied());
     let mut msg_ids = Vec::from(msg_ids);
 
     while let Some(msg_id) = msg_ids_queue.pop_front() {
@@ -1845,7 +1845,7 @@ pub async fn delete_msgs_ex(
             .await?;
     }
 
-    for &msg_id in msg_ids.iter() {
+    for &msg_id in &msg_ids {
         let msg = Message::load_from_db(context, msg_id).await?;
         delete_msg_locally(context, &msg).await?;
     }

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -33,7 +33,8 @@ use crate::log::LogExt;
 use crate::log::{info, warn};
 use crate::logged_debug_assert;
 use crate::message::{
-    self, Message, MessageState, MessengerMessage, MsgId, Viewtype, rfc724_mid_exists,
+    self, Message, MessageState, MessengerMessage, MsgId, Viewtype, get_webxdc_info_messages,
+    rfc724_mid_exists,
 };
 use crate::mimeparser::{AvatarAction, MimeMessage, SystemMessage, parse_message_ids};
 use crate::param::{Param, Params};
@@ -2295,12 +2296,18 @@ async fn handle_edit_delete(
                 let mut modified_chat_ids = HashSet::new();
                 let mut msg_ids = Vec::new();
 
+                let mut deleted_info_msgs = vec![];
                 let rfc724_mid_vec: Vec<&str> = rfc724_mid_list.split_whitespace().collect();
                 for rfc724_mid in rfc724_mid_vec {
                     if let Some((msg_id, _)) =
                         message::rfc724_mid_exists(context, rfc724_mid).await?
                     {
                         if let Some(msg) = Message::load_from_db_optional(context, msg_id).await? {
+                            if msg.viewtype == Viewtype::Webxdc {
+                                let info_msgs = get_webxdc_info_messages(context, &msg).await?;
+                                deleted_info_msgs.extend(&info_msgs);
+                            }
+
                             if msg.from_id == from_id {
                                 message::delete_msg_locally(context, &msg).await?;
                                 msg_ids.push(msg.id);
@@ -2313,6 +2320,15 @@ async fn handle_edit_delete(
                         }
                     } else {
                         warn!(context, "Delete message: {rfc724_mid:?} not found.");
+                    }
+                }
+                if !deleted_info_msgs.is_empty() {
+                    message::delete_msgs(context, &deleted_info_msgs).await?;
+                    for msg_id in deleted_info_msgs {
+                        if let Some(msg) = Message::load_from_db_optional(context, msg_id).await? {
+                            message::delete_msg_locally(context, &msg).await?;
+                            msg_ids.push(msg.id);
+                        }
                     }
                 }
                 message::delete_msgs_locally_done(context, &msg_ids, modified_chat_ids).await?;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -11,7 +11,7 @@ use crate::contact::ContactId;
 use crate::context::Context;
 use crate::log::LogExt;
 use crate::log::{info, warn};
-use crate::message::{Message, MsgId, Viewtype};
+use crate::message::{Message, MsgId, Viewtype, get_webxdc_info_messages};
 use crate::mimeparser::SystemMessage;
 use crate::param::Param;
 use crate::sync::SyncData::{AddQrToken, AlterChat, DeleteQrToken};
@@ -306,10 +306,15 @@ impl Context {
 
     async fn sync_message_deletion(&self, msgs: &Vec<String>) -> Result<()> {
         let mut modified_chat_ids = HashSet::new();
+        let mut deleted_info_msgs = vec![];
         let mut msg_ids = Vec::new();
         for rfc724_mid in msgs {
             if let Some((msg_id, _)) = message::rfc724_mid_exists(self, rfc724_mid).await? {
                 if let Some(msg) = Message::load_from_db_optional(self, msg_id).await? {
+                    if msg.viewtype == Viewtype::Webxdc {
+                        let info_msgs = get_webxdc_info_messages(&self, &msg).await?;
+                        deleted_info_msgs.extend(&info_msgs);
+                    }
                     message::delete_msg_locally(self, &msg).await?;
                     msg_ids.push(msg.id);
                     modified_chat_ids.insert(msg.chat_id);
@@ -318,6 +323,15 @@ impl Context {
                 }
             } else {
                 warn!(self, "Sync message delete: {rfc724_mid:?} not found.");
+            }
+        }
+        if !deleted_info_msgs.is_empty() {
+            message::delete_msgs(&self, &deleted_info_msgs).await?;
+            for msg_id in deleted_info_msgs {
+                if let Some(msg) = Message::load_from_db_optional(&self, msg_id).await? {
+                    message::delete_msg_locally(&self, &msg).await?;
+                    msg_ids.push(msg.id);
+                }
             }
         }
         message::delete_msgs_locally_done(self, &msg_ids, modified_chat_ids).await?;


### PR DESCRIPTION
This PR adds the feature that webxdc info messages belonging to a wexbdc are deleted when the webxdc is deleted. This is implemented by checking every deleted message whether it has referencing messages with the `SystemMessage` `WebxdcInfoMsg`. These messages are then deleted locally, and a delete request is sent out to chat peers. Deletion could also be implemented on the receiving side of a webxdc delete, but with the current implementation, the code is nice and concise and in one place.

close #6999