### PR TITLE
fix: don't break long group names with non-ASCII characters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3354,9 +3354,9 @@ checksum = "9106e1d747ffd48e6be5bb2d97fa706ed25b144fbee4d5c02eae110cd8d6badd"
 
 [[package]]
 name = "mail-builder"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0926cff74776d4af100a95c90a6649486659526ce638bee6648ecc9c41051810"
+checksum = "900998f307338c4013a28ab14d760b784067324b164448c6d98a89e44810473b"
 
 [[package]]
 name = "mailparse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ iroh-gossip = { version = "0.35", default-features = false, features = ["net"] }
 iroh = { version = "0.35", default-features = false }
 kamadak-exif = "0.6.1"
 libc = { workspace = true }
-mail-builder = { version = "0.4.3", default-features = false }
+mail-builder = { version = "0.4.4", default-features = false }
 mailparse = { workspace = true }
 mime = "0.3.17"
 num_cpus = "1.17"

--- a/src/mimefactory/mimefactory_tests.rs
+++ b/src/mimefactory/mimefactory_tests.rs
@@ -91,8 +91,11 @@ fn test_render_rfc724_mid() {
 
 fn render_header_text(text: &str) -> String {
     let mut output = Vec::<u8>::new();
+
+    // Some non-zero length of the header name.
+    let bytes_written = 20;
     mail_builder::headers::text::Text::new(text.to_string())
-        .write_header(&mut output, 0)
+        .write_header(&mut output, bytes_written)
         .unwrap();
 
     String::from_utf8(output).unwrap()


### PR DESCRIPTION
The fix is in mail-builder 0.4.4.