### PR TITLE
docs: create_group_chat_unencrypted() may lead to chat split on the first device

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -1081,7 +1081,9 @@ impl CommandApi {
     /// Create a new unencrypted group chat.
     ///
     /// Same as [`Self::create_group_chat`], but the chat is unencrypted and can only have
-    /// address-contacts.
+    /// address-contacts. NB: Chats with similar names and the same members are merged on other
+    /// devices, but usually users don't create such chats and look up the existing one instead, so
+    /// chat split on the first device is acceptable.
     async fn create_group_chat_unencrypted(&self, account_id: u32, name: String) -> Result<u32> {
         let ctx = self.get_context(account_id).await?;
         chat::create_group_unencrypted(&ctx, &name)

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3556,6 +3556,10 @@ pub async fn create_group_unencrypted(context: &Context, name: &str) -> Result<C
 ///   unencrypted chats currently.
 /// * `grpid` - Group ID. Iff nonempty, the chat is encrypted (with key-contacts).
 /// * `name` - Chat name.
+///
+/// NB: Unencrypted chats with similar names and the same members are merged on other devices, but
+/// usually users don't create such chats and look up the existing one instead, so chat split on the
+/// first device is acceptable.
 pub(crate) async fn create_group_ex(
     context: &Context,
     sync: sync::Sync,


### PR DESCRIPTION
I don't think it's worth changing the API because of this glitch, should be a rare case.