### PR TITLE
fix: check for Chat-Version header before marking the contact as a bot

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -584,7 +584,8 @@ impl MimeMessage {
         };
 
         let is_location_only = parser.location_kml.is_some() && parser.parts.is_empty();
-        if parser.mdn_reports.is_empty()
+        if parser.has_chat_version()
+            && parser.mdn_reports.is_empty()
             && !is_location_only
             && parser.sync_items.is_none()
             && parser.webxdc_status_update.is_none()


### PR DESCRIPTION
Contacts are marked as a bot if incoming message from a contact has `Auto-Submitted: auto-generated` header.
However, such message can be generated by the server, e.g. as an auto-reply.

To prevent accidentally marking the contact as a bot when auto-generated message is sent by the server, we need to check for `Chat-Version` header
to make sure that the message is generated by the client.

This is already how it is documented in `MimeMessage.is_bot` field documentation comment, but was not checked in the implementation.