### PR TITLE
fix: do not reverify already verified contacts via gossip

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1977,8 +1977,9 @@ pub(crate) async fn mark_contact_id_as_verified(
                 }
             }
             transaction.execute(
-                "UPDATE contacts SET verifier=? WHERE id=?",
-                (verifier_id, contact_id),
+                "UPDATE contacts SET verifier=?1
+                 WHERE id=?2 AND (verifier=0 OR ?1=?3)",
+                (verifier_id, contact_id, ContactId::SELF),
             )?;
             Ok(())
         })


### PR DESCRIPTION
If the contact is already introduced by someone,
usually by adding to a verified group,
it should not be reverified because of another
chat message is a verified group.
This usually results is verification loops
and is not meaningful because the verifier
likely got this same contact introduced
in the same group.

Closes #7107