### PR TITLE
feat: replace HSLuv colors with OKLCH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,6 +930,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
+name = "colorutils-rs"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "103c2458789cd7b46e6ed7c7ba1bf969b6569c902e3732843c55962c53eac686"
+dependencies = [
+ "erydanos",
+ "half",
+ "num-traits",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1310,7 @@ dependencies = [
  "brotli",
  "bytes",
  "chrono",
+ "colorutils-rs",
  "criterion",
  "data-encoding",
  "deltachat-contact-tools",
@@ -1896,6 +1908,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
+name = "erydanos"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cbdc4987ed8e9ece64845393c2d53596b3a4ccbfb3948d799d58f6450e89fb1"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "escaper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,9 +2353,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,11 @@ async-native-tls = { version = "0.5", default-features = false, features = ["run
 async-smtp = { version = "0.10.2", default-features = false, features = ["runtime-tokio"] }
 async_zip = { version = "0.0.17", default-features = false, features = ["deflate", "tokio-fs"] }
 base64 = { workspace = true }
+blake3 = "1.8.2"
 brotli = { version = "8", default-features=false, features = ["std"] }
 bytes = "1"
 chrono = { workspace = true, features = ["alloc", "clock", "std"] }
+colorutils-rs = { version = "0.7.5", default-features = false }
 data-encoding = "2.9.0"
 escaper = "0.1"
 fast-socks5 = "0.10"
@@ -85,7 +87,6 @@ quoted_printable = "0.5"
 rand = { workspace = true }
 regex = { workspace = true }
 rusqlite = { workspace = true, features = ["sqlcipher"] }
-rust-hsluv = "0.1"
 rustls-pki-types = "1.12.0"
 rustls = { version = "0.23.22", default-features = false }
 sanitize-filename = { workspace = true }
@@ -112,7 +113,6 @@ tracing = "0.1.41"
 url = "2"
 uuid = { version = "1", features = ["serde", "v4"] }
 webpki-roots = "0.26.8"
-blake3 = "1.8.2"
 
 [dev-dependencies]
 anyhow = { workspace = true, features = ["backtrace"] } # Enable `backtrace` feature in tests.


### PR DESCRIPTION
See https://support.delta.chat/t/dc-desktop-default-chat-avatar-colors/3816/13

I played a bit with using OKLCH model instead of HSLuv. First producing HSL color, then converting OKLCH, then adjusting OKLCH chroma to 0.2 and lightness to 0.5.

The reason for converting to HSL first is to keep hue the same because OKLCH hue/angle does not match HSL hue/angle and we want to have the same hue as before.

Before:
<img width="280" height="1008" alt="image" src="https://github.com/user-attachments/assets/5fb4eafe-2400-4785-ac20-d24c622f48e0" />

After:
<img width="280" height="1008" alt="image" src="https://github.com/user-attachments/assets/db8211b6-93a4-401a-b7b2-4c2ffcf04a31" />

This gets rid of saturated magenta colors while keeping the same lightness. Small problem is that it is not clear how to select chroma, it is not clearly limited and selecting too high values results in clipping as you can see in blue becoming somewhat purple, and selecting too low values results in everything becoming gray.