### PR TITLE
Expire authentication tokens

### DIFF
--- a/src/token.rs
+++ b/src/token.rs
@@ -86,24 +86,6 @@ pub async fn exists(context: &Context, namespace: Namespace, token: &str) -> Res
     Ok(exists)
 }
 
-/// Looks up foreign key by auth token.
-///
-/// Returns None if auth token is not valid.
-/// Returns an empty string if the token corresponds to "setup contact" rather than group join.
-pub async fn auth_foreign_key(context: &Context, token: &str) -> Result<Option<String>> {
-    context
-        .sql
-        .query_row_optional(
-            "SELECT foreign_key FROM tokens WHERE namespc=? AND token=?",
-            (Namespace::Auth, token),
-            |row| {
-                let foreign_key: String = row.get(0)?;
-                Ok(foreign_key)
-            },
-        )
-        .await
-}
-
 /// Resets all tokens corresponding to the `foreign_key`.
 ///
 /// `foreign_key` is a group ID to reset all group tokens


### PR DESCRIPTION
Based on #7116.
Depends on https://github.com/chatmail/core/pull/7176
Closes #7111

Currently we have tokens table which stores invite tokens and auth tokens. Tokens are indexed by `foreign_key` (group ID or empty string in case of contact setup QR codes) and normally there is only one token unless token has been synced from another device.

With this change we generate a new auth codes each time QR code is shown. Each auth token has a timestamp, and 10 minutes later it is considered expired. Expired auth token still works for joining groups, but does not result in verification on Alice's side.

To clean up auth tokens eventually we have a PR #7176 that changes how we reset QR codes. Once one QR code is reset, all related tokens are removed.