### PR TITLE
feat: support receiving Autocrypt-Gossip with `_verified` attribute

### DIFF
--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -35,6 +35,7 @@ impl EncryptHelper {
             addr: self.addr.clone(),
             public_key: self.public_key.clone(),
             prefer_encrypt: self.prefer_encrypt,
+            verified: false,
         }
     }
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1098,6 +1098,7 @@ impl MimeFactory {
                                 // Autocrypt 1.1.0 specification says that
                                 // `prefer-encrypt` attribute SHOULD NOT be included.
                                 prefer_encrypt: EncryptPreference::NoPreference,
+                                verified: false,
                             }
                             .to_string();
 

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -1,7 +1,7 @@
 //! # MIME message parsing module.
 
 use std::cmp::min;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 use std::str;
 use std::str::FromStr;
@@ -35,6 +35,17 @@ use crate::tools::{
     get_filemeta, parse_receive_headers, smeared_time, time, truncate_msg_text, validate_id,
 };
 use crate::{chatlist_events, location, stock_str, tools};
+
+/// Public key extracted from `Autocrypt-Gossip`
+/// header with associated information.
+#[derive(Debug)]
+pub struct GossipedKey {
+    /// Public key extracted from `keydata` attribute.
+    pub public_key: SignedPublicKey,
+
+    /// True if `Autocrypt-Gossip` has a `_verified` attribute.
+    pub verified: bool,
+}
 
 /// A parsed MIME message.
 ///
@@ -85,7 +96,7 @@ pub(crate) struct MimeMessage {
 
     /// The addresses for which there was a gossip header
     /// and their respective gossiped keys.
-    pub gossiped_keys: HashMap<String, SignedPublicKey>,
+    pub gossiped_keys: BTreeMap<String, GossipedKey>,
 
     /// Fingerprint of the key in the Autocrypt header.
     ///
@@ -1967,9 +1978,9 @@ async fn parse_gossip_headers(
     from: &str,
     recipients: &[SingleInfo],
     gossip_headers: Vec<String>,
-) -> Result<HashMap<String, SignedPublicKey>> {
+) -> Result<BTreeMap<String, GossipedKey>> {
     // XXX split the parsing from the modification part
-    let mut gossiped_keys: HashMap<String, SignedPublicKey> = Default::default();
+    let mut gossiped_keys: BTreeMap<String, GossipedKey> = Default::default();
 
     for value in &gossip_headers {
         let header = match value.parse::<Aheader>() {
@@ -2011,7 +2022,12 @@ async fn parse_gossip_headers(
             )
             .await?;
 
-        gossiped_keys.insert(header.addr.to_lowercase(), header.public_key);
+        let gossiped_key = GossipedKey {
+            public_key: header.public_key,
+
+            verified: header.verified,
+        };
+        gossiped_keys.insert(header.addr.to_lowercase(), gossiped_key);
     }
 
     Ok(gossiped_keys)

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -272,7 +272,9 @@ pub(crate) async fn handle_securejoin_handshake(
         let mut self_found = false;
         let self_fingerprint = load_self_public_key(context).await?.dc_fingerprint();
         for (addr, key) in &mime_message.gossiped_keys {
-            if key.dc_fingerprint() == self_fingerprint && context.is_self_addr(addr).await? {
+            if key.public_key.dc_fingerprint() == self_fingerprint
+                && context.is_self_addr(addr).await?
+            {
                 self_found = true;
                 break;
             }
@@ -542,7 +544,7 @@ pub(crate) async fn observe_securejoin_on_other_device(
         return Ok(HandshakeMessage::Ignore);
     };
 
-    if key.dc_fingerprint() != contact_fingerprint {
+    if key.public_key.dc_fingerprint() != contact_fingerprint {
         // Fingerprint does not match, ignore.
         warn!(context, "Fingerprint does not match.");
         return Ok(HandshakeMessage::Ignore);

--- a/src/securejoin/securejoin_tests.rs
+++ b/src/securejoin/securejoin_tests.rs
@@ -5,6 +5,7 @@ use crate::chat::{CantSendReason, remove_contact_from_chat};
 use crate::chatlist::Chatlist;
 use crate::constants::Chattype;
 use crate::key::self_fingerprint;
+use crate::mimeparser::GossipedKey;
 use crate::receive_imf::receive_imf;
 use crate::stock_str::{self, messages_e2e_encrypted};
 use crate::test_utils::{
@@ -185,7 +186,10 @@ async fn test_setup_contact_ex(case: SetupContactCase) {
     );
 
     if case == SetupContactCase::WrongAliceGossip {
-        let wrong_pubkey = load_self_public_key(&bob).await.unwrap();
+        let wrong_pubkey = GossipedKey {
+            public_key: load_self_public_key(&bob).await.unwrap(),
+            verified: false,
+        };
         let alice_pubkey = msg
             .gossiped_keys
             .insert(alice_addr.to_string(), wrong_pubkey)


### PR DESCRIPTION
Based on #7146
Preparing for #7116, but should go into a separate release.

This commit is a preparation for
sending Autocrypt-Gossip with `_verified` attribute instead of `Chat-Verified` header.