### PR TITLE
docs: comment about outdated timespan

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -98,6 +98,7 @@ pub(crate) const DC_RESEND_USER_AVATAR_DAYS: i64 = 14;
 // reference is the release date.
 // as not all system get speedy updates,
 // do not use too small value that will annoy users checking for nonexistent updates.
+// "90 days" has proven to be too short at some point (user were informed but there was no update)
 pub(crate) const DC_OUTDATED_WARNING_DAYS: i64 = 183;
 
 /// messages that should be deleted get this chat_id; the messages are deleted from the working thread later then. This is also needed as rfc724_mid should be preset as long as the message is not deleted on the server (otherwise it is downloaded again)

--- a/src/tools/tools_tests.rs
+++ b/src/tools/tools_tests.rs
@@ -437,7 +437,8 @@ async fn test_maybe_warn_on_outdated() {
     let t = TestContext::new().await;
     let timestamp_now: i64 = time();
 
-    // in about 3 months, the app should not be outdated
+    // in about 3 months, the app should not be outdated.
+    // "90 days" has proven to be too short at some point - user were informed but there was no update
     maybe_warn_on_outdated(
         &t,
         timestamp_now + 90 * 24 * 60 * 60,


### PR DESCRIPTION
this PR adds comments to the "183 days update reminder timestamp" and to the "90 days test"

cmp comment at https://github.com/chatmail/core/pull/7144

