### PR TITLE
feat: withdraw all QR codes when one is withdrawn

### DIFF
--- a/src/qr.rs
+++ b/src/qr.rs
@@ -766,19 +766,18 @@ pub async fn set_config_from_qr(context: &Context, qr: &str) -> Result<()> {
             authcode,
             ..
         } => {
-            token::delete(context, token::Namespace::InviteNumber, &invitenumber).await?;
-            token::delete(context, token::Namespace::Auth, &authcode).await?;
+            token::delete(context, "").await?;
             context
                 .sync_qr_code_token_deletion(invitenumber, authcode)
                 .await?;
         }
         Qr::WithdrawVerifyGroup {
+            grpid,
             invitenumber,
             authcode,
             ..
         } => {
-            token::delete(context, token::Namespace::InviteNumber, &invitenumber).await?;
-            token::delete(context, token::Namespace::Auth, &authcode).await?;
+            token::delete(context, &grpid).await?;
             context
                 .sync_qr_code_token_deletion(invitenumber, authcode)
                 .await?;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -296,8 +296,15 @@ impl Context {
     }
 
     async fn delete_qr_token(&self, token: &QrTokenData) -> Result<()> {
-        token::delete(self, Namespace::InviteNumber, &token.invitenumber).await?;
-        token::delete(self, Namespace::Auth, &token.auth).await?;
+        self.sql
+            .execute(
+                "DELETE FROM tokens
+                 WHERE foreign_key IN
+                 (SELECT foreign_key FROM tokens
+                  WHERE token=? OR token=?)",
+                (&token.invitenumber, &token.auth),
+            )
+            .await?;
         Ok(())
     }
 
@@ -568,8 +575,8 @@ mod tests {
                 .await?
                 .is_none()
         );
-        assert!(token::exists(&t, Namespace::InviteNumber, "yip-in").await?);
-        assert!(token::exists(&t, Namespace::Auth, "yip-auth").await?);
+        assert!(!token::exists(&t, Namespace::InviteNumber, "yip-in").await?);
+        assert!(!token::exists(&t, Namespace::Auth, "yip-auth").await?);
         assert!(!token::exists(&t, Namespace::Auth, "non-existent").await?);
         assert!(!token::exists(&t, Namespace::Auth, "directly deleted").await?);
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -104,13 +104,14 @@ pub async fn auth_foreign_key(context: &Context, token: &str) -> Result<Option<S
         .await
 }
 
-pub async fn delete(context: &Context, namespace: Namespace, token: &str) -> Result<()> {
+/// Resets all tokens corresponding to the `foreign_key`.
+///
+/// `foreign_key` is a group ID to reset all group tokens
+/// or empty string to reset all setup contact tokens.
+pub async fn delete(context: &Context, foreign_key: &str) -> Result<()> {
     context
         .sql
-        .execute(
-            "DELETE FROM tokens WHERE namespc=? AND token=?;",
-            (namespace, token),
-        )
+        .execute("DELETE FROM tokens WHERE foreign_key=?", (foreign_key,))
         .await?;
     Ok(())
 }


### PR DESCRIPTION
This is a preparation for expiring authentication tokens.

If we make authentication token expire,
we need to generate new authentication tokens each time QR code screen is opened in the UI,
so authentication token is fresh.
We however don't want to completely invalidate
old authentication codes at the same time,
e.g. they should still be valid for joining groups, just not result in a verification on the inviter side.

Since a group now can have a lot of authentication tokens, it is easy to lose track of them
without any way to remove them
as they are not displayed anywhere in the UI.
As a solution, we now remove all
tokens corresponding to a group ID
when one token is withdrawn,
or all non-group tokens
when a single non-group token is withdrawn.

"Reset QR code" option already present
in the UI which works by resetting
current QR code will work without any UI changes,
but will now result in invalidation
of all previously created QR codes and invite links.