### PR TITLE
feat: Don't mark MDNs and DSNs as seen on IMAP

### DIFF
--- a/deltachat-rpc-client/tests/test_folders.py
+++ b/deltachat-rpc-client/tests/test_folders.py
@@ -69,12 +69,11 @@ def test_markseen_message_and_mdn(acfactory, direct_imap):
     msg.mark_seen()
 
     rex = re.compile("Marked messages [0-9]+ in folder INBOX as seen.")
-
-    for ac in ac1, ac2:
-        while True:
-            event = ac.wait_for_event()
-            if event.kind == EventType.INFO and rex.search(event.msg):
-                break
+    while True:
+        event = ac2.wait_for_event()
+        if event.kind == EventType.INFO and rex.search(event.msg):
+            break
+    ac1.wait_for_msg(EventType.MSGS_CHANGED)
 
     ac1_direct_imap = direct_imap(ac1)
     ac2_direct_imap = direct_imap(ac2)
@@ -82,9 +81,9 @@ def test_markseen_message_and_mdn(acfactory, direct_imap):
     ac1_direct_imap.select_folder("INBOX")
     ac2_direct_imap.select_folder("INBOX")
 
-    # Check that the mdn and original message is marked as seen
-    assert len(list(ac1_direct_imap.conn.fetch(AND(seen=True), mark_seen=False))) == 2
-    assert len(list(ac2_direct_imap.conn.fetch(AND(seen=True), mark_seen=False))) == 2
+    # Check that the original message is marked as seen.
+    assert len(list(ac1_direct_imap.conn.fetch(AND(seen=True), mark_seen=False))) == 1
+    assert len(list(ac2_direct_imap.conn.fetch(AND(seen=True), mark_seen=False))) == 1
 
 
 def test_trash_multiple_messages(acfactory, direct_imap, log):

--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -429,9 +429,6 @@ def test_send_and_receive_message_markseen(acfactory, lp):
         assert ev.data2 > dc.const.DC_MSG_ID_LAST_SPECIAL
     lp.step("2")
 
-    # Check that ac1 marks the read receipt as read.
-    ac1._evtracker.get_info_contains("Marked messages .* in folder INBOX as seen.")
-
     assert msg1.is_out_mdn_received()
     assert msg3.is_out_mdn_received()
 
@@ -541,10 +538,8 @@ def test_mdn_asymmetric(acfactory, lp):
     lp.sec("ac1: waiting for incoming activity")
     assert len(chat.get_messages()) == 1 + E2EE_INFO_MSGS
 
-    # Wait for the mdn to be marked as seen on IMAP.
-    ac1._evtracker.get_info_contains("Marked messages [0-9]+ in folder INBOX as seen.")
-
     # MDN is received even though MDNs are already disabled
+    ac1._evtracker.get_matching("DC_EVENT_MSG_READ")
     assert msg_out.is_out_mdn_received()
 
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -931,11 +931,6 @@ UPDATE config SET value=? WHERE keyname='configured_addr' AND value!=?1
                 .await?;
             context.scheduler.interrupt_inbox().await;
         }
-        if target.is_none() && !mime_parser.mdn_reports.is_empty() && mime_parser.has_chat_version()
-        {
-            // This is a Delta Chat MDN. Mark as read.
-            markseen_on_imap_table(context, rfc724_mid_orig).await?;
-        }
         if !mime_parser.incoming && !context.get_config_bool(Config::TeamProfile).await? {
             let mut updated_chats = BTreeMap::new();
             let mut archived_chats_maybe_noticed = false;

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1163,8 +1163,9 @@ async fn decide_chat_assignment(
         info!(context, "Message is an MDN (TRASH).");
         true
     } else if mime_parser.delivery_report.is_some() {
+        // Auto-marking DSNs as IMAP-seen should be avoided because the user may want to see them in
+        // another MUA.
         info!(context, "Message is a DSN (TRASH).");
-        markseen_on_imap_table(context, rfc724_mid).await.ok();
         true
     } else if mime_parser.get_header(HeaderDef::ChatEdit).is_some()
         || mime_parser.get_header(HeaderDef::ChatDelete).is_some()


### PR DESCRIPTION
Marking MDNs as seen is useless, they shouldn't be displayed by any MUA. Auto-marking DSNs as seen should be avoided because the user may want to see them in another MUA.

EDIT: Removed the first commit, probably we want to just not mark any encrypted messages as \Seen and for unencrypted ones it doesn't matter much.