### PR TITLE
fix: Delete obsolete "configured*" keys from `config` table (#7171)

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -821,7 +821,6 @@ impl Context {
         let unblocked_msgs = message::get_unblocked_msg_cnt(self).await;
         let request_msgs = message::get_request_msg_cnt(self).await;
         let contacts = Contact::get_real_cnt(self).await?;
-        let is_configured = self.get_config_int(Config::Configured).await?;
         let proxy_enabled = self.get_config_int(Config::ProxyEnabled).await?;
         let dbversion = self
             .sql
@@ -900,7 +899,6 @@ impl Context {
                 .await?
                 .unwrap_or_else(|| "<unset>".to_string()),
         );
-        res.insert("is_configured", is_configured.to_string());
         res.insert("proxy_enabled", proxy_enabled.to_string());
         res.insert("entered_account_settings", l.to_string());
         res.insert("used_account_settings", l2);

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -1310,6 +1310,32 @@ CREATE INDEX gossip_timestamp_index ON gossip_timestamp (chat_id, fingerprint);
         .await?;
     }
 
+    inc_and_check(&mut migration_version, 137)?;
+    if dbversion < migration_version {
+        sql.execute_migration(
+            "DELETE FROM config WHERE keyname IN (
+                'configured',
+                'configured_imap_certificate_checks',
+                'configured_imap_servers',
+                'configured_mail_port',
+                'configured_mail_pw',
+                'configured_mail_security',
+                'configured_mail_server',
+                'configured_mail_user',
+                'configured_send_port',
+                'configured_send_pw',
+                'configured_send_security',
+                'configured_send_server',
+                'configured_send_user',
+                'configured_server_flags',
+                'configured_smtp_certificate_checks',
+                'configured_smtp_servers'
+            )",
+            migration_version,
+        )
+        .await?;
+    }
+
     let new_version = sql
         .get_raw_config_int(VERSION_CFG)
         .await?


### PR DESCRIPTION
Based on #7116 
Close #7171 