### PR TITLE
fix: Don't add "member removed" messages from nonmembers (#7207)

### DIFF
--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -4160,7 +4160,7 @@ async fn test_past_members() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn non_member_cannot_modify_member_list() -> Result<()> {
+async fn test_non_member_cannot_modify_member_list() -> Result<()> {
     let mut tcm = TestContextManager::new();
 
     let alice = &tcm.alice().await;
@@ -4192,6 +4192,12 @@ async fn non_member_cannot_modify_member_list() -> Result<()> {
     alice.recv_msg_trash(&bob_sent_add_msg).await;
     assert_eq!(get_chat_contacts(alice, alice_chat_id).await?.len(), 1);
 
+    // The same for removal.
+    let bob_alice_contact_id = bob.add_or_lookup_contact_id(alice).await;
+    remove_contact_from_chat(bob, bob_chat_id, bob_alice_contact_id).await?;
+    let bob_sent_add_msg = bob.pop_sent_msg().await;
+    alice.recv_msg_trash(&bob_sent_add_msg).await;
+    assert_eq!(get_chat_contacts(alice, alice_chat_id).await?.len(), 1);
     Ok(())
 }
 

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2907,8 +2907,12 @@ async fn apply_group_changes(
         // rather than old display name.
         // This could be fixed by looking up the contact with the highest
         // `remove_timestamp` after applying Chat-Group-Member-Timestamps.
-        removed_id = lookup_key_contact_by_address(context, removed_addr, Some(chat.id)).await?;
-        if let Some(id) = removed_id {
+        if !is_from_in_chat {
+            better_msg = Some(String::new());
+        } else if let Some(id) =
+            lookup_key_contact_by_address(context, removed_addr, Some(chat.id)).await?
+        {
+            removed_id = Some(id);
             better_msg = if id == from_id {
                 silent = true;
                 Some(stock_str::msg_group_left_local(context, from_id).await)
@@ -2919,7 +2923,9 @@ async fn apply_group_changes(
             warn!(context, "Removed {removed_addr:?} has no contact id.")
         }
     } else if let Some(added_addr) = mime_parser.get_header(HeaderDef::ChatGroupMemberAdded) {
-        if let Some(key) = mime_parser.gossiped_keys.get(added_addr) {
+        if !is_from_in_chat {
+            better_msg = Some(String::new());
+        } else if let Some(key) = mime_parser.gossiped_keys.get(added_addr) {
             // TODO: if gossiped keys contain the same address multiple times,
             // we may lookup the wrong contact.
             // This could be fixed by looking up the contact with


### PR DESCRIPTION
Fix #7207 

Checked locally that Rust tests pass.