### PR TITLE
ci: install rustfmt before checking provider database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
         with:
           show-progress: false
           persist-credentials: false
+      - name: Install rustfmt
+        run: rustup component add --toolchain stable-x86_64-unknown-linux-gnu rustfmt
       - name: Check provider database
         run: scripts/update-provider-database.sh
 


### PR DESCRIPTION
Apparently it is not installed by default anymore.