### PR TITLE
ci: fix CI checking Nix formatting

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,10 +24,7 @@ jobs:
           show-progress: false
           persist-credentials: false
       - uses: DeterminateSystems/nix-installer-action@main
-      - run: nix fmt
-
-      # Check that formatting does not change anything.
-      - run: git diff --exit-code
+      - run: nix fmt flake.nix -- --check
 
   build:
     name: nix build


### PR DESCRIPTION
`nix fmt` by itself tries to read stdin,
not `flake.nix`.