### PR TITLE
fix: lowercase "call" in "Missed call" and similar strings

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1222,7 +1222,7 @@ uint32_t        dc_init_webxdc_integration    (dc_context_t* context, uint32_t c
  * Possible actions during ringing:
  *
  * - caller cancels the call using dc_end_call():
- *   callee receives #DC_EVENT_CALL_ENDED and has a "Missed Call"
+ *   callee receives #DC_EVENT_CALL_ENDED and has a "Missed call"
  *
  * - callee accepts using dc_accept_incoming_call():
  *   caller receives #DC_EVENT_OUTGOING_CALL_ACCEPTED.
@@ -1242,8 +1242,8 @@ uint32_t        dc_init_webxdc_integration    (dc_context_t* context, uint32_t c
  *   caller and callee receive #DC_EVENT_CALL_ENDED
  *   to prevent endless ringing of callee
  *   in case caller got offline without being able to send cancellation message.
- *   for caller, this is a "Canceled Call";
- *   for callee, this is a "Missed Call"
+ *   for caller, this is a "Canceled call";
+ *   for callee, this is a "Missed call"
  *
  * Actions during the call:
  *
@@ -7850,19 +7850,19 @@ void dc_event_unref(dc_event_t* event);
 /// "❤️ Seems you're enjoying Delta Chat!"… (donation request device message)
 #define DC_STR_DONATION_REQUEST 193
 
-/// "Outgoing Call"
+/// "Outgoing call"
 #define DC_STR_OUTGOING_CALL 194
 
-/// "Incoming Call"
+/// "Incoming call"
 #define DC_STR_INCOMING_CALL 195
 
-/// "Declined Call"
+/// "Declined call"
 #define DC_STR_DECLINED_CALL 196
 
-/// "Canceled Call"
+/// "Canceled call"
 #define DC_STR_CANCELED_CALL 197
 
-/// "Missed Call"
+/// "Missed call"
 #define DC_STR_MISSED_CALL 198
 
 /// "You left the channel."

--- a/src/calls/calls_tests.rs
+++ b/src/calls/calls_tests.rs
@@ -401,7 +401,7 @@ async fn test_caller_cancels_call() -> Result<()> {
     // Test that message summary says it is a missed call.
     let bob_call_msg = Message::load_from_db(&bob, bob_call.id).await?;
     let summary = bob_call_msg.get_summary(&bob, None).await?;
-    assert_eq!(summary.text, "📞 Missed Call");
+    assert_eq!(summary.text, "📞 Missed call");
 
     bob2.recv_msg_trash(&sent3).await;
     assert_text(&bob2, bob2_call.id, "Missed call").await?;

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -425,19 +425,19 @@ Help keeping us to keep Delta Chat independent and make it more awesome in the f
 https://delta.chat/donate"))]
     DonationRequest = 193,
 
-    #[strum(props(fallback = "Outgoing Call"))]
+    #[strum(props(fallback = "Outgoing call"))]
     OutgoingCall = 194,
 
-    #[strum(props(fallback = "Incoming Call"))]
+    #[strum(props(fallback = "Incoming call"))]
     IncomingCall = 195,
 
-    #[strum(props(fallback = "Declined Call"))]
+    #[strum(props(fallback = "Declined call"))]
     DeclinedCall = 196,
 
-    #[strum(props(fallback = "Canceled Call"))]
+    #[strum(props(fallback = "Canceled call"))]
     CanceledCall = 197,
 
-    #[strum(props(fallback = "Missed Call"))]
+    #[strum(props(fallback = "Missed call"))]
     MissedCall = 198,
 
     #[strum(props(fallback = "You left the channel."))]
@@ -827,27 +827,27 @@ pub(crate) async fn donation_request(context: &Context) -> String {
     translated(context, StockMessage::DonationRequest).await
 }
 
-/// Stock string: `Outgoing Call`.
+/// Stock string: `Outgoing call`.
 pub(crate) async fn outgoing_call(context: &Context) -> String {
     translated(context, StockMessage::OutgoingCall).await
 }
 
-/// Stock string: `Incoming Call`.
+/// Stock string: `Incoming call`.
 pub(crate) async fn incoming_call(context: &Context) -> String {
     translated(context, StockMessage::IncomingCall).await
 }
 
-/// Stock string: `Declined Call`.
+/// Stock string: `Declined call`.
 pub(crate) async fn declined_call(context: &Context) -> String {
     translated(context, StockMessage::DeclinedCall).await
 }
 
-/// Stock string: `Canceled Call`.
+/// Stock string: `Canceled call`.
 pub(crate) async fn canceled_call(context: &Context) -> String {
     translated(context, StockMessage::CanceledCall).await
 }
 
-/// Stock string: `Missed Call`.
+/// Stock string: `Missed call`.
 pub(crate) async fn missed_call(context: &Context) -> String {
     translated(context, StockMessage::MissedCall).await
 }


### PR DESCRIPTION
This string is used in summaries
and message bubbles and is typically not capitalized, unlike menu items.