### PR TITLE
refactor: assert that Iroh node addresses have home relay URL

### DIFF
--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -119,6 +119,11 @@ pub enum HeaderDef {
     AuthenticationResults,
 
     /// Node address from iroh where direct addresses have been removed.
+    ///
+    /// The node address sent in this header must have
+    /// a non-null relay URL as contacting home relay
+    /// is the only way to reach the node without
+    /// direct addresses and global discovery.
     IrohNodeAddr,
 
     /// Advertised gossip topic for one webxdc.

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1522,16 +1522,19 @@ impl MimeFactory {
                 ));
             }
             SystemMessage::IrohNodeAddr => {
+                let node_addr = context
+                    .get_or_try_init_peer_channel()
+                    .await?
+                    .get_node_addr()
+                    .await?;
+
+                // We should not send `null` as relay URL
+                // as this is the only way to reach the node.
+                debug_assert!(node_addr.relay_url().is_some());
                 headers.push((
                     HeaderDef::IrohNodeAddr.into(),
-                    mail_builder::headers::text::Text::new(serde_json::to_string(
-                        &context
-                            .get_or_try_init_peer_channel()
-                            .await?
-                            .get_node_addr()
-                            .await?,
-                    )?)
-                    .into(),
+                    mail_builder::headers::text::Text::new(serde_json::to_string(&node_addr)?)
+                        .into(),
                 ));
             }
             SystemMessage::CallAccepted => {

--- a/src/peer_channels.rs
+++ b/src/peer_channels.rs
@@ -185,9 +185,14 @@ impl Iroh {
     }
 
     /// Get the iroh [NodeAddr] without direct IP addresses.
+    ///
+    /// The address is guaranteed to have home relay URL set
+    /// as it is the only way to reach the node
+    /// without global discovery mechanisms.
     pub(crate) async fn get_node_addr(&self) -> Result<NodeAddr> {
         let mut addr = self.router.endpoint().node_addr().await?;
         addr.direct_addresses = BTreeSet::new();
+        debug_assert!(addr.relay_url().is_some());
         Ok(addr)
     }
 


### PR DESCRIPTION
With newer Iroh it is possible to obtain
own node address before home relay is selected
and accidentally send own address without relay URL.

It took me some time to debug why Iroh 0.92.0
did not work with iroh-relay 0.92.0
so I'm adding these assertions even
while we still use Iroh 0.35.0.