### PR TITLE
build: add nodejs to nix dev env

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -587,6 +587,7 @@
               (python3.withPackages (pypkgs: with pypkgs; [
                 tox
               ]))
+              nodejs
             ];
           };
       }


### PR DESCRIPTION
it is required to build jsonrpc client npm package and for the stdio
server npm package
