### PR TITLE
ci: update to Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,9 +228,9 @@ jobs:
         include:
           # Currently used Rust version.
           - os: ubuntu-latest
-            python: 3.13
+            python: 3.14
           - os: macos-latest
-            python: 3.13
+            python: 3.14
 
           # PyPy tests
           - os: ubuntu-latest
@@ -281,11 +281,11 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python: 3.13
+            python: 3.14
           - os: macos-latest
-            python: 3.13
+            python: 3.14
           - os: windows-latest
-            python: 3.13
+            python: 3.14
 
           # PyPy tests
           - os: ubuntu-latest

--- a/deltachat-rpc-client/pyproject.toml
+++ b/deltachat-rpc-client/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Communications :: Chat",
     "Topic :: Communications :: Email"
 ]


### PR DESCRIPTION
I have not updated Python interpreters for legacy bindings in scripts/run_all.sh because I have not checked
if manylinux images already exist and work for building wheels. Legacy Python bindings are deprecated
and we don't publish new releases for them.