### PR TITLE
fix: accept unknown viewtype in ephemeral/delete-old-messages loop

### DIFF
--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -445,7 +445,11 @@ WHERE
                 |row| {
                     let id: MsgId = row.get("id")?;
                     let chat_id: ChatId = row.get("chat_id")?;
-                    let viewtype: Viewtype = row.get("type")?;
+                    let viewtype: Viewtype = row
+                        .get("type")
+                        .context("Using default viewtype for delete-old handling.")
+                        .log_err(context)
+                        .unwrap_or_default();
                     let location_id: u32 = row.get("location_id")?;
                     Ok((id, chat_id, viewtype, location_id))
                 },


### PR DESCRIPTION
this PR fixes the ephemeral/delete-old-messages loop getting stuck forever when the database contains an unknown viewtype.

unknown viewtype may happen when types are deleted (as for videochat invitation recently) or when viewtypes are added on a device using a newer core (and that is imported via backup or add-second-device)

the fix let `select_expired_messages()` return rows with `Viewtype::Unknown`, this seems needed anyways as we actually want to delete the database row.

still, additionally, it may be good to never land in an infinite loop, but i am currently not deep enough into core/rust to check for that :) 

closes #7299
