### PR TITLE
Meet OSM tile server policy requirements

### DIFF
--- a/src/net/http.rs
+++ b/src/net/http.rs
@@ -106,6 +106,13 @@ fn http_url_cache_timestamps(url: &str, mimetype: Option<&str>) -> (i64, i64) {
     let stale = if url.ends_with(".xdc") {
         // WebXDCs are never stale, they just expire.
         expires
+    } else if url.starts_with("https://tile.openstreetmap.org/")
+        || url.starts_with("https://vector.openstreetmap.org/")
+    {
+        // Policy at <https://operations.osmfoundation.org/policies/tiles/>
+        // requires that we cache tiles for at least 7 days.
+        // Do not revalidate earlier than that.
+        now + 3600 * 24 * 7
     } else if mimetype.is_some_and(|s| s.starts_with("image/")) {
         // Cache images for 1 day.
         //


### PR DESCRIPTION
This PR is for experiments in Desktop trying to route map requests over the core.

OpenStreetMap requires User-Agent to be set: https://operations.osmfoundation.org/policies/api/
Don't know if `hyper` sends anything at all when no `User-Agent` is set. OSM explicitly says that User-Agent should not be faked. We however don't want to send "chatmail" User-Agent in requests for images in HTML emails, so if this works we may need a switch to not fake the user agent for map requests and by default fake some browser User-Agent for privacy.

We may also just hardcode a domain name for which we send User-Agent, this will require no API changes at all.