### PR TITLE
Fix Nix cross-compilation build for x86-64 macOS

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -95,10 +95,11 @@ jobs:
       matrix:
         installable:
           - deltachat-rpc-server
+          - deltachat-rpc-server-x86_64-darwin
 
-          # Fails to bulid
+          # Fails to build
+          # because of <https://github.com/NixOS/nixpkgs/issues/413910>.
           # - deltachat-rpc-server-aarch64-darwin
-          # - deltachat-rpc-server-x86_64-darwin
     steps:
       - uses: actions/checkout@v5
         with:

--- a/flake.nix
+++ b/flake.nix
@@ -237,6 +237,9 @@
             auditable = false; # Avoid cargo-auditable failures.
             doCheck = false; # Disable test as it requires network access.
 
+            CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS = "-Clink-args=-L${pkgsCross.libiconv}/lib";
+            CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS = "-Clink-args=-L${pkgsCross.libiconv}/lib";
+
             CARGO_BUILD_TARGET = rustTarget;
             TARGET_CC = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
             CARGO_BUILD_RUSTFLAGS = [


### PR DESCRIPTION
This fixes the build of `deltachat-rpc-server-x86_64-darwin` which cross-compiles a binary to x86-64 macOS. I have also tested this on arm64 macOS manually.

`deltachat-rpc-server-aarch64-darwin` build still fails because of upstream issue https://github.com/NixOS/nixpkgs/issues/413910, otherwise https://github.com/chatmail/core/issues/6095 would be solved.

Based on https://github.com/chatmail/core/pull/7311 cleanup PR.