### PR TITLE
build(nix): remove unused dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -98,9 +98,6 @@
             nativeBuildInputs = [
               pkgs.perl # Needed to build vendored OpenSSL.
             ];
-            buildInputs = pkgs.lib.optionals isDarwin [
-              pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
-            ];
             auditable = false; # Avoid cargo-auditable failures.
             doCheck = false; # Disable test as it requires network access.
           };
@@ -482,12 +479,6 @@
                   pkgs.cmake
                   pkgs.rustPlatform.cargoSetupHook
                   pkgs.cargo
-                ];
-                buildInputs = pkgs.lib.optionals isDarwin [
-                  pkgs.darwin.apple_sdk.frameworks.CoreFoundation
-                  pkgs.darwin.apple_sdk.frameworks.Security
-                  pkgs.darwin.apple_sdk.frameworks.SystemConfiguration
-                  pkgs.libiconv
                 ];
 
                 postInstall = ''


### PR DESCRIPTION
darwin.apple_sdk.frameworks is deprecated and does nothing according to <https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks>

libiconv dependency also does not seem to be needed for `libdeltachat`, I have checked that `nix build .#libdeltachat` still succeeds on macOS.