### PR TITLE
ci: set 7 days cooldown on Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     commit-message:
       prefix: "chore(cargo)"
     open-pull-requests-limit: 50
+    cooldown:
+      default-days: 7
 
   # Keep GitHub Actions up to date.
   # <https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot>
@@ -14,3 +16,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This fixes the warning
<https://docs.zizmor.sh/audits/#dependabot-cooldown> and avoids updating to freshly published dependencies that are more likely to be unpublished.