### PR TITLE
ci: pin GitHub action astral-sh/setup-uv

### DIFF
--- a/.github/workflows/zizmor-scan.yml
+++ b/.github/workflows/zizmor-scan.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@3259c6206f993105e3a61b142c2d97bf4b9ef83d
 
       - name: Run zizmor
         run: uvx zizmor --format sarif . > results.sarif


### PR DESCRIPTION
Pinned version corresponds to the current v7.1.0 tag.