### PR TITLE
refactor: Remove error stock strings that are rarely used these days

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -6956,11 +6956,6 @@ void dc_event_unref(dc_event_t* event);
 /// Used to build the string returned by dc_get_contact_encrinfo().
 #define DC_STR_ENCR_NONE                  28
 
-/// "This message was encrypted for another setup."
-///
-/// Used as message text if decryption fails.
-#define DC_STR_CANTDECRYPT_MSG_BODY       29
-
 /// "Fingerprints"
 ///
 /// Used to build the string returned by dc_get_contact_encrinfo().
@@ -7677,12 +7672,6 @@ void dc_event_unref(dc_event_t* event);
 ///
 /// `%1$s` will be replaced by the provider's domain.
 #define DC_STR_INVALID_UNENCRYPTED_MAIL 174
-
-/// "⚠️ It seems you are using Delta Chat on multiple devices that cannot decrypt each other's outgoing messages. To fix this, on the older device use \"Settings / Add Second Device\" and follow the instructions."
-///
-/// Added to the device chat if could not decrypt a new outgoing message (i.e. not when fetching
-/// existing messages). But no more than once a day.
-#define DC_STR_CANT_DECRYPT_OUTGOING_MSGS 175
 
 /// "You reacted %1$s to '%2$s'"
 ///

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -34,7 +34,7 @@ use crate::sync::SyncItems;
 use crate::tools::{
     get_filemeta, parse_receive_headers, smeared_time, time, truncate_msg_text, validate_id,
 };
-use crate::{chatlist_events, location, stock_str, tools};
+use crate::{chatlist_events, location, tools};
 
 /// Public key extracted from `Autocrypt-Gossip`
 /// header with associated information.
@@ -622,13 +622,12 @@ impl MimeMessage {
                     parser.parse_mime_recursive(context, mail, false).await?;
                 }
                 Err(err) => {
-                    let msg_body = stock_str::cant_decrypt_msg_body(context).await;
-                    let txt = format!("[{msg_body}]");
+                    let txt = "[This message cannot be decrypted.\n\n• It might already help to simply reply to this message and ask the sender to send the message again.\n\n• If you just re-installed Delta Chat then it is best if you re-setup Delta Chat now and choose \"Add as second device\" or import a backup.]";
 
                     let part = Part {
                         typ: Viewtype::Text,
-                        msg_raw: Some(txt.clone()),
-                        msg: txt,
+                        msg_raw: Some(txt.to_string()),
+                        msg: txt.to_string(),
                         // Don't change the error prefix for now,
                         // receive_imf.rs:lookup_chat_by_reply() checks it.
                         error: Some(format!("Decrypting failed: {err:#}")),

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1166,7 +1166,8 @@ async fn decide_chat_assignment(
             .await?;
         let now = tools::time();
         let update_config = if last_time.saturating_add(24 * 60 * 60) <= now {
-            let mut msg = Message::new_text(stock_str::cant_decrypt_outgoing_msgs(context).await);
+            let txt = "⚠️ It seems you are using Delta Chat on multiple devices that cannot decrypt each other's outgoing messages. To fix this, on the older device use \"Settings / Add Second Device\" and follow the instructions.";
+            let mut msg = Message::new_text(txt.to_string());
             chat::add_device_msg(context, None, Some(&mut msg))
                 .await
                 .log_err(context)

--- a/src/receive_imf/receive_imf_tests.rs
+++ b/src/receive_imf/receive_imf_tests.rs
@@ -3271,7 +3271,7 @@ async fn test_outgoing_undecryptable() -> Result<()> {
     assert!(
         dev_msg
             .text
-            .contains(&stock_str::cant_decrypt_outgoing_msgs(alice).await)
+            .contains("⚠️ It seems you are using Delta Chat on multiple devices that cannot decrypt each other's outgoing messages. To fix this, on the older device use \"Settings / Add Second Device\" and follow the instructions.")
     );
 
     let raw = include_bytes!("../../test-data/message/thunderbird_encrypted_signed.eml");

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -71,9 +71,6 @@ pub enum StockMessage {
     #[strum(props(fallback = "No encryption"))]
     EncrNone = 28,
 
-    #[strum(props(fallback = "This message was encrypted for another setup."))]
-    CantDecryptMsgBody = 29,
-
     #[strum(props(fallback = "Fingerprints"))]
     FingerPrints = 30,
 
@@ -391,11 +388,6 @@ pub enum StockMessage {
         fallback = "⚠️ Your email provider %1$s requires end-to-end encryption which is not setup yet."
     ))]
     InvalidUnencryptedMail = 174,
-
-    #[strum(props(
-        fallback = "⚠️ It seems you are using Delta Chat on multiple devices that cannot decrypt each other's outgoing messages. To fix this, on the older device use \"Settings / Add Second Device\" and follow the instructions."
-    ))]
-    CantDecryptOutgoingMsgs = 175,
 
     #[strum(props(fallback = "You reacted %1$s to \"%2$s\""))]
     MsgYouReacted = 176,
@@ -761,16 +753,6 @@ pub(crate) async fn e2e_available(context: &Context) -> String {
 /// Stock string: `No encryption.`.
 pub(crate) async fn encr_none(context: &Context) -> String {
     translated(context, StockMessage::EncrNone).await
-}
-
-/// Stock string: `This message was encrypted for another setup.`.
-pub(crate) async fn cant_decrypt_msg_body(context: &Context) -> String {
-    translated(context, StockMessage::CantDecryptMsgBody).await
-}
-
-/// Stock string:`Got outgoing message(s) encrypted for another setup...`.
-pub(crate) async fn cant_decrypt_outgoing_msgs(context: &Context) -> String {
-    translated(context, StockMessage::CantDecryptOutgoingMsgs).await
 }
 
 /// Stock string: `Fingerprints`.


### PR DESCRIPTION
This removes the DC_STR_CANTDECRYPT_MSG_BODY and DC_STR_CANT_DECRYPT_OUTGOING_MSGS stock strings.

See https://github.com/deltachat/deltachat-android/pull/3956#issuecomment-3425349195 for reasoning.