### PR TITLE
fix(jsonrpc): fix `ChatListItem::is_self_in_group`

### DIFF
--- a/deltachat-jsonrpc/src/api/types/chat.rs
+++ b/deltachat-jsonrpc/src/api/types/chat.rs
@@ -61,6 +61,13 @@ pub struct FullChat {
     is_contact_request: bool,
 
     is_device_chat: bool,
+    /// Note that this is different from
+    /// [`ChatListItem::is_self_in_group`](`crate::api::types::chat_list::ChatListItemFetchResult::ChatListItem::is_self_in_group`).
+    /// This property should only be accessed
+    /// when [`FullChat::chat_type`] is [`Chattype::Group`].
+    //
+    // We could utilize [`Chat::is_self_in_chat`],
+    // but that would be an extra DB query.
     self_in_group: bool,
     is_muted: bool,
     ephemeral_timer: u32, //TODO look if there are more important properties in newer core versions

--- a/deltachat-jsonrpc/src/api/types/chat_list.rs
+++ b/deltachat-jsonrpc/src/api/types/chat_list.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use deltachat::chat::{Chat, ChatId};
 use deltachat::chatlist::get_last_message_for_chat;
 use deltachat::constants::*;
-use deltachat::contact::{Contact, ContactId};
+use deltachat::contact::Contact;
 use deltachat::{
     chat::{get_chat_contacts, ChatVisibility},
     chatlist::Chatlist,
@@ -126,11 +126,8 @@ pub(crate) async fn get_chat_list_item_by_id(
         None => (None, None),
     };
 
-    let chat_contacts = get_chat_contacts(ctx, chat_id).await?;
-
-    let self_in_group = chat_contacts.contains(&ContactId::SELF);
-
     let (dm_chat_contact, was_seen_recently) = if chat.get_type() == Chattype::Single {
+        let chat_contacts = get_chat_contacts(ctx, chat_id).await?;
         let contact = chat_contacts.first();
         let was_seen_recently = match contact {
             Some(contact) => Contact::get_by_id(ctx, *contact)
@@ -165,7 +162,7 @@ pub(crate) async fn get_chat_list_item_by_id(
         fresh_message_counter,
         is_self_talk: chat.is_self_talk(),
         is_device_talk: chat.is_device_talk(),
-        is_self_in_group: self_in_group,
+        is_self_in_group: chat.is_self_in_chat(ctx).await?,
         is_sending_location: chat.is_sending_locations(),
         is_archived: visibility == ChatVisibility::Archived,
         is_pinned: visibility == ChatVisibility::Pinned,

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1494,7 +1494,7 @@ impl Chat {
     /// Checks if the user is part of a chat
     /// and has basically the permissions to edit the chat therefore.
     /// The function does not check if the chat type allows editing of concrete elements.
-    pub(crate) async fn is_self_in_chat(&self, context: &Context) -> Result<bool> {
+    pub async fn is_self_in_chat(&self, context: &Context) -> Result<bool> {
         match self.typ {
             Chattype::Single | Chattype::OutBroadcast | Chattype::Mailinglist => Ok(true),
             Chattype::Group => is_contact_in_chat(context, self.id, ContactId::SELF).await,


### PR DESCRIPTION
Make it return the correct value for non-Group chats.

This also should improve performance, thanks to the fact that
we now don't have to query all the chat's contacts.
Instead we only need confirm that self-contact
is among the group members, and only when the chat type is `Group`.
