### PR TITLE
api(jsonrpc): restore `protect` argument for create_group_chat

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -993,7 +993,15 @@ impl CommandApi {
     ///
     /// To check, if a chat is still unpromoted, you can look at the `is_unpromoted` property of `BasicChat` or `FullChat`.
     /// This may be useful if you want to show some help for just created groups.
-    async fn create_group_chat(&self, account_id: u32, name: String) -> Result<u32> {
+    ///
+    /// `protect` argument is deprecated as of 2025-10-22 and is left for compatibility.
+    /// Pass `false` here.
+    async fn create_group_chat(
+        &self,
+        account_id: u32,
+        name: String,
+        _protect: bool,
+    ) -> Result<u32> {
         let ctx = self.get_context(account_id).await?;
         chat::create_group(&ctx, &name).await.map(|id| id.to_u32())
     }

--- a/deltachat-rpc-client/src/deltachat_rpc_client/account.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/account.py
@@ -318,7 +318,7 @@ class Account:
         (see `get_full_snapshot()` / `get_basic_snapshot()`).
         This may be useful if you want to show some help for just created groups.
         """
-        return Chat(self, self._rpc.create_group_chat(self.id, name))
+        return Chat(self, self._rpc.create_group_chat(self.id, name, False))
 
     def create_broadcast(self, name: str) -> Chat:
         """Create a new **broadcast channel**


### PR DESCRIPTION
It was removed in 498a8318734de4a11bed6f31a7a1fd36e385e705 Restoring as optional argument to avoid breaking compatibility.