### PR TITLE
fix: fix flaky tests::verified_chats::test_verified_chat_editor_reordering and receive_imf::receive_imf_tests::test_two_group_securejoins

### DIFF
--- a/test-data/golden/two_group_securejoins
+++ b/test-data/golden/two_group_securejoins
@@ -4,6 +4,6 @@ Msg#6004: info (Contact#Contact#Info): alice@example.org invited you to join thi
 
 Waiting for the device of alice@example.org to reply… [NOTICED][INFO]
 Msg#6006: info (Contact#Contact#Info): alice@example.org replied, waiting for being added to the group… [NOTICED][INFO]
-Msg#6002: info (Contact#Contact#Info): Messages are end-to-end encrypted. [NOTICED][INFO]
+Msg#6003: info (Contact#Contact#Info): Messages are end-to-end encrypted. [NOTICED][INFO]
 Msg#6008🔒:  (Contact#Contact#6001): Member Me added by alice@example.org. [FRESH][INFO]
 --------------------------------------------------------------------------------

--- a/test-data/golden/verified_chats_editor_reordering
+++ b/test-data/golden/verified_chats_editor_reordering
@@ -4,7 +4,7 @@ Msg#3004: info (Contact#Contact#Info): alice@example.org invited you to join thi
 
 Waiting for the device of alice@example.org to reply… [NOTICED][INFO]
 Msg#3006: info (Contact#Contact#Info): alice@example.org replied, waiting for being added to the group… [NOTICED][INFO]
-Msg#3002: info (Contact#Contact#Info): Messages are end-to-end encrypted. [NOTICED][INFO]
+Msg#3003: info (Contact#Contact#Info): Messages are end-to-end encrypted. [NOTICED][INFO]
 Msg#3008🔒:  (Contact#Contact#3002):  [FRESH]
 Msg#3009: info (Contact#Contact#Info): Member bob@example.net added. [NOTICED][INFO]
 Msg#3010🔒:  (Contact#Contact#3001): Member Me added by alice@example.org. [FRESH][INFO]


### PR DESCRIPTION
Flakiness was introduced in e7348a4fd8242ad7dbccc71d5396743a16d096de. This change removes a call to joining_chat_id() which created a chat, now we check for existing group chat
without creating it if it does not exist.

Closes #7350