### PR TITLE
api: jsonrpc: typescript remove unused constants

### DIFF
--- a/deltachat-jsonrpc/typescript/scripts/generate-constants.js
+++ b/deltachat-jsonrpc/typescript/scripts/generate-constants.js
@@ -40,7 +40,12 @@ const constants = data
       key.startsWith("DC_DOWNLOAD") ||
       key.startsWith("DC_INFO_") ||
       (key.startsWith("DC_MSG") && !key.startsWith("DC_MSG_ID")) ||
-      key.startsWith("DC_QR_")
+      key.startsWith("DC_QR_") ||
+      key.startsWith("DC_CERTCK_") ||
+      key.startsWith("DC_SOCKET_") ||
+      key.startsWith("DC_LP_AUTH_") ||
+      key.startsWith("DC_PUSH_") ||
+      key.startsWith("DC_TEXT1_")
     );
   })
   .map((row) => {


### PR DESCRIPTION
- `DC_CERTCK_*`, `DC_SOCKET_*`, `DC_LP_AUTH_*` are not used anymore,
`EnteredLoginParam` has their own representations for these values which
are not number based.
- `DC_PUSH_*` the api returning that is not yet
part of jsonrpc and when it will be, then it will return an
enum/string-union anyways
- `DC_TEXT1_*` the type is not returned by the
jsonrpc api
