### PR TITLE
feat: Remove "Download maximum available until" and remove stock string `DC_STR_DOWNLOAD_AVAILABILITY`

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -7247,13 +7247,6 @@ void dc_event_unref(dc_event_t* event);
 /// `%1$s` will be replaced by human-readable size (e.g. "1.2 MiB").
 #define DC_STR_PARTIAL_DOWNLOAD_MSG_BODY  99
 
-/// "Download maximum available until %1$s"
-///
-/// Appended after some separator to @ref DC_STR_PARTIAL_DOWNLOAD_MSG_BODY.
-///
-/// `%1$s` will be replaced by human-readable date and time.
-#define DC_STR_DOWNLOAD_AVAILABILITY      100
-
 /// "Multi Device Synchronization"
 ///
 /// Used in subjects of outgoing sync messages.

--- a/src/download.rs
+++ b/src/download.rs
@@ -13,7 +13,6 @@ use crate::imap::session::Session;
 use crate::log::info;
 use crate::message::{Message, MsgId, Viewtype};
 use crate::mimeparser::{MimeMessage, Part};
-use crate::tools::time;
 use crate::{EventType, chatlist_events, stock_str};
 
 /// Download limits should not be used below `MIN_DOWNLOAD_LIMIT`.
@@ -234,18 +233,10 @@ impl MimeMessage {
             None => "",
             Some(_) => "[❗] ",
         };
-        let mut text = format!(
+        let text = format!(
             "{prefix}[{}]",
             stock_str::partial_download_msg_body(context, org_bytes).await
         );
-        if let Some(delete_server_after) = context.get_config_delete_server_after().await? {
-            let until = stock_str::download_availability(
-                context,
-                time() + max(delete_server_after, MIN_DELETE_SERVER_AFTER),
-            )
-            .await;
-            text += format!(" [{until}]").as_str();
-        };
 
         info!(context, "Partial download: {}", text);
 

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -17,7 +17,6 @@ use crate::contact::{Contact, ContactId, Origin};
 use crate::context::Context;
 use crate::message::{Message, Viewtype};
 use crate::param::Param;
-use crate::tools::timestamp_to_str;
 
 /// Storage for string translations.
 #[derive(Debug, Clone)]
@@ -176,9 +175,6 @@ pub enum StockMessage {
 
     #[strum(props(fallback = "%1$s message"))]
     PartialDownloadMsgBody = 99,
-
-    #[strum(props(fallback = "Download maximum available until %1$s"))]
-    DownloadAvailability = 100,
 
     #[strum(props(fallback = "Multi Device Synchronization"))]
     SyncMsgSubject = 101,
@@ -1176,13 +1172,6 @@ pub(crate) async fn partial_download_msg_body(context: &Context, org_bytes: u32)
     translated(context, StockMessage::PartialDownloadMsgBody)
         .await
         .replace1(size)
-}
-
-/// Stock string: `Download maximum available until %1$s`.
-pub(crate) async fn download_availability(context: &Context, timestamp: i64) -> String {
-    translated(context, StockMessage::DownloadAvailability)
-        .await
-        .replace1(&timestamp_to_str(timestamp))
 }
 
 /// Stock string: `Incoming Messages`.


### PR DESCRIPTION
Remove "Download maximum available until", because it's unreliable - chatmail servers may delete full-messages quicker.

This is part of #7367
