### PR TITLE
build: do not install pdbpp in the test environment for CFFI Python bindings

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -23,7 +23,6 @@ deps =
     pytest
     pytest-timeout
     pytest-xdist
-    pdbpp
     requests
 # urllib3 2.0 does not work in manylinux2014 containers.
 # https://github.com/deltachat/deltachat-core-rust/issues/4788


### PR DESCRIPTION
Closes <https://github.com/chatmail/core/issues/7376>