### PR TITLE
fix: send webm as file, it is not supported by all UI

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1440,7 +1440,15 @@ pub(crate) fn guess_msgtype_from_path_suffix(path: &Path) -> Option<(Viewtype, &
     let extension: &str = &path.extension()?.to_str()?.to_lowercase();
     let info = match extension {
         // before using viewtype other than Viewtype::File,
-        // make sure, all target UIs support that type in the context of the used viewer/player.
+        // make sure, all target UIs support that type.
+        //
+        // it is a non-goal to support as many formats as possible in-app.
+        // additional parser come at security and maintainance costs and
+        // should only be added when strictly neccessary,
+        // eg. when a format comes from the camera app on a significant number of devices.
+        // it is okay, when eg. dragging some video from a browser results in a "File"
+        // for everyone, sender as well as all receivers.
+        //
         // if in doubt, it is better to default to Viewtype::File that passes handing to an external app.
         // (cmp. <https://developer.android.com/guide/topics/media/media-formats>)
         "3gp" => (Viewtype::Video, "video/3gpp"),
@@ -1503,7 +1511,7 @@ pub(crate) fn guess_msgtype_from_path_suffix(path: &Path) -> Option<(Viewtype, &
         "vcf" => (Viewtype::Vcard, "text/vcard"),
         "wav" => (Viewtype::Audio, "audio/wav"),
         "weba" => (Viewtype::File, "audio/webm"),
-        "webm" => (Viewtype::Video, "video/webm"),
+        "webm" => (Viewtype::File, "video/webm"), // not supported natively by iOS nor by SDWebImage
         "webp" => (Viewtype::Image, "image/webp"), // iOS via SDWebImage, Android since 4.0
         "wmv" => (Viewtype::Video, "video/x-ms-wmv"),
         "xdc" => (Viewtype::Webxdc, "application/webxdc+zip"),


### PR DESCRIPTION
this PR forces `.webm` to be sent as file and adds some reasoning to the comment.

one can now rant a lot about apple, but this is the reality.

we tried to [support webm by additional libraries](https://github.com/deltachat/deltachat-ios/pull/2757), but gave up, it was a too heavy lib, that would come with all kind of security issues. also, it seems not worth the effort, afaik, webm does _not_ come to avg user by the normal flow, only by eg. collecting things from the browser or so, dragging it to the deltachat window - but at that point, there are many formats not supported.
with `.heic` being sent as files we have a similar situation, btw.

one can argue that it is also unexpected that a file is not shown in-app, [or gets sorted to "Files"](https://github.com/deltachat/deltachat-desktop/issues/469), sure, but we cannot avoid that reasonably. 

and it is even more unexpected that it is shown on some and not shown on other UI. as happening a lot when one user sends a lot of webm stickers, assuming they are show to other as well. and there is not much the receiver can do about that. so consistently sending as "File" is the better tradeoff

