### PR TITLE
feat: Add Contact::get_or_gen_color. Use it in CFFI and JSON-RPC to avoid gray self-color (#7374)

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -4240,7 +4240,17 @@ pub unsafe extern "C" fn dc_contact_get_color(contact: *mut dc_contact_t) -> u32
         return 0;
     }
     let ffi_contact = &*contact;
-    ffi_contact.contact.get_color()
+    let ctx = &*ffi_contact.context;
+    block_on(async move {
+        ffi_contact
+            .contact
+            // We don't want any UIs displaying gray self-color.
+            .get_or_gen_color(ctx)
+            .await
+            .context("Contact::get_color()")
+            .log_err(ctx)
+            .unwrap_or(0)
+    })
 }
 
 #[no_mangle]

--- a/deltachat-jsonrpc/src/api/types/account.rs
+++ b/deltachat-jsonrpc/src/api/types/account.rs
@@ -32,7 +32,10 @@ impl Account {
             let addr = ctx.get_config(Config::Addr).await?;
             let profile_image = ctx.get_config(Config::Selfavatar).await?;
             let color = color_int_to_hex_string(
-                Contact::get_by_id(ctx, ContactId::SELF).await?.get_color(),
+                Contact::get_by_id(ctx, ContactId::SELF)
+                    .await?
+                    .get_or_gen_color(ctx)
+                    .await?,
             );
             let private_tag = ctx.get_config(Config::PrivateTag).await?;
             Ok(Account::Configured {

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1574,9 +1574,22 @@ impl Contact {
     }
 
     /// Returns a color for the contact.
-    /// See [`self::get_color`].
+    /// For self-contact this returns gray if own keypair doesn't exist yet.
+    /// See also [`self::get_color`].
     pub fn get_color(&self) -> u32 {
         get_color(self.id == ContactId::SELF, &self.addr, &self.fingerprint())
+    }
+
+    /// Returns a color for the contact.
+    /// Ensures that the color isn't gray. For self-contact this generates own keypair if it doesn't
+    /// exist yet.
+    /// See also [`self::get_color`].
+    pub async fn get_or_gen_color(&self, context: &Context) -> Result<u32> {
+        let mut fpr = self.fingerprint();
+        if fpr.is_none() && self.id == ContactId::SELF {
+            fpr = Some(load_self_public_key(context).await?.dc_fingerprint());
+        }
+        Ok(get_color(self.id == ContactId::SELF, &self.addr, &fpr))
     }
 
     /// Gets the contact's status.


### PR DESCRIPTION
`Contact::get_color()` returns gray if own keypair doesn't exist yet and we don't want any UIs
    displaying it. Keypair generation can't be done in `get_color()` or `get_by_id_optional()` to avoid
    breaking Core tests on key import. Also this makes the API clearer, pure getters shouldn't modify
    any visible state.

A previous failed attempt: #7289 
Close #7374 