### PR TITLE
refactor(sql): do not expose rusqlite Error type in query_map methods

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2029,7 +2029,10 @@ impl Chat {
                     ON c.id=cc.contact_id \
                     WHERE cc.chat_id=? AND cc.add_timestamp >= cc.remove_timestamp",
                     (self.id,),
-                    |row| row.get::<_, String>(0),
+                    |row| {
+                        let addr: String = row.get(0)?;
+                        Ok(addr)
+                    },
                 )
                 .await?;
             self.sync(context, SyncAction::SetContacts(addrs)).await?;
@@ -3038,7 +3041,7 @@ pub async fn get_chat_msgs_ex(
             ))
         }
     };
-    let process_rows = |rows: rusqlite::MappedRows<_>| {
+    let process_rows = |rows: rusqlite::AndThenRows<_>| {
         // It is faster to sort here rather than
         // let sqlite execute an ORDER BY clause.
         let mut sorted_rows = Vec::new();
@@ -3120,7 +3123,10 @@ pub async fn marknoticed_chat(context: &Context, chat_id: ChatId) -> Result<()> 
                     LEFT JOIN chats c ON m.chat_id=c.id
                     WHERE m.state=10 AND m.hidden=0 AND m.chat_id>9 AND c.archived=1",
                 (),
-                |row| row.get::<_, ChatId>(0),
+                |row| {
+                    let chat_id: ChatId = row.get(0)?;
+                    Ok(chat_id)
+                },
             )
             .await?;
         if chat_ids_in_archive.is_empty() {
@@ -3298,7 +3304,10 @@ pub async fn get_chat_media(
                     DC_CHAT_ID_TRASH,
                     Viewtype::Webxdc,
                 ),
-                |row| row.get::<_, MsgId>(0),
+                |row| {
+                    let msg_id: MsgId = row.get(0)?;
+                    Ok(msg_id)
+                },
             )
             .await?
     } else {
@@ -3328,7 +3337,10 @@ pub async fn get_chat_media(
                         msg_type
                     },
                 ),
-                |row| row.get::<_, MsgId>(0),
+                |row| {
+                    let msg_id: MsgId = row.get(0)?;
+                    Ok(msg_id)
+                },
             )
             .await?
     };
@@ -3349,7 +3361,10 @@ pub async fn get_chat_contacts(context: &Context, chat_id: ChatId) -> Result<Vec
               WHERE cc.chat_id=? AND cc.add_timestamp >= cc.remove_timestamp
               ORDER BY c.id=1, c.last_seen DESC, c.id DESC;",
             (chat_id,),
-            |row| row.get::<_, ContactId>(0),
+            |row| {
+                let contact_id: ContactId = row.get(0)?;
+                Ok(contact_id)
+            },
         )
         .await
 }
@@ -3371,7 +3386,10 @@ pub async fn get_past_chat_contacts(context: &Context, chat_id: ChatId) -> Resul
              AND ? < cc.remove_timestamp
              ORDER BY c.id=1, cc.remove_timestamp DESC, c.id DESC",
             (chat_id, now.saturating_sub(60 * 24 * 3600)),
-            |row| row.get::<_, ContactId>(0),
+            |row| {
+                let contact_id: ContactId = row.get(0)?;
+                Ok(contact_id)
+            },
         )
         .await
 }
@@ -3734,11 +3752,13 @@ pub(crate) async fn shall_attach_selfavatar(context: &Context, chat_id: ChatId) 
              LEFT JOIN contacts c ON c.id=cc.contact_id
              WHERE cc.chat_id=? AND cc.contact_id!=? AND cc.add_timestamp >= cc.remove_timestamp",
             (chat_id, ContactId::SELF),
-            |row| Ok(row.get::<_, i64>(0)),
+            |row| {
+                let selfavatar_sent: i64 = row.get(0)?;
+                Ok(selfavatar_sent)
+            },
             |rows| {
                 let mut needs_attach = false;
                 for row in rows {
-                    let row = row?;
                     let selfavatar_sent = row?;
                     if selfavatar_sent < timestamp_some_days_ago {
                         needs_attach = true;

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -194,16 +194,11 @@ impl Context {
     pub async fn list_transports(&self) -> Result<Vec<EnteredLoginParam>> {
         let transports = self
             .sql
-            .query_map(
-                "SELECT entered_param FROM transports",
-                (),
-                |row| row.get::<_, String>(0),
-                |rows| {
-                    rows.flatten()
-                        .map(|s| Ok(serde_json::from_str(&s)?))
-                        .collect::<Result<Vec<EnteredLoginParam>>>()
-                },
-            )
+            .query_map_vec("SELECT entered_param FROM transports", (), |row| {
+                let entered_param: String = row.get(0)?;
+                let transport: EnteredLoginParam = serde_json::from_str(&entered_param)?;
+                Ok(transport)
+            })
             .await?;
 
         Ok(transports)

--- a/src/context.rs
+++ b/src/context.rs
@@ -1101,7 +1101,10 @@ impl Context {
                     " ORDER BY m.timestamp DESC,m.id DESC;"
                 ),
                 (MessageState::InFresh, time()),
-                |row| row.get::<_, MsgId>(0),
+                |row| {
+                    let msg_id: MsgId = row.get(0)?;
+                    Ok(msg_id)
+                },
             )
             .await?;
         Ok(list)
@@ -1205,7 +1208,10 @@ impl Context {
                    AND IFNULL(txt_normalized, txt) LIKE ?
                  ORDER BY m.timestamp,m.id;",
                     (chat_id, str_like_in_text),
-                    |row| row.get::<_, MsgId>("id"),
+                    |row| {
+                        let msg_id: MsgId = row.get("id")?;
+                        Ok(msg_id)
+                    },
                 )
                 .await?
         } else {
@@ -1234,7 +1240,10 @@ impl Context {
                    AND IFNULL(txt_normalized, txt) LIKE ?
                  ORDER BY m.id DESC LIMIT 1000",
                     (str_like_in_text,),
-                    |row| row.get::<_, MsgId>("id"),
+                    |row| {
+                        let msg_id: MsgId = row.get("id")?;
+                        Ok(msg_id)
+                    },
                 )
                 .await?
         };

--- a/src/key.rs
+++ b/src/key.rs
@@ -159,13 +159,15 @@ pub(crate) async fn load_self_public_key(context: &Context) -> Result<SignedPubl
 pub(crate) async fn load_self_public_keyring(context: &Context) -> Result<Vec<SignedPublicKey>> {
     let keys = context
         .sql
-        .query_map(
+        .query_map_vec(
             r#"SELECT public_key
                FROM keypairs
                ORDER BY id=(SELECT value FROM config WHERE keyname='key_id') DESC"#,
             (),
-            |row| row.get::<_, Vec<u8>>(0),
-            |keys| keys.collect::<Result<Vec<_>, _>>().map_err(Into::into),
+            |row| {
+                let public_key_bytes: Vec<u8> = row.get(0)?;
+                Ok(public_key_bytes)
+            },
         )
         .await?
         .into_iter()
@@ -232,13 +234,15 @@ pub(crate) async fn load_self_secret_key(context: &Context) -> Result<SignedSecr
 pub(crate) async fn load_self_secret_keyring(context: &Context) -> Result<Vec<SignedSecretKey>> {
     let keys = context
         .sql
-        .query_map(
+        .query_map_vec(
             r#"SELECT private_key
                FROM keypairs
                ORDER BY id=(SELECT value FROM config WHERE keyname='key_id') DESC"#,
             (),
-            |row| row.get::<_, Vec<u8>>(0),
-            |keys| keys.collect::<Result<Vec<_>, _>>().map_err(Into::into),
+            |row| {
+                let bytes: Vec<u8> = row.get(0)?;
+                Ok(bytes)
+            },
         )
         .await?
         .into_iter()

--- a/src/location.rs
+++ b/src/location.rs
@@ -348,7 +348,10 @@ pub async fn set(context: &Context, latitude: f64, longitude: f64, accuracy: f64
         .query_map_vec(
             "SELECT id FROM chats WHERE locations_send_until>?;",
             (now,),
-            |row| row.get::<_, i32>(0),
+            |row| {
+                let id: i32 = row.get(0)?;
+                Ok(id)
+            },
         )
         .await?;
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -377,7 +377,10 @@ async fn get_timestamps(context: &Context, sql_table: &str) -> Result<Vec<i64>> 
         .query_map_vec(
             &format!("SELECT timestamp FROM {sql_table} LIMIT 1000"),
             (),
-            |row| row.get(0),
+            |row| {
+                let timestamp: i64 = row.get(0)?;
+                Ok(timestamp)
+            },
         )
         .await
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -202,7 +202,11 @@ impl Context {
             .query_map(
                 "SELECT id, item FROM multi_device_sync ORDER BY id;",
                 (),
-                |row| Ok((row.get::<_, u32>(0)?, row.get::<_, String>(1)?)),
+                |row| {
+                    let id: u32 = row.get(0)?;
+                    let item: String = row.get(1)?;
+                    Ok((id, item))
+                },
                 |rows| {
                     let mut ids = vec![];
                     let mut serialized = String::default();

--- a/src/webxdc.rs
+++ b/src/webxdc.rs
@@ -732,8 +732,8 @@ impl Context {
                 "SELECT update_item, id FROM msgs_status_updates WHERE msg_id=? AND id>? ORDER BY id",
                 (instance_msg_id, last_known_serial),
                 |row| {
-                    let update_item_str = row.get::<_, String>(0)?;
-                    let serial = row.get::<_, StatusUpdateSerial>(1)?;
+                    let update_item_str: String = row.get(0)?;
+                    let serial: StatusUpdateSerial = row.get(1)?;
                     Ok((update_item_str, serial))
                 },
                 |rows| {


### PR DESCRIPTION
We use query_and_then() instead of query_map() function now. The difference is that row processing function
returns anyhow::Result, so simple fallible processing like JSON parsing can be done inside of it
when calling query_map_vec() and query_map_collect() without having to resort to query_map()
and iterating over all rows again afterwards.