### PR TITLE
refactor(imap): move resync request from Context to Imap

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -565,14 +565,6 @@ async fn configure(ctx: &Context, param: &EnteredLoginParam) -> Result<Option<&'
 
     progress!(ctx, 910);
 
-    if let Some(configured_addr) = ctx.get_config(Config::ConfiguredAddr).await? {
-        if configured_addr != param.addr {
-            // Switched account, all server UIDs we know are invalid
-            info!(ctx, "Scheduling resync because the address has changed.");
-            ctx.schedule_resync().await?;
-        }
-    }
-
     let provider = configured_param.provider;
     configured_param
         .save_to_transports_table(ctx, param)

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -104,6 +104,12 @@ pub(crate) struct Imap {
     /// immediately after logging in or returning an error in response to LOGIN command
     /// due to internal server error.
     ratelimit: Ratelimit,
+
+    /// IMAP UID resync request sender.
+    pub(crate) resync_request_sender: async_channel::Sender<()>,
+
+    /// IMAP UID resync request receiver.
+    pub(crate) resync_request_receiver: async_channel::Receiver<()>,
 }
 
 #[derive(Debug)]
@@ -254,6 +260,7 @@ impl Imap {
         oauth2: bool,
         idle_interrupt_receiver: Receiver<()>,
     ) -> Self {
+        let (resync_request_sender, resync_request_receiver) = async_channel::bounded(1);
         Imap {
             idle_interrupt_receiver,
             addr: addr.to_string(),
@@ -268,6 +275,8 @@ impl Imap {
             conn_backoff_ms: 0,
             // 1 connection per minute + a burst of 2.
             ratelimit: Ratelimit::new(Duration::new(120, 0), 2.0),
+            resync_request_sender,
+            resync_request_receiver,
         }
     }
 
@@ -392,6 +401,7 @@ impl Imap {
             match login_res {
                 Ok(mut session) => {
                     let capabilities = determine_capabilities(&mut session).await?;
+                    let resync_request_sender = self.resync_request_sender.clone();
 
                     let session = if capabilities.can_compress {
                         info!(context, "Enabling IMAP compression.");
@@ -402,9 +412,9 @@ impl Imap {
                             })
                             .await
                             .context("Failed to enable IMAP compression")?;
-                        Session::new(compressed_session, capabilities)
+                        Session::new(compressed_session, capabilities, resync_request_sender)
                     } else {
-                        Session::new(session, capabilities)
+                        Session::new(session, capabilities, resync_request_sender)
                     };
 
                     // Store server ID in the context to display in account info.

--- a/src/imap/select_folder.rs
+++ b/src/imap/select_folder.rs
@@ -206,7 +206,7 @@ impl ImapSession {
                             "The server illegally decreased the uid_next of folder {folder:?} from {old_uid_next} to {new_uid_next} without changing validity ({new_uid_validity}), resyncing UIDs...",
                         );
                         set_uid_next(context, folder, new_uid_next).await?;
-                        context.schedule_resync().await?;
+                        self.resync_request_sender.try_send(()).ok();
                     }
 
                     // If UIDNEXT changed, there are new emails.
@@ -243,7 +243,7 @@ impl ImapSession {
             .await?;
 
         if old_uid_validity != 0 || old_uid_next != 0 {
-            context.schedule_resync().await?;
+            self.resync_request_sender.try_send(()).ok();
         }
         info!(
             context,

--- a/src/imap/session.rs
+++ b/src/imap/session.rs
@@ -48,6 +48,8 @@ pub(crate) struct Session {
     ///
     /// Should be false if no folder is currently selected.
     pub new_mail: bool,
+
+    pub resync_request_sender: async_channel::Sender<()>,
 }
 
 impl Deref for Session {
@@ -68,6 +70,7 @@ impl Session {
     pub(crate) fn new(
         inner: ImapSession<Box<dyn SessionStream>>,
         capabilities: Capabilities,
+        resync_request_sender: async_channel::Sender<()>,
     ) -> Self {
         Self {
             inner,
@@ -77,6 +80,7 @@ impl Session {
             selected_folder_needs_expunge: false,
             last_full_folder_scan: Mutex::new(None),
             new_mail: false,
+            resync_request_sender,
         }
     }
 


### PR DESCRIPTION
For multiple transports we will need to run
multiple IMAP clients in parallel.
UID validity change detected by one IMAP client
should not result in UID resync
for another IMAP client.