### PR TITLE
test: fix flaky test_send_receive_locations

### DIFF
--- a/python/tests/test_1_online.py
+++ b/python/tests/test_1_online.py
@@ -1509,8 +1509,14 @@ def test_send_receive_locations(acfactory, lp):
     assert locations[0].latitude == 2.0
     assert locations[0].longitude == 3.0
     assert locations[0].accuracy == 0.5
-    assert locations[0].timestamp > now
     assert locations[0].marker is None
+
+    # Make sure the timestamp is not in the past.
+    # Note that location timestamp has only 1 second precision,
+    # while `now` has a fractional part, so we have to truncate it
+    # first, otherwise `now` may appear to be in the future
+    # even though it is the same second.
+    assert int(locations[0].timestamp.timestamp()) >= int(now.timestamp())
 
     contact = ac2.create_contact(ac1)
     locations2 = chat2.get_locations(contact=contact)


### PR DESCRIPTION
You need a really fast connection to the mail server for this, but it is flaky with ~0.5 ms ping because I ran it on the server in the same datacenter:
```
PING ci-chatmail.testrun.org(2a01:4f8:c013:13c3::1 (2a01:4f8:c013:13c3::1)) 56 data bytes
64 bytes from 2a01:4f8:c013:13c3::1 (2a01:4f8:c013:13c3::1): icmp_seq=1 ttl=57 time=0.963 ms
64 bytes from 2a01:4f8:c013:13c3::1 (2a01:4f8:c013:13c3::1): icmp_seq=2 ttl=57 time=0.526 ms
64 bytes from 2a01:4f8:c013:13c3::1 (2a01:4f8:c013:13c3::1): icmp_seq=3 ttl=57 time=0.439 ms
64 bytes from 2a01:4f8:c013:13c3::1 (2a01:4f8:c013:13c3::1): icmp_seq=4 ttl=57 time=0.472 ms
64 bytes from 2a01:4f8:c013:13c3::1 (2a01:4f8:c013:13c3::1): icmp_seq=5 ttl=57 time=0.482 ms
64 bytes from 2a01:4f8:c013:13c3::1 (2a01:4f8:c013:13c3::1): icmp_seq=6 ttl=57 time=0.544 ms
64 bytes from 2a01:4f8:c013:13c3::1 (2a01:4f8:c013:13c3::1): icmp_seq=7 ttl=57 time=0.491 ms
64 bytes from 2a01:4f8:c013:13c3::1 (2a01:4f8:c013:13c3::1): icmp_seq=8 ttl=57 time=0.445 ms
64 bytes from 2a01:4f8:c013:13c3::1 (2a01:4f8:c013:13c3::1): icmp_seq=9 ttl=57 time=0.544 ms
64 bytes from 2a01:4f8:c013:13c3::1 (2a01:4f8:c013:13c3::1): icmp_seq=10 ttl=57 time=0.484 ms
64 bytes from 2a01:4f8:c013:13c3::1 (2a01:4f8:c013:13c3::1): icmp_seq=11 ttl=57 time=0.536 ms
```