### PR TITLE
feat: Hide To header in encrypted messages

### DIFF
--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -661,8 +661,6 @@ def test_download_limit_chat_assignment(acfactory, tmp_path, n_accounts):
         contact = alice.create_contact(account)
         alice_group.add_contact(contact)
 
-    if n_accounts == 2:
-        bob_chat_alice = bob.create_chat(alice)
     bob.set_config("download_limit", str(download_limit))
 
     alice_group.send_text("hi")
@@ -678,15 +676,7 @@ def test_download_limit_chat_assignment(acfactory, tmp_path, n_accounts):
         alice_group.send_file(str(path))
         snapshot = bob.wait_for_incoming_msg().get_snapshot()
         assert snapshot.download_state == DownloadState.AVAILABLE
-        if n_accounts > 2:
-            assert snapshot.chat == bob_group
-        else:
-            # Group contains only Alice and Bob,
-            # so partially downloaded messages are
-            # hard to distinguish from private replies to group messages.
-            #
-            # Message may be a private reply, so we assign it to 1:1 chat with Alice.
-            assert snapshot.chat == bob_chat_alice
+        assert snapshot.chat == bob_group
 
 
 def test_markseen_contact_request(acfactory):

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -815,15 +815,6 @@ async fn test_self_talk() -> Result<()> {
     assert!(msg.get_showpadlock());
 
     let sent_msg = t.pop_sent_msg().await;
-    let payload = sent_msg.payload();
-    // Make sure the `To` field contains the address and not
-    // "undisclosed recipients".
-    // Otherwise Delta Chat core <1.153.0 assigns the message
-    // to the trash chat.
-    assert_eq!(
-        payload.match_indices("To: <alice@example.org>\r\n").count(),
-        1
-    );
 
     let t2 = TestContext::new_alice().await;
     t2.recv_msg(&sent_msg).await;

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -9,7 +9,7 @@ use data_encoding::BASE32_NOPAD;
 use deltachat_contact_tools::sanitize_bidi_characters;
 use iroh_gossip::proto::TopicId;
 use mail_builder::headers::HeaderType;
-use mail_builder::headers::address::{Address, EmailAddress};
+use mail_builder::headers::address::Address;
 use mail_builder::mime::MimePart;
 use tokio::fs;
 
@@ -993,24 +993,7 @@ impl MimeFactory {
             } else if header_name == "to" {
                 protected_headers.push(header.clone());
                 if is_encrypted {
-                    let mut to_without_names = to
-                        .clone()
-                        .into_iter()
-                        .filter_map(|header| match header {
-                            Address::Address(mb) => Some(Address::Address(EmailAddress {
-                                name: None,
-                                email: mb.email,
-                            })),
-                            _ => None,
-                        })
-                        .collect::<Vec<_>>();
-                    if to_without_names.is_empty() {
-                        to_without_names.push(hidden_recipients());
-                    }
-                    unprotected_headers.push((
-                        original_header_name,
-                        Address::new_list(to_without_names).into(),
-                    ));
+                    unprotected_headers.push(("To", hidden_recipients().into()));
                 } else {
                     unprotected_headers.push(header.clone());
                 }

--- a/src/mimefactory/mimefactory_tests.rs
+++ b/src/mimefactory/mimefactory_tests.rs
@@ -750,8 +750,6 @@ async fn test_remove_member_bcc() -> Result<()> {
 
     let bob_id = alice.add_or_lookup_contact_id(bob).await;
     let charlie_id = alice.add_or_lookup_contact_id(charlie).await;
-    let charlie_contact = Contact::get_by_id(alice, charlie_id).await?;
-    let charlie_addr = charlie_contact.get_addr();
 
     let alice_chat_id = create_group(alice, "foo").await?;
     add_contact_to_chat(alice, alice_chat_id, bob_id).await?;
@@ -770,11 +768,11 @@ async fn test_remove_member_bcc() -> Result<()> {
     for to_addr in to.iter() {
         match to_addr {
             mailparse::MailAddr::Single(info) => {
-                // Addresses should be of existing members (Alice and Bob) and not Charlie.
-                assert_ne!(info.addr, charlie_addr);
+                panic!("Single addresses are not expected here: {info:?}");
             }
-            mailparse::MailAddr::Group(_) => {
-                panic!("Group addresses are not expected here");
+            mailparse::MailAddr::Group(info) => {
+                assert_eq!(info.group_name, "hidden-recipients");
+                assert_eq!(info.addrs, []);
             }
         }
     }


### PR DESCRIPTION
This is updated #6649 . Actually this is a part of #7130, but independent from #7386, so can be merged earlier.
EDIT: Maybe a separate test would be good, testing this in `test_remove_member_bcc()` isn't straightforward.