### PR TITLE
Add APIs to stop background fetch

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3296,10 +3296,28 @@ void           dc_accounts_maybe_network_lost    (dc_accounts_t* accounts);
  * without forgetting to create notifications caused by timing race conditions.
  *
  * @memberof dc_accounts_t
+ * @param accounts The account manager as created by dc_accounts_new().
  * @param timeout The timeout in seconds
  * @return Return 1 if DC_EVENT_ACCOUNTS_BACKGROUND_FETCH_DONE was emitted and 0 otherwise.
  */
 int            dc_accounts_background_fetch    (dc_accounts_t* accounts, uint64_t timeout);
+
+
+/**
+ * Stop ongoing background fetch.
+ *
+ * Calling this function allows to stop dc_accounts_background_fetch() early.
+ * dc_accounts_background_fetch() will then return immediately
+ * and emit DC_EVENT_ACCOUNTS_BACKGROUND_FETCH_DONE unless
+ * if it has failed and returned 0.
+ *
+ * If there is no ongoing dc_accounts_background_fetch() call,
+ * calling this function does nothing.
+ *
+ * @memberof dc_accounts_t
+ * @param accounts The account manager as created by dc_accounts_new().
+ */
+void           dc_accounts_stop_background_fetch (dc_accounts_t *accounts);
 
 
 /**

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -5028,6 +5028,17 @@ pub unsafe extern "C" fn dc_accounts_background_fetch(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn dc_accounts_stop_background_fetch(accounts: *mut dc_accounts_t) {
+    if accounts.is_null() {
+        eprintln!("ignoring careless call to dc_accounts_stop_background_fetch()");
+        return;
+    }
+
+    let accounts = &*accounts;
+    block_on(accounts.read()).stop_background_fetch();
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn dc_accounts_set_push_device_token(
     accounts: *mut dc_accounts_t,
     token: *const libc::c_char,

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -283,6 +283,11 @@ impl CommandApi {
         Ok(())
     }
 
+    async fn stop_background_fetch(&self) -> Result<()> {
+        self.accounts.read().await.stop_background_fetch();
+        Ok(())
+    }
+
     // ---------------------------------------------
     // Methods that work on individual accounts
     // ---------------------------------------------


### PR DESCRIPTION
New APIs are JSON-RPC method stop_background_fetch(),
Rust method Accounts.stop_background_fetch()
and C method dc_accounts_stop_background_fetch().

These APIs allow to cancel background fetch early
even before the initially set timeout,
for example on Android when the system calls
`Service.onTimeout()` for a `dataSync` foreground service.

In a separate commit JSON-RPC method accounts_background_fetch is renamed to background_fetch.
Delta Chat for Android is using CFFI anyway. Have not checked the other apps, but it should be easy to adapt if needed.