### PR TITLE
fix: always set bcc_self on backup import/export

### DIFF
--- a/deltachat-rpc-client/tests/test_multidevice.py
+++ b/deltachat-rpc-client/tests/test_multidevice.py
@@ -4,6 +4,41 @@ from deltachat_rpc_client import EventType
 from deltachat_rpc_client.const import MessageState
 
 
+def test_bcc_self_delete_server_after_defaults(acfactory):
+    """Test default values for bcc_self and delete_server_after."""
+    ac = acfactory.get_online_account()
+
+    # Initially after getting online
+    # the setting bcc_self is set to 0 because there is only one device
+    # and delete_server_after is "1", meaning immediate deletion.
+    assert ac.get_config("bcc_self") == "0"
+    assert ac.get_config("delete_server_after") == "1"
+
+    # Setup a second device.
+    ac_clone = ac.clone()
+    ac_clone.bring_online()
+
+    # Second device setup
+    # enables bcc_self and changes default delete_server_after.
+    assert ac.get_config("bcc_self") == "1"
+    assert ac.get_config("delete_server_after") == "0"
+
+    assert ac_clone.get_config("bcc_self") == "1"
+    assert ac_clone.get_config("delete_server_after") == "0"
+
+    # Manually disabling bcc_self
+    # also restores the default for delete_server_after.
+    ac.set_config("bcc_self", "0")
+    assert ac.get_config("bcc_self") == "0"
+    assert ac.get_config("delete_server_after") == "1"
+
+    # Cloning the account again enables bcc_self
+    # even though it was manually disabled.
+    ac_clone = ac.clone()
+    assert ac.get_config("bcc_self") == "1"
+    assert ac.get_config("delete_server_after") == "0"
+
+
 def test_one_account_send_bcc_setting(acfactory, log, direct_imap):
     ac1, ac2 = acfactory.get_online_accounts(2)
     ac1_clone = ac1.clone()


### PR DESCRIPTION
Regardless of whether chatmail relay is used or not, bcc_self should be enabled when second device is added. It should also be enabled again even if the user
has turned it off manually.