### PR TITLE
fix: deprecate deletion timer string for '1 Minute'

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -7518,14 +7518,13 @@ void dc_event_unref(dc_event_t* event);
 
 /// "You set message deletion timer to 1 minute."
 ///
-/// Used in status messages.
+/// @deprecated 2025-11-14, this string is no longer needed
 #define DC_STR_EPHEMERAL_TIMER_1_MINUTE_BY_YOU 142
 
 /// "Message deletion timer is set to 1 minute by %1$s."
 ///
 /// `%1$s` will be replaced by name and address of the contact.
-///
-/// Used in status messages.
+/// @deprecated 2025-11-14, this string is no longer needed
 #define DC_STR_EPHEMERAL_TIMER_1_MINUTE_BY_OTHER 143
 
 /// "You set message deletion timer to 1 hour."

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -241,10 +241,9 @@ pub(crate) async fn stock_ephemeral_timer_changed(
     match timer {
         Timer::Disabled => stock_str::msg_ephemeral_timer_disabled(context, from_id).await,
         Timer::Enabled { duration } => match duration {
-            0..=59 => {
+            0..=60 => {
                 stock_str::msg_ephemeral_timer_enabled(context, &timer.to_string(), from_id).await
             }
-            60 => stock_str::msg_ephemeral_timer_minute(context, from_id).await,
             61..=3599 => {
                 stock_str::msg_ephemeral_timer_minutes(
                     context,

--- a/src/ephemeral/ephemeral_tests.rs
+++ b/src/ephemeral/ephemeral_tests.rs
@@ -38,7 +38,7 @@ async fn test_stock_ephemeral_messages() {
     assert_eq!(
         stock_ephemeral_timer_changed(&context, Timer::Enabled { duration: 60 }, ContactId::SELF)
             .await,
-        "You set message deletion timer to 1 minute."
+        "You set message deletion timer to 60 s."
     );
     assert_eq!(
         stock_ephemeral_timer_changed(&context, Timer::Enabled { duration: 90 }, ContactId::SELF)
@@ -142,7 +142,7 @@ async fn test_ephemeral_enable_disable() -> Result<()> {
     let bob_received_message = bob.recv_msg(&sent).await;
     assert_eq!(
         bob_received_message.text,
-        "Message deletion timer is set to 1 minute by alice@example.org."
+        "Message deletion timer is set to 60 s by alice@example.org."
     );
     assert_eq!(
         chat_bob.get_ephemeral_timer(bob).await?,

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -302,12 +302,6 @@ pub enum StockMessage {
     #[strum(props(fallback = "Message deletion timer is set to %1$s s by %2$s."))]
     MsgEphemeralTimerEnabledBy = 141,
 
-    #[strum(props(fallback = "You set message deletion timer to 1 minute."))]
-    MsgYouEphemeralTimerMinute = 142,
-
-    #[strum(props(fallback = "Message deletion timer is set to 1 minute by %1$s."))]
-    MsgEphemeralTimerMinuteBy = 143,
-
     #[strum(props(fallback = "You set message deletion timer to 1 hour."))]
     MsgYouEphemeralTimerHour = 144,
 
@@ -1001,17 +995,6 @@ pub(crate) async fn msg_ephemeral_timer_enabled(
             .await
             .replace1(timer)
             .replace2(&by_contact.get_stock_name(context).await)
-    }
-}
-
-/// Stock string: `Message deletion timer is set to 1 minute.`.
-pub(crate) async fn msg_ephemeral_timer_minute(context: &Context, by_contact: ContactId) -> String {
-    if by_contact == ContactId::SELF {
-        translated(context, StockMessage::MsgYouEphemeralTimerMinute).await
-    } else {
-        translated(context, StockMessage::MsgEphemeralTimerMinuteBy)
-            .await
-            .replace1(&by_contact.get_stock_name(context).await)
     }
 }
 


### PR DESCRIPTION
the minimum timestamp in UI is 5 minutes
and the old string is about to be removed from translations. the 'seconds' fallback is good enough, however.

the dropping of "1 minute" is also because of the time starting already when the chat opened, not when the message is actually in view; cmp https://github.com/deltachat/deltachat-android/pull/3897