### PR TITLE
feat: default bcc_self to 0 for new accounts

### DIFF
--- a/python/tests/test_3_offline.py
+++ b/python/tests/test_3_offline.py
@@ -35,7 +35,7 @@ class TestOfflineAccountBasic:
         d = ac1.get_info()
         assert d["arch"]
         assert d["number_of_chats"] == "0"
-        assert d["bcc_self"] == "1"
+        assert d["bcc_self"] == "0"
 
     def test_is_not_configured(self, acfactory):
         ac1 = acfactory.get_unconfigured_account()
@@ -69,7 +69,7 @@ class TestOfflineAccountBasic:
     def test_has_bccself(self, acfactory):
         ac1 = acfactory.get_unconfigured_account()
         assert "bcc_self" in ac1.get_config("sys.config_keys").split()
-        assert ac1.get_config("bcc_self") == "1"
+        assert ac1.get_config("bcc_self") == "0"
 
     def test_selfcontact_if_unconfigured(self, acfactory):
         ac1 = acfactory.get_unconfigured_account()

--- a/src/config.rs
+++ b/src/config.rs
@@ -144,11 +144,11 @@ pub enum Config {
 
     /// Send BCC copy to self.
     ///
-    /// Should be enabled for multidevice setups.
-    /// Default is 0 for chatmail accounts, 1 otherwise.
+    /// Should be enabled for multi-device setups.
     ///
     /// This is automatically enabled when importing/exporting a backup,
     /// setting up a second device, or receiving a sync message.
+    #[strum(props(default = "0"))]
     BccSelf,
 
     /// True if Message Delivery Notifications (read receipts) should
@@ -523,10 +523,6 @@ impl Context {
 
         // Default values
         let val = match key {
-            Config::BccSelf => match Box::pin(self.is_chatmail()).await? {
-                false => Some("1".to_string()),
-                true => Some("0".to_string()),
-            },
             Config::ConfiguredInboxFolder => Some("INBOX".to_string()),
             Config::DeleteServerAfter => {
                 match !Box::pin(self.get_config_bool(Config::BccSelf)).await?

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -979,11 +979,10 @@ mod tests {
 
         let context1 = &TestContext::new_alice().await;
 
+        // `bcc_self` is enabled by default for test contexts. Unset it.
+        context1.set_config(Config::BccSelf, None).await?;
+
         // Check that the settings are displayed correctly.
-        assert_eq!(
-            context1.get_config(Config::BccSelf).await?,
-            Some("1".to_string())
-        );
         assert_eq!(
             context1.get_config(Config::DeleteServerAfter).await?,
             Some("0".to_string())

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -657,14 +657,11 @@ mod tests {
             alice1.set_config_bool(Config::SyncMsgs, true).await?;
             alice2.set_config_bool(Config::SyncMsgs, true).await?;
 
-            if chatmail {
-                alice1.set_config_bool(Config::IsChatmail, true).await?;
-                alice2.set_config_bool(Config::IsChatmail, true).await?;
-            } else {
-                alice2.set_config_bool(Config::BccSelf, false).await?;
-            }
+            alice1.set_config_bool(Config::IsChatmail, chatmail).await?;
+            alice2.set_config_bool(Config::IsChatmail, chatmail).await?;
 
             alice1.set_config_bool(Config::BccSelf, true).await?;
+            alice2.set_config_bool(Config::BccSelf, false).await?;
 
             let sent_msg = if sync_message_sent {
                 alice1

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -549,6 +549,7 @@ impl TestContext {
         ctx.set_config(Config::SkipStartMessages, Some("1"))
             .await
             .unwrap();
+        ctx.set_config(Config::BccSelf, Some("1")).await.unwrap();
         ctx.set_config(Config::SyncMsgs, Some("0")).await.unwrap();
 
         Self {


### PR DESCRIPTION
This is part of https://github.com/chatmail/core/issues/7357 needed to get rid of is_chatmail distinction between profiles. Previously the setting was default to 1 for non-chatmail and 0 for chatmail.
See also previous PR #7440 