### PR TITLE
fix: ContactId::set_name_ex(): Emit ContactsChanged when transaction is completed

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -130,13 +130,15 @@ impl ContactId {
                             Ok((addr, fingerprint))
                         },
                     )?;
-                    context.emit_event(EventType::ContactsChanged(Some(self)));
                     Ok(Some((addr, fingerprint)))
                 } else {
                     Ok(None)
                 }
             })
             .await?;
+        if row.is_some() {
+            context.emit_event(EventType::ContactsChanged(Some(self)));
+        }
 
         if sync.into()
             && let Some((addr, fingerprint)) = row


### PR DESCRIPTION
This fixes flaky JSON-RPC's `test_rename_synchronization()`: https://github.com/chatmail/core/actions/runs/19411941917/job/55534792395?pr=7426