### PR TITLE
feat: try getting autoconfig info from http://autoconfig.[domain]

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -634,6 +634,20 @@ async fn get_autoconfig(
     }
     progress!(ctx, 310);
 
+    if let Ok(res) = moz_autoconfigure(
+        ctx,
+        // the unsecured http:// call is listed as an optional fallback in the RFC
+        &format!(
+            "http://autoconfig.{param_domain}/mail/config-v1.1.xml?emailaddress={param_addr_urlencoded}"
+        ),
+        &param.addr,
+    )
+    .await
+    {
+        return Some(res);
+    }
+    progress!(ctx, 315);
+
     // Outlook uses always SSL but different domains (this comment describes the next two steps)
     if let Ok(res) = outlk_autodiscover(
         ctx,


### PR DESCRIPTION
The [RFC](https://www.ietf.org/archive/id/draft-bucksch-autoconfig-00.html#section-4.1-4.3.1) cites the http:// endpoint as a third optional source for autoconfig information. This is useful for offline/LAN environments where the mail server is not able to obtain an SSL certificate for serving HTTPS -- something we at Rapidspace encounter with our ORS 4G networks when hosting a Delta.Chat server.