### PR TITLE
docs: add missing RFC 9788 number, unify link

### DIFF
--- a/standards.md
+++ b/standards.md
@@ -19,7 +19,7 @@ Authorization                    | OAuth2 ([RFC 6749][])
 End-to-end encryption            | [Autocrypt Level 1][], OpenPGP ([RFC 4880][]), Security Multiparts for MIME ([RFC 1847][]) and [“Mixed Up” Encryption repairing](https://tools.ietf.org/id/draft-dkg-openpgp-pgpmime-message-mangling-00.html)
 Detect/prevent active attacks    | [securejoin][] protocols
 Compare public keys              | [openpgp4fpr][] URI Scheme
-Header encryption                | [Header Protection for Cryptographically Protected E-mail](https://datatracker.ietf.org/doc/draft-ietf-lamps-header-protection/)
+Metadata minimization            | Header Protection for Cryptographically Protected Email ([RFC 9788][])
 Configuration assistance         | [Autoconfigure](https://web.archive.org/web/20210402044801/https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration) and [Autodiscover][]
 Messenger functions              | [Chat-over-Email](https://github.com/chatmail/core/blob/main/spec.md#chat-mail-specification)
 Detect mailing list              | List-Id ([RFC 2919][]) and Precedence ([RFC 3834][])
@@ -59,3 +59,4 @@ Locations                        | KML ([Open Geospatial Consortium](http://www.
 [RFC 7162]: https://tools.ietf.org/html/rfc7162
 [RFC 8098]: https://tools.ietf.org/html/rfc8098
 [RFC 9078]: https://tools.ietf.org/html/rfc9078
+[RFC 9788]: https://tools.ietf.org/html/rfc9788


### PR DESCRIPTION
this PR updates `standards.md` to show the RFC 9788 number directly and use the same link pattern as elsewhere.

moreover, the row is called "Metadata minimization" now