### PR TITLE
ci: do not use --encoding option for rst-lint

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -46,7 +46,7 @@ deps =
 commands =
     ruff format --diff setup.py src/deltachat examples/ tests/
     ruff check src/deltachat tests/ examples/
-    rst-lint --encoding 'utf-8' README.rst
+    rst-lint README.rst
 
 [testenv:mypy]
 deps =


### PR DESCRIPTION
It was removed in rst-lint 2.0:
https://github.com/twolfson/restructuredtext-lint/commit/7b43036b4d2175d2f339a26cf3383d0c512d7add