### PR TITLE
refactor!: Remove some unneeded stock strings

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -7416,19 +7416,6 @@ void dc_event_unref(dc_event_t* event);
 /// @deprecated 2025-06-05
 #define DC_STR_AEAP_ADDR_CHANGED          122
 
-/// "You changed your email address from %1$s to %2$s.
-/// If you now send a message to a group, contacts there will automatically
-/// replace the old with your new address.\n\n It's highly advised to set up 
-/// your old email provider to forward all emails to your new email address. 
-/// Otherwise you might miss messages of contacts who did not get your new 
-/// address yet." + the link to the AEAP blog post
-/// 
-/// As soon as there is a post about AEAP, the UIs should add it:
-/// set_stock_translation(123, getString(aeap_explanation) + "\n\n" + AEAP_BLOG_LINK)
-///
-/// Used in a device message that explains AEAP.
-#define DC_STR_AEAP_EXPLANATION_AND_LINK  123
-
 /// "You changed group name from \"%1$s\" to \"%2$s\"."
 ///
 /// `%1$s` will be replaced by the old group name.
@@ -7676,12 +7663,6 @@ void dc_event_unref(dc_event_t* event);
 ///
 /// Used in info messages.
 #define DC_STR_CHAT_PROTECTION_ENABLED 170
-
-/// "%1$s sent a message from another device."
-///
-/// Used in info messages.
-/// @deprecated 2025-07
-#define DC_STR_CHAT_PROTECTION_DISABLED 171
 
 /// "Others will only see this group after you sent a first message."
 ///

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3312,10 +3312,7 @@ async fn test_leave_broadcast_multidevice() -> Result<()> {
 
     let leave_msg = bob0.pop_sent_msg().await;
     let parsed = MimeMessage::from_bytes(bob1, leave_msg.payload().as_bytes(), None).await?;
-    assert_eq!(
-        parsed.parts[0].msg,
-        stock_str::msg_group_left_remote(bob0).await
-    );
+    assert_eq!(parsed.parts[0].msg, "I left the group.");
 
     let rcvd = bob1.recv_msg(&leave_msg).await;
 

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1509,18 +1509,6 @@ impl Contact {
         &self.addr
     }
 
-    /// Get authorized name or address.
-    ///
-    /// This string is suitable for sending over email
-    /// as it does not leak the locally set name.
-    pub(crate) fn get_authname_or_addr(&self) -> String {
-        if !self.authname.is_empty() {
-            (&self.authname).into()
-        } else {
-            (&self.addr).into()
-        }
-    }
-
     /// Get a summary of name and address.
     ///
     /// The returned string is either "Name (email@domain.com)" or just

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1521,10 +1521,9 @@ impl MimeFactory {
                             .await?
                             .unwrap_or_default()
                     {
-                        placeholdertext = Some(stock_str::msg_group_left_remote(context).await);
+                        placeholdertext = Some("I left the group.".to_string());
                     } else {
-                        placeholdertext =
-                            Some(stock_str::msg_del_member_remote(context, email_to_remove).await);
+                        placeholdertext = Some(format!("I removed member {email_to_remove}."));
                     };
 
                     if !email_to_remove.is_empty() {
@@ -1547,8 +1546,7 @@ impl MimeFactory {
                     let email_to_add = msg.param.get(Param::Arg).unwrap_or_default();
                     let fingerprint_to_add = msg.param.get(Param::Arg4).unwrap_or_default();
 
-                    placeholdertext =
-                        Some(stock_str::msg_add_member_remote(context, email_to_add).await);
+                    placeholdertext = Some(format!("I added member {email_to_add}."));
 
                     if !email_to_add.is_empty() {
                         headers.push((

--- a/src/stock_str/stock_str_tests.rs
+++ b/src/stock_str/stock_str_tests.rs
@@ -76,10 +76,6 @@ async fn test_stock_system_msg_add_member_by_me() {
         .await
         .expect("failed to create contact");
     assert_eq!(
-        msg_add_member_remote(&t, "alice@example.org").await,
-        "I added member alice@example.org."
-    );
-    assert_eq!(
         msg_add_member_local(&t, alice_contact_id, ContactId::SELF).await,
         "You added member Alice."
     )
@@ -91,10 +87,6 @@ async fn test_stock_system_msg_add_member_by_me_with_displayname() {
     let alice_contact_id = Contact::create(&t, "Alice", "alice@example.org")
         .await
         .expect("failed to create contact");
-    assert_eq!(
-        msg_add_member_remote(&t, "alice@example.org").await,
-        "I added member alice@example.org."
-    );
     assert_eq!(
         msg_add_member_local(&t, alice_contact_id, ContactId::SELF).await,
         "You added member Alice."


### PR DESCRIPTION
There are quite some unneeded stock strings; this PR removes some of them. None of these stock strings were actually set by the UI, or even have translations in Transifex.
- We don't have AEAP anymore.
- The "I added/removed member" and "I left the group" strings are anyways not meant to be shown to the user. Also, starting to translate them now would leak the device language.

BREAKING CHANGE: This can theoretically be a breaking change because a UI could reference one of the removed stock strings, so I marked it as breaking just in case.