### PR TITLE
fix: use the same webxdc ratelimit for all email servers

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -453,7 +453,7 @@ impl Context {
             translated_stockstrings: stockstrings,
             events,
             scheduler: SchedulerState::new(),
-            ratelimit: RwLock::new(Ratelimit::new(Duration::new(60, 0), 6.0)), // Allow at least 1 message every 10 seconds + a burst of 6.
+            ratelimit: RwLock::new(Ratelimit::new(Duration::new(3, 0), 3.0)), // Allow at least 1 message every second + a burst of 3.
             quota: RwLock::new(None),
             new_msgs_notify,
             server_id: RwLock::new(None),
@@ -483,12 +483,6 @@ impl Context {
         if !self.is_configured().await.unwrap_or_default() {
             warn!(self, "can not start io on a context that is not configured");
             return;
-        }
-
-        if self.is_chatmail().await.unwrap_or_default() {
-            let mut lock = self.ratelimit.write().await;
-            // Allow at least 1 message every second + a burst of 3.
-            *lock = Ratelimit::new(Duration::new(3, 0), 3.0);
         }
 
         // The next line is mainly for iOS:

--- a/src/webxdc/webxdc_tests.rs
+++ b/src/webxdc/webxdc_tests.rs
@@ -1289,7 +1289,7 @@ async fn test_get_webxdc_info() -> Result<()> {
     let info = instance.get_webxdc_info(&t).await?;
     assert_eq!(info.name, "minimal.xdc");
     assert_eq!(info.icon, WEBXDC_DEFAULT_ICON.to_string());
-    assert_eq!(info.send_update_interval, 10000);
+    assert_eq!(info.send_update_interval, 1000);
     assert_eq!(info.send_update_max_size, RECOMMENDED_FILE_SIZE as usize);
 
     let mut instance = create_webxdc_instance(


### PR DESCRIPTION
This removes another distinction between chatmail and non-chatmail and fixes flaky tests/test_webxdc.py::test_webxdc

Closes <https://github.com/chatmail/core/issues/7522>