### PR TITLE
build: make scripts for remote testing usable

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -26,10 +26,10 @@ and an own build machine.
    i.e. `deltachat-rpc-client` and `deltachat-rpc-server`.
 
 - `remote_tests_python.sh` rsyncs to a build machine and runs
-  `run-python-test.sh` remotely on the build machine. 
+  JSON-RPC Python tests remotely on the build machine. 
 
 - `remote_tests_rust.sh` rsyncs to the build machine and runs
-  `run-rust-test.sh` remotely on the build machine. 
+  Rust tests remotely on the build machine. 
 
 - `run-doxygen.sh` generates C-docs which are then uploaded to https://c.delta.chat/
 

--- a/scripts/remote_tests_python.sh
+++ b/scripts/remote_tests_python.sh
@@ -1,45 +1,32 @@
-#!/bin/bash 
+#!/usr/bin/env bash
+set -euo pipefail
 
-BUILD_ID=${1:?specify build ID}
-
-SSHTARGET=${SSHTARGET-ci@b1.delta.chat}
-BUILDDIR=ci_builds/$BUILD_ID
+set -x
+if ! test -v SSHTARGET; then
+	echo >&2 SSHTARGET is not set
+	exit 1
+fi
+BUILDDIR=ci_builds/chatmailcore
 
 echo "--- Copying files to $SSHTARGET:$BUILDDIR"
 
-set -xe
-
-ssh -oBatchMode=yes -oStrictHostKeyChecking=no  $SSHTARGET mkdir -p "$BUILDDIR"
-git ls-files >.rsynclist 
-# we seem to need .git for setuptools_scm versioning 
-find .git >>.rsynclist
-rsync --delete --files-from=.rsynclist -az ./ "$SSHTARGET:$BUILDDIR"
-
-set +x
+rsync -az --delete --mkpath --files-from=<(git ls-files) ./ "$SSHTARGET:$BUILDDIR"
 
 echo "--- Running Python tests remotely"
 
-ssh $SSHTARGET <<_HERE
+ssh -oBatchMode=yes -- "$SSHTARGET" <<_HERE
     set +x -e
 
     # make sure all processes exit when ssh dies
     shopt -s huponexit
 
-    export RUSTC_WRAPPER=\`which sccache\`
+    export RUSTC_WRAPPER=\`command -v sccache\`
     cd $BUILDDIR
-    export TARGET=release
     export CHATMAIL_DOMAIN=$CHATMAIL_DOMAIN
 
-    #we rely on tox/virtualenv being available in the host
-    #rm -rf virtualenv venv
-    #virtualenv -q -p python3.7 venv 
-    #source venv/bin/activate
-    #pip install -q tox virtualenv
+    scripts/make-rpc-testenv.sh
+    . venv/bin/activate
 
-    set -x
-    which python
-    source \$HOME/venv/bin/activate
-    which python
-
-    bash scripts/run-python-test.sh 
+    cd deltachat-rpc-client
+    pytest -n6 $@
 _HERE


### PR DESCRIPTION
This updates `scripts/remote_tests_{rust,python}.sh`. The scripts were previously used to run tests
from CI on remote faster machine,
but they are still usable to run tests remotely
e.g. from a laptop that is on battery.