### PR TITLE
feat: Don't update self-{avatar,status} from received messages (#7002)

### DIFF
--- a/src/config/config_tests.rs
+++ b/src/config/config_tests.rs
@@ -278,7 +278,6 @@ async fn test_sync() -> Result<()> {
     Ok(())
 }
 
-/// Sync message mustn't be sent if self-{status,avatar} is changed by a self-sent message.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_no_sync_on_self_sent_msg() -> Result<()> {
     let mut tcm = TestContextManager::new();
@@ -288,7 +287,7 @@ async fn test_no_sync_on_self_sent_msg() -> Result<()> {
         a.set_config_bool(Config::SyncMsgs, true).await?;
     }
 
-    let status = "Synced via usual message";
+    let status = "Sent via usual message";
     alice0.set_config(Config::Selfstatus, Some(status)).await?;
     alice0.send_sync_msg().await?;
     alice0.pop_sent_sync_msg().await;
@@ -297,7 +296,7 @@ async fn test_no_sync_on_self_sent_msg() -> Result<()> {
     tcm.send_recv(alice0, alice1, "hi Alice!").await;
     assert_eq!(
         alice1.get_config(Config::Selfstatus).await?,
-        Some(status.to_string())
+        Some(status1.to_string())
     );
     sync(alice1, alice0).await;
     assert_eq!(
@@ -328,7 +327,7 @@ async fn test_no_sync_on_self_sent_msg() -> Result<()> {
         alice1
             .get_config(Config::Selfavatar)
             .await?
-            .filter(|path| path.ends_with(".png"))
+            .filter(|path| path.ends_with(".jpg"))
             .is_some()
     );
     sync(alice1, alice0).await;

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -991,42 +991,6 @@ Content-Disposition: reaction\n\
         Ok(())
     }
 
-    /// Regression test for reaction resetting self-status.
-    ///
-    /// Reactions do not contain the status,
-    /// but should not result in self-status being reset on other devices.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_reaction_status_multidevice() -> Result<()> {
-        let mut tcm = TestContextManager::new();
-        let alice1 = tcm.alice().await;
-        let alice2 = tcm.alice().await;
-
-        alice1
-            .set_config(Config::Selfstatus, Some("New status"))
-            .await?;
-
-        let alice2_msg = tcm.send_recv(&alice1, &alice2, "Hi!").await;
-        assert_eq!(
-            alice2.get_config(Config::Selfstatus).await?.as_deref(),
-            Some("New status")
-        );
-
-        // Alice reacts to own message from second device,
-        // first device receives rection.
-        {
-            send_reaction(&alice2, alice2_msg.id, "👍").await?;
-            let msg = alice2.pop_sent_msg().await;
-            alice1.recv_msg_hidden(&msg).await;
-        }
-
-        // Check that the status is still the same.
-        assert_eq!(
-            alice1.get_config(Config::Selfstatus).await?.as_deref(),
-            Some("New status")
-        );
-        Ok(())
-    }
-
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_send_reaction_multidevice() -> Result<()> {
         let mut tcm = TestContextManager::new();


### PR DESCRIPTION
The normal way of synchronizing self-avatar and -status nowadays is sync messages.
This is the second commit from #7123
Fixes (probably) #7002 