### PR TITLE
ci: set timeout-minutes for all jobs in ci.yaml workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
   lint_rust:
     name: Lint Rust
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
         with:
@@ -52,6 +53,7 @@ jobs:
   cargo_deny:
     name: cargo deny
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
         with:
@@ -66,6 +68,7 @@ jobs:
   provider_database:
     name: Check provider database
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
         with:
@@ -79,6 +82,7 @@ jobs:
   docs:
     name: Rust doc comments
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     env:
       RUSTDOCFLAGS: -Dwarnings
     steps:
@@ -107,6 +111,7 @@ jobs:
           - os: ubuntu-latest
             rust: minimum
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - run:
           echo "RUSTUP_TOOLCHAIN=$MSRV" >> $GITHUB_ENV
@@ -155,6 +160,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
         with:
@@ -180,6 +186,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
         with:
@@ -202,6 +209,7 @@ jobs:
   python_lint:
     name: Python lint
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
         with:
@@ -245,6 +253,7 @@ jobs:
             python: 3.8
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
         with:
@@ -298,6 +307,7 @@ jobs:
             python: 3.8
 
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
Default is 360 minutes, that is 6 hours.
If the job is running for more than 1 hour,
it is surely stuck, no need to keep running it.