### PR TITLE
feat!: increase backup version from 3 to 4

### DIFF
--- a/src/qr.rs
+++ b/src/qr.rs
@@ -42,7 +42,7 @@ pub(crate) const DCBACKUP_SCHEME_PREFIX: &str = "DCBACKUP";
 
 /// Version written to Backups and Backup-QR-Codes.
 /// Imports will fail when they have a larger version.
-pub(crate) const DCBACKUP_VERSION: i32 = 3;
+pub(crate) const DCBACKUP_VERSION: i32 = 4;
 
 /// Scanned QR code.
 #[derive(Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
Migration 140 merged in version 2.28.0
introduced `NOT NULL` transport_id
columns, so old versions of core not aware of it
fail e.g. when they expect conflict on `(folder)`
column rather than `(transport_id, folder)`.

Closes #7529