### PR TITLE
feat: Case-insensitive search for non-ASCII chat and contact names (#7477)

### DIFF
--- a/src/calls.rs
+++ b/src/calls.rs
@@ -10,11 +10,11 @@ use crate::context::{Context, WeakContext};
 use crate::events::EventType;
 use crate::headerdef::HeaderDef;
 use crate::log::warn;
-use crate::message::{self, Message, MsgId, Viewtype};
+use crate::message::{Message, MsgId, Viewtype};
 use crate::mimeparser::{MimeMessage, SystemMessage};
 use crate::net::dns::lookup_host_with_cache;
 use crate::param::Param;
-use crate::tools::time;
+use crate::tools::{normalize_text, time};
 use anyhow::{Context as _, Result, ensure};
 use sdp::SessionDescription;
 use serde::Serialize;
@@ -86,7 +86,7 @@ impl CallInfo {
             .sql
             .execute(
                 "UPDATE msgs SET txt=?, txt_normalized=? WHERE id=?",
-                (text, message::normalize_text(text), self.msg.id),
+                (text, normalize_text(text), self.msg.id),
             )
             .await?;
         Ok(())

--- a/src/message.rs
+++ b/src/message.rs
@@ -2248,14 +2248,5 @@ impl Viewtype {
     }
 }
 
-/// Returns text for storing in the `msgs.txt_normalized` column (to make case-insensitive search
-/// possible for non-ASCII messages).
-pub(crate) fn normalize_text(text: &str) -> Option<String> {
-    if text.is_ascii() {
-        return None;
-    };
-    Some(text.to_lowercase()).filter(|t| t != text)
-}
-
 #[cfg(test)]
 mod message_tests;

--- a/src/sql/migrations/migrations_tests.rs
+++ b/src/sql/migrations/migrations_tests.rs
@@ -160,9 +160,7 @@ async fn test_key_contacts_migration_verified() -> Result<()> {
     "#,
     )?)).await?;
 
-    STOP_MIGRATIONS_AT
-        .scope(133, t.sql.run_migrations(&t))
-        .await?;
+    t.sql.run_migrations(&t).await?;
 
     // Hidden address-contact can't be looked up.
     assert!(

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -779,6 +779,15 @@ pub(crate) fn to_lowercase(s: &str) -> Cow<'_, str> {
     }
 }
 
+/// Returns text for storing in special db columns to make case-insensitive search possible for
+/// non-ASCII messages, chat and contact names.
+pub(crate) fn normalize_text(text: &str) -> Option<String> {
+    if text.is_ascii() {
+        return None;
+    };
+    Some(text.to_lowercase()).filter(|t| t != text)
+}
+
 /// Increments `*t` and checks that it equals to `expected` after that.
 pub(crate) fn inc_and_check<T: PrimInt + AddAssign + std::fmt::Debug>(
     t: &mut T,


### PR DESCRIPTION
This makes `Contact::get_all()` and `Chatlist::try_load()` case-insensitive for non-ASCII chat and contact names as well. The same approach as in f6f4ccc6ea4df2959a98e45c665b57aedf0a6b49 "feat: Case-insensitive search for non-ASCII messages (#5052)" is used: `chats.name_normalized` and `contacts.name_normalized` colums are added which store lowercased/normalized names (for a contact, if the name is unset, it's a normalized authname). If a normalized name is the same as the chat/contact name, it's not stored to reduce the db size. A db migration is added for 10000 random chats and the same number of the most recently seen contacts, for users it will probably migrate all chats/contacts and for bots which may have more data it's not important.

Fix #7477 