### PR TITLE
chore: remove two outdated todo comments

### DIFF
--- a/deltachat-jsonrpc/src/api/types/account.rs
+++ b/deltachat-jsonrpc/src/api/types/account.rs
@@ -15,7 +15,7 @@ pub enum Account {
         display_name: Option<String>,
         addr: Option<String>,
         // size: u32,
-        profile_image: Option<String>, // TODO: This needs to be converted to work with blob http server.
+        profile_image: Option<String>,
         color: String,
         /// Optional tag as "Work", "Family".
         /// Meant to help profile owner to differ between profiles with similar names.

--- a/deltachat-jsonrpc/src/api/types/chat.rs
+++ b/deltachat-jsonrpc/src/api/types/chat.rs
@@ -69,7 +69,7 @@ pub struct FullChat {
     // but that would be an extra DB query.
     self_in_group: bool,
     is_muted: bool,
-    ephemeral_timer: u32, //TODO look if there are more important properties in newer core versions
+    ephemeral_timer: u32,
     can_send: bool,
     was_seen_recently: bool,
     mailing_list_address: Option<String>,


### PR DESCRIPTION
remove two small outdated to do comments that are not relevant anymore (already done or solved differently)