### PR TITLE
ci: use "trusted publishing" for NPM packages

### DIFF
--- a/.github/workflows/deltachat-rpc-server.yml
+++ b/.github/workflows/deltachat-rpc-server.yml
@@ -388,6 +388,9 @@ jobs:
     name: Build & Publish npm prebuilds and deltachat-rpc-server
     needs: ["build_linux", "build_windows", "build_macos"]
     runs-on: "ubuntu-latest"
+    environment:
+      name: npm-stdio-rpc-server
+      url: https://www.npmjs.com/package/@deltachat/stdio-rpc-server
     permissions:
       id-token: write
 
@@ -521,5 +524,3 @@ jobs:
         run: |
           ls -lah platform_package
           for platform in *.tgz; do npm publish --provenance "$platform" --access public; done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/jsonrpc-client-npm-package.yml
+++ b/.github/workflows/jsonrpc-client-npm-package.yml
@@ -10,6 +10,9 @@ jobs:
   pack-module:
     name: "Publish @deltachat/jsonrpc-client"
     runs-on: ubuntu-latest
+    environment:
+      name: npm-jsonrpc-client
+      url: https://www.npmjs.com/package/@deltachat/jsonrpc-client
     permissions:
       id-token: write
       contents: read
@@ -37,5 +40,3 @@ jobs:
       - name: Publish
         working-directory: deltachat-jsonrpc/typescript
         run: npm publish --provenance deltachat-jsonrpc-client-* --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
See the documentation at <https://docs.npmjs.com/trusted-publishers>. I have removed the token that was used since <https://github.com/chatmail/core/pull/5575>, created two new GitHub deployment environments and configured trusted publishing for two packages (see the environment URLs) on https://www.npmjs.com/