### PR TITLE
ci: update npm before publishing packages

### DIFF
--- a/.github/workflows/deltachat-rpc-server.yml
+++ b/.github/workflows/deltachat-rpc-server.yml
@@ -518,6 +518,11 @@ jobs:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
 
+      # Ensure npm 11.5.1 or later is installed.
+      # It is needed for <https://docs.npmjs.com/trusted-publishers>
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Publish npm packets for prebuilds and `@deltachat/stdio-rpc-server`
         if: github.event_name == 'release'
         working-directory: deltachat-rpc-server/npm-package

--- a/.github/workflows/jsonrpc-client-npm-package.yml
+++ b/.github/workflows/jsonrpc-client-npm-package.yml
@@ -27,6 +27,11 @@ jobs:
           node-version: 20
           registry-url: "https://registry.npmjs.org"
 
+      # Ensure npm 11.5.1 or later is installed.
+      # It is needed for <https://docs.npmjs.com/trusted-publishers>
+      - name: Update npm
+        run: npm install -g npm@latest
+
       - name: Install dependencies without running scripts
         working-directory: deltachat-jsonrpc/typescript
         run: npm install --ignore-scripts


### PR DESCRIPTION
Newer npm is apparently needed for "trusted publishing".

Closes #7563 