### PR TITLE
fix: recognize all transport addresses as own addresses

### DIFF
--- a/deltachat-rpc-client/tests/test_multitransport.py
+++ b/deltachat-rpc-client/tests/test_multitransport.py
@@ -201,3 +201,19 @@ def test_transport_synchronization(acfactory, log) -> None:
 
     assert ac1.wait_for_incoming_msg().get_snapshot().text == "Hello!"
     assert ac1_clone.wait_for_incoming_msg().get_snapshot().text == "Hello!"
+
+
+def test_recognize_self_address(acfactory) -> None:
+    alice, bob = acfactory.get_online_accounts(2)
+
+    bob_chat = bob.create_chat(alice)
+
+    qr = acfactory.get_account_qr()
+    alice.add_transport_from_qr(qr)
+
+    new_alice_addr = alice.list_transports()[1]["addr"]
+    alice.set_config("configured_addr", new_alice_addr)
+
+    bob_chat.send_text("Hello!")
+    msg = alice.wait_for_incoming_msg().get_snapshot()
+    assert msg.chat == alice.create_chat(bob)

--- a/src/imap/imap_tests.rs
+++ b/src/imap/imap_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::test_utils::TestContext;
+use crate::transport::add_pseudo_transport;
 
 #[test]
 fn test_get_folder_meaning_by_name() {
@@ -271,12 +272,14 @@ async fn test_get_imap_search_command() -> Result<()> {
         r#"FROM "alice@example.org""#
     );
 
+    add_pseudo_transport(&t, "alice@another.com").await?;
     t.ctx.set_primary_self_addr("alice@another.com").await?;
     assert_eq!(
         get_imap_self_sent_search_command(&t.ctx).await?,
         r#"OR (FROM "alice@another.com") (FROM "alice@example.org")"#
     );
 
+    add_pseudo_transport(&t, "alice@third.com").await?;
     t.ctx.set_primary_self_addr("alice@third.com").await?;
     assert_eq!(
         get_imap_self_sent_search_command(&t.ctx).await?,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -756,6 +756,21 @@ pub(crate) async fn sync_transports(
     Ok(())
 }
 
+/// Adds transport entry to the `transports` table with empty configuration.
+pub(crate) async fn add_pseudo_transport(context: &Context, addr: &str) -> Result<()> {
+    context.sql
+        .execute(
+            "INSERT INTO transports (addr, entered_param, configured_param) VALUES (?, ?, ?)",
+            (
+                addr,
+                serde_json::to_string(&EnteredLoginParam::default())?,
+                format!(r#"{{"addr":"{addr}","imap":[],"imap_user":"","imap_password":"","smtp":[],"smtp_user":"","smtp_password":"","certificate_checks":"Automatic","oauth2":false}}"#)
+            ),
+        )
+        .await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Fix get_secondary_addrs() which was using
`secondary_addrs` config that is not updated anymore. Instead of using `secondary_addrs` config,
use the `transports` table which contains all the addresses.

Fixes #7566