### PR TITLE
feat: Disable partial search by contact address

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1133,7 +1133,8 @@ VALUES (?, ?, ?, ?, ?, ?)
             Origin::IncomingReplyTo
         };
         if query.is_some() {
-            let s3str_like_cmd = format!("%{}%", query.unwrap_or("").to_lowercase());
+            let query_lowercased = query.unwrap_or("").to_lowercase();
+            let s3str_like_cmd = format!("%{}%", query_lowercased);
             context
                 .sql
                 .query_map(
@@ -1151,7 +1152,7 @@ ORDER BY c.origin>=? DESC, c.last_seen DESC, c.id DESC
                         flag_address,
                         minimal_origin,
                         &s3str_like_cmd,
-                        &s3str_like_cmd,
+                        &query_lowercased,
                         Origin::CreateChat,
                     ),
                     |row| {

--- a/src/contact/contact_tests.rs
+++ b/src/contact/contact_tests.rs
@@ -85,10 +85,15 @@ async fn test_get_contacts() -> Result<()> {
     assert_eq!(contacts.len(), 1);
     assert_eq!(contacts.first(), Some(&id));
 
-    // Search by address.
+    // Search by address is case-insensitive, but only returns direct matches.
     let contacts = Contact::get_all(&context, 0, Some("alice@example.org")).await?;
     assert_eq!(contacts.len(), 1);
     assert_eq!(contacts.first(), Some(&id));
+    let contacts = Contact::get_all(&context, 0, Some("Alice@example.org")).await?;
+    assert_eq!(contacts.len(), 1);
+    assert_eq!(contacts.first(), Some(&id));
+    let contacts = Contact::get_all(&context, 0, Some("alice@")).await?;
+    assert_eq!(contacts.len(), 0);
 
     let contacts = Contact::get_all(&context, 0, Some("Foobar")).await?;
     assert_eq!(contacts.len(), 0);


### PR DESCRIPTION
Implement suggestion from #7477 so that there's no incremental search by contact address in UIs, only direct matches are returned.