### PR TITLE
fix: add multi-transport information to Context.get_info (own key for each transport, alternative to #7583)

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -356,9 +356,7 @@ pub unsafe extern "C" fn dc_get_info(context: *const dc_context_t) -> *mut libc:
     }
 }
 
-fn render_info(
-    info: BTreeMap<&'static str, String>,
-) -> std::result::Result<String, std::fmt::Error> {
+fn render_info(info: BTreeMap<String, String>) -> std::result::Result<String, std::fmt::Error> {
     let mut res = String::new();
     for (key, value) in &info {
         writeln!(&mut res, "{key}={value}")?;

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -363,7 +363,7 @@ impl CommandApi {
     }
 
     /// Get system info for an account.
-    async fn get_info(&self, account_id: u32) -> Result<BTreeMap<&'static str, String>> {
+    async fn get_info(&self, account_id: u32) -> Result<BTreeMap<String, String>> {
         let ctx = self.get_context(account_id).await?;
         ctx.get_info().await
     }


### PR DESCRIPTION
This is an alternative for https://github.com/chatmail/core/pull/7583 which gives each transport its own key, which makes it more readable.
Though downside is that this approach touches more code, because it needed to change the rust return type of get_info (from `&'static str` to `String`) to allow adding new keys at runtime.

closes #7581