### PR TITLE
feat: double ringing time to 120 seconds

### DIFF
--- a/src/calls.rs
+++ b/src/calls.rs
@@ -33,7 +33,7 @@ use tokio::time::sleep;
 ///
 /// For the caller, this means they should also not wait longer,
 /// as the callee won't start the call afterwards.
-const RINGING_SECONDS: i64 = 60;
+const RINGING_SECONDS: i64 = 120;
 
 // For persisting parameters in the call, we use Param::Arg*
 


### PR DESCRIPTION
the ringing of 60 seconds is indeed a bit short,
esp. when messages are already delayed.
but also if everythings is fast and working, 60 seconds are short.

the 60 seconds also come from the first implementation,
where we did not had a "reject" message from callee to caller,
so that caller should not wait unnecessarily.

this has changed,
however, the other constraints are still valid -
phone may get offline, and we should not ring for stale calls.

sure, that can be fixed also differently,
but for the current implementation,
the 120 seconds seem to be a good compromise.
