### PR TITLE
refactor: Simplify the logic for downloading a bit

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -609,7 +609,7 @@ impl Context {
                     convert_folder_meaning(self, folder_meaning).await?
                 {
                     connection
-                        .fetch_move_delete(self, &mut session, true, &watch_folder, folder_meaning)
+                        .fetch_move_delete(self, &mut session, &watch_folder, folder_meaning)
                         .await?;
                 }
             }

--- a/src/download.rs
+++ b/src/download.rs
@@ -26,13 +26,7 @@ pub(crate) const MIN_DELETE_SERVER_AFTER: i64 = 48 * 60 * 60;
 // current value is a bit less than the minimum auto download setting from the UIs (which is 160 KiB)
 pub(crate) const PRE_MSG_ATTACHMENT_SIZE_THRESHOLD: u64 = 140_000;
 
-/// Max message size to be fetched in the background.
-/// This limit defines what messages are fully fetched in the background.
-/// This is for all messages that don't have the Post-Message header.
-pub(crate) const MAX_FETCH_MSG_SIZE: u32 = 1_000_000;
-
 /// Max size for pre messages. A warning is emitted when this is exceeded.
-/// Should be well below `MAX_FETCH_MSG_SIZE`
 pub(crate) const PRE_MSG_SIZE_WARNING_THRESHOLD: usize = 150_000;
 
 /// Download state of the message.

--- a/src/imap/scan_folders.rs
+++ b/src/imap/scan_folders.rs
@@ -76,7 +76,7 @@ impl Imap {
                 && folder_meaning != FolderMeaning::Trash
                 && folder_meaning != FolderMeaning::Unknown
             {
-                self.fetch_move_delete(context, session, false, folder.name(), folder_meaning)
+                self.fetch_move_delete(context, session, folder.name(), folder_meaning)
                     .await
                     .context("Can't fetch new msgs in scanned folder")
                     .log_err(context)

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -573,7 +573,7 @@ async fn fetch_idle(
     {
         // Fetch the watched folder.
         connection
-            .fetch_move_delete(ctx, &mut session, true, &watch_folder, folder_meaning)
+            .fetch_move_delete(ctx, &mut session, &watch_folder, folder_meaning)
             .await
             .context("fetch_move_delete")?;
 
@@ -617,7 +617,7 @@ async fn fetch_idle(
                 // no new messages. We want to select the watched folder anyway before going IDLE
                 // there, so this does not take additional protocol round-trip.
                 connection
-                    .fetch_move_delete(ctx, &mut session, true, &watch_folder, folder_meaning)
+                    .fetch_move_delete(ctx, &mut session, &watch_folder, folder_meaning)
                     .await
                     .context("fetch_move_delete after scan_folders")?;
             }


### PR DESCRIPTION
Immediately fully download all messages that do not have the `Chat-Is-Post-Message` header. This way, we simplify the logic for when which messages are downloaded, there are no differences at all anymore between 'background_fetch' and 'normal fetch'.

Also, we prevent message reordering when reveiving a message from a legacy client.

Messages larger than 1MB without `Chat-Is-Post-Message` should be rare, so, we do not expect this to worsen things.

I adapted the pseudo-code in https://github.com/chatmail/core/issues/7367 accordingly.