### PR TITLE
fix: Let securejoin succeed even if the chat was deleted in the meantime

### DIFF
--- a/src/blob/blob_tests.rs
+++ b/src/blob/blob_tests.rs
@@ -3,11 +3,8 @@ use std::time::Duration;
 use super::*;
 use crate::message::{Message, Viewtype};
 use crate::param::Param;
-use crate::securejoin::{get_securejoin_qr, join_securejoin};
 use crate::sql;
-use crate::test_utils::{
-    self, AVATAR_64x64_BYTES, AVATAR_64x64_DEDUPLICATED, TestContext, TestContextManager,
-};
+use crate::test_utils::{self, AVATAR_64x64_BYTES, AVATAR_64x64_DEDUPLICATED, TestContext};
 use crate::tools::SystemTime;
 
 fn check_image_size(path: impl AsRef<Path>, width: u32, height: u32) -> image::DynamicImage {
@@ -798,36 +795,6 @@ async fn test_create_and_deduplicate_from_bytes() -> Result<()> {
         let blob4_content = fs::read(blob4.to_abs_path()).await?;
         assert_eq!(blob4_content, b"blabla");
     }
-
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_user_deletes_chat_before_securejoin_completes() -> Result<()> {
-    let mut tcm = TestContextManager::new();
-    let alice = &tcm.alice().await;
-    let bob = &tcm.bob().await;
-
-    let qr = get_securejoin_qr(alice, None).await?;
-    let bob_chat_id = join_securejoin(bob, &qr).await?;
-
-    let bob_alice_chat = bob.get_chat(alice).await;
-    // It's not possible yet to send to the chat, because Bob doesn't have Alice's key:
-    assert_eq!(bob_alice_chat.can_send(bob).await?, false);
-    assert_eq!(bob_alice_chat.id, bob_chat_id);
-
-    let request = bob.pop_sent_msg().await;
-
-    bob_chat_id.delete(bob).await?;
-
-    alice.recv_msg_trash(&request).await;
-    let auth_required = alice.pop_sent_msg().await;
-
-    bob.recv_msg_trash(&auth_required).await;
-
-    // The chat with Alice should be recreated,
-    // and it should be sendable now:
-    assert!(bob.get_chat(alice).await.can_send(bob).await?);
 
     Ok(())
 }

--- a/src/securejoin/securejoin_tests.rs
+++ b/src/securejoin/securejoin_tests.rs
@@ -1217,3 +1217,33 @@ async fn test_qr_no_implicit_inviter_addition() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_user_deletes_chat_before_securejoin_completes() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = &tcm.alice().await;
+    let bob = &tcm.bob().await;
+
+    let qr = get_securejoin_qr(alice, None).await?;
+    let bob_chat_id = join_securejoin(bob, &qr).await?;
+
+    let bob_alice_chat = bob.get_chat(alice).await;
+    // It's not possible yet to send to the chat, because Bob doesn't have Alice's key:
+    assert_eq!(bob_alice_chat.can_send(bob).await?, false);
+    assert_eq!(bob_alice_chat.id, bob_chat_id);
+
+    let request = bob.pop_sent_msg().await;
+
+    bob_chat_id.delete(bob).await?;
+
+    alice.recv_msg_trash(&request).await;
+    let auth_required = alice.pop_sent_msg().await;
+
+    bob.recv_msg_trash(&auth_required).await;
+
+    // The chat with Alice should be recreated,
+    // and it should be sendable now:
+    assert!(bob.get_chat(alice).await.can_send(bob).await?);
+
+    Ok(())
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -896,6 +896,15 @@ impl TestContext {
     /// If the contact does not exist yet, a new contact will be created
     /// with the correct fingerprint, but without the public key.
     pub async fn add_or_lookup_contact_no_key(&self, other: &TestContext) -> Contact {
+        let contact_id = self.add_or_lookup_contact_id_no_key(other).await;
+        Contact::get_by_id(&self.ctx, contact_id).await.unwrap()
+    }
+
+    /// Returns the [`ContactId`] for the other [`TestContext`], creating it if necessary.
+    ///
+    /// If the contact does not exist yet, a new contact will be created
+    /// with the correct fingerprint, but without the public key.
+    async fn add_or_lookup_contact_id_no_key(&self, other: &TestContext) -> ContactId {
         let primary_self_addr = other.ctx.get_primary_self_addr().await.unwrap();
         let addr = ContactAddress::new(&primary_self_addr).unwrap();
         let fingerprint = self_fingerprint(other).await.unwrap();
@@ -904,7 +913,7 @@ impl TestContext {
             Contact::add_or_lookup_ex(self, "", &addr, fingerprint, Origin::MailinglistAddress)
                 .await
                 .expect("add_or_lookup");
-        Contact::get_by_id(&self.ctx, contact_id).await.unwrap()
+        contact_id
     }
 
     /// Returns 1:1 [`Chat`] with another account address-contact.
@@ -935,9 +944,9 @@ impl TestContext {
     /// so may create a key-contact with a fingerprint
     /// but without the key.
     pub async fn get_chat(&self, other: &TestContext) -> Chat {
-        let contact = self.add_or_lookup_contact_no_key(other).await;
+        let contact = self.add_or_lookup_contact_id_no_key(other).await;
 
-        let chat_id = ChatIdBlocked::lookup_by_contact(&self.ctx, contact.id)
+        let chat_id = ChatIdBlocked::lookup_by_contact(&self.ctx, contact)
             .await
             .unwrap()
             .map(|chat_id_blocked| chat_id_blocked.id)


### PR DESCRIPTION
Fix https://github.com/chatmail/core/issues/7478 by creating the 1:1 chat in `handle_auth_required` if it doesn't exist anymore.