### PR TITLE
fix: Make pre-messages db migration backwards-compatible

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -82,8 +82,8 @@ impl MsgId {
                 context
                     .sql
                     .execute(
-                        "INSERT INTO download (rfc724_mid) VALUES (?)",
-                        (msg.rfc724_mid(),),
+                        "INSERT INTO download (rfc724_mid, msg_id) VALUES (?,?)",
+                        (msg.rfc724_mid(), msg.id),
                     )
                     .await?;
                 context.scheduler.interrupt_inbox().await;

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -825,7 +825,7 @@ impl Imap {
                 context
                     .sql
                     .insert(
-                        "INSERT INTO download (rfc724_mid) VALUES (?)",
+                        "INSERT INTO download (rfc724_mid, msg_id) VALUES (?,0)",
                         (rfc724_mid,),
                     )
                     .await?;

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -1506,12 +1506,16 @@ ORDER BY last_seen DESC LIMIT 10000
 
     inc_and_check(&mut migration_version, 144)?;
     if dbversion < migration_version {
+        // `msg_id` in `download` table is not needed anymore,
+        // but we still keep it so that it's possible to import a backup into an older DC version,
+        // because we don't always release at the same time on all platforms.
         sql.execute_migration(
             "CREATE TABLE download_new (
-                rfc724_mid TEXT NOT NULL
+                rfc724_mid TEXT NOT NULL DEFAULT '',
+                msg_id INTEGER NOT NULL DEFAULT 0
             ) STRICT;
-            INSERT OR IGNORE INTO download_new (rfc724_mid)
-             SELECT m.rfc724_mid FROM download d
+            INSERT OR IGNORE INTO download_new (rfc724_mid, msg_id)
+             SELECT m.rfc724_mid, d.msg_id FROM download d
              JOIN msgs m ON d.msg_id = m.id
              WHERE m.rfc724_mid IS NOT NULL AND m.rfc724_mid != '';
             DROP TABLE download;


### PR DESCRIPTION
I described the problem at https://github.com/chatmail/core/pull/7371/files#r2612182387:

> The migration removes the `msg_id` column from the `download` table, so that, if you import the backup into an older DC version, you get the error `Failed inbox fetch_idle: Failed to download messages: no such column: msg_id in SELECT msg_id FROM download at offset 7: Error code 1: SQL error or missing database.`
>
> So, we need:
> - either to make sure that things somewhat work if the user downgrades
> - or to again increase `backup_version`, and then again coordinate that releases are done on all platforms simultaneously (which I would like to avoid).

This PR here implements the first solution: Re-add `download.msg_id`, so that an older core can handle the database scheme.