### PR TITLE
fix: do not set normalized name for existing chats and contacts in a migration

### DIFF
--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -19,7 +19,7 @@ use crate::log::warn;
 use crate::message::MsgId;
 use crate::provider::get_provider_info;
 use crate::sql::Sql;
-use crate::tools::{Time, inc_and_check, normalize_text, time_elapsed};
+use crate::tools::{Time, inc_and_check, time_elapsed};
 use crate::transport::ConfiguredLoginParam;
 
 const DBVERSION: i32 = 68;
@@ -1456,52 +1456,14 @@ CREATE INDEX imap_sync_index ON imap_sync(transport_id, folder);
 
     inc_and_check(&mut migration_version, 143)?;
     if dbversion < migration_version {
-        let trans_fn = |t: &mut rusqlite::Transaction| {
-            t.execute_batch(
-                "
+        sql.execute_migration(
+            "
 ALTER TABLE chats ADD COLUMN name_normalized TEXT;
 ALTER TABLE contacts ADD COLUMN name_normalized TEXT;
                 ",
-            )?;
-
-            let mut stmt = t.prepare("UPDATE chats SET name_normalized=? WHERE id=?")?;
-            for res in t
-                .prepare("SELECT id, name FROM chats LIMIT 10000")?
-                .query_map((), |row| {
-                    let id: u32 = row.get(0)?;
-                    let name: String = row.get(1)?;
-                    Ok((id, name))
-                })?
-            {
-                let (id, name) = res?;
-                if let Some(name_normalized) = normalize_text(&name) {
-                    stmt.execute((name_normalized, id))?;
-                }
-            }
-
-            let mut stmt = t.prepare("UPDATE contacts SET name_normalized=? WHERE id=?")?;
-            for res in t
-                .prepare(
-                    "
-SELECT id, IIF(name='', authname, name) FROM contacts
-ORDER BY last_seen DESC LIMIT 10000
-                ",
-                )?
-                .query_map((), |row| {
-                    let id: u32 = row.get(0)?;
-                    let name: String = row.get(1)?;
-                    Ok((id, name))
-                })?
-            {
-                let (id, name) = res?;
-                if let Some(name_normalized) = normalize_text(&name) {
-                    stmt.execute((name_normalized, id))?;
-                }
-            }
-            Ok(())
-        };
-        sql.execute_migration_transaction(trans_fn, migration_version)
-            .await?;
+            migration_version,
+        )
+        .await?;
     }
 
     let new_version = sql


### PR DESCRIPTION
We got a report that application is not responding after update on Android and getting killed before it can start, suspected to be a slow SQL migration:
<https://github.com/chatmail/core/issues/7602>

This change removes calculation of normalized names for existing chats and contacts added in
<https://github.com/chatmail/core/pull/7548>
to exclude the possibility of this migration being slow. New chats and contacts will still get normalized names and all chats and contacts will get it when they are renamed.