### PR TITLE
misc: log entered login params and actual used params on configuration failure

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -291,7 +291,7 @@ impl Context {
                 let configured_param = get_configured_param(self, param).await;
                 warn!(
                     self,
-                    "configure failed: entered params {}, used params {}",
+                    "configure failed: Entered params: {}. Used params: {}. Error: {error}.",
                     param.to_string(),
                     configured_param
                         .map(|param| param.to_string())


### PR DESCRIPTION
 #7587 removed  "used_account_settings" and "entered_account_settings" from Context.get_info(). link2xt pointed out that entered_account_settings can still be useful to debug login issues, so tis pr adds logs both on failed configuration attempts.

example warning event:
```
Warning src/configure.rs:292: configure failed: entered params myself@merlinux.eu imap:unset:***:unset:0:Automatic:AUTH_NORMAL smtp:unset:0:unset:0:Automatic:AUTH_NORMAL cert_automatic, used params myself@merlinux.eu imap:[mailcow.testrun.org:993:tls:myself@merlinux.eu, mailcow.testrun.org:143:starttls:myself@merlinux.eu] smtp:[mailcow.testrun.org:465:tls:myself@merlinux.eu, mailcow.testrun.org:587:starttls:myself@merlinux.eu] provider:none cert_automatic
```
