### PR TITLE
docs: set_config_from_qr() configures context for "DCACCOUNT:" and "DCLOGIN:" QRs (#7450)

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -575,11 +575,10 @@ int             dc_set_stock_translation(dc_context_t* context, uint32_t stock_i
 
 /**
  * Set configuration values from a QR code.
- * Before this function is called, dc_check_qr() should confirm the type of the
- * QR code is DC_QR_ACCOUNT or DC_QR_LOGIN.
+ * Before this function is called, dc_check_qr() should be used to get the QR code type.
  *
- * Internally, the function will call dc_set_config() with the appropriate keys,
- * e.g. `addr` and `mail_pw` for DC_QR_ACCOUNT and DC_QR_LOGIN.
+ * DC_QR_ACCOUNT and DC_QR_LOGIN QR codes configure the context, but I/O mustn't be started for such
+ * QR codes.
  *
  * @memberof dc_context_t
  * @param context The context object.

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -416,11 +416,11 @@ impl CommandApi {
         Ok(())
     }
 
-    /// Set configuration values from a QR code. (technically from the URI that is stored in the qrcode)
-    /// Before this function is called, `checkQr()` should confirm the type of the
-    /// QR code is `account` or `webrtcInstance`.
+    /// Set configuration values from a QR code (technically from the URI stored in it).
+    /// Before this function is called, `check_qr()` should be used to get the QR code type.
     ///
-    /// Internally, the function will call dc_set_config() with the appropriate keys,
+    /// "DCACCOUNT:" and "DCLOGIN:" QR codes configure the account, but I/O mustn't be started for
+    /// such QR codes, consider using [`Self::add_transport_from_qr`] which also restarts I/O.
     async fn set_config_from_qr(&self, account_id: u32, qr_content: String) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
         qr::set_config_from_qr(&ctx, &qr_content).await

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -1231,7 +1231,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
         "setqr" => {
             ensure!(!arg1.is_empty(), "Argument <qr-content> missing.");
             match set_config_from_qr(&context, arg1).await {
-                Ok(()) => println!("Config set from QR code, you can now call 'configure'"),
+                Ok(()) => eprintln!("Config set from the QR code."),
                 Err(err) => eprintln!("Cannot set config from QR code: {err:?}"),
             }
         }

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -834,6 +834,8 @@ pub(crate) async fn login_param_from_account_qr(
 }
 
 /// Sets configuration values from a QR code.
+/// "DCACCOUNT:" and "DCLOGIN:" QR codes configure `context`, but I/O mustn't be started for such QR
+/// codes, consider using [`Context::add_transport_from_qr`] which also restarts I/O.
 pub async fn set_config_from_qr(context: &Context, qr: &str) -> Result<()> {
     match check_qr(context, qr).await? {
         Qr::Account { .. } => {


### PR DESCRIPTION
Also remove "you can now call 'configure'" from the REPL output, probably users of the REPL tool can read the code documentation to know when 'configure' should be run.
Close #7450 