### PR TITLE
fix: When accepting group, add members with Origin::IncomingTo and sort them down in the contact list (7592)

### DIFF
--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1144,7 +1144,7 @@ WHERE c.id>?
     AND c.origin>=?
     AND c.blocked=0
     AND (IFNULL(c.name_normalized,IIF(c.name='',c.authname,c.name)) LIKE ? OR c.addr LIKE ?)
-ORDER BY c.last_seen DESC, c.id DESC
+ORDER BY c.origin>=? DESC, c.last_seen DESC, c.id DESC
                     ",
                     (
                         ContactId::LAST_SPECIAL,
@@ -1152,6 +1152,7 @@ ORDER BY c.last_seen DESC, c.id DESC
                         minimal_origin,
                         &s3str_like_cmd,
                         &s3str_like_cmd,
+                        Origin::CreateChat,
                     ),
                     |row| {
                         let id: ContactId = row.get(0)?;
@@ -1201,8 +1202,13 @@ ORDER BY c.last_seen DESC, c.id DESC
                  AND (fingerprint='')=?
                  AND origin>=?
                  AND blocked=0
-                 ORDER BY last_seen DESC, id DESC;",
-                    (ContactId::LAST_SPECIAL, flag_address, minimal_origin),
+                 ORDER BY origin>=? DESC, last_seen DESC, id DESC",
+                    (
+                        ContactId::LAST_SPECIAL,
+                        flag_address,
+                        minimal_origin,
+                        Origin::CreateChat,
+                    ),
                     |row| {
                         let id: ContactId = row.get(0)?;
                         let addr: String = row.get(1)?;

--- a/src/receive_imf/receive_imf_tests.rs
+++ b/src/receive_imf/receive_imf_tests.rs
@@ -3878,8 +3878,9 @@ async fn test_group_contacts_goto_bottom() -> Result<()> {
     assert_eq!(contacts[1], bob_fiona_id);
 
     ChatId::create_for_contact(bob, bob_fiona_id).await?;
-    // Unfortunately, nothing has changed.
-    assert_eq!(Contact::get_all(bob, 0, None).await?, contacts);
+    let contacts = Contact::get_all(bob, 0, None).await?;
+    assert_eq!(contacts.len(), 2);
+    assert_eq!(contacts[0], bob_fiona_id);
     Ok(())
 }
 


### PR DESCRIPTION
When accepting a chat, its members are promoted to `Origin::CreateChat`, but for groups it makes
    sense to use lower origin because users don't always check all members before accepting a chat and
    may not want to have the group members mixed with existing contacts. `IncomingTo` fits here by its
    definition: "additional To:'s of incoming message of known sender", i.e. we assume that the sender
    of some message is known to the user. This way we can show contacts coming from groups in the bottom
    of contact list, maybe even add some separator later. It makes sense not to hide such contacts
    completely, otherwise if the user remembers the contact name, but not the chat it's a member of, it
    would be difficult to find the contact.
    
See also #7592 

EDIT: We could even use `ContactId::UNDEFINED` as a separator, but i haven't checked that it doesn't break the current UIs. EDIT: Finally i think this isn't needed, see below: https://github.com/chatmail/core/pull/7616#issuecomment-3661597234