### PR TITLE
refactor: Remove unneeded `deprecated` attr

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -416,7 +416,6 @@ impl Context {
     ///
     /// Returns true if passphrase is correct, false is passphrase is not correct. Fails on other
     /// errors.
-    #[deprecated(since = "TBD")]
     pub async fn open(&self, passphrase: String) -> Result<bool> {
         if self.sql.check_passphrase(passphrase.clone()).await? {
             self.sql.open(self, passphrase).await?;


### PR DESCRIPTION
Was marked as deprecated as of https://github.com/chatmail/core/pull/7489#discussion_r2553283165, but since it's still in use (and not discouraged to use), I just stumbled over it while browsing the code.