### PR TITLE
feat: Don't scale up Origin of multiple and broadcast recipients when sending a message

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -426,8 +426,16 @@ impl MimeFactory {
                     },
                 )
                 .await?;
-            let recipient_ids: Vec<_> = recipient_ids.into_iter().collect();
-            ContactId::scaleup_origin(context, &recipient_ids, Origin::OutgoingTo).await?;
+            let recipient_ids: Vec<_> = recipient_ids
+                .into_iter()
+                .filter(|id| *id != ContactId::SELF)
+                .collect();
+            if recipient_ids.len() == 1
+                && msg.param.get_cmd() != SystemMessage::MemberRemovedFromGroup
+                && chat.typ != Chattype::OutBroadcast
+            {
+                ContactId::scaleup_origin(context, &recipient_ids, Origin::OutgoingTo).await?;
+            }
 
             if !msg.is_system_message()
                 && msg.param.get_int(Param::Reaction).unwrap_or_default() == 0

--- a/src/receive_imf/receive_imf_tests.rs
+++ b/src/receive_imf/receive_imf_tests.rs
@@ -3878,6 +3878,29 @@ async fn test_group_contacts_goto_bottom() -> Result<()> {
     let contacts = Contact::get_all(bob, 0, None).await?;
     assert_eq!(contacts.len(), 2);
     assert_eq!(contacts[0], bob_fiona_id);
+
+    send_text_msg(
+        bob,
+        bob_chat_id,
+        "Hi Alice, stay down in my contact list".to_string(),
+    )
+    .await?;
+    bob.pop_sent_msg().await;
+    let contacts = Contact::get_all(bob, 0, None).await?;
+    assert_eq!(contacts[0], bob_fiona_id);
+
+    remove_contact_from_chat(bob, bob_chat_id, bob_fiona_id).await?;
+    bob.pop_sent_msg().await;
+    let contacts = Contact::get_all(bob, 0, None).await?;
+    // Fiona is still the 0th contact. This makes sense, maybe Bob is going to remove Alice from the
+    // chat too, so no need to make Alice a more "important" contact yet.
+    assert_eq!(contacts[0], bob_fiona_id);
+
+    send_text_msg(bob, bob_chat_id, "Alice, jump up!".to_string()).await?;
+    bob.pop_sent_msg().await;
+    let contacts = Contact::get_all(bob, 0, None).await?;
+    let bob_alice_id = bob.add_or_lookup_contact_id(alice).await;
+    assert_eq!(contacts[0], bob_alice_id);
     Ok(())
 }
 


### PR DESCRIPTION
84161f4202177cb8ff1e2948d80cacd32ccc796b promotes group members to `Origin::IncomingTo` when accepting it, instead of `CreateChat` as before, but this changes almost nothing because it happens rarely that the user only accepts a group and writes nothing there soon. Now if a message has multiple recipients, i.e. it's a 3-or-more-member group, or if it's a broadcast message, we don't scale up its recipients to `Origin::OutgoingTo`.

Follow-up to #7616 

Maybe when accepting a 2-member group it also makes sense to use `Origin::CreateChat` as before because it's a "1:1 group"?