### PR TITLE
test: Synchronization of new transport as primary between devices

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -753,6 +753,7 @@ pub(crate) async fn sync_transports(
         .await?;
 
     context.emit_event(EventType::TransportsModified);
+    // context.scheduler.restart(context).await;
     Ok(())
 }
 


### PR DESCRIPTION
This reproduces the bug when a new transport doesn't become primary on the 2nd device because I/O isn't restarted when a new transport is added from a sync message, so INBOX from the new transport isn't fetched.