### PR TITLE
fix: inner_configure: Check Config::OnlyFetchMvbox before MvboxMove for multi-transport (#7637)

### DIFF
--- a/src/configure.rs
+++ b/src/configure.rs
@@ -272,14 +272,16 @@ impl Context {
                 )
                 .await?
         {
-            if self.get_config(Config::MvboxMove).await?.as_deref() != Some("0") {
-                bail!(
-                    "To use additional relays, disable the legacy option \"Settings / Advanced / Move automatically to DeltaChat Folder\"."
-                );
-            }
+            // Should be checked before `MvboxMove` because the latter makes no sense in presense of
+            // `OnlyFetchMvbox` and even grayed out in the UIs in this case.
             if self.get_config(Config::OnlyFetchMvbox).await?.as_deref() != Some("0") {
                 bail!(
                     "To use additional relays, disable the legacy option \"Settings / Advanced / Only Fetch from DeltaChat Folder\"."
+                );
+            }
+            if self.get_config(Config::MvboxMove).await?.as_deref() != Some("0") {
+                bail!(
+                    "To use additional relays, disable the legacy option \"Settings / Advanced / Move automatically to DeltaChat Folder\"."
                 );
             }
             if self.get_config(Config::ShowEmails).await?.as_deref() != Some("2") {


### PR DESCRIPTION
`Config::OnlyFetchMvbox` should be checked before `MvboxMove` because the latter makes no sense in presense of `OnlyFetchMvbox` and even grayed out in the UIs in this case. Otherwise users will see an error mentioning the wrong setting.

Fix #7637 