### PR TITLE
feat: add transports event to ffi

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -6702,6 +6702,16 @@ void dc_event_unref(dc_event_t* event);
  */
 #define DC_EVENT_CALL_ENDED                               2580
 
+/**
+ * Transport relay added/deleted or default has changed.
+ * UI should update the list.
+ *
+ * The event is emitted when the transports are modified on this or on another device
+ * using the jsonrpc calls `add_or_update_transport`, `add_transport_from_qr`, `delete_transport`
+ * or `set_config(configured_addr)`.
+ */
+#define DC_EVENT_TRANSPORTS_MODIFIED           2600
+
 
 /**
  * @}


### PR DESCRIPTION
seems, this event is not only for tests or debugging, but needed also when transport was modified on another device.

came over that via https://github.com/deltachat/deltachat-desktop/pull/5895

once merged, UI issues/PR should be filed to listen to that event and update the list