### PR TITLE
docs: delete_chat(): Don't lie that messages aren't deleted from server

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1611,10 +1611,10 @@ void            dc_set_chat_visibility       (dc_context_t* context, uint32_t ch
  *
  * Messages are deleted from the device and the chat database entry is deleted.
  * After that, the event #DC_EVENT_MSGS_CHANGED is posted.
+ * Messages are deleted from the server in background.
  *
  * Things that are _not_ done implicitly:
  *
- * - Messages are **not deleted from the server**.
  * - The chat or the contact is **not blocked**, so new messages from the user/the group may appear
  *   and the user may create the chat again.
  * - **Groups are not left** - this would

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -795,11 +795,11 @@ impl CommandApi {
     /// Delete a chat.
     ///
     /// Messages are deleted from the device and the chat database entry is deleted.
-    /// After that, the event #DC_EVENT_MSGS_CHANGED is posted.
+    /// After that, a `MsgsChanged` event is emitted.
+    /// Messages are deleted from the server in background.
     ///
     /// Things that are _not done_ implicitly:
     ///
-    /// - Messages are **not deleted from the server**.
     /// - The chat or the contact is **not blocked**, so new messages from the user/the group may appear as a contact request
     ///   and the user may create the chat again.
     /// - **Groups are not left** - this would

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -600,6 +600,10 @@ impl ChatId {
     }
 
     /// Deletes a chat.
+    ///
+    /// Messages are deleted from the device and the chat database entry is deleted.
+    /// After that, a `MsgsChanged` event is emitted.
+    /// Messages are deleted from the server in background.
     pub async fn delete(self, context: &Context) -> Result<()> {
         self.delete_ex(context, Sync).await
     }


### PR DESCRIPTION
Messages are actually deleted from the server. I've checked this in Desktop.

See `ChatId::delete_ex()`:
```Rust
"UPDATE imap SET target=? WHERE rfc724_mid IN (SELECT rfc724_mid FROM msgs WHERE chat_id=?)",
(delete_msgs_target, self,),
```