### PR TITLE
docs: update documentation for TransportsModified event

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -6706,8 +6706,8 @@ void dc_event_unref(dc_event_t* event);
  * Transport relay added/deleted or default has changed.
  * UI should update the list.
  *
- * The event is emitted when the transports are modified on this or on another device
- * using the jsonrpc calls `add_or_update_transport`, `add_transport_from_qr`, `delete_transport`
+ * The event is emitted when the transports are modified on another device
+ * using the JSON-RPC calls `add_or_update_transport`, `add_transport_from_qr`, `delete_transport`
  * or `set_config(configured_addr)`.
  */
 #define DC_EVENT_TRANSPORTS_MODIFIED           2600

--- a/deltachat-jsonrpc/src/api/types/events.rs
+++ b/deltachat-jsonrpc/src/api/types/events.rs
@@ -463,11 +463,11 @@ pub enum EventType {
 
     /// One or more transports has changed.
     ///
-    /// This event is used for tests to detect when transport
-    /// synchronization messages arrives.
-    /// UIs don't need to use it, it is unlikely
-    /// that user modifies transports on multiple
-    /// devices simultaneously.
+    /// UI should update the list.
+    ///
+    /// This event is emitted when transport
+    /// synchronization messages arrives,
+    /// but not when the UI modifies the transport list by itself.
     TransportsModified,
 }
 

--- a/src/events/payload.rs
+++ b/src/events/payload.rs
@@ -419,11 +419,11 @@ pub enum EventType {
 
     /// One or more transports has changed.
     ///
-    /// This event is used for tests to detect when transport
-    /// synchronization messages arrives.
-    /// UIs don't need to use it, it is unlikely
-    /// that user modifies transports on multiple
-    /// devices simultaneously.
+    /// UI should update the list.
+    ///
+    /// This event is emitted when transport
+    /// synchronization messages arrives,
+    /// but not when the UI modifies the transport list by itself.
     TransportsModified,
 
     /// Event for using in tests, e.g. as a fence between normally generated events.


### PR DESCRIPTION
It is a follow-up to https://github.com/chatmail/core/pull/7643 Event is not emitted when the transports are modified on this device and we should consistently say that this event is not only for testing.