### PR TITLE
feat: do not unconditionally watch mvbox for non-chatmail

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -598,8 +598,7 @@ impl Context {
     /// Returns true if movebox ("DeltaChat" folder) should be watched.
     pub(crate) async fn should_watch_mvbox(&self) -> Result<bool> {
         Ok(self.get_config_bool(Config::MvboxMove).await?
-            || self.get_config_bool(Config::OnlyFetchMvbox).await?
-            || !self.get_config_bool(Config::IsChatmail).await?)
+            || self.get_config_bool(Config::OnlyFetchMvbox).await?)
     }
 
     /// Returns true if sync messages should be sent.


### PR DESCRIPTION
Since commit 25750de4e19296aba6915cf0c11d1b047aa56c8e released in 2.36.0 we do not move messages to mvbox without explicit
mvbox_move setting, so do not need to watch it as well as long as other devices are updated to the same change.

Closes #7655