### PR TITLE
feat: send vc- prefix instead of vg- in Secure-Join where accepted

### DIFF
--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -491,19 +491,10 @@ pub(crate) async fn handle_securejoin_handshake(
             )
             .await?;
 
-            let prefix = mime_message
-                .get_header(HeaderDef::SecureJoin)
-                .and_then(|step| step.get(..2))
-                .unwrap_or("vc");
-
             // Alice -> Bob
-            send_alice_handshake_msg(
-                context,
-                autocrypt_contact_id,
-                &format!("{prefix}-auth-required"),
-            )
-            .await
-            .context("failed sending auth-required handshake message")?;
+            send_alice_handshake_msg(context, autocrypt_contact_id, "vc-auth-required")
+                .await
+                .context("Failed sending auth-required handshake message")?;
             Ok(HandshakeMessage::Done)
         }
         SecureJoinStep::AuthRequired => {

--- a/src/securejoin/bob.rs
+++ b/src/securejoin/bob.rs
@@ -29,7 +29,7 @@ use crate::{chatlist_events, mimefactory};
 /// If Bob already has Alice's key, he sends `AUTH` token
 /// and forgets about the invite.
 /// If Bob does not yet have Alice's key, he sends `vc-request`
-/// or `vg-request` message and stores a row in the `bobstate` table
+/// message and stores a row in the `bobstate` table
 /// so he can check Alice's key against the fingerprint
 /// and send `AUTH` token later.
 ///
@@ -332,7 +332,7 @@ pub(crate) async fn send_handshake_message(
     } else {
         let mut msg = Message {
             viewtype: Viewtype::Text,
-            text: step.body_text(invite),
+            text: step.body_text(),
             hidden: true,
             ..Default::default()
         };
@@ -340,7 +340,7 @@ pub(crate) async fn send_handshake_message(
         msg.param.set_cmd(SystemMessage::SecurejoinMessage);
 
         // Sends the step in Secure-Join header.
-        msg.param.set(Param::Arg, step.securejoin_header(invite));
+        msg.param.set(Param::Arg, step.securejoin_header());
 
         match step {
             BobHandshakeMsg::Request => {
@@ -378,9 +378,9 @@ pub(crate) async fn send_handshake_message(
 
 /// Identifies the SecureJoin handshake messages Bob can send.
 pub(crate) enum BobHandshakeMsg {
-    /// vc-request or vg-request
+    /// vc-request
     Request,
-    /// vc-request-with-auth or vg-request-with-auth
+    /// vc-request-with-auth
     RequestWithAuth,
 }
 
@@ -390,8 +390,8 @@ impl BobHandshakeMsg {
     /// This text has no significance to the protocol, but would be visible if users see
     /// this email message directly, e.g. when accessing their email without using
     /// DeltaChat.
-    fn body_text(&self, invite: &QrInvite) -> String {
-        format!("Secure-Join: {}", self.securejoin_header(invite))
+    fn body_text(&self) -> String {
+        format!("Secure-Join: {}", self.securejoin_header())
     }
 
     /// Returns the `Secure-Join` header value.
@@ -399,18 +399,10 @@ impl BobHandshakeMsg {
     /// This identifies the step this message is sending information about.  Most protocol
     /// steps include additional information into other headers, see
     /// [`send_handshake_message`] for these.
-    fn securejoin_header(&self, invite: &QrInvite) -> &'static str {
+    fn securejoin_header(&self) -> &'static str {
         match self {
-            Self::Request => match invite {
-                QrInvite::Contact { .. } => "vc-request",
-                QrInvite::Group { .. } => "vg-request",
-                QrInvite::Broadcast { .. } => "vg-request",
-            },
-            Self::RequestWithAuth => match invite {
-                QrInvite::Contact { .. } => "vc-request-with-auth",
-                QrInvite::Group { .. } => "vg-request-with-auth",
-                QrInvite::Broadcast { .. } => "vg-request-with-auth",
-            },
+            Self::Request => "vc-request",
+            Self::RequestWithAuth => "vc-request-with-auth",
         }
     }
 }
@@ -480,7 +472,7 @@ async fn joining_chat_id(
 /// This has an `From<JoinerProgress> for usize` impl yielding numbers between 0 and a 1000
 /// which can be shown as a progress bar.
 pub(crate) enum JoinerProgress {
-    /// vg-vc-request-with-auth sent.
+    /// vc-request-with-auth sent.
     ///
     /// Typically shows as "alice@addr verified, introducing myself."
     RequestWithAuthSent,

--- a/src/securejoin/securejoin_tests.rs
+++ b/src/securejoin/securejoin_tests.rs
@@ -483,7 +483,7 @@ async fn test_secure_join_group_ex(v3: bool, remove_invite: bool) -> Result<()> 
         if v3 {
             "vc-request-pubkey"
         } else {
-            "vg-request"
+            "vc-request"
         }
     );
     assert_eq!(msg.get_header(HeaderDef::SecureJoinAuth).is_some(), v3);
@@ -509,7 +509,7 @@ async fn test_secure_join_group_ex(v3: bool, remove_invite: bool) -> Result<()> 
     assert!(msg.was_encrypted());
     assert_eq!(
         msg.get_header(HeaderDef::SecureJoin).unwrap(),
-        if v3 { "vc-pubkey" } else { "vg-auth-required" }
+        if v3 { "vc-pubkey" } else { "vc-auth-required" }
     );
 
     tcm.section("Step 4: Bob receives vc-pubkey or vg-auth-required, sends v*-request-with-auth");
@@ -546,7 +546,7 @@ async fn test_secure_join_group_ex(v3: bool, remove_invite: bool) -> Result<()> 
     assert!(msg.was_encrypted());
     assert_eq!(
         msg.get_header(HeaderDef::SecureJoin).unwrap(),
-        "vg-request-with-auth"
+        "vc-request-with-auth"
     );
     assert!(msg.get_header(HeaderDef::SecureJoinAuth).is_some());
     let bob_fp = self_fingerprint(&bob).await?;


### PR DESCRIPTION
This way we always send `Secure-Join: vc-request`, even when joining the group,
and it is not visible to the server if we setup a new contact or join a group/channel.