### PR TITLE
chore: update lru 0.12.3 to 0.12.5 and add RUSTSEC-2026-0002 exception

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,18 +63,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2380,20 +2368,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -2403,7 +2383,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2920,7 +2900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown",
 ]
 
 [[package]]
@@ -3184,7 +3164,7 @@ dependencies = [
  "iroh-metrics",
  "iroh-quinn",
  "iroh-quinn-proto",
- "lru 0.12.3",
+ "lru 0.12.5",
  "n0-future",
  "num_enum",
  "pin-project",
@@ -3374,11 +3354,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -16,7 +16,12 @@ ignore = [
     # Unmaintained rustls-pemfile
     # It is a transitive dependency of iroh 0.35.0,
     # this should be fixed by upgrading to iroh 1.0 once it is released.
-    "RUSTSEC-2025-0134"
+    "RUSTSEC-2025-0134",
+
+    # Old versions of "lru" are transitive dependencies of iroh 0.35.0.
+    # <https://rustsec.org/advisories/RUSTSEC-2026-0002>
+    # <https://github.com/chatmail/core/issues/7692>
+    "RUSTSEC-2026-0002",
 ]
 
 [bans]
@@ -31,11 +36,10 @@ skip = [
      { name = "derive_more", version = "1.0.0" },
      { name = "event-listener", version = "2.5.3" },
      { name = "getrandom", version = "0.2.12" },
-     { name = "hashbrown", version = "0.14.5" },
      { name = "heck", version = "0.4.1" },
      { name = "http", version = "0.2.12" },
      { name = "linux-raw-sys", version = "0.4.14" },
-     { name = "lru", version = "0.12.3" },
+     { name = "lru", version = "0.12.5" },
      { name = "netlink-packet-route", version = "0.17.1" },
      { name = "nom", version = "7.1.3" },
      { name = "rand_chacha", version = "0.3.1" },


### PR DESCRIPTION
Closes https://github.com/chatmail/core/issues/7692