### PR TITLE
fix: take transport_id into account when marking messages with \Seen flags

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1143,13 +1143,16 @@ impl Session {
             return Ok(());
         }
 
+        let transport_id = self.transport_id();
         let rows = context
             .sql
             .query_map_vec(
                 "SELECT imap.id, uid, folder FROM imap, imap_markseen
-                 WHERE imap.id = imap_markseen.id AND target = folder
+                 WHERE imap.id = imap_markseen.id
+                 AND imap.transport_id=?
+                 AND target = folder
                  ORDER BY folder, uid",
-                [],
+                (transport_id,),
                 |row| {
                     let rowid: i64 = row.get(0)?;
                     let uid: u32 = row.get(1)?;


### PR DESCRIPTION
Otherwise wrong IMAP client corresponding to a different transport may pick up the job to mark the message as seen there, and fail to do it as the message does not exist.
It may also mark the wrong message with the correct folder and UID, but wrong IMAP server.

Follow-up to https://github.com/chatmail/core/pull/7617