### PR TITLE
test(rpc-client): Replace remaining print()s with `logging` (#6082)

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import pathlib
 import platform
@@ -204,14 +205,13 @@ def log():
 
     class Printer:
         def section(self, msg: str) -> None:
-            print()
-            print("=" * 10, msg, "=" * 10)
+            logging.info("\n%s %s %s", "=" * 10, msg, "=" * 10)
 
         def step(self, msg: str) -> None:
-            print("-" * 5, "step " + msg, "-" * 5)
+            logging.info("%s step %s %s", "-" * 5, msg, "-" * 5)
 
         def indent(self, msg: str) -> None:
-            print("  " + msg)
+            logging.info("  " + msg)
 
     return Printer()
 
@@ -261,7 +261,7 @@ def get_core_python_env(tmp_path_factory):
             envs[core_version] = venv
         python = find_path(venv, "python")
         rpc_server_path = find_path(venv, "deltachat-rpc-server")
-        print(f"python={python}\nrpc_server={rpc_server_path}")
+        logging.info(f"Paths:\npython={python}\nrpc_server={rpc_server_path}")
         return python, rpc_server_path
 
     return get_versioned_venv

--- a/deltachat-rpc-client/tests/conftest.py
+++ b/deltachat-rpc-client/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import imaplib
 import io
+import logging
 import pathlib
 import ssl
 from contextlib import contextmanager
@@ -45,13 +46,13 @@ class DirectImap:
         try:
             self.conn.logout()
         except (OSError, imaplib.IMAP4.abort):
-            print("Could not logout direct_imap conn")
+            logging.warning("Could not logout direct_imap conn")
 
     def create_folder(self, foldername):
         try:
             self.conn.folder.create(foldername)
         except errors.MailboxFolderCreateError as e:
-            print("Can't create", foldername, "probably it already exists:", str(e))
+            logging.warning(f"Cannot create '{foldername}', probably it already exists: {str(e)}")
 
     def select_folder(self, foldername: str) -> tuple:
         assert not self._idling
@@ -95,7 +96,7 @@ class DirectImap:
         messages = self.get_unread_messages()
         if messages:
             res = self.conn.flag(messages, MailMessageFlags.SEEN, True)
-            print("marked seen:", messages, res)
+            logging.info(f"Marked seen: {messages} {res}")
 
     def get_unread_cnt(self) -> int:
         return len(self.get_unread_messages())

--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -370,13 +370,13 @@ def test_selfavatar_sync(acfactory, data, log) -> None:
     alice.set_config("selfavatar", image)
     avatar_config = alice.get_config("selfavatar")
     avatar_hash = os.path.basename(avatar_config)
-    print("Info: avatar hash is ", avatar_hash)
+    logging.info(f"Avatar hash is {avatar_hash}")
 
     log.section("First device receives avatar change")
     alice2.wait_for_event(EventType.SELFAVATAR_CHANGED)
     avatar_config2 = alice2.get_config("selfavatar")
     avatar_hash2 = os.path.basename(avatar_config2)
-    print("Info: avatar hash on second device is ", avatar_hash2)
+    logging.info(f"Avatar hash on second device is {avatar_hash2}")
     assert avatar_hash == avatar_hash2
     assert avatar_config != avatar_config2
 


### PR DESCRIPTION
This is to fix tests failing with `OSError: [Errno 9] Bad file descriptor`. Maybe stdout closes earlier than stderr, before the test finishes, not sure. For reference, the previous commit removing print()s is 800edc6fcefd11cf485b2eb118db012e39e0f5de.
Close #6082 