### PR TITLE
fix: Use only lowercase letters for stats id

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -9,6 +9,7 @@ use anyhow::{Context as _, Result};
 use deltachat_derive::FromSql;
 use num_traits::ToPrimitive;
 use pgp::types::PublicKeyTrait;
+use rand::distr::SampleString as _;
 use rusqlite::OptionalExtension;
 use serde::Serialize;
 
@@ -21,7 +22,7 @@ use crate::key::load_self_public_keyring;
 use crate::log::LogExt;
 use crate::message::{Message, Viewtype};
 use crate::securejoin::QrInvite;
-use crate::tools::{create_id, time};
+use crate::tools::time;
 
 pub(crate) const STATISTICS_BOT_EMAIL: &str = "self_reporting@testrun.org";
 const STATISTICS_BOT_VCARD: &str = include_str!("../assets/statistics-bot.vcf");
@@ -390,7 +391,9 @@ pub(crate) async fn stats_id(context: &Context) -> Result<String> {
     Ok(match context.get_config(Config::StatsId).await? {
         Some(id) => id,
         None => {
-            let id = create_id();
+            let id = rand::distr::Alphabetic
+                .sample_string(&mut rand::rng(), 25)
+                .to_lowercase();
             context
                 .set_config_internal(Config::StatsId, Some(&id))
                 .await?;


### PR DESCRIPTION
If the user enables statistics-sending in the advanced settings, they will be asked whether they also want to take part in a survey. We use a short ID to then link the survey result to the sent statistics.

However, the survey website didn't like our base64 ids, especially the fact that the id could contain a `-`. This PR makes it so that the id only contains lowecase letters.