### PR TITLE
docs: fix chat types

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3770,30 +3770,7 @@ uint32_t        dc_chat_get_id               (const dc_chat_t* chat);
 
 
 /**
- * Get chat type as one of the @ref DC_CHAT_TYPE constants:
- *
- * - @ref DC_CHAT_TYPE_SINGLE - a normal chat is a chat with a single contact,
- *   chats_contacts contains one record for the user. DC_CONTACT_ID_SELF
- *   (see dc_contact_t::id) is added _only_ for a self talk.
- *   These chats are created by dc_create_chat_by_contact_id().
- *
- * - @ref DC_CHAT_TYPE_GROUP - a group chat, chats_contacts contain all group
- *   members, incl. DC_CONTACT_ID_SELF.
- *   Groups are created by dc_create_group_chat().
- *
- * - @ref DC_CHAT_TYPE_MAILINGLIST - a mailing list, this is similar to groups,
- *   however, the member list cannot be retrieved completely
- *   and cannot be changed using this api.
- *   Mailing lists are created as needed by incoming messages
- *   and usually require some special server;
- *   they cannot be created by a function call as the other chat types.
- *   Moreover, for now, mailing lists are read-only.
- *
- * - @ref DC_CHAT_TYPE_BROADCAST - a broadcast list,
- *   the recipients will get messages in a one-to-one chats and
- *   the sender will get answers in a one-to-one as well.
- *   chats_contacts contain all recipients but DC_CONTACT_ID_SELF.
- *   Broadcasts are created by dc_create_broadcast_list().
+ * Get chat type as one of the @ref DC_CHAT_TYPE constants.
  *
  * @memberof dc_chat_t
  * @param chat The chat object.
@@ -5799,17 +5776,32 @@ int64_t         dc_lot_get_timestamp     (const dc_lot_t* lot);
 #define         DC_CHAT_TYPE_UNDEFINED       0
 
 /**
- * A one-to-one chat with a single contact. See dc_chat_get_type() for details.
+ * A one-to-one chat with a single contact.
+ *
+ * dc_get_chat_contacts() contains one record for the user.
+ * DC_CONTACT_ID_SELF is added _only_ for a self talk.
+ * These chats are created by dc_create_chat_by_contact_id().
  */
 #define         DC_CHAT_TYPE_SINGLE          100
 
 /**
- * A group chat. See dc_chat_get_type() for details.
+ * A group chat.
+ *
+ * dc_get_chat_contacts() contain all group members,
+ * including DC_CONTACT_ID_SELF.
+ * Groups are created by dc_create_group_chat().
  */
 #define         DC_CHAT_TYPE_GROUP           120
 
 /**
- * A mailing list. See dc_chat_get_type() for details.
+ * A mailing list.
+ *
+ * This is similar to groups,
+ * however, the member list cannot be retrieved completely
+ * and cannot be changed using an API from this library.
+ * Mailing lists are created as needed by incoming messages
+ * and usually require some special server;
+ * they cannot be created by a function call as the other chat types.
  */
 #define         DC_CHAT_TYPE_MAILINGLIST     140
 


### PR DESCRIPTION
- DC_CHAT_TYPE_BROADCAST does no longer exist
- DC_CHAT_TYPE_MAILINGLIST is no longer always read-only
- avoid double docs by moving everything to [DC_CHAT_TYPE group](https://c.delta.chat/group__DC__CHAT__TYPE.html) (here, things were also updated recently)