### PR TITLE
fix: logging errors in deltachat-rpc-server during startup

### DIFF
--- a/deltachat-rpc-server/src/main.rs
+++ b/deltachat-rpc-server/src/main.rs
@@ -24,6 +24,14 @@ use yerpc::{RpcClient, RpcSession};
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
+    // Logs from `log` crate and traces from `tracing` crate
+    // are configurable with `RUST_LOG` environment variable
+    // and go to stderr to avoid interfering with JSON-RPC using stdout.
+    tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .init();
+
     let r = main_impl().await;
     // From tokio documentation:
     // "For technical reasons, stdin is implemented by using an ordinary blocking read on a separate
@@ -63,14 +71,6 @@ async fn main_impl() -> Result<()> {
     let _ctrl_c = tokio::signal::ctrl_c();
     #[cfg(target_family = "unix")]
     let mut sigterm = signal_unix::signal(signal_unix::SignalKind::terminate())?;
-
-    // Logs from `log` crate and traces from `tracing` crate
-    // are configurable with `RUST_LOG` environment variable
-    // and go to stderr to avoid interfering with JSON-RPC using stdout.
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .with_writer(std::io::stderr)
-        .init();
 
     let path = std::env::var("DC_ACCOUNTS_PATH").unwrap_or_else(|_| "accounts".to_string());
     log::info!("Starting with accounts directory `{path}`.");


### PR DESCRIPTION
Before this pr there were cases where error messages never reach the user because logging was not initialized yet.
This pr moves log initialization to the start of the program, so that all logged messages reach the user.

Before:
```
$ ./target/debug/deltachat-rpc-server --invalid-argument

$
```
After:
```
$ ./target/debug/deltachat-rpc-server --invalid-argument
2026-01-11T02:20:46.801830Z ERROR deltachat_rpc_server: Error: Unrecognized option "--invalid-argument".

$
```