### PR TITLE
feat: Don't put text into post-message

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1872,19 +1872,23 @@ impl MimeFactory {
 
         let footer = if is_reaction { "" } else { &self.selfstatus };
 
-        let message_text = format!(
-            "{}{}{}{}{}{}",
-            fwdhint.unwrap_or_default(),
-            quoted_text.unwrap_or_default(),
-            escape_message_footer_marks(final_text),
-            if !final_text.is_empty() && !footer.is_empty() {
-                "\r\n\r\n"
-            } else {
-                ""
-            },
-            if !footer.is_empty() { "-- \r\n" } else { "" },
-            footer
-        );
+        let message_text = if self.pre_message_mode == PreMessageMode::Post {
+            "".to_string()
+        } else {
+            format!(
+                "{}{}{}{}{}{}",
+                fwdhint.unwrap_or_default(),
+                quoted_text.unwrap_or_default(),
+                escape_message_footer_marks(final_text),
+                if !final_text.is_empty() && !footer.is_empty() {
+                    "\r\n\r\n"
+                } else {
+                    ""
+                },
+                if !footer.is_empty() { "-- \r\n" } else { "" },
+                footer
+            )
+        };
 
         let mut main_part = MimePart::new("text/plain", message_text);
         if is_reaction {

--- a/src/tests/pre_messages/receiving.rs
+++ b/src/tests/pre_messages/receiving.rs
@@ -130,7 +130,7 @@ async fn test_out_of_order_receiving() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_msg_text_on_lost_pre_msg() -> Result<()> {
+async fn test_lost_pre_msg() -> Result<()> {
     let mut tcm = TestContextManager::new();
     let alice = &tcm.alice().await;
     let bob = &tcm.bob().await;
@@ -144,7 +144,7 @@ async fn test_msg_text_on_lost_pre_msg() -> Result<()> {
     let _pre_msg = alice.pop_sent_msg().await;
     let msg = bob.recv_msg(&full_msg).await;
     assert_eq!(msg.download_state, DownloadState::Done);
-    assert_eq!(msg.text, "populate");
+    assert_eq!(msg.text, "");
     Ok(())
 }
 


### PR DESCRIPTION
Before this PR, when a user with current main sends a large message to a user with an old Delta Chat (before #7431), the text will be duplicated: One message will arrive with only the text, and one message with attachment+text.

This PR changes this - there will be one message with only the text, and one message with only the attachment.

If we want to guard against lost pre-messages, then we can revert this PR in a few months, though I'm not sure that's necessary - it's unlikely that the small pre-message gets lost but the big post-message gets through.

**Edit: The disadvantage of this PR is that message reordering can lead to lost text: If the pre-message arrives after the post-message, then the text won't be added to the post-message. I'm merging it anyways for now, since message reordering is very rare.**