### PR TITLE
fix: jsonrpc: emit events when stockstrings change for the resources that changes, so desktop refetches the affected data automatically.

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -35,6 +35,7 @@ use deltachat::qr_code_generator::{generate_backup_qr, get_securejoin_qr_svg};
 use deltachat::reaction::{get_msg_reactions, send_reaction};
 use deltachat::securejoin;
 use deltachat::stock_str::StockMessage;
+use deltachat::stock_str::{emit_events_for_updated_stock_strings, StockMessage};
 use deltachat::storage_usage::{get_blobdir_storage_usage, get_storage_usage};
 use deltachat::webxdc::StatusUpdateSerial;
 use deltachat::EventEmitter;
@@ -466,6 +467,10 @@ impl CommandApi {
                     .set_stock_translation(stock_id, stock_message)
                     .await?;
             }
+        }
+        // In the existing clients only one account is visible at a time.
+        if let Some(context) = accounts.get_selected_account() {
+            emit_events_for_updated_stock_strings(&context);
         }
         Ok(())
     }

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -1289,6 +1289,21 @@ impl Context {
     }
 }
 
+/// Emits events to invalidate cached data which contains core translated content
+///
+/// Only call this once after updating all your stockstrings,
+/// NOT after every single call to set_stock_translation, just once in the end.
+pub fn emit_events_for_updated_stock_strings(ctx: &Context) {
+    // update chatlist, which can contain all kinds of stockstrings in the message summary
+    ctx.emit_event(crate::EventType::ChatlistItemChanged { chat_id: None });
+    // And to update contact name [StockMessage::SelfMsg]
+    ctx.emit_event(crate::EventType::ContactsChanged(Some(ContactId::SELF)));
+    // To update bio/status [StockMessage::DeviceMessagesHint]
+    ctx.emit_event(crate::EventType::ContactsChanged(Some(ContactId::DEVICE)));
+    // reload connectivity view, which contains various stock stings
+    ctx.emit_event(crate::EventType::ConnectivityChanged);
+}
+
 impl Accounts {
     /// Set the stock string for the [StockMessage].
     ///


### PR DESCRIPTION
Better solution for https://github.com/deltachat/deltachat-desktop/issues/5403
Reasoning in https://github.com/deltachat/deltachat-desktop/pull/5404#issuecomment-3750453743

Bring back seamless translation switching on desktop and make code more correct by emitting events when resources change.
