### PR TITLE
fix: more reliable parsing of `dclogin:` links with ip address as host

### DIFF
--- a/src/qr/dclogin_scheme.rs
+++ b/src/qr/dclogin_scheme.rs
@@ -59,9 +59,6 @@ pub enum LoginOptions {
 /// scheme: `dclogin://user@host/?p=password&v=1[&options]`
 /// read more about the scheme at <https://github.com/deltachat/interface/blob/master/uri-schemes.md#DCLOGIN>
 pub(super) fn decode_login(qr: &str) -> Result<Qr> {
-    if !qr.to_ascii_lowercase().starts_with("dclogin") {
-        bail!("Bad scheme for account URL: {qr:?}.");
-    }
     let qr = qr.replacen("://", ":", 1);
 
     let url = url::Url::parse(&qr).with_context(|| format!("Malformed url: {qr:?}"))?;


### PR DESCRIPTION
Also adds a test for it.

closes #7733

- [x] add ipv6 address to test