### PR TITLE
docs: custom paths and tokens in `DCACCOUNT` ar codes are not supported anymore

### DIFF
--- a/src/qr.rs
+++ b/src/qr.rs
@@ -655,7 +655,6 @@ async fn decode_ideltachat(context: &Context, prefix: &str, qr: &str) -> Result<
 
 /// scheme: `DCACCOUNT:example.org`
 /// or `DCACCOUNT:https://example.org/new`
-/// or `DCACCOUNT:https://example.org/new_email?t=1w_7wDjgjelxeX884x96v3`
 fn decode_account(qr: &str) -> Result<Qr> {
     let payload = qr
         .get(DCACCOUNT_SCHEME.len()..)


### PR DESCRIPTION
Doc comment still mentioned a case that does not work anymore, so I removed the outdated doc comment.
Since some versions it only actually uses the host part of the url, nothing else.

(#7705 will add another attribute, but that will be for the client and not for the server, so it is unrelated to this change.)
