### PR TITLE
Send and apply MDNs to self (#7005)

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -106,6 +106,7 @@ pub struct MimeFactory {
     /// addresses and OpenPGP keys
     /// to use for encryption.
     ///
+    /// If `Some`, encrypt to self also.
     /// `None` if the message is not encrypted.
     encryption_pubkeys: Option<Vec<(String, SignedPublicKey)>>,
 
@@ -234,7 +235,6 @@ impl MimeFactory {
             encryption_pubkeys = if msg.param.get_bool(Param::ForcePlaintext).unwrap_or(false) {
                 None
             } else {
-                // Encrypt, but only to self.
                 Some(Vec::new())
             };
         } else if chat.is_mailing_list() {
@@ -539,7 +539,9 @@ impl MimeFactory {
         let timestamp = create_smeared_timestamp(context);
 
         let addr = contact.get_addr().to_string();
-        let encryption_pubkeys = if contact.is_key_contact() {
+        let encryption_pubkeys = if from_id == ContactId::SELF {
+            Some(Vec::new())
+        } else if contact.is_key_contact() {
             if let Some(key) = contact.public_key(context).await? {
                 Some(vec![(addr.clone(), key)])
             } else {

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -2159,9 +2159,9 @@ pub(crate) struct Report {
     ///
     /// It MUST be present if the original message has a Message-ID according to RFC 8098.
     /// In case we can't find it (shouldn't happen), this is None.
-    original_message_id: Option<String>,
+    pub original_message_id: Option<String>,
     /// Additional-Message-IDs
-    additional_message_ids: Vec<String>,
+    pub additional_message_ids: Vec<String>,
 }
 
 /// Delivery Status Notification (RFC 3464, RFC 6533)
@@ -2468,13 +2468,7 @@ async fn handle_mdn(
     timestamp_sent: i64,
 ) -> Result<()> {
     if from_id == ContactId::SELF {
-        warn!(
-            context,
-            "Ignoring MDN sent to self, this is a bug on the sender device."
-        );
-
-        // This is not an error on our side,
-        // we successfully ignored an invalid MDN and return `Ok`.
+        // MDNs to self are handled in receive_imf_inner().
         return Ok(());
     }
 

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -747,13 +747,23 @@ Content-Disposition: reaction\n\
             alice_reaction_msg.id.get_state(&alice).await?,
             MessageState::InSeen
         );
-        // Reactions don't request MDNs.
+        // Reactions don't request MDNs, but an MDN to self is sent.
         assert_eq!(
             alice
                 .sql
                 .count("SELECT COUNT(*) FROM smtp_mdns", ())
                 .await?,
-            0
+            1
+        );
+        assert_eq!(
+            alice
+                .sql
+                .count(
+                    "SELECT COUNT(*) FROM smtp_mdns WHERE from_id=?",
+                    (ContactId::SELF,)
+                )
+                .await?,
+            1
         );
 
         // Alice reacts to own message.


### PR DESCRIPTION
We currently synchronize "seen" status of messages by setting `\Seen` flag on IMAP and then looking
    for new `\Seen` flags using `CONDSTORE` IMAP extension. This approach has multiple disadvantages:
- It requires that the server supports `CONDSTORE` extension. For example Maddy does not support
      CONDSTORE yet: https://github.com/foxcpp/maddy/issues/727
- It leaks the seen status to the server without any encryption.
- It requires more than just store-and-forward queues and prevents replacing IMAP with simpler
      protocols like POP3 or UUCP or some HTTP-based API for queue polling.
    
A simpler approach is to send MDNs to self when `Config::BccSelf` (aka multidevice) is enabled,
    regardless of whether the message requested and MDN. If MDN was requested and we have MDNs enabled,
    then also send to the message sender, but MDN to self is sent regardless of whether read receipts
    are actually enabled.
    
`sync_seen_flags()` and `CONDSTORE` check is better completely removed, maybe after one
    release. `store_seen_flags_on_imap()` can be kept for unencrypted non-chat messages.
    
One potential problem with sending MDNs is that it may trigger ratelimits on some providers and
    count as another recipient.
    
Close #7005 