### PR TITLE
fix: Emit MsgsChanged instead of MsgsNoticed on self-MDN if chat still has fresh messages

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1017,12 +1017,12 @@ UPDATE msgs SET state=? WHERE
                     )
                     .await
                     .context("UPDATE msgs.state")?;
-                // Removes all notifications for the chat in UIs. Ideally should be under
-                // `if chat_id.get_fresh_msg_cnt(context).await? == 0`, but this causes a not
-                // updated profile badge counter in the UIs as of v2.35.0. Removed notifications for
-                // new messages is an already existing and known problem, so let's emit the event
-                // unconditionally for now.
-                context.emit_event(EventType::MsgsNoticed(chat_id));
+                if chat_id.get_fresh_msg_cnt(context).await? == 0 {
+                    // Removes all notifications for the chat in UIs.
+                    context.emit_event(EventType::MsgsNoticed(chat_id));
+                } else {
+                    context.emit_msgs_changed_without_msg_id(chat_id);
+                }
                 chatlist_events::emit_chatlist_item_changed(context, chat_id);
             }
             if archived_chats_maybe_noticed {


### PR DESCRIPTION
Otherwise if the user reads messages being offline and then the device comes online, sent MDNs will remove all notifications from other devices even if new messages have arrived. Notifications not removed at all look more acceptable.

This is a follow-up PR as suggested in https://github.com/chatmail/core/pull/7738#discussion_r2701564378. The idea comes from https://github.com/chatmail/core/issues/7659.
Checked this in Desktop. ~Can add a test if the change is agreed, but as the w/a for a not updated profile badge counter looks weird and may not work in all UIs, maybe we should emit another event.~