### PR TITLE
fix: Make it possible to leave and immediately delete a chat

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -636,10 +636,6 @@ impl ChatId {
                     (&delete_msgs_target, self,),
                 )?;
                 transaction.execute(
-                    "DELETE FROM smtp WHERE msg_id IN (SELECT id FROM msgs WHERE chat_id=?)",
-                    (self,),
-                )?;
-                transaction.execute(
                     "DELETE FROM msgs_mdns WHERE msg_id IN (SELECT id FROM msgs WHERE chat_id=?)",
                     (self,),
                 )?;


### PR DESCRIPTION
Without this PR, if you leave and immediately delete a chat, the leave message won't be sent.

This is needed for
https://github.com/deltachat/deltachat-android/issues/4158.