### PR TITLE
feat: Make it possible to specify IP addresses in `dcaccount:` scheme

### DIFF
--- a/deltachat-jsonrpc/src/api/types/login_param.rs
+++ b/deltachat-jsonrpc/src/api/types/login_param.rs
@@ -54,6 +54,9 @@ pub struct EnteredLoginParam {
     /// If true, login via OAUTH2 (not recommended anymore).
     /// Default: false
     pub oauth2: Option<bool>,
+
+    /// IP addresses for prefilling DNS
+    pub dns_prefill: Vec<String>,
 }
 
 impl From<dc::EnteredLoginParam> for EnteredLoginParam {
@@ -75,6 +78,7 @@ impl From<dc::EnteredLoginParam> for EnteredLoginParam {
             smtp_password: param.smtp.password.into_option(),
             certificate_checks: certificate_checks.into_option(),
             oauth2: param.oauth2.into_option(),
+            dns_prefill: param.dns_prefill,
         }
     }
 }
@@ -101,6 +105,7 @@ impl TryFrom<EnteredLoginParam> for dc::EnteredLoginParam {
             },
             certificate_checks: param.certificate_checks.unwrap_or_default().into(),
             oauth2: param.oauth2.unwrap_or_default(),
+            dns_prefill: param.dns_prefill,
         })
     }
 }

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -13,6 +13,8 @@ mod auto_mozilla;
 mod auto_outlook;
 pub(crate) mod server_params;
 
+use std::net::IpAddr;
+
 use anyhow::{Context as _, Result, bail, ensure, format_err};
 use auto_mozilla::moz_autoconfigure;
 use auto_outlook::outlk_autodiscover;
@@ -556,6 +558,25 @@ async fn configure(ctx: &Context, param: &EnteredLoginParam) -> Result<Option<&'
 
     let ctx2 = ctx.clone();
     let update_device_chats_handle = task::spawn(async move { ctx2.update_device_chats().await });
+
+    if !param.dns_prefill.is_empty() {
+        let mut ips: Vec<IpAddr> = Vec::new();
+        for ip in &param.dns_prefill {
+            match ip.parse::<IpAddr>() {
+                Ok(ip) => ips.push(ip),
+                Err(err) => {
+                    error!(
+                        ctx,
+                        "IP address prefill failed: parsing of address '{ip}' failed: {err}"
+                    );
+                }
+            }
+        }
+        ctx.dns_memory_cache
+            .write()
+            .await
+            .insert(param.imap.server.clone(), ips);
+    }
 
     let configured_param = get_configured_param(ctx, param).await?;
     let proxy_config = ProxyConfig::load(ctx).await?;

--- a/src/context.rs
+++ b/src/context.rs
@@ -318,6 +318,11 @@ pub struct InnerContext {
             ) -> mail_builder::mime::MimePart<'a>,
         >,
     >,
+
+    /// Short lived DNS cache which only lives in memory.
+    /// Used for configuration from `dcaccount` links with ip address.
+    /// Like `dcaccount:example.org?a=127.0.0.1,[::1]`
+    pub(crate) dns_memory_cache: Arc<RwLock<HashMap<String, Vec<std::net::IpAddr>>>>,
 }
 
 /// The state of ongoing process.

--- a/src/context.rs
+++ b/src/context.rs
@@ -499,6 +499,7 @@ impl Context {
             self_fingerprint: OnceLock::new(),
             connectivities: parking_lot::Mutex::new(Vec::new()),
             pre_encrypt_mime_hook: None.into(),
+            dns_memory_cache: Arc::new(RwLock::new(HashMap::new())),
         };
 
         let ctx = Context {

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -97,6 +97,9 @@ pub struct EnteredLoginParam {
 
     /// If true, login via OAUTH2 (not recommended anymore)
     pub oauth2: bool,
+
+    /// IP addresses for prefilling DNS
+    pub dns_prefill: Vec<String>,
 }
 
 impl EnteredLoginParam {
@@ -191,6 +194,7 @@ impl EnteredLoginParam {
             },
             certificate_checks,
             oauth2,
+            dns_prefill: Default::default(),
         })
     }
 
@@ -360,6 +364,7 @@ mod tests {
             },
             certificate_checks: Default::default(),
             oauth2: false,
+            dns_prefill: Default::default(),
         };
         param.save(&t).await?;
         assert_eq!(

--- a/src/net/dns.rs
+++ b/src/net/dns.rs
@@ -860,6 +860,14 @@ pub(crate) async fn lookup_host_with_cache(
                 }
             }
         }
+        if let Some(ips) = context.dns_memory_cache.read().await.get(hostname) {
+            for ip in ips {
+                let addr = SocketAddr::new(*ip, port);
+                if !cache.contains(&addr) {
+                    cache.push(addr);
+                }
+            }
+        }
 
         merge_with_cache(resolved_addrs, cache)
     } else {

--- a/src/qr/dclogin_scheme.rs
+++ b/src/qr/dclogin_scheme.rs
@@ -191,6 +191,7 @@ pub(crate) fn login_param_from_login_qr(
                 },
                 certificate_checks: certificate_checks.unwrap_or_default(),
                 oauth2: false,
+                dns_prefill: Default::default(),
             };
             Ok(param)
         }

--- a/src/qr/qr_tests.rs
+++ b/src/qr/qr_tests.rs
@@ -712,6 +712,31 @@ async fn test_decode_account() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_decode_account_with_dns_prefill() -> Result<()> {
+    let ctx = &TestContext::new().await;
+
+    for (qr, prefill_ips) in [
+        (
+            "dcaccount:example.org?a=127.0.0.1,[::1]",
+            vec!["127.0.0.1", "[::1]"],
+        ),
+        (
+            "DCACCOUNT:example.org?a=127.0.0.1,[::1]",
+            vec!["127.0.0.1", "[::1]"],
+        ),
+        ("dcaccount:example.org?a=[::1]", vec!["[::1]"]),
+        ("DCACCOUNT:example.org?a=127.0.0.1", vec!["127.0.0.1"]),
+    ] {
+        let param = login_param_from_account_qr(ctx, qr).await?;
+        println!("addr {}", param.addr);
+        assert!(param.addr.ends_with("example.org"));
+        assert_eq!(param.dns_prefill, prefill_ips);
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_decode_tg_socks_proxy() -> Result<()> {
     let t = TestContext::new().await;
 


### PR DESCRIPTION
- [x] **add dns_prefill attribute to entered login params and implement parsing for it**
- [x] **introduce shortlived in-memory dns cache and prefill ip addresses into it during configuration.**
- [x] test parsing
- [ ] integration test (test that it can use the prefill as fallback)
- [x] update docs in interface repo: https://github.com/deltachat/interface/pull/90

closes #7705