### PR TITLE
api: rename properties to be more consistent

### DIFF
--- a/deltachat-jsonrpc/src/api/types/chat.rs
+++ b/deltachat-jsonrpc/src/api/types/chat.rs
@@ -59,7 +59,7 @@ pub struct FullChat {
 
     is_device_chat: bool,
     /// Note that this is different from
-    /// [`ChatListItem::is_self_in_group`](`crate::api::types::chat_list::ChatListItemFetchResult::ChatListItem::is_self_in_group`).
+    /// [`ChatListItem::self_in_group`](`crate::api::types::chat_list::ChatListItemFetchResult::ChatListItem::self_in_group`).
     /// This property should only be accessed
     /// when [`FullChat::chat_type`] is [`Chattype::Group`].
     //
@@ -178,8 +178,9 @@ pub struct BasicChat {
     is_self_talk: bool,
     color: String,
     is_contact_request: bool,
-
+    // deprecated 2026-01, use is_device_talk instead
     is_device_chat: bool,
+    is_device_talk: bool,
     is_muted: bool,
 }
 
@@ -207,6 +208,7 @@ impl BasicChat {
             color,
             is_contact_request: chat.is_contact_request(),
             is_device_chat: chat.is_device_talk(),
+            is_device_talk: chat.is_device_talk(),
             is_muted: chat.is_muted(),
         })
     }

--- a/deltachat-jsonrpc/src/api/types/chat_list.rs
+++ b/deltachat-jsonrpc/src/api/types/chat_list.rs
@@ -17,6 +17,7 @@ use super::message::MessageViewtype;
 
 #[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(tag = "kind")]
+#[allow(clippy::large_enum_variant)]
 pub enum ChatListItemFetchResult {
     #[serde(rename_all = "camelCase")]
     ChatListItem {
@@ -63,9 +64,8 @@ pub enum ChatListItemFetchResult {
         is_self_talk: bool,
         is_device_talk: bool,
         is_sending_location: bool,
-        /// deprecated 2026-01, use self_in_group instead
+        /// deprecated 2026-01
         is_self_in_group: bool,
-        self_in_group: bool,
         /// deprecated 2026-01, use archived instead
         is_archived: bool,
         archived: bool,
@@ -173,7 +173,6 @@ pub(crate) async fn get_chat_list_item_by_id(
         is_self_talk: chat.is_self_talk(),
         is_device_talk: chat.is_device_talk(),
         is_self_in_group: chat.is_self_in_chat(ctx).await?,
-        self_in_group: chat.is_self_in_chat(ctx).await?,
         is_sending_location: chat.is_sending_locations(),
         archived: visibility == ChatVisibility::Archived,
         is_archived: visibility == ChatVisibility::Archived,

--- a/deltachat-jsonrpc/src/api/types/chat_list.rs
+++ b/deltachat-jsonrpc/src/api/types/chat_list.rs
@@ -17,7 +17,7 @@ use super::message::MessageViewtype;
 
 #[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(tag = "kind")]
-#[allow(clippy::large_enum_variant)]
+#[expect(clippy::large_enum_variant)]
 pub enum ChatListItemFetchResult {
     #[serde(rename_all = "camelCase")]
     ChatListItem {

--- a/deltachat-jsonrpc/src/api/types/chat_list.rs
+++ b/deltachat-jsonrpc/src/api/types/chat_list.rs
@@ -22,7 +22,9 @@ pub enum ChatListItemFetchResult {
     ChatListItem {
         id: u32,
         name: String,
+        /// deprecated 2026-01, use profile_image instead
         avatar_path: Option<String>,
+        profile_image: Option<String>,
         color: String,
         chat_type: JsonrpcChatType,
         last_updated: Option<i64>,
@@ -61,9 +63,15 @@ pub enum ChatListItemFetchResult {
         is_self_talk: bool,
         is_device_talk: bool,
         is_sending_location: bool,
+        /// deprecated 2026-01, use self_in_group instead
         is_self_in_group: bool,
+        self_in_group: bool,
+        /// deprecated 2026-01, use archived instead
         is_archived: bool,
+        archived: bool,
+        /// deprecated 2026-01, use pinned instead
         is_pinned: bool,
+        pinned: bool,
         is_muted: bool,
         is_contact_request: bool,
         /// contact id if this is a dm chat (for view profile entry in context menu)
@@ -105,7 +113,7 @@ pub(crate) async fn get_chat_list_item_by_id(
 
     let visibility = chat.get_visibility();
 
-    let avatar_path = chat
+    let profile_image = chat
         .get_profile_image(ctx)
         .await?
         .map(|path| path.to_str().unwrap_or("invalid/path").to_owned());
@@ -150,7 +158,8 @@ pub(crate) async fn get_chat_list_item_by_id(
     Ok(ChatListItemFetchResult::ChatListItem {
         id: chat_id.to_u32(),
         name: chat.get_name().to_owned(),
-        avatar_path,
+        profile_image: profile_image.clone(),
+        avatar_path: profile_image.clone(),
         color,
         chat_type: chat.get_type().into(),
         last_updated,
@@ -164,8 +173,11 @@ pub(crate) async fn get_chat_list_item_by_id(
         is_self_talk: chat.is_self_talk(),
         is_device_talk: chat.is_device_talk(),
         is_self_in_group: chat.is_self_in_chat(ctx).await?,
+        self_in_group: chat.is_self_in_chat(ctx).await?,
         is_sending_location: chat.is_sending_locations(),
+        archived: visibility == ChatVisibility::Archived,
         is_archived: visibility == ChatVisibility::Archived,
+        pinned: visibility == ChatVisibility::Pinned,
         is_pinned: visibility == ChatVisibility::Pinned,
         is_muted: chat.is_muted(),
         is_contact_request: chat.is_contact_request(),


### PR DESCRIPTION
There is no need to have different names for the same props in chat and chat_list_item. So let's rename them:
- is_self_in_group → self_in_group
- is_archived → archived
- is_pinned → pinned
- avatar_path → profile_image
- is_device_chat → is_device_talk