### PR TITLE
feat: use more fitting encryption info message

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -7012,7 +7012,7 @@ void dc_event_unref(dc_event_t* event);
 
 /// "End-to-end encryption available."
 ///
-/// Used to build the string returned by dc_get_contact_encrinfo().
+/// @deprecated 2026-01-23
 #define DC_STR_E2E_AVAILABLE              25
 
 /// "No encryption."

--- a/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
@@ -22,7 +22,7 @@ from .rpc import Rpc
 E2EE_INFO_MSGS = 1
 """
 The number of info messages added to new e2ee chats.
-Currently this is "End-to-end encryption available".
+Currently this is "Messages are end-to-end encrypted."
 """
 
 

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1152,7 +1152,7 @@ SELECT id, rfc724_mid, pre_rfc724_mid, timestamp, ?, 1 FROM msgs WHERE chat_id=?
             return Ok(stock_str::encr_none(context).await);
         }
 
-        let mut ret = stock_str::e2e_available(context).await + "\n";
+        let mut ret = stock_str::messages_e2e_encrypted(context).await + "\n";
 
         for &contact_id in get_chat_contacts(context, self)
             .await?

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3816,13 +3816,13 @@ async fn test_chat_get_encryption_info() -> Result<()> {
     let chat_id = create_group(alice, "Group").await?;
     assert_eq!(
         chat_id.get_encryption_info(alice).await?,
-        "End-to-end encryption available"
+        "Messages are end-to-end encrypted."
     );
 
     add_contact_to_chat(alice, chat_id, contact_bob).await?;
     assert_eq!(
         chat_id.get_encryption_info(alice).await?,
-        "End-to-end encryption available\n\
+        "Messages are end-to-end encrypted.\n\
          \n\
          bob@example.net\n\
          CCCB 5AA9 F6E1 141C 9431\n\
@@ -3832,7 +3832,7 @@ async fn test_chat_get_encryption_info() -> Result<()> {
     add_contact_to_chat(alice, chat_id, contact_fiona).await?;
     assert_eq!(
         chat_id.get_encryption_info(alice).await?,
-        "End-to-end encryption available\n\
+        "Messages are end-to-end encrypted.\n\
          \n\
          fiona@example.net\n\
          C8BA 50BF 4AC1 2FAF 38D7\n\
@@ -3846,13 +3846,13 @@ async fn test_chat_get_encryption_info() -> Result<()> {
     let email_chat = alice.create_email_chat(bob).await;
     assert_eq!(
         email_chat.id.get_encryption_info(alice).await?,
-        "No encryption"
+        "No encryption."
     );
 
     alice.sql.execute("DELETE FROM public_keys", ()).await?;
     assert_eq!(
         chat_id.get_encryption_info(alice).await?,
-        "End-to-end encryption available\n\
+        "Messages are end-to-end encrypted.\n\
          \n\
          fiona@example.net\n\
          (key missing)\n\

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1342,13 +1342,13 @@ WHERE addr=?
         let fingerprint_other = fingerprint_other.to_string();
 
         let stock_message = if contact.public_key(context).await?.is_some() {
-            stock_str::e2e_available(context).await
+            stock_str::messages_e2e_encrypted(context).await
         } else {
             stock_str::encr_none(context).await
         };
 
         let finger_prints = stock_str::finger_prints(context).await;
-        let mut ret = format!("{stock_message}.\n{finger_prints}:");
+        let mut ret = format!("{stock_message}\n{finger_prints}:");
 
         let fingerprint_self = load_self_public_key(context)
             .await?

--- a/src/contact/contact_tests.rs
+++ b/src/contact/contact_tests.rs
@@ -823,7 +823,7 @@ async fn test_contact_get_encrinfo() -> Result<()> {
 
     let address_contact_bob_id = alice.add_or_lookup_address_contact_id(bob).await;
     let encrinfo = Contact::get_encrinfo(alice, address_contact_bob_id).await?;
-    assert_eq!(encrinfo, "No encryption");
+    assert_eq!(encrinfo, "No encryption.");
 
     let contact = Contact::get_by_id(alice, address_contact_bob_id).await?;
     assert!(!contact.e2ee_avail(alice).await?);
@@ -832,7 +832,7 @@ async fn test_contact_get_encrinfo() -> Result<()> {
     let encrinfo = Contact::get_encrinfo(alice, contact_bob_id).await?;
     assert_eq!(
         encrinfo,
-        "End-to-end encryption available.
+        "Messages are end-to-end encrypted.
 Fingerprints:
 
 Me (alice@example.org):

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -63,10 +63,7 @@ pub enum StockMessage {
     #[strum(props(fallback = "GIF"))]
     Gif = 23,
 
-    #[strum(props(fallback = "End-to-end encryption available"))]
-    E2eAvailable = 25,
-
-    #[strum(props(fallback = "No encryption"))]
+    #[strum(props(fallback = "No encryption."))]
     EncrNone = 28,
 
     #[strum(props(fallback = "Fingerprints"))]
@@ -705,11 +702,6 @@ pub(crate) async fn msg_reacted(
 /// Stock string: `GIF`.
 pub(crate) async fn gif(context: &Context) -> String {
     translated(context, StockMessage::Gif).await
-}
-
-/// Stock string: `End-to-end encryption available.`.
-pub(crate) async fn e2e_available(context: &Context) -> String {
-    translated(context, StockMessage::E2eAvailable).await
 }
 
 /// Stock string: `No encryption.`.

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -44,7 +44,7 @@ use crate::stock_str::StockStrings;
 use crate::tools::time;
 
 /// The number of info messages added to new e2ee chats.
-/// Currently this is "End-to-end encryption available", string `E2eAvailable`.
+/// Currently this is "Messages are end-to-end encrypted.", string `ChatProtectionEnabled`.
 pub const E2EE_INFO_MSGS: usize = 1;
 
 #[allow(non_upper_case_globals)]


### PR DESCRIPTION
this PR changes the encryption-info to use the string "Messages are end-to-end encrypted." instead of "End-to-end encryption available"

- "available" is a bit vague, and comes from times of opportunistic encryption.

- re-use the string anyway used for the info-message