### PR TITLE
test: Encrypted incoming message goes to encrypted 1:1 chat even if references messages in ad-hoc group

### DIFF
--- a/src/receive_imf/receive_imf_tests.rs
+++ b/src/receive_imf/receive_imf_tests.rs
@@ -3284,7 +3284,8 @@ async fn test_blocked_contact_creates_group() -> Result<()> {
 
     let sent = bob.send_text(group_id, "Heyho, I'm a spammer!").await;
     let rcvd = alice.recv_msg(&sent).await;
-    // Alice blocked Bob, so she shouldn't get the message
+    // Alice blocked Bob, so she shouldn't be notified.
+    assert_eq!(rcvd.state, MessageState::InSeen);
     assert_eq!(rcvd.chat_blocked, Blocked::Yes);
 
     // Fiona didn't block Bob, though, so she gets the message


### PR DESCRIPTION
This is an important thing forgotten to be checked in 332527089.

Also there's another test which currently doesn't work as we want: outgoing encrypted messages continue to arrive to ad-hoc group even if we already have contact's key. This should be fixed by sending and receiving Intended Recipient Fingerprint subpackets.

The good thing is that apparently there are no scenarios requiring the contact to update their
software, the user should just update own devices.

`test: Message in blocked chat arrives as InSeen` -- unrelated, but just a one-line test improvement.