### PR TITLE
feat: do not collect email addresses from messages after configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -175,11 +175,6 @@ pub enum Config {
     #[strum(props(default = "0"))] // also change MediaQuality.default() on changes
     MediaQuality,
 
-    /// If set to "1", then existing messages are considered to be already fetched.
-    /// This flag is reset after successful configuration.
-    #[strum(props(default = "1"))]
-    FetchedExistingMsgs,
-
     /// Timer in seconds after which the message is deleted from the
     /// server.
     ///

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -23,7 +23,7 @@ use percent_encoding::utf8_percent_encode;
 use server_params::{ServerParams, expand_param_vector};
 use tokio::task;
 
-use crate::config::{self, Config};
+use crate::config::Config;
 use crate::constants::NON_ALPHANUMERIC_WITHOUT_DOT;
 use crate::context::Context;
 use crate::imap::Imap;
@@ -631,8 +631,6 @@ async fn configure(ctx: &Context, param: &EnteredLoginParam) -> Result<Option<&'
 
     progress!(ctx, 920);
 
-    ctx.set_config_internal(Config::FetchedExistingMsgs, config::from_bool(false))
-        .await?;
     ctx.scheduler.interrupt_inbox().await;
 
     progress!(ctx, 940);

--- a/src/context.rs
+++ b/src/context.rs
@@ -947,12 +947,6 @@ impl Context {
 
         res.insert("secondary_addrs", secondary_addrs);
         res.insert(
-            "fetched_existing_msgs",
-            self.get_config_bool(Config::FetchedExistingMsgs)
-                .await?
-                .to_string(),
-        );
-        res.insert(
             "show_emails",
             self.get_config_int(Config::ShowEmails).await?.to_string(),
         );

--- a/src/imap/imap_tests.rs
+++ b/src/imap/imap_tests.rs
@@ -1,6 +1,6 @@
 use super::*;
+use crate::contact::Contact;
 use crate::test_utils::TestContext;
-use crate::transport::add_pseudo_transport;
 
 #[test]
 fn test_get_folder_meaning_by_name() {
@@ -261,31 +261,6 @@ async fn test_target_folder_setupmsg() -> Result<()> {
         )
         .await?;
     }
-    Ok(())
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_get_imap_search_command() -> Result<()> {
-    let t = TestContext::new_alice().await;
-    assert_eq!(
-        get_imap_self_sent_search_command(&t.ctx).await?,
-        r#"FROM "alice@example.org""#
-    );
-
-    add_pseudo_transport(&t, "alice@another.com").await?;
-    t.ctx.set_primary_self_addr("alice@another.com").await?;
-    assert_eq!(
-        get_imap_self_sent_search_command(&t.ctx).await?,
-        r#"OR (FROM "alice@another.com") (FROM "alice@example.org")"#
-    );
-
-    add_pseudo_transport(&t, "alice@third.com").await?;
-    t.ctx.set_primary_self_addr("alice@third.com").await?;
-    assert_eq!(
-        get_imap_self_sent_search_command(&t.ctx).await?,
-        r#"OR (OR (FROM "alice@third.com") (FROM "alice@another.com")) (FROM "alice@example.org")"#
-    );
-
     Ok(())
 }
 


### PR DESCRIPTION
This can only result in adding unencrypted email-contacts and we do not want to encourage creating unencrypted chats.