### PR TITLE
feat: Make summary for pre-messages look like summary for fully downloaded messages (#7775)

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4374,10 +4374,7 @@ pub async fn forward_msgs_2ctx(
         if msg.get_viewtype() == Viewtype::Call {
             msg.viewtype = Viewtype::Text;
         }
-
-        if msg.download_state != DownloadState::Done {
-            msg.text += &msg.additional_text;
-        }
+        msg.text += &msg.additional_text;
 
         let param = &mut param;
 
@@ -4465,9 +4462,7 @@ pub(crate) async fn save_copy_in_self_talk(
     msg.param.remove(Param::PostMessageFileBytes);
     msg.param.remove(Param::PostMessageViewtype);
 
-    if msg.download_state != DownloadState::Done {
-        msg.text += &msg.additional_text;
-    }
+    msg.text += &msg.additional_text;
 
     if !msg.original_msg_id.is_unset() {
         bail!("message already saved.");

--- a/src/tests/pre_messages/util.rs
+++ b/src/tests/pre_messages/util.rs
@@ -17,10 +17,10 @@ pub async fn send_large_file_message<'a>(
     content: &[u8],
 ) -> Result<(SentMessage<'a>, SentMessage<'a>, MsgId)> {
     let mut msg = Message::new(view_type);
-    let file_name = if view_type == Viewtype::Webxdc {
-        "test.xdc"
-    } else {
-        "test.bin"
+    let file_name = match view_type {
+        Viewtype::Webxdc => "test.xdc",
+        Viewtype::Vcard => "test.vcf",
+        _ => "test.bin",
     };
     msg.set_file_from_bytes(sender, file_name, content, None)?;
     msg.set_text("test".to_owned());


### PR DESCRIPTION
See commit the message.

Close #7775 