### PR TITLE
api(jsonrpc): process events forever by default

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/client.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/client.py
@@ -104,7 +104,7 @@ class Client:
 
     def _process_events(
         self,
-        until_func: Callable[[AttrDict], bool],
+        until_func: Callable[[AttrDict], bool] = _forever,
         until_event: EventType = False,
     ) -> AttrDict:
         """Process events until the given callable evaluates to True,


### PR DESCRIPTION
Follow-up for https://github.com/chatmail/core/pull/7688 where I forgot to make this argument optional