### PR TITLE
perf: use recv_direct() instead of recv() on the event channel

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -71,7 +71,7 @@ impl EventEmitter {
     /// [`try_recv`]: Self::try_recv
     pub async fn recv(&self) -> Option<Event> {
         let mut lock = self.0.lock().await;
-        match lock.recv().await {
+        match lock.recv_direct().await {
             Err(async_broadcast::RecvError::Overflowed(n)) => Some(Event {
                 id: 0,
                 typ: EventType::EventChannelOverflow { n },


### PR DESCRIPTION
The difference between recv_direct()[1] and recv()[2] is that recv() allocates memory for the future on the heap. Using recv_direct() removes one pointer indirection.

[1] https://docs.rs/async-broadcast/0.7.2/async_broadcast/struct.Receiver.html#method.recv_direct
[2] https://docs.rs/async-broadcast/0.7.2/async_broadcast/struct.Receiver.html#method.recv