### PR TITLE
feat: do not require ShowEmails to be set to All for adding second relay

### DIFF
--- a/deltachat-rpc-client/tests/test_multitransport.py
+++ b/deltachat-rpc-client/tests/test_multitransport.py
@@ -37,8 +37,8 @@ def test_add_second_address(acfactory) -> None:
         with pytest.raises(JsonRpcError):
             account.set_config(option, "1")
 
-    with pytest.raises(JsonRpcError):
-        account.set_config("show_emails", "0")
+    # show_emails does not matter for multi-relay, can be set to anything
+    account.set_config("show_emails", "0")
 
 
 @pytest.mark.parametrize("key", ["mvbox_move", "only_fetch_mvbox"])
@@ -57,8 +57,8 @@ def test_no_second_transport_with_mvbox(acfactory, key) -> None:
         account.add_transport_from_qr(qr)
 
 
-def test_no_second_transport_without_classic_emails(acfactory) -> None:
-    """Test that second transport cannot be configured if classic emails are not fetched."""
+def test_second_transport_without_classic_emails(acfactory) -> None:
+    """Test that second transport can be configured if classic emails are not fetched."""
     account = acfactory.new_configured_account()
     assert len(account.list_transports()) == 1
 
@@ -67,8 +67,7 @@ def test_no_second_transport_without_classic_emails(acfactory) -> None:
     qr = acfactory.get_account_qr()
     account.set_config("show_emails", "0")
 
-    with pytest.raises(JsonRpcError):
-        account.add_transport_from_qr(qr)
+    account.add_transport_from_qr(qr)
 
 
 def test_change_address(acfactory) -> None:

--- a/src/config.rs
+++ b/src/config.rs
@@ -712,12 +712,7 @@ impl Context {
         Self::check_config(key, value)?;
 
         let n_transports = self.count_transports().await?;
-        if n_transports > 1
-            && matches!(
-                key,
-                Config::MvboxMove | Config::OnlyFetchMvbox | Config::ShowEmails
-            )
-        {
+        if n_transports > 1 && matches!(key, Config::MvboxMove | Config::OnlyFetchMvbox) {
             bail!("Cannot reconfigure {key} when multiple transports are configured");
         }
 

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -286,11 +286,6 @@ impl Context {
                     "To use additional relays, disable the legacy option \"Settings / Advanced / Move automatically to DeltaChat Folder\"."
                 );
             }
-            if self.get_config(Config::ShowEmails).await?.as_deref() != Some("2") {
-                bail!(
-                    "To use additional relays, set the legacy option \"Settings / Advanced / Show Classic Emails\" to \"All\"."
-                );
-            }
 
             if self
                 .sql


### PR DESCRIPTION
This check does not really matter for mulit-relay and we will replace it with https://github.com/chatmail/core/issues/7494