### PR TITLE
test: Fix flaky test_transport_synchronization (hopefully)

### DIFF
--- a/deltachat-rpc-client/tests/test_multitransport.py
+++ b/deltachat-rpc-client/tests/test_multitransport.py
@@ -192,7 +192,7 @@ def test_transport_synchronization(acfactory, log) -> None:
     def wait_for_io_started(ac):
         while True:
             ev = ac.wait_for_event(EventType.INFO)
-            if ev.msg == "scheduler is running":
+            if "scheduler is running" in ev.msg:
                 return
 
     ac1, ac2 = acfactory.get_online_accounts(2)


### PR DESCRIPTION
Fix https://github.com/chatmail/core/issues/7835 (hopefully).

The problem was most probably:
- `ac1_clone` receives the sync message, sends `TRANSPORTS_MODIFIED` event, and launches a task that will restart IO
- After IO was stopped, but before it is started again, `ac1_clone.add_transport_from_qr(qr)` is called
- this check fails:
  ```rust
        ensure!(
            !self.scheduler.is_running().await,
            "cannot configure, already running"
        );
  ```

There are multiple possible ways to fix this; if you think something else should be done, you can also just push it.