### PR TITLE
build(git-cliff): do not capitalize the first letter of commit message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -375,7 +375,7 @@ that failed to be published for 2.31.0 due to not configured "trusted publishers
 
 ### Features / Changes
 
-- Lookup_or_create_adhoc_group(): Add context to SQL errors ([#7554](https://github.com/chatmail/core/pull/7554)).
+- `lookup_or_create_adhoc_group()`: Add context to SQL errors ([#7554](https://github.com/chatmail/core/pull/7554)).
 
 ## [2.31.0] - 2025-12-04
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -66,7 +66,7 @@ body = """
     {% for commit in commits %}
         - {% if commit.breaking %}[**breaking**] {% endif %}\
 	{% if commit.scope %}{{ commit.scope }}: {% endif %}\
-	{{ commit.message | upper_first }}.\
+	{{ commit.message }}.\
 	{% if commit.footers is defined %}\
 	  {% for footer in commit.footers %}{% if 'BREAKING CHANGE' in footer.token %}
 	    {% raw %}  {% endraw %}- {{ footer.value }}\


### PR DESCRIPTION
Some commit messages start with the function names for additional context and these should not be capitalized.