### PR TITLE
fix: add missing group description strings to cffi

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -7609,6 +7609,12 @@ void dc_event_unref(dc_event_t* event);
 /// "Incoming video call"
 #define DC_STR_INCOMING_VIDEO_CALL 235
 
+/// "You changed the chat description."
+#define DC_STR_GROUP_DESCRIPTION_CHANGED_BY_YOU 240
+
+/// "Chat description changed by %1$s."
+#define DC_STR_GROUP_DESCRIPTION_CHANGED_BY_OTHER 241
+
 /**
  * @}
  */


### PR DESCRIPTION
the strings were added to rust, but not to cffi at  https://github.com/chatmail/core/pull/7829

needed at least for https://github.com/deltachat/deltachat-ios/pull/3007