### PR TITLE
fix: chat-description-changed text in old clients

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4264,7 +4264,9 @@ async fn set_chat_description_ex(
 
     if chat.is_promoted() {
         let mut msg = Message::new(Viewtype::Text);
-        msg.text = "[Chat description changed. To see this and other new features, update to version 2.43]".to_string();
+        msg.text =
+            "[Chat description changed. To see this and other new features, please update the app]"
+                .to_string();
         msg.param.set_cmd(SystemMessage::GroupDescriptionChanged);
 
         msg.id = send_msg(context, chat_id, &mut msg).await?;

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3231,7 +3231,7 @@ async fn test_chat_description(initial_description: &str, join_via_qr: bool) -> 
         let sent = alice.pop_sent_msg().await;
         assert_eq!(
             sent.load_from_db().await.text,
-            "[Chat description changed. To see this and other new features, update to version 2.43]"
+            "[Chat description changed. To see this and other new features, please update the app]"
         );
 
         tcm.section("Bob receives the description change");


### PR DESCRIPTION
instead of Alice saying to Bob "You changed the chat description",
we now say "[Chat description changed, please update ...]

i was also considering to say "[Chat description changed to:\n\n...]" but then there is no incentive for ppl to update, and chat descriptions for chat creation would still be missing. and this is probably far more often used.

successor of https://github.com/chatmail/core/pull/7829