### PR TITLE
test: fail fast when CHATMAIL_DOMAIN is unset

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
@@ -54,13 +54,13 @@ class ACFactory:
 
     def get_credentials(self) -> (str, str):
         """Generate new credentials for chatmail account."""
-        domain = os.getenv("CHATMAIL_DOMAIN")
+        domain = os.environ["CHATMAIL_DOMAIN"]
         username = "ci-" + "".join(random.choice("2345789acdefghjkmnpqrstuvwxyz") for i in range(6))
         return f"{username}@{domain}", f"{username}${username}"
 
     def get_account_qr(self):
         """Return "dcaccount:" QR code for testing chatmail relay."""
-        domain = os.getenv("CHATMAIL_DOMAIN")
+        domain = os.environ["CHATMAIL_DOMAIN"]
         return f"dcaccount:{domain}"
 
     @futuremethod


### PR DESCRIPTION
This code does not expect the variable to be unset, so use indexing to fail with KeyError instead.
Otherwise getenv() returns None which is then converted to "none" string by formatting and the test only fails because of connection attempts to "none" domain.