### PR TITLE
fix: Make clicking broadcast member-added messages work for the second device

### DIFF
--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -170,6 +170,7 @@ def test_qr_securejoin_broadcast(acfactory, all_devices_online):
         member_added_msg = chat_msgs.pop(0).get_snapshot()
         if inviter_side:
             assert member_added_msg.text == f"Member {contact_snapshot.display_name} added."
+            assert member_added_msg.info_contact_id == contact_snapshot.id
         else:
             assert member_added_msg.text == "You joined the channel."
         assert member_added_msg.is_info

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -3716,6 +3716,7 @@ async fn apply_out_broadcast_changes(
 
     let mut send_event_chat_modified = false;
     let mut better_msg = None;
+    let mut added_removed_id: Option<ContactId> = None;
 
     if from_id == ContactId::SELF {
         apply_chat_name_avatar_and_description_changes(
@@ -3748,6 +3749,7 @@ async fn apply_out_broadcast_changes(
                         stock_str::msg_add_member_local(context, added_id, ContactId::UNDEFINED)
                             .await;
                     better_msg.get_or_insert(msg);
+                    added_removed_id = Some(added_id);
                     send_event_chat_modified = true;
                 }
             } else {
@@ -3772,6 +3774,7 @@ async fn apply_out_broadcast_changes(
             better_msg.get_or_insert(
                 stock_str::msg_del_member_local(context, removed_id, ContactId::SELF).await,
             );
+            added_removed_id = Some(removed_id);
         }
     }
 
@@ -3781,7 +3784,7 @@ async fn apply_out_broadcast_changes(
     }
     Ok(GroupChangesInfo {
         better_msg,
-        added_removed_id: None,
+        added_removed_id,
         silent: false,
         extra_msgs: vec![],
     })


### PR DESCRIPTION
fix #7876 