### PR TITLE
fix: Don't generate new timestamp for re-sent messages (#7889)

### DIFF
--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -150,7 +150,7 @@ def test_qr_securejoin_broadcast(acfactory, all_devices_online):
         assert snapshot1.chat_id == chat.id
         assert snapshot2.chat_id == chat.id
 
-    def check_account(ac, contact, inviter_side, please_wait_info_msg=False):
+    def check_account(ac, contact, inviter_side, please_wait_info_msg=False, resent_msg=False):
         # Check that the chat partner is verified.
         contact_snapshot = contact.get_snapshot()
         assert contact_snapshot.is_verified
@@ -167,11 +167,12 @@ def test_qr_securejoin_broadcast(acfactory, all_devices_online):
             assert "invited you to join this channel" in first_msg.text
             assert first_msg.is_info
 
-        member_added_msg = chat_msgs.pop(0).get_snapshot()
         if inviter_side:
+            member_added_msg = chat_msgs.pop(0).get_snapshot()
             assert member_added_msg.text == f"Member {contact_snapshot.display_name} added."
             assert member_added_msg.info_contact_id == contact_snapshot.id
         else:
+            member_added_msg = chat_msgs.pop(1 if resent_msg else 0).get_snapshot()
             assert member_added_msg.text == "You joined the channel."
         assert member_added_msg.is_info
 
@@ -242,7 +243,7 @@ def test_qr_securejoin_broadcast(acfactory, all_devices_online):
     snapshot = fiona.wait_for_incoming_msg().get_snapshot()
     assert snapshot.text == "Hello everyone!"
 
-    check_account(fiona, fiona.create_contact(alice), inviter_side=False, please_wait_info_msg=True)
+    check_account(fiona, fiona.create_contact(alice), inviter_side=False, please_wait_info_msg=True, resent_msg=True)
 
     # For Bob, the channel must not have changed:
     check_account(bob, bob.create_contact(alice), inviter_side=False, please_wait_info_msg=True)

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4664,7 +4664,6 @@ pub async fn resend_msgs(context: &Context, msg_ids: &[MsgId]) -> Result<()> {
             }
             msg_state => bail!("Unexpected message state {msg_state}"),
         }
-        msg.timestamp_sort = create_smeared_timestamp(context);
         if create_send_msg_jobs(context, &mut msg).await?.is_empty() {
             continue;
         }

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -2641,7 +2641,7 @@ async fn test_resend_own_message() -> Result<()> {
     );
     let msg_from = Contact::get_by_id(&fiona, msg.get_from_id()).await?;
     assert_eq!(msg_from.get_addr(), "alice@example.org");
-    assert!(sent1_ts_sent < msg.timestamp_sent);
+    assert!(sent1_ts_sent == msg.timestamp_sent);
 
     Ok(())
 }


### PR DESCRIPTION
Timestamp renewal was introduced in 1dbf924c6a05ba358ec39f5db5288f4b39a04cf9 "feat: chat::resend_msgs: Guarantee strictly increasing time in the Date header" so that re-sent messages can be deduplicated on the reciver side, but the deduplication logic doesn't depend on "Date" anymore.

Fix #7889 