### PR TITLE
refactor(ffi): Correctly declare dc_event_channel_new() as having no params (#7831)

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -6037,7 +6037,7 @@ char* dc_jsonrpc_blocking_call(dc_jsonrpc_instance_t* jsonrpc_instance, const ch
   * @memberof dc_event_channel_t
   * @return An event channel wrapper object (dc_event_channel_t).
   */
- dc_event_channel_t* dc_event_channel_new();
+ dc_event_channel_t* dc_event_channel_new(void);
  
  /**
   * Release/free the events channel structure.


### PR DESCRIPTION
In C, `foo()` means that the function accepts an unspecified number of arguments and this is deprecated.
Close #7831 