### PR TITLE
feat: advertise SEIPDv2 feature for new keys

### DIFF
--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -99,6 +99,7 @@ pub(crate) fn create_keypair(addr: EmailAddress) -> Result<KeyPair> {
         .key_type(signing_key_type)
         .can_certify(true)
         .can_sign(true)
+        .feature_seipd_v2(true)
         .primary_user_id(user_id)
         .passphrase(None)
         .preferred_symmetric_algorithms(smallvec![


### PR DESCRIPTION
SEIPDv2 is supported, but adding feature flag
to keys is not enabled by default in rPGP.

Closes #6673