### PR TITLE
refactor: do not chain Autocrypt key verification to parsing

### DIFF
--- a/src/aheader.rs
+++ b/src/aheader.rs
@@ -108,13 +108,11 @@ impl FromStr for Aheader {
             .remove("keydata")
             .context("keydata attribute is not found")
             .and_then(|raw| {
-                SignedPublicKey::from_base64(&raw).context("autocrypt key cannot be decoded")
-            })
-            .and_then(|key| {
-                key.verify_bindings()
-                    .and(Ok(key))
-                    .context("Autocrypt key cannot be verified")
+                SignedPublicKey::from_base64(&raw).context("Autocrypt key cannot be decoded")
             })?;
+        public_key
+            .verify_bindings()
+            .context("Autocrypt key cannot be verified")?;
 
         let prefer_encrypt = attributes
             .remove("prefer-encrypt")


### PR DESCRIPTION
.and_then() and Ok() are unnecessary here.