### PR TITLE
feat: Always download messages w/o Chat-Version header if contact isn't blocked

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -18,7 +18,6 @@ use async_channel::{self, Receiver, Sender};
 use async_imap::types::{Fetch, Flag, Name, NameAttribute, UnsolicitedResponse};
 use futures::{FutureExt as _, TryStreamExt};
 use futures_lite::FutureExt;
-use num_traits::FromPrimitive;
 use ratelimit::Ratelimit;
 use url::Url;
 
@@ -28,7 +27,7 @@ use crate::calls::{
 use crate::chat::{self, ChatId, ChatIdBlocked, add_device_msg};
 use crate::chatlist_events;
 use crate::config::Config;
-use crate::constants::{self, Blocked, DC_VERSION_STR, ShowEmails};
+use crate::constants::{self, Blocked, DC_VERSION_STR};
 use crate::contact::ContactId;
 use crate::context::Context;
 use crate::events::EventType;
@@ -2131,16 +2130,11 @@ pub(crate) async fn prefetch_should_download(
         false
     };
 
-    // Autocrypt Setup Message should be shown even if it is from non-chat client.
-    let is_autocrypt_setup_message = headers
-        .get_header_value(HeaderDef::AutocryptSetupMessage)
-        .is_some();
-
     let from = match mimeparser::get_from(headers) {
         Some(f) => f,
         None => return Ok(false),
     };
-    let (_from_id, blocked_contact, origin) =
+    let (_from_id, blocked_contact, _origin) =
         match from_field_to_contact_id(context, &from, None, true, true).await? {
             Some(res) => res,
             None => return Ok(false),
@@ -2153,28 +2147,7 @@ pub(crate) async fn prefetch_should_download(
         return Ok(false);
     }
 
-    let is_chat_message = headers.get_header_value(HeaderDef::ChatVersion).is_some();
-    let accepted_contact = origin.is_known();
-    let is_reply_to_chat_message = get_prefetch_parent_message(context, headers)
-        .await?
-        .is_some_and(|parent| match parent.is_dc_message {
-            MessengerMessage::No => false,
-            MessengerMessage::Yes | MessengerMessage::Reply => true,
-        });
-
-    let show_emails =
-        ShowEmails::from_i32(context.get_config_int(Config::ShowEmails).await?).unwrap_or_default();
-
-    let show = is_autocrypt_setup_message
-        || match show_emails {
-            ShowEmails::Off => is_chat_message || is_reply_to_chat_message,
-            ShowEmails::AcceptedContacts => {
-                is_chat_message || is_reply_to_chat_message || accepted_contact
-            }
-            ShowEmails::All => true,
-        };
-
-    let should_download = (show && !blocked_contact) || maybe_ndn;
+    let should_download = !blocked_contact || maybe_ndn;
     Ok(should_download)
 }
 


### PR DESCRIPTION
This allows to remove the Chat-Version header earlier in future releases.