### PR TITLE
feat(tls): do not verify TLS certificates for hostnames starting with `_`

### DIFF
--- a/src/net/tls.rs
+++ b/src/net/tls.rs
@@ -10,6 +10,9 @@ use crate::net::session::SessionStream;
 use tokio_rustls::rustls;
 use tokio_rustls::rustls::client::ClientSessionStore;
 
+mod danger;
+use danger::NoCertificateVerification;
+
 pub async fn wrap_tls<'a>(
     strict_tls: bool,
     hostname: &str,
@@ -123,6 +126,18 @@ pub async fn wrap_rustls<'a>(
         .tls12_resumption(rustls::client::Tls12Resumption::Disabled);
     config.resumption = resumption;
     config.enable_sni = use_sni;
+
+    // Do not verify certificates for hostnames starting with `_`.
+    // They are used for servers with self-signed certificates, e.g. for local testing.
+    // Hostnames starting with `_` can have only self-signed TLS certificates or wildcard certificates.
+    // It is not possible to get valid non-wildcard TLS certificates because CA/Browser Forum requirements
+    // explicitly state that domains should start with a letter, digit or hyphen:
+    // https://github.com/cabforum/servercert/blob/24f38fd4765e019db8bb1a8c56bf63c7115ce0b0/docs/BR.md
+    if hostname.starts_with("_") {
+        config
+            .dangerous()
+            .set_certificate_verifier(Arc::new(NoCertificateVerification::new()));
+    }
 
     let tls = tokio_rustls::TlsConnector::from(Arc::new(config));
     let name = tokio_rustls::rustls::pki_types::ServerName::try_from(hostname)?.to_owned();

--- a/src/net/tls/danger.rs
+++ b/src/net/tls/danger.rs
@@ -1,0 +1,55 @@
+//! Dangerous TLS implementation of accepting invalid certificates for Rustls.
+
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use tokio_rustls::rustls;
+
+#[derive(Debug)]
+pub(super) struct NoCertificateVerification();
+
+impl NoCertificateVerification {
+    pub(super) fn new() -> Self {
+        Self()
+    }
+}
+
+impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        let provider = rustls::crypto::ring::default_provider();
+        let supported_schemes = &provider.signature_verification_algorithms;
+        rustls::crypto::verify_tls12_signature(message, cert, dss, supported_schemes)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        let provider = rustls::crypto::ring::default_provider();
+        let supported_schemes = &provider.signature_verification_algorithms;
+        rustls::crypto::verify_tls13_signature(message, cert, dss, supported_schemes)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        let provider = rustls::crypto::ring::default_provider();
+        provider
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}


### PR DESCRIPTION
This is for running tests against LXC containers set up with https://github.com/chatmail/relay/pull/884

Once this is merged we can do more interesting things with TLS like fingerprint pinning and #7996
This is also a base for #7926