### PR TITLE
test: Fix flaky test_qr_securejoin_broadcast

### DIFF
--- a/deltachat-rpc-client/tests/test_securejoin.py
+++ b/deltachat-rpc-client/tests/test_securejoin.py
@@ -150,7 +150,7 @@ def test_qr_securejoin_broadcast(acfactory, all_devices_online):
         assert snapshot1.chat_id == chat.id
         assert snapshot2.chat_id == chat.id
 
-    def check_account(ac, contact, inviter_side, please_wait_info_msg=False, resent_msg=False):
+    def check_account(ac, contact, inviter_side, please_wait_info_msg=False):
         # Check that the chat partner is verified.
         contact_snapshot = contact.get_snapshot()
         assert contact_snapshot.is_verified
@@ -172,8 +172,11 @@ def test_qr_securejoin_broadcast(acfactory, all_devices_online):
             assert member_added_msg.text == f"Member {contact_snapshot.display_name} added."
             assert member_added_msg.info_contact_id == contact_snapshot.id
         else:
-            member_added_msg = chat_msgs.pop(1 if resent_msg else 0).get_snapshot()
-            assert member_added_msg.text == "You joined the channel."
+            if chat_msgs[0].get_snapshot().text == "You joined the channel.":
+                member_added_msg = chat_msgs.pop(0).get_snapshot()
+            else:
+                member_added_msg = chat_msgs.pop(1).get_snapshot()
+                assert member_added_msg.text == "You joined the channel."
         assert member_added_msg.is_info
 
         hello_msg = chat_msgs.pop(0).get_snapshot()
@@ -243,7 +246,7 @@ def test_qr_securejoin_broadcast(acfactory, all_devices_online):
     snapshot = fiona.wait_for_incoming_msg().get_snapshot()
     assert snapshot.text == "Hello everyone!"
 
-    check_account(fiona, fiona.create_contact(alice), inviter_side=False, please_wait_info_msg=True, resent_msg=True)
+    check_account(fiona, fiona.create_contact(alice), inviter_side=False, please_wait_info_msg=True)
 
     # For Bob, the channel must not have changed:
     check_account(bob, bob.create_contact(alice), inviter_side=False, please_wait_info_msg=True)


### PR DESCRIPTION
I assume that the problem is that sometimes, alice2 or fiona doesn't accept alice's smeared timestamp, because `calc_sort_timestamp()` doesn't allow the timestamp of a received message to be in the future. I tried this patch:

```diff
diff --cc src/chat.rs
index 9565437cf,9565437cf..a2e4f97d0
--- a/src/chat.rs
+++ b/src/chat.rs
@@@ -46,6 -46,6 +46,7 @@@ use crate::receive_imf::ReceivedMsg
  use crate::smtp::{self, send_msg_to_smtp};
  use crate::stock_str;
  use crate::sync::{self, Sync::*, SyncData};
++use crate::timesmearing::MAX_SECONDS_TO_LEND_FROM_FUTURE;
  use crate::tools::{
      IsNoneOrEmpty, SystemTime, buf_compress, create_broadcast_secret, create_id,
      create_outgoing_rfc724_mid, create_smeared_timestamp, create_smeared_timestamps, get_abs_path,
@@@ -1212,7 -1212,7 +1213,11 @@@ SELECT id, rfc724_mid, pre_rfc724_mid, 
          received: bool,
          incoming: bool,
      ) -> Result<i64> {
--        let mut sort_timestamp = cmp::min(message_timestamp, smeared_time(context));
++        let mut sort_timestamp = cmp::min(
++            message_timestamp,
++            // Add MAX_SECONDS_TO_LEND_FROM_FUTURE in order to allow other senders to do timesmearing, too:
++            smeared_time(context) + MAX_SECONDS_TO_LEND_FROM_FUTURE,
++        );
  
          let last_msg_time: Option<i64> = if always_sort_to_bottom {
              // get newest message for this chat
```

...maybe this patch makes sense anyways, but you still get the problem that the message sent by alice2 (i.e. the add-fiona message) will have an earlier timestamp than the message sent by alice, because alice already sent more messages, and therefore has more timesmearing-seconds.

Since all this timesmearing is a bit best-effort right now, I decided to instead just make the test more relaxed.