### PR TITLE
fix: Set proper placeholder texts for system messages

### DIFF
--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3716,7 +3716,7 @@ async fn test_leave_broadcast_multidevice() -> Result<()> {
 
     let leave_msg = bob0.pop_sent_msg().await;
     let parsed = MimeMessage::from_bytes(bob1, leave_msg.payload().as_bytes()).await?;
-    assert_eq!(parsed.parts[0].msg, "I left the group.");
+    assert_eq!(parsed.parts[0].msg, "bob@example.net left the group.");
 
     let rcvd = bob1.recv_msg(&leave_msg).await;
 
@@ -3783,7 +3783,7 @@ async fn test_only_broadcast_owner_can_send_1() -> Result<()> {
         "Bob receives an answer, but shows it in 1:1 chat because of a fingerprint mismatch",
     );
     let rcvd = bob.recv_msg(&member_added).await;
-    assert_eq!(rcvd.text, "I added member bob@example.net.");
+    assert_eq!(rcvd.text, "Member bob@example.net was added.");
 
     let bob_alice_chat_id = bob.get_chat(alice).await.id;
     assert_eq!(rcvd.chat_id, bob_alice_chat_id);

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1409,9 +1409,9 @@ impl MimeFactory {
                             .await?
                             .unwrap_or_default()
                     {
-                        placeholdertext = Some("I left the group.".to_string());
+                        placeholdertext = Some(format!("{email_to_remove} left the group."));
                     } else {
-                        placeholdertext = Some(format!("I removed member {email_to_remove}."));
+                        placeholdertext = Some(format!("Member {email_to_remove} was removed."));
                     };
 
                     if !email_to_remove.is_empty() {
@@ -1434,7 +1434,7 @@ impl MimeFactory {
                     let email_to_add = msg.param.get(Param::Arg).unwrap_or_default();
                     let fingerprint_to_add = msg.param.get(Param::Arg4).unwrap_or_default();
 
-                    placeholdertext = Some(format!("I added member {email_to_add}."));
+                    placeholdertext = Some(format!("Member {email_to_add} was added."));
 
                     if !email_to_add.is_empty() {
                         headers.push((
@@ -1459,6 +1459,7 @@ impl MimeFactory {
                     }
                 }
                 SystemMessage::GroupNameChanged => {
+                    placeholdertext = Some("Group name changed.".to_string());
                     let old_name = msg.param.get(Param::Arg).unwrap_or_default().to_string();
                     headers.push((
                         "Chat-Group-Name-Changed",
@@ -1475,6 +1476,7 @@ impl MimeFactory {
                     ));
                 }
                 SystemMessage::GroupImageChanged => {
+                    placeholdertext = Some("Group image changed.".to_string());
                     headers.push((
                         "Chat-Content",
                         mail_builder::headers::text::Text::new("group-avatar-changed").into(),
@@ -1486,7 +1488,24 @@ impl MimeFactory {
                         ));
                     }
                 }
-                _ => {}
+                SystemMessage::Unknown => {}
+                SystemMessage::AutocryptSetupMessage => {}
+                SystemMessage::SecurejoinMessage => {}
+                SystemMessage::LocationStreamingEnabled => {}
+                SystemMessage::LocationOnly => {}
+                SystemMessage::EphemeralTimerChanged => {}
+                SystemMessage::ChatProtectionEnabled => {}
+                SystemMessage::ChatProtectionDisabled => {}
+                SystemMessage::InvalidUnencryptedMail => {}
+                SystemMessage::SecurejoinWait => {}
+                SystemMessage::SecurejoinWaitTimeout => {}
+                SystemMessage::MultiDeviceSync => {}
+                SystemMessage::WebxdcStatusUpdate => {}
+                SystemMessage::WebxdcInfoMessage => {}
+                SystemMessage::IrohNodeAddr => {}
+                SystemMessage::ChatE2ee => {}
+                SystemMessage::CallAccepted => {}
+                SystemMessage::CallEnded => {}
             }
 
             if command == SystemMessage::GroupDescriptionChanged


### PR DESCRIPTION
Don't use first-person form in placeholder texts,
as these can be misleading when broadcasted to group.
Additionally ensures that broadcasted system messages
are not localized to not leak locally-set language 
to the group chat.

Fixes #7930