### PR TITLE
fix: Correct channel system messages

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -7579,6 +7579,19 @@ void dc_event_unref(dc_event_t* event);
 /// `%1$s` and `%2$s` will both be replaced by the name of the inviter.
 #define DC_STR_SECURE_JOIN_CHANNEL_STARTED 203
 
+/// "Channel name changed from %1$s to %2$s."
+///
+/// Used in status messages.
+///
+/// `%1$s` will be replaced by the old channel name.
+/// `%2$s` will be replaced by the new channel name.
+#define DC_STR_CHANNEL_NAME_CHANGED 204
+
+/// "Channel image changed."
+///
+/// Used in status messages.
+#define DC_STR_CHANNEL_IMAGE_CHANGED 205
+
 /// "The attachment contains anonymous usage statistics, which help us improve Delta Chat. Thank you!"
 ///
 /// Used as the message body for statistics sent out.

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4322,8 +4322,11 @@ async fn rename_ex(
                 && sanitize_single_line(&chat.name) != new_name
             {
                 msg.viewtype = Viewtype::Text;
-                msg.text =
-                    stock_str::msg_grp_name(context, &chat.name, &new_name, ContactId::SELF).await;
+                msg.text = if chat.typ == Chattype::OutBroadcast {
+                    stock_str::msg_broadcast_name_changed(context, &chat.name, &new_name).await
+                } else {
+                    stock_str::msg_grp_name(context, &chat.name, &new_name, ContactId::SELF).await
+                };
                 msg.param.set_cmd(SystemMessage::GroupNameChanged);
                 if !chat.name.is_empty() {
                     msg.param.set(Param::Arg, &chat.name);
@@ -4384,7 +4387,11 @@ pub async fn set_chat_profile_image(
     if new_image.is_empty() {
         chat.param.remove(Param::ProfileImage);
         msg.param.remove(Param::Arg);
-        msg.text = stock_str::msg_grp_img_deleted(context, ContactId::SELF).await;
+        msg.text = if chat.typ == Chattype::OutBroadcast {
+            stock_str::msg_broadcast_img_changed(context).await
+        } else {
+            stock_str::msg_grp_img_deleted(context, ContactId::SELF).await
+        };
     } else {
         let mut image_blob = BlobObject::create_and_deduplicate(
             context,
@@ -4394,7 +4401,11 @@ pub async fn set_chat_profile_image(
         image_blob.recode_to_avatar_size(context).await?;
         chat.param.set(Param::ProfileImage, image_blob.as_name());
         msg.param.set(Param::Arg, image_blob.as_name());
-        msg.text = stock_str::msg_grp_img_changed(context, ContactId::SELF).await;
+        msg.text = if chat.typ == Chattype::OutBroadcast {
+            stock_str::msg_broadcast_img_changed(context).await
+        } else {
+            stock_str::msg_grp_img_changed(context, ContactId::SELF).await
+        };
     }
     chat.update_param(context).await?;
     if chat.is_promoted() {

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3114,7 +3114,7 @@ async fn test_broadcasts_name_and_avatar() -> Result<()> {
     assert_eq!(rcvd.get_info_type(), SystemMessage::GroupNameChanged);
     assert_eq!(
         rcvd.text,
-        r#"Group name changed from "My Channel" to "New Channel name" by Alice."#
+        r#"Channel name changed from "My Channel" to "New Channel name"."#
     );
     let bob_chat = Chat::load_from_db(bob, bob_chat.id).await?;
     assert_eq!(bob_chat.name, "New Channel name");
@@ -3131,7 +3131,7 @@ async fn test_broadcasts_name_and_avatar() -> Result<()> {
     let rcvd = bob.recv_msg(&sent).await;
     assert!(rcvd.get_override_sender_name().is_none());
     assert_eq!(rcvd.get_info_type(), SystemMessage::GroupImageChanged);
-    assert_eq!(rcvd.text, "Group image changed by Alice.");
+    assert_eq!(rcvd.text, "Channel image changed.");
     assert_eq!(rcvd.chat_id, bob_chat.id);
 
     let bob_chat = Chat::load_from_db(bob, bob_chat.id).await?;
@@ -3885,7 +3885,7 @@ async fn test_sync_broadcast_avatar_and_name() -> Result<()> {
     assert_eq!(rcvd.param.get_cmd(), SystemMessage::GroupNameChanged);
     assert_eq!(
         rcvd.text,
-        r#"You changed group name from "foo" to "New name"."#
+        r#"Channel name changed from "foo" to "New name"."#
     );
 
     let a2_broadcast_chat = Chat::load_from_db(alice2, a2_broadcast_id).await?;
@@ -3899,7 +3899,7 @@ async fn test_sync_broadcast_avatar_and_name() -> Result<()> {
     let rcvd = alice1.recv_msg(&sent).await;
     assert_eq!(rcvd.chat_id, a1_broadcast_id);
     assert_eq!(rcvd.param.get_cmd(), SystemMessage::GroupImageChanged);
-    assert_eq!(rcvd.text, "You changed the group image.");
+    assert_eq!(rcvd.text, "Channel image changed.");
 
     let a1_broadcast_chat = Chat::load_from_db(alice1, a1_broadcast_id).await?;
     let avatar = a1_broadcast_chat.get_profile_image(alice1).await?.unwrap();
@@ -4768,7 +4768,7 @@ async fn test_sync_name() -> Result<()> {
     assert_eq!(rcvd.to_id, ContactId::SELF);
     assert_eq!(
         rcvd.text,
-        "You changed group name from \"Channel\" to \"Broadcast channel 42\"."
+        "Channel name changed from \"Channel\" to \"Broadcast channel 42\"."
     );
     assert_eq!(rcvd.param.get_cmd(), SystemMessage::GroupNameChanged);
     let a1_broadcast_id = get_chat_id_by_grpid(alice1, &a0_broadcast_chat.grpid)

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1466,7 +1466,7 @@ impl MimeFactory {
                     }
                 }
                 SystemMessage::GroupNameChanged => {
-                    placeholdertext = Some("Group name changed.".to_string());
+                    placeholdertext = Some("Chat name changed.".to_string());
                     let old_name = msg.param.get(Param::Arg).unwrap_or_default().to_string();
                     headers.push((
                         "Chat-Group-Name-Changed",
@@ -1483,7 +1483,7 @@ impl MimeFactory {
                     ));
                 }
                 SystemMessage::GroupImageChanged => {
-                    placeholdertext = Some("Group image changed.".to_string());
+                    placeholdertext = Some("Chat image changed.".to_string());
                     headers.push((
                         "Chat-Content",
                         mail_builder::headers::text::Text::new("group-avatar-changed").into(),

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -3332,8 +3332,13 @@ async fn apply_chat_name_avatar_and_description_changes(
             .is_some()
         {
             let old_name = &sanitize_single_line(old_name);
-            better_msg
-                .get_or_insert(stock_str::msg_grp_name(context, old_name, grpname, from_id).await);
+            better_msg.get_or_insert(
+                if matches!(chat.typ, Chattype::InBroadcast | Chattype::OutBroadcast) {
+                    stock_str::msg_broadcast_name_changed(context, old_name, grpname).await
+                } else {
+                    stock_str::msg_grp_name(context, old_name, grpname, from_id).await
+                },
+            );
         }
     }
 
@@ -3390,10 +3395,18 @@ async fn apply_chat_name_avatar_and_description_changes(
     {
         // this is just an explicit message containing the group-avatar,
         // apart from that, the group-avatar is send along with various other messages
-        better_msg.get_or_insert(match avatar_action {
-            AvatarAction::Delete => stock_str::msg_grp_img_deleted(context, from_id).await,
-            AvatarAction::Change(_) => stock_str::msg_grp_img_changed(context, from_id).await,
-        });
+        better_msg.get_or_insert(
+            if matches!(chat.typ, Chattype::InBroadcast | Chattype::OutBroadcast) {
+                stock_str::msg_broadcast_img_changed(context).await
+            } else {
+                match avatar_action {
+                    AvatarAction::Delete => stock_str::msg_grp_img_deleted(context, from_id).await,
+                    AvatarAction::Change(_) => {
+                        stock_str::msg_grp_img_changed(context, from_id).await
+                    }
+                }
+            },
+        );
     }
 
     if let Some(avatar_action) = &mime_parser.group_avatar {

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -391,6 +391,12 @@ https://delta.chat/donate"))]
                              Waiting for the device of %2$s to reply…"))]
     SecureJoinBroadcastStarted = 203,
 
+    #[strum(props(fallback = "Channel name changed from \"%1$s\" to \"%2$s\"."))]
+    MsgBroadcastNameChanged = 204,
+
+    #[strum(props(fallback = "Channel image changed."))]
+    MsgBroadcastImgChanged = 205,
+
     #[strum(props(
         fallback = "The attachment contains anonymous usage statistics, which helps us improve Delta Chat. Thank you!"
     ))]
@@ -706,6 +712,19 @@ pub(crate) async fn secure_join_broadcast_started(
     } else {
         format!("secure_join_started: unknown contact {inviter_contact_id}")
     }
+}
+
+/// Stock string: `Channel name changed from "1%s" to "2$s".`
+pub(crate) async fn msg_broadcast_name_changed(context: &Context, from: &str, to: &str) -> String {
+    translated(context, StockMessage::MsgBroadcastNameChanged)
+        .await
+        .replace1(from)
+        .replace2(to)
+}
+
+/// Stock string `Channel image changed.`
+pub(crate) async fn msg_broadcast_img_changed(context: &Context) -> String {
+    translated(context, StockMessage::MsgBroadcastImgChanged).await
 }
 
 /// Stock string: `You reacted %1$s to "%2$s"` or `%1$s reacted %2$s to "%3$s"`.

--- a/test-data/golden/test_broadcast_joining_golden_alice
+++ b/test-data/golden/test_broadcast_joining_golden_alice
@@ -1,6 +1,6 @@
 OutBroadcast#Chat#1001: My Channel [1 member(s)] Icon: e9b6c7a78aa2e4f415644f55a553e73.png
 --------------------------------------------------------------------------------
 Msg#1001: info (Contact#Contact#Info): Messages are end-to-end encrypted. [NOTICED][INFO]
-Msg#1002🔒: Me (Contact#Contact#Self): You changed the group image. [INFO] √
+Msg#1002🔒: Me (Contact#Contact#Self): Channel image changed. [INFO] √
 Msg#1005🔒: Me (Contact#Contact#Self): Member bob@example.net added. [INFO] √
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Previously channels used the same system messages
as groups, which can be confusing.

Fixes #7951