### PR TITLE
test: Work around test_sync_broadcast_and_send_message flakiness

### DIFF
--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -4702,7 +4702,7 @@ async fn test_sync_broadcast_and_send_message() -> Result<()> {
     );
 
     // alice2's smeared clock may be behind alice's one, so "hi" from alice2 may appear before "You
-    // joined the channel." for bob. Work around this for now.
+    // joined the channel." for bob.
     SystemTime::shift(Duration::from_secs(1));
     tcm.section("Alice's second device sends a message to the channel");
     let sent_msg = alice2.send_text(a2_broadcast_id, "hi").await;


### PR DESCRIPTION
The test sometimes fails because of wrong message ordering for bob (https://github.com/chatmail/core/actions/runs/22780794012/job/66085797963):
```
     [...]
     Waiting for the device of alice@example.org to reply… [NOTICED][INFO]
    <Msg#2010🔒:  (Contact#Contact#2001): hi [FRESH]
     Msg#2008🔒:  (Contact#Contact#2001): You joined the channel. [FRESH][INFO]
    >Msg#2010🔒:  (Contact#Contact#2001): hi [FRESH]
     Msg#2011🔒:  (Contact#Contact#2001): Member Me removed by alice@example.org. [FRESH][INFO]
```

This adds `SystemTime::shift(Duration::from_secs(1))` as a workaround.