### PR TITLE
fix: use correct string for encryption info

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -7496,7 +7496,7 @@ void dc_event_unref(dc_event_t* event);
 
 /// "Messages are end-to-end encrypted."
 ///
-/// Used in info messages.
+/// Used in info-messages, UI may add smth. as "Tap to learn more."
 #define DC_STR_CHAT_PROTECTION_ENABLED 170
 
 /// "Others will only see this group after you sent a first message."
@@ -7629,6 +7629,11 @@ void dc_event_unref(dc_event_t* event);
 
 /// "Chat description changed by %1$s."
 #define DC_STR_GROUP_DESCRIPTION_CHANGED_BY_OTHER 241
+
+/// "Messages are end-to-end encrypted."
+///
+/// Used when creating text for the "Encryption Info" dialogs.
+#define DC_STR_MESSAGES_ARE_E2EE 242
 
 /**
  * @}

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -475,7 +475,7 @@ impl ChatId {
 
     /// Adds message "Messages are end-to-end encrypted".
     pub(crate) async fn add_e2ee_notice(self, context: &Context, timestamp: i64) -> Result<()> {
-        let text = stock_str::messages_e2e_encrypted(context).await;
+        let text = stock_str::messages_e2ee_info_msg(context).await;
         add_info_msg_with_cmd(
             context,
             self,
@@ -1157,7 +1157,7 @@ SELECT id, rfc724_mid, pre_rfc724_mid, timestamp, ?, 1 FROM msgs WHERE chat_id=?
             return Ok(stock_str::encr_none(context).await);
         }
 
-        let mut ret = stock_str::messages_e2e_encrypted(context).await + "\n";
+        let mut ret = stock_str::messages_are_e2ee(context).await + "\n";
 
         for &contact_id in get_chat_contacts(context, self)
             .await?

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1344,7 +1344,7 @@ WHERE addr=?
         let fingerprint_other = fingerprint_other.to_string();
 
         let stock_message = if contact.public_key(context).await?.is_some() {
-            stock_str::messages_e2e_encrypted(context).await
+            stock_str::messages_are_e2ee(context).await
         } else {
             stock_str::encr_none(context).await
         };

--- a/src/securejoin/securejoin_tests.rs
+++ b/src/securejoin/securejoin_tests.rs
@@ -12,7 +12,7 @@ use crate::key::self_fingerprint;
 use crate::mimeparser::{GossipedKey, SystemMessage};
 use crate::qr::Qr;
 use crate::receive_imf::receive_imf;
-use crate::stock_str::{self, messages_e2e_encrypted};
+use crate::stock_str::{self, messages_e2ee_info_msg};
 use crate::test_utils::{
     AVATAR_64x64_BYTES, AVATAR_64x64_DEDUPLICATED, TestContext, TestContextManager,
     TimeShiftFalsePositiveNote, get_chat_msg, sync,
@@ -109,7 +109,7 @@ async fn test_setup_contact_ex(case: SetupContactCase) {
     let mut i = 0..msg_cnt;
     let msg = get_chat_msg(&bob, bob_chat.get_id(), i.next().unwrap(), msg_cnt).await;
     assert!(msg.is_info());
-    assert_eq!(msg.get_text(), messages_e2e_encrypted(&bob).await);
+    assert_eq!(msg.get_text(), messages_e2ee_info_msg(&bob).await);
     let msg = get_chat_msg(&bob, bob_chat.get_id(), i.next().unwrap(), msg_cnt).await;
     assert!(msg.is_info());
     assert_eq!(msg.get_text(), stock_str::securejoin_wait(&bob).await);
@@ -250,7 +250,7 @@ async fn test_setup_contact_ex(case: SetupContactCase) {
         let chat = alice.get_chat(&bob).await;
         let msg = get_chat_msg(&alice, chat.get_id(), 0, 1).await;
         assert!(msg.is_info());
-        let expected_text = messages_e2e_encrypted(&alice).await;
+        let expected_text = messages_e2ee_info_msg(&alice).await;
         assert_eq!(msg.get_text(), expected_text);
     }
 
@@ -295,7 +295,7 @@ async fn test_setup_contact_ex(case: SetupContactCase) {
     // The `SecurejoinWait` info message has been removed, but the e2ee notice remains.
     let msg = get_chat_msg(&bob, bob_chat.get_id(), 0, 1).await;
     assert!(msg.is_info());
-    assert_eq!(msg.get_text(), messages_e2e_encrypted(&bob).await);
+    assert_eq!(msg.get_text(), messages_e2ee_info_msg(&bob).await);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -625,7 +625,7 @@ async fn test_secure_join_group_ex(v3: bool, remove_invite: bool) -> Result<()> 
         // - You added member bob@example.net
         let msg = get_chat_msg(&alice, alice_chatid, 0, 2).await;
         assert!(msg.is_info());
-        let expected_text = messages_e2e_encrypted(&alice).await;
+        let expected_text = messages_e2ee_info_msg(&alice).await;
         assert_eq!(msg.get_text(), expected_text);
     }
 

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -435,6 +435,9 @@ https://delta.chat/donate"))]
 
     #[strum(props(fallback = "Chat description changed by %1$s."))]
     MsgChatDescriptionChangedBy = 241,
+
+    #[strum(props(fallback = "Messages are end-to-end encrypted."))]
+    MessagesAreE2ee = 242,
 }
 
 impl StockMessage {
@@ -1068,9 +1071,14 @@ pub(crate) async fn error_no_network(context: &Context) -> String {
     translated(context, StockMessage::ErrorNoNetwork).await
 }
 
-/// Stock string: `Messages are end-to-end encrypted.`
-pub(crate) async fn messages_e2e_encrypted(context: &Context) -> String {
+/// Stock string: `Messages are end-to-end encrypted.`, used in info-messages, UI may add smth. as `Tap to learn more.`
+pub(crate) async fn messages_e2ee_info_msg(context: &Context) -> String {
     translated(context, StockMessage::ChatProtectionEnabled).await
+}
+
+/// Stock string: `Messages are end-to-end encrypted.`
+pub(crate) async fn messages_are_e2ee(context: &Context) -> String {
+    translated(context, StockMessage::MessagesAreE2ee).await
 }
 
 /// Stock string: `Reply`.

--- a/src/tests/verified_chats.rs
+++ b/src/tests/verified_chats.rs
@@ -195,7 +195,7 @@ async fn test_degrade_verified_oneonone_chat() -> Result<()> {
     .await?;
 
     let msg0 = get_chat_msg(&alice, alice_chat.id, 0, 1).await;
-    let enabled = stock_str::messages_e2e_encrypted(&alice).await;
+    let enabled = stock_str::messages_e2ee_info_msg(&alice).await;
     assert_eq!(msg0.text, enabled);
     assert_eq!(msg0.param.get_cmd(), SystemMessage::ChatE2ee);
 


### PR DESCRIPTION
encryption info needs a dedicated string for "Messages are end-to-end encrypted" as the UI will add more infomation to the info messages, smth. as "Tap for more information".

an alternative fix would have been to let the UI render the info-message differently, but adding another string to core causes less friction.

the issue was reported in the forum at https://support.delta.chat/t/encryption-info-link-doesnt-work-wrong-string-tap-to-learn-more/4879