### PR TITLE
feat!: fire `MsgRead` on subsequent MDNs

### DIFF
--- a/deltachat-jsonrpc/src/api/types/events.rs
+++ b/deltachat-jsonrpc/src/api/types/events.rs
@@ -192,8 +192,7 @@ pub enum EventType {
         msg_id: u32,
     },
 
-    /// A single message is read by the receiver. State changed from DC_STATE_OUT_DELIVERED to
-    /// DC_STATE_OUT_MDN_RCVD, see `Message.state`.
+    /// A single message is read by a receiver.
     #[serde(rename_all = "camelCase")]
     MsgRead {
         /// ID of the chat which the message belongs to.
@@ -201,6 +200,12 @@ pub enum EventType {
 
         /// ID of the message that was read.
         msg_id: u32,
+
+        /// Read for the first time (e.g. by just one group member
+        /// / channel subscriber).
+        /// State changed from DC_STATE_OUT_DELIVERED to
+        /// DC_STATE_OUT_MDN_RCVD, see dc_msg_get_state().
+        first_time: bool,
     },
 
     /// A single message was deleted.
@@ -540,9 +545,14 @@ impl From<CoreEventType> for EventType {
                 chat_id: chat_id.to_u32(),
                 msg_id: msg_id.to_u32(),
             },
-            CoreEventType::MsgRead { chat_id, msg_id } => MsgRead {
+            CoreEventType::MsgRead {
+                chat_id,
+                msg_id,
+                first_time,
+            } => MsgRead {
                 chat_id: chat_id.to_u32(),
                 msg_id: msg_id.to_u32(),
+                first_time,
             },
             CoreEventType::MsgDeleted { chat_id, msg_id } => MsgDeleted {
                 chat_id: chat_id.to_u32(),

--- a/src/events/payload.rs
+++ b/src/events/payload.rs
@@ -171,14 +171,19 @@ pub enum EventType {
         msg_id: MsgId,
     },
 
-    /// A single message is read by the receiver. State changed from DC_STATE_OUT_DELIVERED to
-    /// DC_STATE_OUT_MDN_RCVD, see dc_msg_get_state().
+    /// A single message is read by a receiver.
     MsgRead {
         /// ID of the chat which the message belongs to.
         chat_id: ChatId,
 
         /// ID of the message that was read.
         msg_id: MsgId,
+
+        /// Read for the first time (e.g. by just one group member
+        /// / channel subscriber).
+        /// State changed from DC_STATE_OUT_DELIVERED to
+        /// DC_STATE_OUT_MDN_RCVD, see dc_msg_get_state().
+        first_time: bool,
     },
 
     /// A single message was deleted.

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -2596,8 +2596,12 @@ async fn handle_mdn(
             (msg_id, from_id, timestamp_sent),
         )
         .await?;
+    context.emit_event(EventType::MsgRead {
+        chat_id,
+        msg_id,
+        first_time: !has_mdns,
+    });
     if !has_mdns {
-        context.emit_event(EventType::MsgRead { chat_id, msg_id });
         // note(treefit): only matters if it is the last message in chat (but probably too expensive to check, debounce also solves it)
         chatlist_events::emit_chatlist_item_changed(context, chat_id);
     }


### PR DESCRIPTION
BREAKING CHANGE: previously this event only fired
if message state really did just transition
from `DC_STATE_OUT_DELIVERED` to `DC_STATE_OUT_MDN_RCVD`.
Now this is only the case for `MsgRead` events
that have the newly added `first_time == true`.

Closes https://github.com/deltachat/deltachat-desktop/issues/5220.

This is also useful for channels
as it facilitates updating the post (message) read count live.

Despite the fact that it's a breaking change,
this should not be problematic in most cases
because clients mostly use this event as an "it's time to reload"
indicator.

There is a case in Delta Chat Desktop where an adjustment
will be needed:
https://github.com/deltachat/deltachat-desktop/blob/d1fbb309793934b3ca09ed5a0266b6c84e333dd0/packages/frontend/src/stores/messagelist.ts#L119-L123
It seems that the message state could later transition
to `DC_STATE_OUT_FAILED`, so we should not uncoditionally set it
to `DC_STATE_OUT_MDN_RCVD`.

On Android I have also searched for the usages of this event,
and it seems that, without adjustments on Android side,
this would only cause excessive reloading:
- https://github.com/deltachat/deltachat-android/blob/1894425ad2726fd21dde5275f5b137e6f3fb1499/src/main/java/org/thoughtcrime/securesms/search/SearchFragment.java#L212-L216
- https://github.com/deltachat/deltachat-android/blob/1894425ad2726fd21dde5275f5b137e6f3fb1499/src/main/java/org/thoughtcrime/securesms/ConversationListFragment.java#L364-L366
- https://github.com/deltachat/deltachat-android/blob/1894425ad2726fd21dde5275f5b137e6f3fb1499/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java#L1156-L1160

It might also fix what seems to be a bug with "seen recently",
which on release Core doesn't get updated if the message
is already read:
https://github.com/deltachat/deltachat-android/blob/1894425ad2726fd21dde5275f5b137e6f3fb1499/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java#L1672-L1676

TODO:
- [ ] Check whether iOS client is fine with this change
- [ ] Double-check if Android client is fine with this change
- [ ] Note that this does not expose `first_time` in CFFI. I guess we could, but only in `dc_event_get_data2_str`. Would Android like that?

And alternative is to introduce another event, `MsgReadV2`. If the fact that this change is breaking is icky to you, let me know and I'll do that. It's easy.