### PR TITLE
Safer accounts.toml updates

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -699,6 +699,14 @@ impl Config {
         fs::rename(&tmp_path, &self.file)
             .await
             .context("failed to rename config")?;
+        // Sync the rename().
+        #[cfg(not(windows))]
+        {
+            let parent = self.file.parent().context("No parent directory")?;
+            let parent_file = fs::File::open(parent).await?;
+            parent_file.sync_all().await?;
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
It is not clear what the problem with Ubuntu Touch was that caused this, but the changes make accounts.toml sync safer in any case. There are other operating systems and possibly incorrect fdatasync() implementations, it is safer to just always use fsync(). This PR also syncs the rename().

-----
There was a report that on Ubuntu Touch with `fscrypt`-encrypted filesystem, accounts.toml turned into a file with random contents.

Reading on `fscrypt`, it says each file has its own "nonce" which protects the file:
https://www.kernel.org/doc/html/v6.19/filesystems/fscrypt.html#per-file-encryption-keys
It is not clear if nonce is part of the "metadata" synced with fsync on the file handle. Also this does not explain why filename did not get corrupted, but only the bytes. Filenames in fscrypt are kind of special because they are also part of the directory, so it is still possible that it is fscrypt problem: https://www.kernel.org/doc/html/v6.19/filesystems/fscrypt.html#filenames-encryption

UBPorts documentation for fscrypt is at https://docs.ubports.com/en/latest/porting/configure_test_fix/Fscrypt.html

It could be that contents was corrupted because of use-after-free that is fixed with https://github.com/chatmail/core/pull/7962
Account manager got freed and its memory was reused.

The file though looks entirely random. Does not have zero bytes, one 0xff, one 0x01, three 0x02, two 0x03, ..., two 0xd7, one 0xd8,  two 0xd9 etc.