### PR TITLE
feat: decode `dcaccount://` URLs and error out on empty URLs early

### DIFF
--- a/src/qr.rs
+++ b/src/qr.rs
@@ -682,6 +682,12 @@ fn decode_account(qr: &str) -> Result<Qr> {
     let payload = qr
         .get(DCACCOUNT_SCHEME.len()..)
         .context("Invalid DCACCOUNT payload")?;
+
+    // Handle `dcaccount://...` URLs.
+    let payload = payload.strip_prefix("//").unwrap_or(payload);
+    if payload.is_empty() {
+        bail!("dcaccount payload is empty");
+    }
     if payload.starts_with("https://") {
         let url = url::Url::parse(payload).context("Invalid account URL")?;
         if url.scheme() == "https" {
@@ -695,6 +701,12 @@ fn decode_account(qr: &str) -> Result<Qr> {
             bail!("Bad scheme for account URL: {:?}.", url.scheme());
         }
     } else {
+        if payload.starts_with("/") {
+            // Handle `dcaccount:///` URL reported to have been created
+            // by Telegram link parser at
+            // <https://support.delta.chat/t/could-not-find-dns-resolutions-for-imap-993-when-adding-a-relay/4907>
+            bail!("Hostname in dcaccount URL cannot start with /");
+        }
         Ok(Qr::Account {
             domain: payload.to_string(),
         })

--- a/src/qr/qr_tests.rs
+++ b/src/qr/qr_tests.rs
@@ -721,7 +721,9 @@ async fn test_decode_account() -> Result<()> {
 
     for text in [
         "DCACCOUNT:example.org",
+        "DCACCOUNT://example.org",
         "dcaccount:example.org",
+        "dcaccount://example.org",
         "DCACCOUNT:https://example.org/new_email?t=1w_7wDjgjelxeX884x96v3",
         "dcaccount:https://example.org/new_email?t=1w_7wDjgjelxeX884x96v3",
     ] {
@@ -732,6 +734,21 @@ async fn test_decode_account() -> Result<()> {
                 domain: "example.org".to_string()
             }
         );
+    }
+
+    Ok(())
+}
+
+/// Tests that decoding empty `dcaccount://` URL results in an error.
+/// We should not suggest trying to configure an account in this case.
+/// Such links may be created by copy-paste error or because of incorrect parsing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_decode_empty_account() -> Result<()> {
+    let ctx = TestContext::new().await;
+
+    for text in ["DCACCOUNT:", "dcaccount:", "dcaccount://", "dcaccount:///"] {
+        let qr = check_qr(&ctx.ctx, text).await;
+        assert!(qr.is_err(), "Invalid {text:?} is parsed as dcaccount URL");
     }
 
     Ok(())


### PR DESCRIPTION
The problem was reported at
<https://support.delta.chat/t/could-not-find-dns-resolutions-for-imap-993-when-adding-a-relay/4907>

iOS typically transforms `:` into `://`,
we already handle this in `dclogin` URLs,
so handle it for `dcaccount` as well.