### PR TITLE
feat: enable anonymous OpenPGP key IDs

### DIFF
--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -40,7 +40,6 @@ impl EncryptHelper {
         keyring: Vec<SignedPublicKey>,
         mail_to_encrypt: MimePart<'static>,
         compress: bool,
-        anonymous_recipients: bool,
         seipd_version: SeipdVersion,
     ) -> Result<String> {
         let sign_key = load_self_secret_key(context).await?;
@@ -49,15 +48,8 @@ impl EncryptHelper {
         let cursor = Cursor::new(&mut raw_message);
         mail_to_encrypt.clone().write_part(cursor).ok();
 
-        let ctext = pgp::pk_encrypt(
-            raw_message,
-            keyring,
-            sign_key,
-            compress,
-            anonymous_recipients,
-            seipd_version,
-        )
-        .await?;
+        let ctext =
+            pgp::pk_encrypt(raw_message, keyring, sign_key, compress, seipd_version).await?;
 
         Ok(ctext)
     }

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1163,17 +1163,6 @@ impl MimeFactory {
                 _ => None,
             };
 
-            // Do not anonymize OpenPGP recipients.
-            //
-            // This is disabled to avoid interoperability problems
-            // with old core versions <1.160.0 that do not support
-            // receiving messages with wildcard Key IDs:
-            // <https://github.com/chatmail/core/issues/7378>
-            //
-            // The option should be changed to true
-            // once new core versions are sufficiently deployed.
-            let anonymous_recipients = false;
-
             if context.get_config_bool(Config::TestHooks).await?
                 && let Some(hook) = &*context.pre_encrypt_mime_hook.lock()
             {
@@ -1211,7 +1200,6 @@ impl MimeFactory {
                         encryption_keyring,
                         message,
                         compress,
-                        anonymous_recipients,
                         seipd_version,
                     )
                     .await?

--- a/src/pgp.rs
+++ b/src/pgp.rs
@@ -151,7 +151,6 @@ pub async fn pk_encrypt(
     public_keys_for_encryption: Vec<SignedPublicKey>,
     private_key_for_signing: SignedSecretKey,
     compress: bool,
-    anonymous_recipients: bool,
     seipd_version: SeipdVersion,
 ) -> Result<String> {
     Handle::current()
@@ -198,11 +197,7 @@ pub async fn pk_encrypt(
                     let mut msg = msg.seipd_v1(&mut rng, SYMMETRIC_KEY_ALGORITHM);
 
                     for pkey in pkeys {
-                        if anonymous_recipients {
-                            msg.encrypt_to_key_anonymous(&mut rng, &pkey)?;
-                        } else {
-                            msg.encrypt_to_key(&mut rng, &pkey)?;
-                        }
+                        msg.encrypt_to_key_anonymous(&mut rng, &pkey)?;
                     }
 
                     let hash_algorithm = private_key_for_signing.hash_alg();
@@ -227,11 +222,7 @@ pub async fn pk_encrypt(
                     );
 
                     for pkey in pkeys {
-                        if anonymous_recipients {
-                            msg.encrypt_to_key_anonymous(&mut rng, &pkey)?;
-                        } else {
-                            msg.encrypt_to_key(&mut rng, &pkey)?;
-                        }
+                        msg.encrypt_to_key_anonymous(&mut rng, &pkey)?;
                     }
 
                     let hash_algorithm = private_key_for_signing.hash_alg();
@@ -707,7 +698,6 @@ mod tests {
 
     /// A ciphertext encrypted to Alice & Bob, signed by Alice.
     async fn ctext_signed() -> &'static String {
-        let anonymous_recipients = true;
         CTEXT_SIGNED
             .get_or_init(|| async {
                 let keyring = vec![KEYS.alice_public.clone(), KEYS.bob_public.clone()];
@@ -718,7 +708,6 @@ mod tests {
                     keyring,
                     KEYS.alice_secret.clone(),
                     compress,
-                    anonymous_recipients,
                     SeipdVersion::V2,
                 )
                 .await
@@ -905,12 +894,12 @@ mod tests {
         let pk_for_encryption = load_self_public_key(alice).await?;
 
         // Encrypt a message, but only to self, not to Bob:
+        let compress = true;
         let ctext = pk_encrypt(
             plain,
             vec![pk_for_encryption],
             KEYS.alice_secret.clone(),
-            true,
-            true,
+            compress,
             SeipdVersion::V2,
         )
         .await?;

--- a/src/reaction.rs
+++ b/src/reaction.rs
@@ -1031,13 +1031,11 @@ Content-Transfer-Encoding: base64\r
         let alice_secret_key = load_self_secret_key(alice).await?;
         let public_keys_for_encryption = vec![alice_public_key, bob_public_key];
         let compress = true;
-        let anonymous_recipients = true;
         let encrypted_payload = pk_encrypt(
             plain_text.as_bytes().to_vec(),
             public_keys_for_encryption,
             alice_secret_key,
             compress,
-            anonymous_recipients,
             SeipdVersion::V2,
         )
         .await?;


### PR DESCRIPTION
This was disabled for interoperability in
098084b9a717e0cad8256bdd317055fb32ec2b2d,
enabling it back now.

Closes https://github.com/chatmail/core/issues/7384