### PR TITLE
fix(deltachat_rpc_client): make sphinx documentation display method parameters

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/_utils.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/_utils.py
@@ -187,13 +187,9 @@ class futuremethod:  # noqa: N801
     """Decorator for async methods."""
 
     def __init__(self, func):
-        functools.update_wrapper(self, func)
         self._func = func
 
     def __get__(self, instance, owner=None):
-        if instance is None:
-            return self
-
         def future(*args):
             generator = self._func(instance, *args)
             res = next(generator)
@@ -206,6 +202,7 @@ class futuremethod:  # noqa: N801
 
             return f
 
+        @functools.wraps(self._func)
         def wrapper(*args):
             f = future(*args)
             return f()


### PR DESCRIPTION
This is a follow-up to #7982 

Before:
<img width="446" height="192" alt="image" src="https://github.com/user-attachments/assets/d7d5f0f3-bf2d-496e-9633-d8377008f0bb" />

After:
<img width="464" height="203" alt="image" src="https://github.com/user-attachments/assets/9905ae84-8a62-4c9f-ae42-e94e8bfaf41a" />
