### PR TITLE
fix: Make pre-messages w/o text  want MDNs (#8004)

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1879,9 +1879,10 @@ pub async fn markseen_msgs(context: &Context, msg_ids: Vec<MsgId>) -> Result<()>
             //
             // We also don't send read receipts for contact requests.
             // Read receipts will not be sent even after accepting the chat.
+            let wants_mdn = curr_param.get_bool(Param::WantsMdn).unwrap_or_default();
             let to_id = if curr_blocked == Blocked::Not
                 && !curr_hidden
-                && curr_param.get_bool(Param::WantsMdn).unwrap_or_default()
+                && wants_mdn
                 && curr_param.get_cmd() == SystemMessage::Unknown
                 && context.should_send_mdns().await?
             {
@@ -1903,6 +1904,11 @@ pub async fn markseen_msgs(context: &Context, msg_ids: Vec<MsgId>) -> Result<()>
                 None
             };
             if let Some(to_id) = to_id {
+                info!(
+                    context,
+                    "Queuing MDN to {to_id} for {id} from {curr_from_id}, wants_mdn={wants_mdn}, cmd={}.",
+                    curr_param.get_cmd()
+                );
                 context
                     .sql
                     .execute(

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -922,14 +922,16 @@ impl MimeMessage {
         self.parse_attachments();
 
         // See if an MDN is requested from the other side
+        let mut wants_mdn = false;
         if self.decryption_error.is_none()
-            && !self.parts.is_empty()
+            && (!self.parts.is_empty() || matches!(&self.pre_message, PreMessageMode::Pre { .. }))
             && let Some(ref dn_to) = self.chat_disposition_notification_to
         {
             // Check that the message is not outgoing.
             let from = &self.from.addr;
             if !context.is_self_addr(from).await? {
                 if from.to_lowercase() == dn_to.addr.to_lowercase() {
+                    wants_mdn = true;
                     if let Some(part) = self.parts.last_mut() {
                         part.param.set_int(Param::WantsMdn, 1);
                     }
@@ -951,7 +953,9 @@ impl MimeMessage {
                 typ: Viewtype::Text,
                 ..Default::default()
             };
-
+            if wants_mdn {
+                part.param.set_int(Param::WantsMdn, 1);
+            }
             if let Some(ref subject) = self.get_subject()
                 && !self.has_chat_version()
                 && self.webxdc_status_update.is_none()
@@ -2460,6 +2464,9 @@ async fn handle_mdn(
     let Some((msg_id, chat_id, has_mdns, is_dup)) = context
         .sql
         .query_row_optional(
+            // MDN on a pre-message (message preview) references the post-message. So we can't tell
+            // if the pre-message or fully downloaded message was seen, but this is on purpose. For
+            // images this problem is going to be solved by showing thumbnails.
             "SELECT
                 m.id AS msg_id,
                 c.id AS chat_id,

--- a/src/tests/pre_messages/receiving.rs
+++ b/src/tests/pre_messages/receiving.rs
@@ -262,6 +262,61 @@ async fn test_lost_pre_msg() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_pre_msg_mdn_before_sending_full() -> Result<()> {
+    pre_msg_mdn_before_sending_full("").await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_pre_msg_mdn_before_sending_full_with_text() -> Result<()> {
+    pre_msg_mdn_before_sending_full("text").await
+}
+
+async fn pre_msg_mdn_before_sending_full(text: &str) -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = &tcm.alice().await;
+    let bob = &tcm.bob().await;
+    let alice_chat_id = alice.create_group_with_members("", &[bob]).await;
+
+    let file_bytes = include_bytes!("../../../test-data/image/screenshot.gif");
+    let mut msg = Message::new(Viewtype::Image);
+    msg.set_file_from_bytes(alice, "a.jpg", file_bytes, None)?;
+    msg.set_text(text.to_string());
+    chat::send_msg(alice, alice_chat_id, &mut msg).await?;
+    let rev_order = false;
+    let pre_msg = alice.pop_sent_msg_ex(rev_order).await.unwrap();
+    let alice_msg_id = msg.id;
+
+    let msg = bob.recv_msg(&pre_msg).await;
+    assert_eq!(msg.download_state, DownloadState::Available);
+    assert_eq!(msg.id.get_state(bob).await?, MessageState::InFresh);
+    assert_eq!(msg.text, text);
+    assert!(msg.param.get_bool(Param::WantsMdn).unwrap_or_default());
+    msg.chat_id.accept(bob).await?;
+    markseen_msgs(bob, vec![msg.id]).await?;
+    assert_eq!(msg.id.get_state(bob).await?, MessageState::InSeen);
+    assert_eq!(
+        bob.sql
+            .count(
+                "SELECT COUNT(*) FROM smtp_mdns WHERE from_id=?",
+                (msg.from_id,)
+            )
+            .await?,
+        1
+    );
+    assert_eq!(
+        alice_msg_id.get_state(alice).await?,
+        MessageState::OutPending
+    );
+
+    let _full_msg = alice.pop_sent_msg().await;
+    assert_eq!(
+        alice_msg_id.get_state(alice).await?,
+        MessageState::OutDelivered
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_post_msg_bad_sender() -> Result<()> {
     let mut tcm = TestContextManager::new();
     let alice = &tcm.alice().await;
@@ -743,7 +798,10 @@ async fn test_markseen_pre_msg() -> Result<()> {
     assert_eq!(
         alice
             .sql
-            .count("SELECT COUNT(*) FROM smtp_mdns", ())
+            .count(
+                "SELECT COUNT(*) FROM smtp_mdns WHERE from_id=?",
+                (msg.from_id,)
+            )
             .await?,
         1
     );


### PR DESCRIPTION
This fixes #8004 . Maybe it's even good that MDNs will
    be sent for pre-messages only having placeholder text with the viewtype and size, at least this way
    we notify the contact that we've noticed the message. Anyway, with adding message previews the
    problem will be solved for the corresponding viewtypes.