### PR TITLE
api: Rename Transport to TransportListEntry

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -68,7 +68,7 @@ use self::types::{
     },
 };
 use crate::api::types::chat_list::{get_chat_list_item_by_id, ChatListItemFetchResult};
-use crate::api::types::login_param::Transport;
+use crate::api::types::login_param::TransportListEntry;
 use crate::api::types::qr::{QrObject, SecurejoinSource, SecurejoinUiPath};
 
 #[derive(Debug)]
@@ -571,7 +571,7 @@ impl CommandApi {
     /// Returns the list of all email accounts that are used as a transport in the current profile.
     /// Use [Self::add_or_update_transport()] to add or change a transport
     /// and [Self::delete_transport()] to delete a transport.
-    async fn list_transports_ex(&self, account_id: u32) -> Result<Vec<Transport>> {
+    async fn list_transports_ex(&self, account_id: u32) -> Result<Vec<TransportListEntry>> {
         let ctx = self.get_context(account_id).await?;
         let res = ctx
             .list_transports()

--- a/deltachat-jsonrpc/src/api/types/login_param.rs
+++ b/deltachat-jsonrpc/src/api/types/login_param.rs
@@ -6,7 +6,7 @@ use yerpc::TypeDef;
 
 #[derive(Serialize, TypeDef, schemars::JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct Transport {
+pub struct TransportListEntry {
     /// The login data entered by the user.
     pub param: EnteredLoginParam,
     /// Whether this transport is set to 'unpublished'.
@@ -66,9 +66,9 @@ pub struct EnteredLoginParam {
     pub oauth2: Option<bool>,
 }
 
-impl From<dc::Transport> for Transport {
-    fn from(transport: dc::Transport) -> Self {
-        Transport {
+impl From<dc::TransportListEntry> for TransportListEntry {
+    fn from(transport: dc::TransportListEntry) -> Self {
+        TransportListEntry {
             param: transport.param.into(),
             is_unpublished: transport.is_unpublished,
         }

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -29,7 +29,7 @@ use crate::context::Context;
 use crate::imap::Imap;
 use crate::log::warn;
 pub use crate::login_param::EnteredLoginParam;
-use crate::login_param::{EnteredCertificateChecks, Transport};
+use crate::login_param::{EnteredCertificateChecks, TransportListEntry};
 use crate::message::Message;
 use crate::net::proxy::ProxyConfig;
 use crate::oauth2::get_oauth2_addr;
@@ -189,7 +189,7 @@ impl Context {
     /// Returns the list of all email accounts that are used as a transport in the current profile.
     /// Use [Self::add_or_update_transport()] to add or change a transport
     /// and [Self::delete_transport()] to delete a transport.
-    pub async fn list_transports(&self) -> Result<Vec<Transport>> {
+    pub async fn list_transports(&self) -> Result<Vec<TransportListEntry>> {
         let transports = self
             .sql
             .query_map_vec(
@@ -199,7 +199,7 @@ impl Context {
                     let param: String = row.get(0)?;
                     let param: EnteredLoginParam = serde_json::from_str(&param)?;
                     let is_published: bool = row.get(1)?;
-                    Ok(Transport {
+                    Ok(TransportListEntry {
                         param,
                         is_unpublished: !is_published,
                     })

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -81,7 +81,7 @@ pub struct EnteredServerLoginParam {
 
 /// A transport, as shown in the "relays" list in the UI.
 #[derive(Debug)]
-pub struct Transport {
+pub struct TransportListEntry {
     /// The login data entered by the user.
     pub param: EnteredLoginParam,
     /// Whether this transport is set to 'unpublished'.


### PR DESCRIPTION
Follow-up to https://github.com/chatmail/core/pull/7994/, in order to prevent clashes with other things that are called `Transport`, and in order to make this more greppable