### PR TITLE
fix: Make newlines work in chat descriptions

### DIFF
--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3335,7 +3335,12 @@ async fn test_chat_description(
         initial_description
     );
 
-    for description in ["This is a cool chat", "", "ä ẟ 😂"] {
+    for description in [
+        &"This<>is 'a' \"cool\" chat:/\\|?*".repeat(50),
+        "multiple\nline\n\nbreaks\n\n\r\n.",
+        "",
+        "ä ẟ 😂",
+    ] {
         tcm.section(&format!(
             "Alice sets the chat description to '{description}'"
         ));

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1525,7 +1525,7 @@ impl MimeFactory {
                 let description = chat::get_chat_description(context, chat.id).await?;
                 headers.push((
                     "Chat-Group-Description",
-                    mail_builder::headers::text::Text::new(description.clone()).into(),
+                    mail_builder::headers::raw::Raw::new(b_encode(&description)).into(),
                 ));
                 if let Some(ts) = chat.param.get_i64(Param::GroupDescriptionTimestamp) {
                     headers.push((


### PR DESCRIPTION
This fixes a bug: If there is a multi-line chat description, only the first line was shown on recipient devices.

Credits to @lk108 for noticing!