### PR TITLE
chore: add RUSTSEC-2026-0049 exception to deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,13 @@ ignore = [
     # It is a transitive dependency of iroh 0.35.0,
     # this should be fixed by upgrading to iroh 1.0 once it is released.
     "RUSTSEC-2025-0134",
+
+    # rustls-webpki v0.102.8
+    # We cannot upgrade to >=0.103.10 because
+    # it is a transitive dependency of iroh 0.35.0
+    # which depends on ^0.102.
+    # <https://rustsec.org/advisories/RUSTSEC-2026-0049>
+    "RUSTSEC-2026-0049",
 ]
 
 [bans]


### PR DESCRIPTION
We cannot upgrade the crate because it is a transitive dependency and the issue described in
<https://rustsec.org/advisories/RUSTSEC-2026-0049> is not dangerous because it requiers a compromised CA and revoked certificate. Worst case that happens
with iroh is that outer layer of encryption to
iroh relay is compromised, but iroh traffic is
still encrypted between peers without relying on CAs.