### PR TITLE
fix: Don't fall into infinite loop if the folder is missing

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -566,6 +566,8 @@ impl Imap {
             info!(context, "No new emails in folder {folder:?}.");
             return Ok(false);
         }
+        // Make sure not to return before setting new_mail to false
+        // Otherwise, we will skip IDLE and go into an infinite loop
         session.new_mail = false;
 
         if !folder_exists {


### PR DESCRIPTION
Previously, if the mvbox_move folder is missing, then core will loop infinitely, because `new_mail` is never set to false.

The fix is to first set `new_mail` to false, then return if the folder is missing.

This is the bug @hpk42 experienced when commenting in https://github.com/chatmail/core/issues/7989