### PR TITLE
refactor(securejoin): do not check for self address in forwarding protection

### DIFF
--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -450,10 +450,8 @@ pub(crate) async fn handle_securejoin_handshake(
     ) {
         let mut self_found = false;
         let self_fingerprint = load_self_public_key(context).await?.dc_fingerprint();
-        for (addr, key) in &mime_message.gossiped_keys {
-            if key.public_key.dc_fingerprint() == self_fingerprint
-                && context.is_self_addr(addr).await?
-            {
+        for key in mime_message.gossiped_keys.values() {
+            if key.public_key.dc_fingerprint() == self_fingerprint {
                 self_found = true;
                 break;
             }


### PR DESCRIPTION
If our key is gossiped, the message is intended for us. The check for address is redundant for incoming messages as if we received the message then it was addressed to us.

This whole protection code can eventually be removed as we have intended recipient fingerprints already, it only protects against forwarding of messages
sent by old clients.