### PR TITLE
fix: don't forward quote

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -4524,8 +4524,6 @@ pub async fn forward_msgs_2ctx(
         msg.param.steal(param, Param::Height);
         msg.param.steal(param, Param::Duration);
         msg.param.steal(param, Param::MimeType);
-        msg.param.steal(param, Param::ProtectQuote);
-        msg.param.steal(param, Param::Quote);
         msg.param.steal(param, Param::Summary1);
         if msg.has_html() {
             msg.set_html(src_msg_id.get_html(ctx_src).await?);

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -2300,14 +2300,11 @@ async fn test_forward_quote() -> Result<()> {
     let forwarded_msg = alice.pop_sent_msg().await;
     let alice_forwarded_msg = bob.recv_msg(&forwarded_msg).await;
     assert!(alice_forwarded_msg.quoted_message(&alice).await?.is_none());
-    assert_eq!(
-        alice_forwarded_msg.quoted_text(),
-        Some("Hi Bob".to_string())
-    );
+    assert!(alice_forwarded_msg.quoted_text().is_none());
 
     let bob_forwarded_msg = bob.get_last_msg().await;
     assert!(bob_forwarded_msg.quoted_message(&bob).await?.is_none());
-    assert_eq!(bob_forwarded_msg.quoted_text(), Some("Hi Bob".to_string()));
+    assert!(bob_forwarded_msg.quoted_text().is_none());
 
     Ok(())
 }


### PR DESCRIPTION
This change might be controversal.
According to the `test_forward_quote` test
(introduced in 6b3b33d2a0ea2e1a77fb13fd734e7a2e4ee4afe1,
https://github.com/chatmail/core/pull/2843),
this behavior is intentional.
That MR only removed the message ID assignment
but did _not_ remove the text altogether.

On the other hand other messengers, including Telegram and WhatsApp,
don't do this (they don't forward quotes together with messages).
I argue that doing this is not expected by most users,
and is bad for privacy.
Forwarding a message should only forward that message,
and not carry any more information.

How I came to this: I was working on
https://github.com/chatmail/core/issues/8053
trying to undestand why the quoted message ID defaults
to the last message of the target chat.
And, thanks to 3f27be9bcb9c8feb8ef116d6fa93747a1b4ced00,
I questioned: "Why are we forwarding quotes in the first place?".
So this also closes https://github.com/chatmail/core/issues/8053.

Note that this commit does not alter `quoted_message()`.
That's for displaying old messages,
and for compatibility with senders that do not remove the quote
from forwarded messages.
