### PR TITLE
test: Fix flaky test_no_old_msg_is_fresh: Wait for incoming message before sending outgoing one

### DIFF
--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -1047,6 +1047,7 @@ def test_no_old_msg_is_fresh(acfactory):
     assert ac1.create_chat(ac2).get_fresh_message_count() == 1
     assert len(list(ac1.get_fresh_messages())) == 1
 
+    ac1_clone.wait_for_incoming_msg_event()
     ac1.wait_for_event(EventType.IMAP_INBOX_IDLE)
 
     logging.info("Send a message from ac1_clone to ac2 and check that ac1 marks the first message as 'noticed'")


### PR DESCRIPTION
We don't want to send an outgoing message from the 2nd device (`ac1_clone`) before receiving the incoming one and expect that the messages will be ordered correctly on the 1st device (`ac1`). Let's ensure the correct message order locally in the first place. I checked logs of a failed test run and it indeed happened that `ac1_clone` sent the message earlier, so it can't reference the incoming message and `tweak_sort_timestamp()` does nothing on `ac1`, so the messages can't be ordered correctly considering that smeared clocks on the devices are different.