### PR TITLE
refactor: Don't temporarily extend `signatures` for signed-only messages

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -490,11 +490,13 @@ impl MimeMessage {
         let mail = mail.as_ref().map(|mail| {
             let (content, signatures_detached) = validate_detached_signature(mail, &public_keyring)
                 .unwrap_or((mail, Default::default()));
-            let signatures_detached = signatures_detached
-                .into_iter()
-                .map(|fp| (fp, Vec::new()))
-                .collect::<HashMap<_, _>>();
-            signatures.extend(signatures_detached);
+            if is_encrypted {
+                let signatures_detached = signatures_detached
+                    .into_iter()
+                    .map(|fp| (fp, Vec::new()))
+                    .collect::<HashMap<_, _>>();
+                signatures.extend(signatures_detached);
+            }
             content
         });
 


### PR DESCRIPTION
~It was unclear why some `mimeparser` checks look at signatures for signed-only messages, e.g. when deciding whether to remove secured headers such as "Secure-Join", and others don't do that. Better don't look at signatures of signed-only messages at all, we don't want to process them in any special way, they should follow the same code paths as usual unencrypted messages.~

~This is also to avoid further discussions like https://github.com/chatmail/core/pull/8058#discussion_r3019001571~

After 4c0180298202ea557b056e285346c5425ff9ebf4 this becomes `refactor` as it doesn't change any behavior, just `signatures` var isn't temporarily extended with signatures for signed-only messages anymore.