### PR TITLE
fix: do not create 1:1 chat on second device when scanning a QR code

### DIFF
--- a/python/tests/test_0_complex_or_slow.py
+++ b/python/tests/test_0_complex_or_slow.py
@@ -288,6 +288,7 @@ def test_use_new_verified_group_after_going_online(acfactory, data, tmp_path, lp
     assert open(contact.get_profile_image(), "rb").read() == open(avatar_path, "rb").read()
 
     lp.sec("ac2_offl: sending message")
+    chat2.accept()
     msg_out = chat2.send_text("hello")
 
     lp.sec("ac1: receiving message")

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3768,14 +3768,7 @@ async fn test_leave_broadcast_multidevice() -> Result<()> {
     // The contact should be marked as verified.
     check_direct_chat_is_hidden_and_contact_is_verified(alice, bob0).await;
     check_direct_chat_is_hidden_and_contact_is_verified(bob0, alice).await;
-
-    // TODO: There is a known bug in `observe_securejoin_on_other_device()`:
-    // When Bob joins a group or broadcast with his first device,
-    // then a chat with Alice will pop up on his second device.
-    // When it's fixed, the 2 following lines can be replaced with
-    // `check_direct_chat_is_hidden_and_contact_is_verified(bob1, alice).await;`
-    let bob1_alice_contact = bob1.add_or_lookup_contact_no_key(alice).await;
-    assert!(bob1_alice_contact.is_verified(bob1).await.unwrap());
+    check_direct_chat_is_hidden_and_contact_is_verified(bob1, alice).await;
 
     tcm.section("Alice sends first message to broadcast.");
     let sent_msg = alice.send_text(alice_chat_id, "Hello!").await;

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -3562,7 +3562,14 @@ async fn create_or_lookup_mailinglist_or_broadcast(
             chattype,
             &listid,
             name,
-            create_blocked,
+            if chattype == Chattype::InBroadcast {
+                // If we joined the broadcast, we have scanned a QR code.
+                // Even if 1:1 chat does not exist or is in a contact request,
+                // create the channel as unblocked.
+                Blocked::Not
+            } else {
+                create_blocked
+            },
             param,
             mime_parser.timestamp_sent,
         )

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -839,13 +839,6 @@ pub(crate) async fn observe_securejoin_on_other_device(
         inviter_progress(context, contact_id, chat_id, chat_type)?;
     }
 
-    if matches!(step, SecureJoinStep::RequestWithAuth) {
-        // This actually reflects what happens on the first device (which does the secure
-        // join) and causes a subsequent "vg-member-added" message to create an unblocked
-        // verified group.
-        ChatId::create_for_contact_with_blocked(context, contact_id, Blocked::Not).await?;
-    }
-
     if matches!(step, SecureJoinStep::MemberAdded) {
         Ok(HandshakeMessage::Propagate)
     } else {


### PR DESCRIPTION
This avoids creating 1:1 chat on a second device when joining a channel. Now when joining a channel there may be no 1:1 chat with the inviter when the channel is created. In this case we still create the channel as unblocked even if 1:1 chat would be a contact request because joining the channel is an explicit action
and it is not possible to add someone who did not scan a QR to the channel manually.

Closes #8081