### PR TITLE
fix: Set Param::GuaranteeE2ee before preparing message blob (#8090)

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2737,7 +2737,7 @@ async fn prepare_send_msg(
         msg.state,
         MessageState::Undefined | MessageState::OutPreparing
     )
-        // v2 SecureJoin "v*-request" messages are unencrypted.
+        // Legacy SecureJoin "v*-request" messages are unencrypted.
         && msg.param.get_cmd() != SystemMessage::SecurejoinMessage
         && chat.is_encrypted(context).await?
     {

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2628,7 +2628,7 @@ pub async fn send_msg(context: &Context, chat_id: ChatId, msg: &mut Message) -> 
     if msg.state != MessageState::Undefined && msg.state != MessageState::OutPreparing {
         msg.param.remove(Param::GuaranteeE2ee);
         msg.param.remove(Param::ForcePlaintext);
-        msg.update_param(context).await?;
+        // create_send_msg_jobs() will update `param` in the db.
     }
 
     // protect all system messages against RTLO attacks
@@ -2733,7 +2733,19 @@ async fn prepare_send_msg(
         None
     };
 
-    // ... then change the MessageState in the message object
+    if matches!(
+        msg.state,
+        MessageState::Undefined | MessageState::OutPreparing
+    )
+        // v2 SecureJoin "v*-request" messages are unencrypted.
+        && msg.param.get_cmd() != SystemMessage::SecurejoinMessage
+        && chat.is_encrypted(context).await?
+    {
+        msg.param.set_int(Param::GuaranteeE2ee, 1);
+        if !msg.id.is_unset() {
+            msg.update_param(context).await?;
+        }
+    }
     msg.state = MessageState::OutPending;
 
     msg.timestamp_sort = create_smeared_timestamp(context);

--- a/src/message.rs
+++ b/src/message.rs
@@ -1393,6 +1393,8 @@ pub enum MessageState {
     /// For files which need time to be prepared before they can be
     /// sent, the message enters this state before
     /// OutPending.
+    ///
+    /// Deprecated 2024-12-07.
     OutPreparing = 18,
 
     /// Message saved as draft.


### PR DESCRIPTION
**Have only tested in Desktop, but it doesn't have the reported problem. Need to test in Android.**

Otherwise `Param::GuaranteeE2ee` is set only after rendering the message and some UIs, e.g. DC Android, display the message as unencrypted while preparing the blob and rendering and encrypting the message. NB: DC Desktop doesn't display the message until `send_msg()` returns.
Fix #8090 