### PR TITLE
perf: enable clippy::large_futures lint

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -2779,15 +2779,13 @@ async fn render_mime_message_and_pre_message(
 
         let mut mimefactory_post_msg = mimefactory.clone();
         mimefactory_post_msg.set_as_post_message();
-        let rendered_msg = mimefactory_post_msg
-            .render(context)
+        let rendered_msg = Box::pin(mimefactory_post_msg.render(context))
             .await
             .context("Failed to render post-message")?;
 
         let mut mimefactory_pre_msg = mimefactory;
         mimefactory_pre_msg.set_as_pre_message_for(&rendered_msg);
-        let rendered_pre_msg = mimefactory_pre_msg
-            .render(context)
+        let rendered_pre_msg = Box::pin(mimefactory_pre_msg.render(context))
             .await
             .context("pre-message failed to render")?;
 
@@ -2802,7 +2800,7 @@ async fn render_mime_message_and_pre_message(
 
         Ok((Some(rendered_pre_msg), rendered_msg))
     } else {
-        Ok((None, mimefactory.render(context).await?))
+        Ok((None, Box::pin(mimefactory.render(context)).await?))
     }
 }
 

--- a/src/download.rs
+++ b/src/download.rs
@@ -173,9 +173,7 @@ pub(crate) async fn download_msg(
     if msg_transport_id != transport_id {
         return Ok(None);
     }
-    session
-        .fetch_single_msg(context, &server_folder, server_uid, rfc724_mid)
-        .await?;
+    Box::pin(session.fetch_single_msg(context, &server_folder, server_uid, rfc724_mid)).await?;
     Ok(Some(()))
 }
 

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -589,9 +589,9 @@ impl Imap {
 
         let mut read_cnt = 0;
         loop {
-            let (n, fetch_more) = self
-                .fetch_new_msg_batch(context, session, folder, folder_meaning)
-                .await?;
+            let (n, fetch_more) =
+                Box::pin(self.fetch_new_msg_batch(context, session, folder, folder_meaning))
+                    .await?;
             read_cnt += n;
             if !fetch_more {
                 return Ok(read_cnt > 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
     clippy::cloned_instead_of_copied,
     clippy::manual_is_variant_and
 )]
+#![cfg_attr(not(test), warn(clippy::large_futures))]
 #![cfg_attr(not(test), warn(clippy::arithmetic_side_effects))]
 #![cfg_attr(not(test), forbid(clippy::indexing_slicing))]
 #![cfg_attr(not(test), forbid(clippy::string_slice))]

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -580,7 +580,7 @@ async fn send_mdn_rfc724_mid(
     )
     .await?;
     let encrypted = mimefactory.will_be_encrypted();
-    let rendered_msg = mimefactory.render(context).await?;
+    let rendered_msg = Box::pin(mimefactory.render(context)).await?;
     let body = rendered_msg.message;
 
     let mut recipients = Vec::new();


### PR DESCRIPTION
Large size of Mimefactor.render() futures
increases the size of all callers
down to set_config() and background_fetch().
I also had to Box::pin one call to fetch_new_msg_batch and one call to fetch_single_msg.

Based on https://github.com/chatmail/core/pull/8125