### PR TITLE
fix: fetch_single_msg(): Lock fetch_msgs_mutex before fetching

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -202,8 +202,11 @@ impl Session {
         let mut uid_message_ids: BTreeMap<u32, String> = BTreeMap::new();
         uid_message_ids.insert(uid, rfc724_mid);
         let (sender, receiver) = async_channel::unbounded();
-        self.fetch_many_msgs(context, folder, vec![uid], &uid_message_ids, sender)
-            .await?;
+        {
+            let _fetch_msgs_lock_guard = context.fetch_msgs_mutex.lock().await;
+            self.fetch_many_msgs(context, folder, vec![uid], &uid_message_ids, sender)
+                .await?;
+        }
         if receiver.recv().await.is_err() {
             bail!("Failed to fetch UID {uid}");
         }

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1313,8 +1313,9 @@ async fn decide_chat_assignment(
         ..
     } = &mime_parser.pre_message
     {
-        let msg_id = rfc724_mid_exists(context, post_msg_rfc724_mid).await?;
-        if let Some(msg_id) = msg_id {
+        let post_msg_exists = if let Some((msg_id, not_downloaded)) =
+            message::rfc724_mid_exists_ex(context, post_msg_rfc724_mid, "download_state<>0").await?
+        {
             context
                 .sql
                 .execute(
@@ -1322,8 +1323,10 @@ async fn decide_chat_assignment(
                     (rfc724_mid, msg_id),
                 )
                 .await?;
-        }
-        let post_msg_exists = msg_id.is_some();
+            !not_downloaded
+        } else {
+            false
+        };
         info!(
             context,
             "Message {rfc724_mid} is a pre-message for {post_msg_rfc724_mid} (post_msg_exists:{post_msg_exists})."

--- a/src/tests/pre_messages/receiving.rs
+++ b/src/tests/pre_messages/receiving.rs
@@ -118,7 +118,13 @@ async fn test_receive_pre_message() -> Result<()> {
     let msg = bob.recv_msg(&pre_message).await;
     assert_eq!(msg.download_state, DownloadState::Available);
     assert_summary_texts(&msg, bob, "👤 test").await;
+    let chat_id = msg.chat_id;
 
+    assert!(bob.recv_msg_opt(&pre_message).await.is_none());
+    let msg = Message::load_from_db(bob, msg.id).await?;
+    assert_eq!(msg.download_state, DownloadState::Available);
+    assert_summary_texts(&msg, bob, "👤 test").await;
+    assert_eq!(msg.chat_id, chat_id);
     Ok(())
 }
 


### PR DESCRIPTION
This is to avoid race conditions in `receive_imf` which also happened previously when
    multi-transport was added.
    
This should fix flaky JSON-RPC Python test_download_on_demand, see https://github.com/chatmail/core/pull/8127#issuecomment-4244549988 for a failure example.