### PR TITLE
feat: Don't send Chat-Group-Name* headers for InBroadcast-s

### DIFF
--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -2805,6 +2805,15 @@ async fn test_broadcast_members_cant_see_each_other() -> Result<()> {
             "alice@example.org charlie@example.net"
         );
 
+        // Check additionally that subscribers don't send "Chat-Group-Name*" headers.
+        let parsed = alice.parse_msg(&request_with_auth).await;
+        assert!(parsed.get_header(HeaderDef::ChatGroupName).is_none());
+        assert!(
+            parsed
+                .get_header(HeaderDef::ChatGroupNameTimestamp)
+                .is_none()
+        );
+
         alice.recv_msg_trash(&request_with_auth).await;
     }
 

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1394,10 +1394,7 @@ impl MimeFactory {
             }
         }
 
-        if chat.typ == Chattype::Group
-            || chat.typ == Chattype::OutBroadcast
-            || chat.typ == Chattype::InBroadcast
-        {
+        if chat.typ == Chattype::Group || chat.typ == Chattype::OutBroadcast {
             headers.push((
                 "Chat-Group-Name",
                 mail_builder::headers::text::Text::new(chat.name.to_string()).into(),
@@ -1408,7 +1405,11 @@ impl MimeFactory {
                     mail_builder::headers::text::Text::new(ts.to_string()).into(),
                 ));
             }
-
+        }
+        if chat.typ == Chattype::Group
+            || chat.typ == Chattype::OutBroadcast
+            || chat.typ == Chattype::InBroadcast
+        {
             match command {
                 SystemMessage::MemberRemovedFromGroup => {
                     let email_to_remove = msg.param.get(Param::Arg).unwrap_or_default();


### PR DESCRIPTION
Broadcast subscribers can't change the chat name, so sending the "Chat-Group-Name{,-Timestamp}" headers looks unnecessary. That could be useful for other subscriber's devices, but having only the chat name isn't enough anyway, at least knowing the secret is necessary which is sent by the broadcast owner.

Moved this from #7836 which should probably be closed