### PR TITLE
feat: Never remove primary transport when applying SyncTransports message

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -806,8 +806,6 @@ UPDATE config SET value=? WHERE keyname='configured_addr' AND value!=?1
                 if transport_changed {
                     info!(context, "Primary transport changed to {from_addr:?}.");
                     context.sql.uncache_raw_config("configured_addr").await;
-
-                    // Regenerate User ID in V4 keys.
                     context.self_public_key.lock().await.take();
 
                     context.emit_event(EventType::TransportsModified);

--- a/src/tests/pre_messages/forward_and_save.rs
+++ b/src/tests/pre_messages/forward_and_save.rs
@@ -97,8 +97,7 @@ async fn test_receive_both() -> Result<()> {
     let alice_chat_id = alice.create_group_with_members("", &[bob]).await;
 
     let (pre_message, post_message, alice_msg_id) =
-        send_large_file_message(alice, alice_chat_id, Viewtype::File, &vec![0u8; 200_000])
-            .await?;
+        send_large_file_message(alice, alice_chat_id, Viewtype::File, &vec![0u8; 200_000]).await?;
 
     let msg = bob.recv_msg(&pre_message).await;
     let _ = bob.recv_msg_trash(&post_message).await;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -791,7 +791,18 @@ pub(crate) async fn sync_transports(
     context
         .sql
         .transaction(|transaction| {
+            let configured_addr = transaction.query_row(
+                "SELECT value FROM config WHERE keyname='configured_addr'",
+                (),
+                |row| {
+                    let addr: String = row.get(0)?;
+                    Ok(addr)
+                },
+            )?;
             for RemovedTransportData { addr, timestamp } in removed_transports {
+                if *addr == configured_addr {
+                    continue;
+                }
                 modified |= transaction.execute(
                     "DELETE FROM transports
                      WHERE addr=? AND add_timestamp<=?",


### PR DESCRIPTION
If we missed a message changing the primary transport, we shouldn't remove it when applying a SyncTransports message, such a state doesn't look correct even if it's temporary.

Replaces #7727 