### PR TITLE
fix: add error cause to connectivity view for IMAP errors

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -489,7 +489,7 @@ impl Imap {
         let session = match self.connect(context, configuring).await {
             Ok(session) => session,
             Err(err) => {
-                self.connectivity.set_err(context, &err);
+                self.connectivity.set_err(context, format!("{err:#}"));
                 return Err(err);
             }
         };

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -631,7 +631,7 @@ async fn smtp_loop(
             info!(ctx, "SMTP fake idle started.");
             match &connection.last_send_error {
                 None => connection.connectivity.set_idle(&ctx),
-                Some(err) => connection.connectivity.set_err(&ctx, err),
+                Some(err) => connection.connectivity.set_err(&ctx, err.clone()),
             }
 
             // If send_smtp_messages() failed, we set a timeout for the fake-idle so that

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -157,8 +157,8 @@ impl ConnectivityStore {
         context.emit_event(EventType::ConnectivityChanged);
     }
 
-    pub(crate) fn set_err(&self, context: &Context, e: impl ToString) {
-        self.set(context, DetailedConnectivity::Error(e.to_string()));
+    pub(crate) fn set_err(&self, context: &Context, e: String) {
+        self.set(context, DetailedConnectivity::Error(e));
     }
     pub(crate) fn set_connecting(&self, context: &Context) {
         self.set(context, DetailedConnectivity::Connecting);


### PR DESCRIPTION
For SMTP errors we already format `last_send_error` with {:#}, but for IMAP errors we have formatted the errors with .to_string(). This resulted in errors such as
"Error: IMAP failed to connect to example.org:443:tls" instead of
"Error: IMAP failed to connect to example.org:443:tls: Connection failure: Network is unreachable (os error 101)." in the connectivity view HTML.