### PR TITLE
feat: Don't show non-delivery-notfications in broadcast channels

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -16,7 +16,7 @@ use mime::Mime;
 use crate::aheader::Aheader;
 use crate::authres::handle_authres;
 use crate::blob::BlobObject;
-use crate::chat::ChatId;
+use crate::chat::{Chat, ChatId};
 use crate::config::Config;
 use crate::constants;
 use crate::contact::{ContactId, import_public_key};
@@ -2582,6 +2582,10 @@ async fn handle_ndn(
 
     for msg_id in msg_ids {
         let mut message = Message::load_from_db(context, msg_id).await?;
+        let chat = Chat::load_from_db(context, message.chat_id).await?;
+        if chat.typ == constants::Chattype::OutBroadcast {
+            continue;
+        }
         let aggregated_error = message
             .error
             .as_ref()


### PR DESCRIPTION
Looking forward, it is unclear how exactly we want to handle errors, but in the meantime, this is a simple thing we can do to improve the situation.

If you have a broadcast channel, chances are that some of your recipients have some problems receiving your messages. You are probably not too interested in that.

In reality, some channel operators were quite confused by these errors, and we told them to just ignore them, but at this point we may as well just hide them.

Theoretically we can start removing recipients that never get our messages at some point.