### PR TITLE
api: jsonrpc: remove unused set_draft_vcard()

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -1877,20 +1877,6 @@ impl CommandApi {
         deltachat::contact::make_vcard(&ctx, &contacts).await
     }
 
-    /// Sets vCard containing the given contacts to the message draft.
-    async fn set_draft_vcard(
-        &self,
-        account_id: u32,
-        msg_id: u32,
-        contacts: Vec<u32>,
-    ) -> Result<()> {
-        let ctx = self.get_context(account_id).await?;
-        let contacts: Vec<_> = contacts.iter().map(|&c| ContactId::new(c)).collect();
-        let mut msg = Message::load_from_db(&ctx, MsgId::new(msg_id)).await?;
-        msg.make_vcard(&ctx, &contacts).await?;
-        msg.get_chat_id().set_draft(&ctx, Some(&mut msg)).await
-    }
-
     // ---------------------------------------------
     //                   chat
     // ---------------------------------------------


### PR DESCRIPTION
this PR removes the unused set_draft_vcard() jsonrpc api, see comment at #7960

closes #7960

cc @nicodh - maybe also remove the [comment in desktop about why set_draft_vcard is not working](https://github.com/deltachat/deltachat-desktop/blob/3d67e496d563dafdc758b1909fa35fc5f44548d4/packages/frontend/src/components/dialogs/ViewProfile/menu.tsx#L214-L218)