### PR TITLE
api: add JSON-RPC APIs for location streaming

### DIFF
--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2561,14 +2561,16 @@ pub unsafe extern "C" fn dc_is_sending_locations_to_chat(
         return 0;
     }
     let ctx = &*context;
-    let chat_id = if chat_id == 0 {
-        None
+    if chat_id == 0 {
+        block_on(location::is_sending_locations(ctx))
+            .unwrap_or_log_default(ctx, "Failed is_sending_locations()") as libc::c_int
     } else {
-        Some(ChatId::new(chat_id))
-    };
-
-    block_on(location::is_sending_locations_to_chat(ctx, chat_id))
-        .unwrap_or_log_default(ctx, "Failed dc_is_sending_locations_to_chat()") as libc::c_int
+        block_on(location::is_sending_locations_to_chat(
+            ctx,
+            ChatId::new(chat_id),
+        ))
+        .unwrap_or_log_default(ctx, "Failed is_sending_locations_to_chat()") as libc::c_int
+    }
 }
 
 #[no_mangle]

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2541,7 +2541,7 @@ pub unsafe extern "C" fn dc_send_locations_to_chat(
     }
     let ctx = &*context;
 
-    block_on(location::send_locations_to_chat(
+    block_on(location::send_to_chat(
         ctx,
         ChatId::new(chat_id),
         seconds as i64,
@@ -2562,14 +2562,12 @@ pub unsafe extern "C" fn dc_is_sending_locations_to_chat(
     }
     let ctx = &*context;
     if chat_id == 0 {
-        block_on(location::is_sending_locations(ctx))
+        block_on(location::is_sending(ctx))
             .unwrap_or_log_default(ctx, "Failed is_sending_locations()") as libc::c_int
     } else {
-        block_on(location::is_sending_locations_to_chat(
-            ctx,
-            ChatId::new(chat_id),
-        ))
-        .unwrap_or_log_default(ctx, "Failed is_sending_locations_to_chat()") as libc::c_int
+        block_on(location::is_sending_to_chat(ctx, ChatId::new(chat_id)))
+            .unwrap_or_log_default(ctx, "Failed is_sending_locations_to_chat()")
+            as libc::c_int
     }
 }
 

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -22,9 +22,6 @@ use deltachat::context::get_info;
 use deltachat::ephemeral::Timer;
 use deltachat::imex;
 use deltachat::location;
-use deltachat::location::is_sending_locations;
-use deltachat::location::is_sending_locations_to_chat;
-use deltachat::location::send_locations_to_chat;
 use deltachat::message::{
     self, delete_msgs_ex, get_existing_msg_ids, get_msg_read_receipt_count, get_msg_read_receipts,
     markseen_msgs, Message, MessageState, MsgId, Viewtype,
@@ -2171,21 +2168,21 @@ impl CommandApi {
     ) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
         let chat_id = ChatId::new(chat_id);
-        send_locations_to_chat(&ctx, chat_id, seconds).await?;
+        location::send_to_chat(&ctx, chat_id, seconds).await?;
         Ok(())
     }
 
     /// Returns whether any chat is sending locations.
     async fn is_sending_locations(&self, account_id: u32) -> Result<bool> {
         let ctx = self.get_context(account_id).await?;
-        is_sending_locations(&ctx).await
+        location::is_sending(&ctx).await
     }
 
     /// Returns whether `chat_id` is sending locations.
     async fn is_sending_locations_to_chat(&self, account_id: u32, chat_id: u32) -> Result<bool> {
         let ctx = self.get_context(account_id).await?;
         let chat_id = ChatId::new(chat_id);
-        is_sending_locations_to_chat(&ctx, chat_id).await
+        location::is_sending_to_chat(&ctx, chat_id).await
     }
 
     /// Stops sending locations to all chats.

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -22,6 +22,9 @@ use deltachat::context::get_info;
 use deltachat::ephemeral::Timer;
 use deltachat::imex;
 use deltachat::location;
+use deltachat::location::is_sending_locations;
+use deltachat::location::is_sending_locations_to_chat;
+use deltachat::location::send_locations_to_chat;
 use deltachat::message::{
     self, delete_msgs_ex, get_existing_msg_ids, get_msg_read_receipt_count, get_msg_read_receipts,
     markseen_msgs, Message, MessageState, MsgId, Viewtype,
@@ -2120,6 +2123,21 @@ impl CommandApi {
     //                  locations
     // ---------------------------------------------
 
+    /// Sets current location.
+    ///
+    /// Returns true if location streaming is currently
+    /// enabled and locations should be updated.
+    ///
+    /// Location is represented as latitude and longitude in degrees
+    /// and horizontal accuracy in meters.
+    async fn set_location(&self, latitude: f64, longitude: f64, accuracy: f64) -> Result<bool> {
+        self.accounts
+            .read()
+            .await
+            .set_location(latitude, longitude, accuracy)
+            .await
+    }
+
     async fn get_locations(
         &self,
         account_id: u32,
@@ -2140,6 +2158,39 @@ impl CommandApi {
         .await?;
 
         Ok(locations.into_iter().map(|l| l.into()).collect())
+    }
+
+    /// Enables location streaming in chat identified by `chat_id` for `seconds` seconds.
+    ///
+    /// Pass 0 as the number of seconds to disable location streaming in the chat.
+    async fn send_locations_to_chat(
+        &self,
+        account_id: u32,
+        chat_id: u32,
+        seconds: i64,
+    ) -> Result<()> {
+        let ctx = self.get_context(account_id).await?;
+        let chat_id = ChatId::new(chat_id);
+        send_locations_to_chat(&ctx, chat_id, seconds).await?;
+        Ok(())
+    }
+
+    /// Returns whether any chat is sending locations.
+    async fn is_sending_locations(&self, account_id: u32) -> Result<bool> {
+        let ctx = self.get_context(account_id).await?;
+        is_sending_locations(&ctx).await
+    }
+
+    /// Returns whether `chat_id` is sending locations.
+    async fn is_sending_locations_to_chat(&self, account_id: u32, chat_id: u32) -> Result<bool> {
+        let ctx = self.get_context(account_id).await?;
+        let chat_id = ChatId::new(chat_id);
+        is_sending_locations_to_chat(&ctx, chat_id).await
+    }
+
+    /// Stops sending locations to all chats.
+    async fn stop_sending_locations(&self) -> Result<()> {
+        self.accounts.read().await.stop_sending_locations().await
     }
 
     // ---------------------------------------------

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -573,7 +573,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                     );
                 }
             }
-            if location::is_sending_locations_to_chat(&context, None).await? {
+            if location::is_sending_locations(&context).await? {
                 println!("Location streaming enabled.");
             }
             println!("{cnt} chats");
@@ -782,7 +782,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                 "Location streaming: {}",
                 location::is_sending_locations_to_chat(
                     &context,
-                    Some(sel_chat.as_ref().unwrap().get_id())
+                    sel_chat.as_ref().unwrap().get_id()
                 )
                 .await?,
             );

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -573,7 +573,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                     );
                 }
             }
-            if location::is_sending_locations(&context).await? {
+            if location::is_sending(&context).await? {
                 println!("Location streaming enabled.");
             }
             println!("{cnt} chats");
@@ -780,11 +780,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
 
             println!(
                 "Location streaming: {}",
-                location::is_sending_locations_to_chat(
-                    &context,
-                    sel_chat.as_ref().unwrap().get_id()
-                )
-                .await?,
+                location::is_sending_to_chat(&context, sel_chat.as_ref().unwrap().get_id()).await?,
             );
         }
         "getlocations" => {
@@ -824,12 +820,7 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
             ensure!(!arg1.is_empty(), "No timeout given.");
 
             let seconds = arg1.parse()?;
-            location::send_locations_to_chat(
-                &context,
-                sel_chat.as_ref().unwrap().get_id(),
-                seconds,
-            )
-            .await?;
+            location::send_to_chat(&context, sel_chat.as_ref().unwrap().get_id(), seconds).await?;
             println!(
                 "Locations will be sent to Chat#{} for {} seconds. Use 'setlocation <lat> <lng>' to play around.",
                 sel_chat.as_ref().unwrap().get_id(),

--- a/deltachat-rpc-client/src/deltachat_rpc_client/account.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/account.py
@@ -495,3 +495,7 @@ class Account:
         """Return ICE servers for WebRTC configuration."""
         ice_servers_json = self._rpc.ice_servers(self.id)
         return json.loads(ice_servers_json)
+
+    def is_sending_locations(self) -> bool:
+        """Return True if sending locations to any chat."""
+        return self._rpc.is_sending_locations(self.id)

--- a/deltachat-rpc-client/src/deltachat_rpc_client/chat.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/chat.py
@@ -277,6 +277,16 @@ class Chat:
         """Remove profile image of this chat."""
         self._rpc.set_chat_profile_image(self.account.id, self.id, None)
 
+    def send_locations(self, seconds) -> None:
+        """Enable location streaming in the chat for the given number of seconds.
+
+        Pass 0 to disable location streaming."""
+        self._rpc.send_locations_to_chat(self.account.id, self.id, seconds)
+
+    def is_sending_locations(self) -> bool:
+        """Return True if sending locations to this chat."""
+        return self._rpc.is_sending_locations_to_chat(self.account.id, self.id)
+
     def get_locations(
         self,
         contact: Optional[Contact] = None,

--- a/deltachat-rpc-client/src/deltachat_rpc_client/deltachat.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/deltachat.py
@@ -59,3 +59,11 @@ class DeltaChat:
     def set_translations(self, translations: dict[str, str]) -> None:
         """Set stock translation strings."""
         self.rpc.set_stock_strings(translations)
+
+    def set_location(self, latitude, longitude, accuracy) -> bool:
+        """Set location, return True if location streaming should continue."""
+        return self.rpc.set_location(latitude, longitude, accuracy)
+
+    def stop_sending_locations(self) -> None:
+        """Stop sending locations to all chats."""
+        return self.rpc.stop_sending_locations()

--- a/deltachat-rpc-client/tests/test_location.py
+++ b/deltachat-rpc-client/tests/test_location.py
@@ -1,0 +1,32 @@
+def test_set_location(dc, acfactory) -> None:
+    # Try setting location without any accounts.
+    assert not dc.set_location(1.0, 2.0, 0.1)
+
+    # Create one account that does not stream,
+    # set location.
+    acfactory.new_configured_account()
+    assert not dc.set_location(3.0, 4.0, 0.1)
+
+
+def test_send_locations_to_chat(dc, acfactory):
+    alice, bob = acfactory.get_online_accounts(2)
+
+    assert not alice.is_sending_locations()
+    alice_chat_bob = alice.create_chat(bob)
+    assert not alice_chat_bob.is_sending_locations()
+
+    # Test starting and stopping location streaming in a chat.
+    alice_chat_bob.send_locations(3600)
+    assert alice.is_sending_locations()
+    assert alice_chat_bob.is_sending_locations()
+    alice_chat_bob.send_locations(0)
+    assert not alice.is_sending_locations()
+    assert not alice_chat_bob.is_sending_locations()
+
+    # Test stop_sending_locations() for all accounts and chats.
+    alice_chat_bob.send_locations(3600)
+    assert alice.is_sending_locations()
+    assert alice_chat_bob.is_sending_locations()
+    dc.stop_sending_locations()
+    assert not alice.is_sending_locations()
+    assert not alice_chat_bob.is_sending_locations()

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -22,6 +22,8 @@ use tokio::time::{Duration, sleep};
 
 use crate::context::{Context, ContextBuilder};
 use crate::events::{Event, EventEmitter, EventType, Events};
+use crate::location;
+use crate::location::stop_sending_locations;
 use crate::log::warn;
 use crate::push::PushSubscriber;
 use crate::stock_str::StockStrings;
@@ -534,6 +536,27 @@ impl Accounts {
     /// Sets notification token for Apple Push Notification service.
     pub async fn set_push_device_token(&self, token: &str) -> Result<()> {
         self.push_subscriber.set_device_token(token).await;
+        Ok(())
+    }
+
+    /// Sets location for all accounts.
+    ///
+    /// Returns true if location should still be streamed.
+    pub async fn set_location(&self, latitude: f64, longitude: f64, accuracy: f64) -> Result<bool> {
+        let mut continue_streaming = false;
+        for account in self.accounts.values() {
+            if location::set(account, latitude, longitude, accuracy).await? {
+                continue_streaming = true;
+            }
+        }
+        Ok(continue_streaming)
+    }
+
+    /// Stops sending locations to all chats.
+    pub async fn stop_sending_locations(&self) -> Result<()> {
+        for account in self.accounts.values() {
+            stop_sending_locations(account).await?;
+        }
         Ok(())
     }
 }

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -543,12 +543,16 @@ impl Accounts {
     ///
     /// Returns true if location should still be streamed.
     pub async fn set_location(&self, latitude: f64, longitude: f64, accuracy: f64) -> Result<bool> {
-        let mut continue_streaming = false;
-        for account in self.accounts.values() {
-            if location::set(account, latitude, longitude, accuracy).await? {
-                continue_streaming = true;
-            }
-        }
+        let continue_streaming = future::try_join_all(self.accounts.iter().map(
+            |(account_id, account)| async move {
+                location::set(account, latitude, longitude, accuracy)
+                    .await
+                    .with_context(|| format!("Failed to set location for account {account_id}"))
+            },
+        ))
+        .await?
+        .into_iter()
+        .any(|continue_streaming| continue_streaming);
         Ok(continue_streaming)
     }
 

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use anyhow::{Context as _, Result, bail, ensure};
 use async_channel::{self, Receiver, Sender};
 use futures::FutureExt as _;
+use futures::future;
 use futures_lite::FutureExt as _;
 use serde::{Deserialize, Serialize};
 use tokio::fs;
@@ -553,9 +554,16 @@ impl Accounts {
 
     /// Stops sending locations to all chats.
     pub async fn stop_sending_locations(&self) -> Result<()> {
-        for account in self.accounts.values() {
-            location::stop_sending(account).await?;
-        }
+        future::try_join_all(
+            self.accounts
+                .iter()
+                .map(|(account_id, account)| async move {
+                    location::stop_sending(account).await.with_context(|| {
+                        format!("Failed to stop sending locations for account {account_id}")
+                    })
+                }),
+        )
+        .await?;
         Ok(())
     }
 }

--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -23,7 +23,6 @@ use tokio::time::{Duration, sleep};
 use crate::context::{Context, ContextBuilder};
 use crate::events::{Event, EventEmitter, EventType, Events};
 use crate::location;
-use crate::location::stop_sending_locations;
 use crate::log::warn;
 use crate::push::PushSubscriber;
 use crate::stock_str::StockStrings;
@@ -555,7 +554,7 @@ impl Accounts {
     /// Stops sending locations to all chats.
     pub async fn stop_sending_locations(&self) -> Result<()> {
         for account in self.accounts.values() {
-            stop_sending_locations(account).await?;
+            location::stop_sending(account).await?;
         }
         Ok(())
     }

--- a/src/location.rs
+++ b/src/location.rs
@@ -272,7 +272,7 @@ pub async fn send_locations_to_chat(
     ensure!(seconds >= 0);
     ensure!(!chat_id.is_special());
     let now = time();
-    let is_sending_locations_before = is_sending_locations_to_chat(context, Some(chat_id)).await?;
+    let is_sending_locations_before = is_sending_locations_to_chat(context, chat_id).await?;
     context
         .sql
         .execute(
@@ -305,35 +305,26 @@ pub async fn send_locations_to_chat(
     Ok(())
 }
 
-/// Returns whether `chat_id` or any chat is sending locations.
-///
-/// If `chat_id` is `Some` only that chat is checked, otherwise returns `true` if any chat
-/// is sending locations.
-pub async fn is_sending_locations_to_chat(
-    context: &Context,
-    chat_id: Option<ChatId>,
-) -> Result<bool> {
-    let exists = match chat_id {
-        Some(chat_id) => {
-            context
-                .sql
-                .exists(
-                    "SELECT COUNT(id) FROM chats  WHERE id=?  AND locations_send_until>?;",
-                    (chat_id, time()),
-                )
-                .await?
-        }
-        None => {
-            context
-                .sql
-                .exists(
-                    "SELECT COUNT(id) FROM chats  WHERE locations_send_until>?;",
-                    (time(),),
-                )
-                .await?
-        }
-    };
-    Ok(exists)
+/// Returns whether any chat is sending locations.
+pub async fn is_sending_locations(context: &Context) -> Result<bool> {
+    context
+        .sql
+        .exists(
+            "SELECT COUNT(id) FROM chats WHERE locations_send_until>?",
+            (time(),),
+        )
+        .await
+}
+
+/// Returns whether `chat_id` is sending locations.
+pub async fn is_sending_locations_to_chat(context: &Context, chat_id: ChatId) -> Result<bool> {
+    context
+        .sql
+        .exists(
+            "SELECT COUNT(id) FROM chats WHERE id=? AND locations_send_until>?",
+            (chat_id, time()),
+        )
+        .await
 }
 
 /// Sets current location of the user device.

--- a/src/location.rs
+++ b/src/location.rs
@@ -327,6 +327,29 @@ pub async fn is_sending_locations_to_chat(context: &Context, chat_id: ChatId) ->
         .await
 }
 
+/// Returns a list of chats in which location streaming is enabled.
+async fn get_chats_with_location_streaming(context: &Context) -> Result<Vec<ChatId>> {
+    context
+        .sql
+        .query_map_vec(
+            "SELECT id FROM chats WHERE locations_send_until>?",
+            (time(),),
+            |row| {
+                let chat_id: ChatId = row.get(0)?;
+                Ok(chat_id)
+            },
+        )
+        .await
+}
+
+/// Stop sending locations in all chats.
+pub async fn stop_sending_locations(context: &Context) -> Result<()> {
+    for chat_id in get_chats_with_location_streaming(context).await? {
+        send_locations_to_chat(context, chat_id, 0).await?;
+    }
+    Ok(())
+}
+
 /// Sets current location of the user device.
 pub async fn set(context: &Context, latitude: f64, longitude: f64, accuracy: f64) -> Result<bool> {
     if latitude == 0.0 && longitude == 0.0 {

--- a/src/location.rs
+++ b/src/location.rs
@@ -264,15 +264,11 @@ impl Kml {
 
 /// Enables location streaming in chat identified by `chat_id` for `seconds` seconds.
 #[expect(clippy::arithmetic_side_effects)]
-pub async fn send_locations_to_chat(
-    context: &Context,
-    chat_id: ChatId,
-    seconds: i64,
-) -> Result<()> {
+pub async fn send_to_chat(context: &Context, chat_id: ChatId, seconds: i64) -> Result<()> {
     ensure!(seconds >= 0);
     ensure!(!chat_id.is_special());
     let now = time();
-    let is_sending_locations_before = is_sending_locations_to_chat(context, chat_id).await?;
+    let is_sending_locations_before = is_sending_to_chat(context, chat_id).await?;
     context
         .sql
         .execute(
@@ -306,7 +302,7 @@ pub async fn send_locations_to_chat(
 }
 
 /// Returns whether any chat is sending locations.
-pub async fn is_sending_locations(context: &Context) -> Result<bool> {
+pub async fn is_sending(context: &Context) -> Result<bool> {
     context
         .sql
         .exists(
@@ -317,7 +313,7 @@ pub async fn is_sending_locations(context: &Context) -> Result<bool> {
 }
 
 /// Returns whether `chat_id` is sending locations.
-pub async fn is_sending_locations_to_chat(context: &Context, chat_id: ChatId) -> Result<bool> {
+pub async fn is_sending_to_chat(context: &Context, chat_id: ChatId) -> Result<bool> {
     context
         .sql
         .exists(
@@ -343,9 +339,9 @@ async fn get_chats_with_location_streaming(context: &Context) -> Result<Vec<Chat
 }
 
 /// Stop sending locations in all chats.
-pub async fn stop_sending_locations(context: &Context) -> Result<()> {
+pub async fn stop_sending(context: &Context) -> Result<()> {
     for chat_id in get_chats_with_location_streaming(context).await? {
-        send_locations_to_chat(context, chat_id, 0).await?;
+        send_to_chat(context, chat_id, 0).await?;
     }
     Ok(())
 }
@@ -502,7 +498,7 @@ pub(crate) async fn delete_expired(context: &Context, now: i64) -> Result<()> {
 ///
 /// This function is used when a message is deleted
 /// that has a corresponding `location_id`.
-pub(crate) async fn delete_poi_location(context: &Context, location_id: u32) -> Result<()> {
+pub(crate) async fn delete_poi(context: &Context, location_id: u32) -> Result<()> {
     context
         .sql
         .execute(
@@ -514,7 +510,7 @@ pub(crate) async fn delete_poi_location(context: &Context, location_id: u32) -> 
 }
 
 /// Deletes POI locations that don't have corresponding message anymore.
-pub(crate) async fn delete_orphaned_poi_locations(context: &Context) -> Result<()> {
+pub(crate) async fn delete_orphaned_poi(context: &Context) -> Result<()> {
     context.sql.execute("
     DELETE FROM locations
     WHERE independent=1 AND id NOT IN
@@ -723,9 +719,9 @@ pub(crate) async fn save(
 
 pub(crate) async fn location_loop(context: &Context, interrupt_receiver: Receiver<()>) {
     loop {
-        let next_event = match maybe_send_locations(context).await {
+        let next_event = match maybe_send(context).await {
             Err(err) => {
-                warn!(context, "maybe_send_locations failed: {:#}", err);
+                warn!(context, "location::maybe_send failed: {:#}", err);
                 Some(60) // Retry one minute later.
             }
             Ok(next_event) => next_event,
@@ -763,7 +759,7 @@ pub(crate) async fn location_loop(context: &Context, interrupt_receiver: Receive
 /// Returns number of seconds until the next time location streaming for some chat ends
 /// automatically.
 #[expect(clippy::arithmetic_side_effects)]
-async fn maybe_send_locations(context: &Context) -> Result<Option<u64>> {
+async fn maybe_send(context: &Context) -> Result<Option<u64>> {
     let mut next_event: Option<u64> = None;
 
     let now = time();
@@ -1058,7 +1054,7 @@ Content-Disposition: attachment; filename="location.kml"
         let bob = TestContext::new_bob().await;
 
         let alice_chat = alice.create_chat(&bob).await;
-        send_locations_to_chat(&alice, alice_chat.id, 1000).await?;
+        send_to_chat(&alice, alice_chat.id, 1000).await?;
         let sent = alice.pop_sent_msg().await;
         let msg = bob.recv_msg(&sent).await;
         assert_eq!(msg.text, "Location streaming enabled by alice@example.org.");
@@ -1110,7 +1106,7 @@ Content-Disposition: attachment; filename="location.kml"
 
         // Alice enables location streaming.
         // Bob receives a message saying that Alice enabled location streaming.
-        send_locations_to_chat(alice, alice_chat.id, 60).await?;
+        send_to_chat(alice, alice_chat.id, 60).await?;
         bob.recv_msg(&alice.pop_sent_msg().await).await;
 
         // Alice gets new location from GPS.
@@ -1120,7 +1116,7 @@ Content-Disposition: attachment; filename="location.kml"
         // 10 seconds later location sending stream manages to send location.
         SystemTime::shift(Duration::from_secs(10));
         delete_expired(alice, time()).await?;
-        maybe_send_locations(alice).await?;
+        maybe_send(alice).await?;
         bob.recv_msg_opt(&alice.pop_sent_msg().await).await;
         assert_eq!(get_range(alice, None, None, 0, 0).await?.len(), 1);
         assert_eq!(get_range(bob, None, None, 0, 0).await?.len(), 1);

--- a/src/message.rs
+++ b/src/message.rs
@@ -25,7 +25,7 @@ use crate::download::DownloadState;
 use crate::ephemeral::{Timer as EphemeralTimer, start_ephemeral_timers_msgids};
 use crate::events::EventType;
 use crate::imap::markseen_on_imap_table;
-use crate::location::delete_poi_location;
+use crate::location;
 use crate::log::warn;
 use crate::mimeparser::{SystemMessage, parse_message_id};
 use crate::param::{Param, Params};
@@ -739,7 +739,7 @@ impl Message {
     /// at a position different from the self-location.
     /// You should not call this function
     /// if you want to bind the current self-location to a message;
-    /// this is done by [`location::set()`] and [`send_locations_to_chat()`].
+    /// this is done by [`location::set()`] and [`location::send_to_chat()`].
     ///
     /// Typically results in the event [`LocationChanged`] with
     /// `contact_id` set to [`ContactId::SELF`].
@@ -748,7 +748,7 @@ impl Message {
     /// `longitude` is the East-west position of the location.
     ///
     /// [`location::set()`]: crate::location::set
-    /// [`send_locations_to_chat()`]: crate::location::send_locations_to_chat
+    /// [`location::send_to_chat()`]: crate::location::send_to_chat
     /// [`LocationChanged`]: crate::events::EventType::LocationChanged
     pub fn set_location(&mut self, latitude: f64, longitude: f64) {
         if latitude == 0.0 && longitude == 0.0 {
@@ -1649,7 +1649,7 @@ pub(crate) async fn get_mime_headers(context: &Context, msg_id: MsgId) -> Result
 /// This may be called in batches; the final events are emitted in delete_msgs_locally_done() then.
 pub(crate) async fn delete_msg_locally(context: &Context, msg: &Message) -> Result<()> {
     if msg.location_id > 0 {
-        delete_poi_location(context, msg.location_id).await?;
+        location::delete_poi(context, msg.location_id).await?;
     }
     let on_server = true;
     msg.id

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1829,7 +1829,7 @@ impl MimeFactory {
             parts.push(msg_kml_part);
         }
 
-        if location::is_sending_locations_to_chat(context, msg.chat_id).await?
+        if location::is_sending_to_chat(context, msg.chat_id).await?
             && let Some(part) = self.get_location_kml_part(context).await?
         {
             parts.push(part);

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1829,7 +1829,7 @@ impl MimeFactory {
             parts.push(msg_kml_part);
         }
 
-        if location::is_sending_locations_to_chat(context, Some(msg.chat_id)).await?
+        if location::is_sending_locations_to_chat(context, msg.chat_id).await?
             && let Some(part) = self.get_location_kml_part(context).await?
         {
             parts.push(part);

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -15,7 +15,7 @@ use crate::context::Context;
 use crate::debug_logging::set_debug_logging_xdc;
 use crate::ephemeral::start_ephemeral_timers;
 use crate::imex::BLOBS_BACKUP_NAME;
-use crate::location::delete_orphaned_poi_locations;
+use crate::location;
 use crate::log::{LogExt, warn};
 use crate::message::MsgId;
 use crate::net::dns::prune_dns_cache;
@@ -902,7 +902,7 @@ pub async fn housekeeping(context: &Context) -> Result<()> {
 
     // Delete POI locations
     // which don't have corresponding message.
-    delete_orphaned_poi_locations(context)
+    location::delete_orphaned_poi(context)
         .await
         .context("Failed to delete orphaned POI locations")
         .log_err(context)


### PR DESCRIPTION
New API stop_sending_locations() only available
in JSON-RPC stops location streaming
in all accounts and chats.