### PR TITLE
api!: Remove unused info_only option when loading a chatlist

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -1387,7 +1387,6 @@ dc_msg_t*       dc_get_draft                 (dc_context_t* context, uint32_t ch
 
 
 #define         DC_GCM_ADDDAYMARKER          0x01
-#define         DC_GCM_INFO_ONLY             0x02
 
 
 /**
@@ -1408,7 +1407,6 @@ dc_msg_t*       dc_get_draft                 (dc_context_t* context, uint32_t ch
  * @param flags If set to DC_GCM_ADDDAYMARKER, the marker DC_MSG_ID_DAYMARKER will
  *     be added before each day (regarding the local timezone). Set this to 0 if you do not want this behaviour.
  *     The day marker timestamp is the midnight one for the corresponding (following) day in the local timezone.
- *     If set to DC_GCM_INFO_ONLY, only system messages will be returned, can be combined with DC_GCM_ADDDAYMARKER.
  * @param marker1before Deprecated, set this to 0.
  * @return Array of message IDs, must be dc_array_unref()'d when no longer used.
  */

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -60,7 +60,6 @@ use self::string::*;
 // - finally, this behaviour matches the old core-c API and UIs already depend on it
 
 const DC_GCM_ADDDAYMARKER: u32 = 0x01;
-const DC_GCM_INFO_ONLY: u32 = 0x02;
 
 // dc_context_t
 
@@ -1338,17 +1337,13 @@ pub unsafe extern "C" fn dc_get_chat_msgs(
     }
     let ctx = &*context;
 
-    let info_only = (flags & DC_GCM_INFO_ONLY) != 0;
     let add_daymarker = (flags & DC_GCM_ADDDAYMARKER) != 0;
     block_on(async move {
         Box::into_raw(Box::new(
             chat::get_chat_msgs_ex(
                 ctx,
                 ChatId::new(chat_id),
-                MessageListOptions {
-                    info_only,
-                    add_daymarker,
-                },
+                MessageListOptions { add_daymarker },
             )
             .await
             .unwrap_or_log_default(ctx, "failed to get chat msgs")

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -1366,8 +1366,22 @@ impl CommandApi {
         markseen_msgs(&ctx, msg_ids.into_iter().map(MsgId::new).collect()).await
     }
 
-    /// Returns all messages of a particular chat.
+    /// Get all message IDs belonging to a chat.
     ///
+    /// The list is already sorted and starts with the oldest message.
+    /// Clients should not try to re-sort the list as this would be an expensive action
+    /// and would result in inconsistencies between clients.
+    /// Note that the messages are not necessarily sorted by their ID or by their displayed timestamp;
+    /// UIs need to handle both the case of descending message IDs
+    /// and of decreasing timestamps.
+    ///
+    /// Optionally, 'daymarkers' added to the ID array may help to
+    /// implement virtual lists.
+    ///
+    /// Parameters:
+    ///
+    /// * chat_id The chat ID of which the messages IDs should be queried.
+    /// * _info_only: Deprecated, pass `false` here.
     /// * `add_daymarker` - If `true`, add day markers as `DC_MSG_ID_DAYMARKER` to the result,
     ///   e.g. [1234, 1237, 9, 1239]. The day marker timestamp is the midnight one for the
     ///   corresponding (following) day in the local timezone.
@@ -1414,6 +1428,12 @@ impl CommandApi {
         }
     }
 
+    /// Get all messages belonging to a chat.
+    ///
+    /// Similar to `get_message_ids` / `getMessageIds`,
+    /// see that function for details.
+    /// The difference is that this function here returns a list of `MessageListItem`,
+    /// which is an enum of a message or a daymarker.
     async fn get_message_list_items(
         &self,
         account_id: u32,

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -1375,17 +1375,14 @@ impl CommandApi {
         &self,
         account_id: u32,
         chat_id: u32,
-        info_only: bool,
+        _info_only: bool,
         add_daymarker: bool,
     ) -> Result<Vec<u32>> {
         let ctx = self.get_context(account_id).await?;
         let msg = get_chat_msgs_ex(
             &ctx,
             ChatId::new(chat_id),
-            MessageListOptions {
-                info_only,
-                add_daymarker,
-            },
+            MessageListOptions { add_daymarker },
         )
         .await?;
         Ok(msg
@@ -1421,17 +1418,14 @@ impl CommandApi {
         &self,
         account_id: u32,
         chat_id: u32,
-        info_only: bool,
+        _info_only: bool,
         add_daymarker: bool,
     ) -> Result<Vec<JsonrpcMessageListItem>> {
         let ctx = self.get_context(account_id).await?;
         let msg = get_chat_msgs_ex(
             &ctx,
             ChatId::new(chat_id),
-            MessageListOptions {
-                info_only,
-                add_daymarker,
-            },
+            MessageListOptions { add_daymarker },
         )
         .await?;
         Ok(msg

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -622,7 +622,6 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
                 &context,
                 sel_chat.get_id(),
                 chat::MessageListOptions {
-                    info_only: false,
                     add_daymarker: true,
                 },
             )

--- a/deltachat-rpc-client/src/deltachat_rpc_client/chat.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/chat.py
@@ -206,9 +206,9 @@ class Chat:
         snapshot["message"] = Message(self.account, snapshot.id)
         return snapshot
 
-    def get_messages(self, info_only: bool = False, add_daymarker: bool = False) -> list[Message]:
+    def get_messages(self, add_daymarker: bool = False) -> list[Message]:
         """Get the list of messages in this chat."""
-        msgs = self._rpc.get_message_ids(self.account.id, self.id, info_only, add_daymarker)
+        msgs = self._rpc.get_message_ids(self.account.id, self.id, False, add_daymarker)
         return [Message(self.account, msg_id) for msg_id in msgs]
 
     def get_fresh_message_count(self) -> int:

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -6,7 +6,6 @@ use std::fmt;
 use std::io::Cursor;
 use std::marker::Sync;
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::{Context as _, Result, anyhow, bail, ensure};
@@ -3097,9 +3096,6 @@ async fn donation_request_maybe(context: &Context) -> Result<()> {
 /// Chat message list request options.
 #[derive(Debug)]
 pub struct MessageListOptions {
-    /// Return only info messages.
-    pub info_only: bool,
-
     /// Add day markers before each date regarding the local timezone.
     pub add_daymarker: bool,
 }
@@ -3110,7 +3106,6 @@ pub async fn get_chat_msgs(context: &Context, chat_id: ChatId) -> Result<Vec<Cha
         context,
         chat_id,
         MessageListOptions {
-            info_only: false,
             add_daymarker: false,
         },
     )
@@ -3125,43 +3120,13 @@ pub async fn get_chat_msgs_ex(
     chat_id: ChatId,
     options: MessageListOptions,
 ) -> Result<Vec<ChatItem>> {
-    let MessageListOptions {
-        info_only,
-        add_daymarker,
-    } = options;
-    // TODO: Remove `info_only` parameter; it's not used by anything
-    let process_row = if info_only {
-        |row: &rusqlite::Row| {
-            // is_info logic taken from Message.is_info()
-            let params = row.get::<_, String>("param")?;
-            let (from_id, to_id) = (
-                row.get::<_, ContactId>("from_id")?,
-                row.get::<_, ContactId>("to_id")?,
-            );
-            let is_info_msg: bool = from_id == ContactId::INFO
-                || to_id == ContactId::INFO
-                || match Params::from_str(&params) {
-                    Ok(p) => {
-                        let cmd = p.get_cmd();
-                        cmd != SystemMessage::Unknown && cmd != SystemMessage::AutocryptSetupMessage
-                    }
-                    _ => false,
-                };
-
-            Ok((
-                row.get::<_, i64>("timestamp")?,
-                row.get::<_, MsgId>("id")?,
-                !is_info_msg,
-            ))
-        }
-    } else {
-        |row: &rusqlite::Row| {
-            Ok((
-                row.get::<_, i64>("timestamp")?,
-                row.get::<_, MsgId>("id")?,
-                false,
-            ))
-        }
+    let MessageListOptions { add_daymarker } = options;
+    let process_row = |row: &rusqlite::Row| {
+        Ok((
+            row.get::<_, i64>("timestamp")?,
+            row.get::<_, MsgId>("id")?,
+            false,
+        ))
     };
     let process_rows = |rows: rusqlite::AndThenRows<_>| {
         // It is faster to sort here rather than
@@ -3196,39 +3161,18 @@ pub async fn get_chat_msgs_ex(
         Ok(ret)
     };
 
-    let items = if info_only {
-        context
-            .sql
-            .query_map(
-        // GLOB is used here instead of LIKE because it is case-sensitive
-                "SELECT m.id AS id, m.timestamp AS timestamp, m.param AS param, m.from_id AS from_id, m.to_id AS to_id
-               FROM msgs m
-              WHERE m.chat_id=?
-                AND m.hidden=0
-                AND (
-                    m.param GLOB '*\nS=*' OR param GLOB 'S=*'
-                    OR m.from_id == ?
-                    OR m.to_id == ?
-                );",
-                (chat_id, ContactId::INFO, ContactId::INFO),
-                process_row,
-                process_rows,
-            )
-            .await?
-    } else {
-        context
-            .sql
-            .query_map(
-                "SELECT m.id AS id, m.timestamp AS timestamp
+    let items = context
+        .sql
+        .query_map(
+            "SELECT m.id AS id, m.timestamp AS timestamp
                FROM msgs m
               WHERE m.chat_id=?
                 AND m.hidden=0;",
-                (chat_id,),
-                process_row,
-                process_rows,
-            )
-            .await?
-    };
+            (chat_id,),
+            process_row,
+            process_rows,
+        )
+        .await?;
     Ok(items)
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1104,7 +1104,6 @@ ORDER BY id"
             self,
             chat_id,
             MessageListOptions {
-                info_only: false,
                 add_daymarker: false,
             },
         )


### PR DESCRIPTION
Remove unused info_only option from `get_chat_msgs_ex()`.

This option was meant to show an "audit log" of a group, i.e. only the info messages. This feature was removed again from Desktop, but the option still lingered around in Core.

The second commit adds a doc comment to the JsonRPC functions, because I wanted to note somewhere that the parameter is deprecated, and I needed some place to put this note.