### PR TITLE
docs: Discourage  `into()`, `try_into()` and `parse()`

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -174,7 +174,3 @@ Calling `into()`, `try_into()` or `parse()`
 creates an indirection,
 which is hard to follow for people who are not familiar with Rust,
 or who are not using rust-analyzer.
-
-A notable exception is the Json-RPC API bindings,
-where the API types have `From` implementatons to and from the core types.
-Here, it is assumed to be clear enough which code is called.

--- a/STYLE.md
+++ b/STYLE.md
@@ -167,10 +167,14 @@ Follow Rust guidelines for the documentation comments:
 For internal types, implementing `From`, `TryFrom` or `FromStr` is discouraged.
 Instead, a `new()` function is recommended.
 
-For external types, use `Type::from()`, `Type::try_from()` or `Type::from_str()` directly
-rather than `into()`, `try_into()` or `parse()`.
+For external types, prefer using `Type::from()`, `Type::try_from()` or `Type::from_str()`
+over `into()`, `try_into()` or `parse()`.
 
 Calling `into()`, `try_into()` or `parse()`
 creates an indirection,
 which is hard to follow for people who are not familiar with Rust,
 or who are not using rust-analyzer.
+
+A notable exception is the Json-RPC API bindings,
+where the API types have `From` implementatons to and from the core types.
+Here, it is assumed to be clear enough which code is called.

--- a/STYLE.md
+++ b/STYLE.md
@@ -161,3 +161,16 @@ are documented.
 
 Follow Rust guidelines for the documentation comments:
 <https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#summary-sentence>
+
+## Do not use `into()`, `try_into()` or `parse()`
+
+For internal types, implementing `From`, `TryFrom` or `FromStr` is discouraged.
+Instead, a `new()` function is recommended.
+
+For external types, use `Type::from()`, `Type::try_from()` or `Type::from_str()` directly
+rather than `into()`, `try_into()` or `parse()`.
+
+Calling `into()`, `try_into()` or `parse()`
+creates an indirection,
+which is hard to follow for people who are not familiar with Rust,
+or who are not using rust-analyzer.


### PR DESCRIPTION
Follow-up to https://github.com/chatmail/core/pull/8178#issuecomment-4322738959

I'm not completely sure if the note on the JsonRPC API (last paragraph) should be included.