### PR TITLE
build: increase MSRV to 1.89

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ env:
   RUST_VERSION: 1.95.0
 
   # Minimum Supported Rust Version
-  MSRV: 1.88.0
+  MSRV: 1.89.0
 
 jobs:
   lint_rust:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "deltachat"
 version = "2.50.0-dev"
 edition = "2024"
 license = "MPL-2.0"
-rust-version = "1.88"
+rust-version = "1.89"
 repository = "https://github.com/chatmail/core"
 
 [profile.dev]


### PR DESCRIPTION
This is required by iroh 0.98.1,
so we will need to update MSRV eventually
when iroh 1.0 is released.