### PR TITLE
chore(json-rpc): deprecate send_sticker

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -2421,6 +2421,7 @@ impl CommandApi {
         chat::resend_msgs(&ctx, &message_ids).await
     }
 
+    /// @deprecated as of 2026-04; use `send_msg` with `Viewtype::Sticker` instead.
     async fn send_sticker(
         &self,
         account_id: u32,

--- a/deltachat-rpc-client/src/deltachat_rpc_client/chat.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/chat.py
@@ -164,7 +164,7 @@ class Chat:
         return Message(self.account, msg_id)
 
     def send_sticker(self, path: str) -> Message:
-        """Send an sticker and return the resulting Message instance."""
+        """Deprecated as of 2026-04; use `send_message` with `Viewtype.STICKER` instead."""
         msg_id = self._rpc.send_sticker(self.account.id, self.id, path)
         return Message(self.account, msg_id)
 


### PR DESCRIPTION
send_sticker is not needed anymore since https://github.com/chatmail/core/pull/8162/changes/4dbbd4d8e