### PR TITLE
chore: update astral-tokio-tar from 0.6.0 to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c23f3af104b40a3430ccb90ed5f7bd877a8dc5c26fc92fde51a22b40890dcf9"
+checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
 dependencies = [
  "filetime",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ thiserror = { workspace = true }
 tokio-io-timeout = "1.2.1"
 tokio-rustls = { version = "0.26.2", default-features = false }
 tokio-stream = { version = "0.1.17", features = ["fs"] }
-astral-tokio-tar = { version = "0.6", default-features = false }
+astral-tokio-tar = { version = "0.6.1", default-features = false }
 tokio-util = { workspace = true }
 tokio = { workspace = true, features = ["fs", "rt-multi-thread", "macros"] }
 toml = "0.9"


### PR DESCRIPTION
Fixes https://rustsec.org/advisories/RUSTSEC-2026-0112