### PR TITLE
ci: make Rust cache more useful

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           save-if: false
           shared-key: ${{ runner.os }}-${{ env.RUST_VERSION }}
+          add-rust-environment-hash-key: false
       - name: Run rustfmt
         run: cargo fmt --all -- --check
       - name: Run clippy
@@ -102,6 +103,7 @@ jobs:
         with:
           save-if: false
           shared-key: ${{ runner.os }}-${{ env.RUST_VERSION }}
+          add-rust-environment-hash-key: false
       - name: Rustdoc
         run: cargo doc --document-private-items --no-deps
 
@@ -151,6 +153,11 @@ jobs:
           ##save-if: ${{ github.ref == 'refs/heads/main' }}
           shared-key: ${{ matrix.os }}-${{ matrix.rust }}
 
+          # Do not hash Cargo.lock.
+          # We want the cache to be used later in PRs
+          # even if it updates some dependency.
+          add-rust-environment-hash-key: false
+
       - name: Install nextest
         uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458
         with:
@@ -190,6 +197,7 @@ jobs:
         with:
           save-if: false
           shared-key: ${{ matrix.os }}-${{ env.RUST_VERSION }}
+          add-rust-environment-hash-key: false
 
       - name: Build C library
         run: cargo build -p deltachat_ffi
@@ -222,6 +230,7 @@ jobs:
         with:
           save-if: false
           shared-key: ${{ runner.os }}-${{ env.RUST_VERSION }}
+          add-rust-environment-hash-key: false
 
       - name: Build deltachat-rpc-server
         run: cargo build -p deltachat-rpc-server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
         shell: bash
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        with:
+          save-if: false
+          shared-key: ${{ runner.os }}-${{ env.RUST_VERSION }}
       - name: Run rustfmt
         run: cargo fmt --all -- --check
       - name: Run clippy
@@ -90,8 +93,15 @@ jobs:
         with:
           show-progress: false
           persist-credentials: false
+
+      - run: rustup override set $RUST_VERSION
+        shell: bash
+
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        with:
+          save-if: false
+          shared-key: ${{ runner.os }}-${{ env.RUST_VERSION }}
       - name: Rustdoc
         run: cargo doc --document-private-items --no-deps
 
@@ -135,6 +145,11 @@ jobs:
 
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        with:
+          # Only save the cache from the main branch runs.
+          # No need for PRs to write to the cache.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          shared-key: ${{ matrix.os }}-${{ matrix.rust }}
 
       - name: Install nextest
         uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458
@@ -167,8 +182,14 @@ jobs:
           show-progress: false
           persist-credentials: false
 
+      - run: rustup override set $RUST_VERSION
+        shell: bash
+
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        with:
+          save-if: false
+          shared-key: ${{ matrix.os }}-${{ env.RUST_VERSION }}
 
       - name: Build C library
         run: cargo build -p deltachat_ffi
@@ -193,8 +214,14 @@ jobs:
           show-progress: false
           persist-credentials: false
 
+      - run: rustup override set $RUST_VERSION
+        shell: bash
+
       - name: Cache rust cargo artifacts
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        with:
+          save-if: false
+          shared-key: ${{ runner.os }}-${{ env.RUST_VERSION }}
 
       - name: Build deltachat-rpc-server
         run: cargo build -p deltachat-rpc-server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           save-if: false
-          shared-key: ${{ runner.os }}-${{ env.RUST_VERSION }}
           add-rust-environment-hash-key: false
       - name: Run rustfmt
         run: cargo fmt --all -- --check
@@ -102,7 +101,6 @@ jobs:
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           save-if: false
-          shared-key: ${{ runner.os }}-${{ env.RUST_VERSION }}
           add-rust-environment-hash-key: false
       - name: Rustdoc
         run: cargo doc --document-private-items --no-deps
@@ -151,7 +149,6 @@ jobs:
           # Only save the cache from the main branch runs.
           # No need for PRs to write to the cache.
           ##save-if: ${{ github.ref == 'refs/heads/main' }}
-          shared-key: ${{ matrix.os }}-${{ matrix.rust }}
 
           # Do not hash Cargo.lock.
           # We want the cache to be used later in PRs
@@ -196,7 +193,6 @@ jobs:
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           save-if: false
-          shared-key: ${{ matrix.os }}-${{ env.RUST_VERSION }}
           add-rust-environment-hash-key: false
 
       - name: Build C library
@@ -229,7 +225,6 @@ jobs:
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:
           save-if: false
-          shared-key: ${{ runner.os }}-${{ env.RUST_VERSION }}
           add-rust-environment-hash-key: false
 
       - name: Build deltachat-rpc-server

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
         with:
           # Only save the cache from the main branch runs.
           # No need for PRs to write to the cache.
-          save-if: ${{ github.ref == 'refs/heads/main' }}
+          ##save-if: ${{ github.ref == 'refs/heads/main' }}
           shared-key: ${{ matrix.os }}-${{ matrix.rust }}
 
       - name: Install nextest


### PR DESCRIPTION
Separate the cache for different Rust versions
and only write to the cache from the main branch.