### PR TITLE
fix: Reduce key creation timestamp resolution in the statistics reports

### DIFF
--- a/src/stats.rs
+++ b/src/stats.rs
@@ -29,6 +29,7 @@ const STATISTICS_BOT_VCARD: &str = include_str!("../assets/statistics-bot.vcf");
 const SENDING_INTERVAL_SECONDS: i64 = 3600 * 24 * 7; // 1 week
 // const SENDING_INTERVAL_SECONDS: i64 = 60; // 1 minute (for testing)
 const MESSAGE_STATS_UPDATE_INTERVAL_SECONDS: i64 = 4 * 60; // 4 minutes (less than the lowest ephemeral messages timeout)
+const KEY_CREATE_TIMESTAMP_RESOLUTION: u32 = 3600 * 24 * 7 * 4; // 4 weeks
 
 #[derive(Serialize)]
 struct Statistics {
@@ -348,7 +349,13 @@ async fn get_stats(context: &Context) -> Result<String> {
     let key_create_timestamps: Vec<u32> = load_self_public_keyring(context)
         .await?
         .iter()
-        .map(|k| k.created_at().as_secs())
+        .map(|k| {
+            k.created_at()
+                .as_secs()
+                .div_ceil(KEY_CREATE_TIMESTAMP_RESOLUTION)
+                .checked_mul(KEY_CREATE_TIMESTAMP_RESOLUTION)
+                .unwrap_or(0)
+        })
         .collect();
 
     let sending_enabled_timestamps =

--- a/src/stats/stats_tests.rs
+++ b/src/stats/stats_tests.rs
@@ -488,11 +488,13 @@ async fn test_stats_key_creation_timestamp() -> Result<()> {
 
     // The key creation time's resolution is reduced in order to prevent deanonymization:
     const CENSORED_KEY_CREATION_TIME: u128 = 1584576000;
-    assert!(CENSORED_KEY_CREATION_TIME.is_multiple_of(KEY_CREATE_TIMESTAMP_RESOLUTION as u128));
-    assert!(CENSORED_KEY_CREATION_TIME > ALICE_KEY_CREATION_TIME);
+    assert!(CENSORED_KEY_CREATION_TIME.is_multiple_of(u128::from(KEY_CREATE_TIMESTAMP_RESOLUTION)));
+    const {
+        assert!(CENSORED_KEY_CREATION_TIME > ALICE_KEY_CREATION_TIME);
+    }
     assert!(
         CENSORED_KEY_CREATION_TIME - ALICE_KEY_CREATION_TIME
-            < KEY_CREATE_TIMESTAMP_RESOLUTION as u128
+            < u128::from(KEY_CREATE_TIMESTAMP_RESOLUTION)
     );
 
     let alice = &TestContext::new_alice().await;

--- a/src/stats/stats_tests.rs
+++ b/src/stats/stats_tests.rs
@@ -486,6 +486,15 @@ async fn test_stats_key_creation_timestamp() -> Result<()> {
     // Alice uses a pregenerated key. It was created at this timestamp:
     const ALICE_KEY_CREATION_TIME: u128 = 1582855645;
 
+    // The key creation time's resolution is reduced in order to prevent deanonymization:
+    const CENSORED_KEY_CREATION_TIME: u128 = 1584576000;
+    assert!(CENSORED_KEY_CREATION_TIME.is_multiple_of(KEY_CREATE_TIMESTAMP_RESOLUTION as u128));
+    assert!(CENSORED_KEY_CREATION_TIME > ALICE_KEY_CREATION_TIME);
+    assert!(
+        CENSORED_KEY_CREATION_TIME - ALICE_KEY_CREATION_TIME
+            < KEY_CREATE_TIMESTAMP_RESOLUTION as u128
+    );
+
     let alice = &TestContext::new_alice().await;
     alice.set_config_bool(Config::StatsSending, true).await?;
 
@@ -495,7 +504,7 @@ async fn test_stats_key_creation_timestamp() -> Result<()> {
     assert_eq!(
         key_create_timestamps,
         &vec![Value::Number(
-            Number::from_u128(ALICE_KEY_CREATION_TIME).unwrap()
+            Number::from_u128(CENSORED_KEY_CREATION_TIME).unwrap()
         )]
     );
 


### PR DESCRIPTION
To decide: What exactly do we want the resolution to be?