### PR TITLE
fix: set dir to "auto" in body tag when converting plain-text to HTML

### DIFF
--- a/src/plaintext.rs
+++ b/src/plaintext.rs
@@ -39,7 +39,7 @@ impl PlainText {
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto">
 "#
         .to_string();
 


### PR DESCRIPTION
close #8223 