### PR TITLE
feat: remove Content-Description and Content-Disposition from multipart/encrypted parts

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1948,23 +1948,9 @@ pub(crate) fn wrap_encrypted_part(encrypted: String) -> MimePart<'static> {
         "multipart/encrypted; protocol=\"application/pgp-encrypted\"",
         vec![
             // Autocrypt part 1
-            MimePart::new("application/pgp-encrypted", "Version: 1\r\n").header(
-                "Content-Description",
-                mail_builder::headers::raw::Raw::new("PGP/MIME version identification"),
-            ),
+            MimePart::new("application/pgp-encrypted", "Version: 1\r\n"),
             // Autocrypt part 2
-            MimePart::new(
-                "application/octet-stream; name=\"encrypted.asc\"",
-                encrypted,
-            )
-            .header(
-                "Content-Description",
-                mail_builder::headers::raw::Raw::new("OpenPGP encrypted message"),
-            )
-            .header(
-                "Content-Disposition",
-                mail_builder::headers::raw::Raw::new("inline; filename=\"encrypted.asc\";"),
-            ),
+            MimePart::new("application/octet-stream", encrypted),
         ],
     )
 }


### PR DESCRIPTION
This is not required by <https://datatracker.ietf.org/doc/html/rfc3156>.

Looks like Content-Description and Content-Disposition are the same as what Thunderbird produces,
e.g. in `test-data/message/thunderbird_encrypted_signed.eml`, and the same values also made it into Autocrypt spec.

Content-Description is likely not used by anyone.

For Content-Disposition specification see <https://datatracker.ietf.org/doc/html/rfc2183>. While it is explicitly allowed to set the filename for inline attachment, it does not look useful to specify generic "encrypted.asc" explicitly. Content-Disposition for the second part results in some webmail clients showing the second part as an attachment with "encrypted.asc" filename. They will likely show it differently after this change, e.g. with a different filename or actually inline.