### PR TITLE
chore: allow passing arguments to scripts/clippy.sh

### DIFF
--- a/scripts/clippy.sh
+++ b/scripts/clippy.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 # Run clippy for all Rust code in the project.
-cargo clippy --workspace --all-targets --all-features -- -D warnings
+#
+# To check, run
+#   scripts/clippy.sh 
+#
+# To automatically fix warnings, run
+#   scripts/clippy.sh --fix --allow-dirty
+cargo clippy --workspace --all-targets --all-features "$@" -- -D warnings


### PR DESCRIPTION
This makes it possible to run `scripts/clippy.sh --fix --allow-dirty` to fix clippy warnings automatically.