### PR TITLE
docs: Update README.md: Use ci-chatmail instead of nine

### DIFF
--- a/deltachat-rpc-client/README.md
+++ b/deltachat-rpc-client/README.md
@@ -29,7 +29,7 @@ $ pip install .
 
 1. Build `deltachat-rpc-server` with `cargo build -p deltachat-rpc-server`.
 2. Install tox `pip install -U tox`
-3. Run `CHATMAIL_DOMAIN=nine.testrun.org PATH="../target/debug:$PATH" tox`.
+3. Run `CHATMAIL_DOMAIN=ci-chatmail.testrun.org PATH="../target/debug:$PATH" tox`.
 
 Additional arguments to `tox` are passed to pytest, e.g. `tox -- -s` does not capture test output.
 


### PR DESCRIPTION
IIRC, using nine.testrun.org for testing is bad, and ci-chatmail should be used instead?