### PR TITLE
ci: use --locked flag with `cargo build`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           cache-bin: false
 
       - name: Build C library
-        run: cargo build -p deltachat_ffi
+        run: cargo build -p deltachat_ffi --locked
 
       - name: Upload C library
         uses: actions/upload-artifact@v7
@@ -212,7 +212,7 @@ jobs:
           cache-bin: false
 
       - name: Build deltachat-rpc-server
-        run: cargo build -p deltachat-rpc-server
+        run: cargo build -p deltachat-rpc-server --locked
 
       - name: Upload deltachat-rpc-server
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Not really important, but will fail now if lockfile is not updated.