### PR TITLE
refactor: remove outdated comment

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2344,8 +2344,6 @@ INSERT INTO msgs
 
 /// Checks for "Chat-Edit" and "Chat-Delete" headers,
 /// and edits/deletes existing messages accordingly.
-///
-/// Returns `true` if this message is an edit/deletion request.
 async fn handle_edit_delete(
     context: &Context,
     mime_parser: &MimeMessage,


### PR DESCRIPTION
This function doesn't return `bool` since
416131b4a25d7fb308439e2ef12c03633e6e459f.
