### PR TITLE
fix: hide connectivity HTML quota if not supported

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -7056,11 +7056,6 @@ void dc_event_unref(dc_event_t* event);
 /// `%1$s` will be replaced by a possibly more detailed, typically english, error description.
 #define DC_STR_ERROR                      112
 
-/// "Not supported by your provider."
-///
-/// Used in the connectivity view.
-#define DC_STR_NOT_SUPPORTED_BY_PROVIDER  113
-
 /// "Messages"
 ///
 /// Used as a subtitle in quota context; can be plural always.

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -3,13 +3,13 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use anyhow::{Context as _, Result, anyhow};
+use anyhow::{Context as _, Result};
 use async_imap::types::{Quota, QuotaResource};
 
+use crate::EventType;
 use crate::context::Context;
 use crate::imap::session::Session as ImapSession;
 use crate::tools::{self, time_elapsed};
-use crate::{EventType, stock_str};
 
 /// quota icon in connectivity is "yellow".
 pub const QUOTA_WARN_THRESHOLD_PERCENTAGE: u64 = 80;
@@ -17,13 +17,25 @@ pub const QUOTA_WARN_THRESHOLD_PERCENTAGE: u64 = 80;
 /// quota icon in connectivity is "red".
 pub const QUOTA_ERROR_THRESHOLD_PERCENTAGE: u64 = 95;
 
+/// [QuotaInfo] error.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Quota info not supported by the provider
+    #[error("Quota info not supported by the provider")]
+    NotSupportedByProvider,
+
+    /// Any other error: network, parsing, etc.
+    #[error("{0:#}")]
+    Other(#[from] anyhow::Error),
+}
+
 /// Server quota information with an update timestamp.
 #[derive(Debug)]
 pub struct QuotaInfo {
     /// Recently loaded quota information.
     /// set to `Err()` if the provider does not support quota or on other errors,
     /// set to `Ok()` for valid quota information.
-    pub(crate) recent: Result<BTreeMap<String, Vec<QuotaResource>>>,
+    pub(crate) recent: Result<BTreeMap<String, Vec<QuotaResource>>, Error>,
 
     /// When the structure was modified.
     pub(crate) modified: tools::Time,
@@ -76,9 +88,11 @@ impl Context {
         info!(self, "Transport {transport_id}: Updating quota.");
 
         let quota = if session.can_check_quota() {
-            get_unique_quota_roots_and_usage(session, folder).await
+            get_unique_quota_roots_and_usage(session, folder)
+                .await
+                .map_err(Error::Other)
         } else {
-            Err(anyhow!(stock_str::not_supported_by_provider(self)))
+            Err(Error::NotSupportedByProvider)
         };
 
         self.quota.write().await.insert(

--- a/src/scheduler/connectivity.rs
+++ b/src/scheduler/connectivity.rs
@@ -418,7 +418,11 @@ impl Context {
             };
             match &quota.recent {
                 Err(e) => {
-                    ret += &escaper::encode_minimal(&e.to_string());
+                    // If not supported by the provider,
+                    // just skip the "quota" section.
+                    if !matches!(e, crate::quota::Error::NotSupportedByProvider) {
+                        ret += &escaper::encode_minimal(&e.to_string());
+                    }
                 }
                 Ok(quota) => {
                     if quota.is_empty() {

--- a/src/stock_str.rs
+++ b/src/stock_str.rs
@@ -189,9 +189,6 @@ pub enum StockMessage {
     #[strum(props(fallback = "Error: %1$s"))]
     Error = 112,
 
-    #[strum(props(fallback = "Not supported by your provider."))]
-    NotSupportedByProvider = 113,
-
     #[strum(props(fallback = "Messages"))]
     Messages = 114,
 
@@ -1135,11 +1132,6 @@ pub(crate) fn last_msg_sent_successfully(context: &Context) -> String {
 /// `%1$s` will be replaced by a possibly more detailed, typically english, error description.
 pub(crate) fn error(context: &Context, error: &str) -> String {
     translated(context, StockMessage::Error).replace1(error)
-}
-
-/// Stock string: `Not supported by your provider.`.
-pub(crate) fn not_supported_by_provider(context: &Context) -> String {
-    translated(context, StockMessage::NotSupportedByProvider)
 }
 
 /// Stock string: `Messages`.


### PR DESCRIPTION
This also solves the problem with the fact that
it's not clear from the resulting HTML
that this error message is referring to quota and not something else.
See https://github.com/chatmail/core/pull/8130.

TODO:
- [x] Delete the string from Transifex?
  https://github.com/deltachat/deltachat-android/pull/4433