### PR TITLE
fix: use correct dir converting plaintext to HTML

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -304,7 +304,7 @@ mod tests {
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto" style="unicode-bidi: plaintext">
 This message does not have Content-Type nor Subject.<br/>
 </body></html>
 "#
@@ -322,7 +322,7 @@ This message does not have Content-Type nor Subject.<br/>
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto" style="unicode-bidi: plaintext">
 message with a non-UTF-8 encoding: äöüßÄÖÜ<br/>
 </body></html>
 "#
@@ -341,7 +341,7 @@ message with a non-UTF-8 encoding: äöüßÄÖÜ<br/>
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto" style="unicode-bidi: plaintext">
 This line ends with a space and will be merged with the next one due to format=flowed.<br/>
 <br/>
 This line does not end with a space<br/>
@@ -362,7 +362,7 @@ and will be wrapped as usual.<br/>
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto" style="unicode-bidi: plaintext">
 mime-modified should not be set set as there is no html and no special stuff;<br/>
 although not being a delta-message.<br/>
 test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x27; :)<br/>

--- a/src/plaintext.rs
+++ b/src/plaintext.rs
@@ -39,7 +39,7 @@ impl PlainText {
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto" style="unicode-bidi: plaintext">
 "#
         .to_string();
 
@@ -132,7 +132,7 @@ http://link-at-start-of-line.org
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto" style="unicode-bidi: plaintext">
 line 1<br/>
 line 2<br/>
 line with <a href="https://link-mid-of-line.org">https://link-mid-of-line.org</a> and <a href="http://link-end-of-line.com/file?foo=bar%20">http://link-end-of-line.com/file?foo=bar%20</a><br/>
@@ -156,7 +156,7 @@ line with <a href="https://link-mid-of-line.org">https://link-mid-of-line.org</a
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto" style="unicode-bidi: plaintext">
 Foo<br/>
 bar<br/>
 </body></html>
@@ -178,7 +178,7 @@ bar<br/>
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto" style="unicode-bidi: plaintext">
 line with &lt;<a href="http://encapsulated.link/?foo=_bar">http://encapsulated.link/?foo=_bar</a>&gt; here!<br/>
 </body></html>
 "#
@@ -199,7 +199,7 @@ line with &lt;<a href="http://encapsulated.link/?foo=_bar">http://encapsulated.l
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto" style="unicode-bidi: plaintext">
 line with nohttp://no.link here<br/>
 </body></html>
 "#
@@ -220,7 +220,7 @@ line with nohttp://no.link here<br/>
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto" style="unicode-bidi: plaintext">
 just an address: <a href="mailto:foo@bar.org">foo@bar.org</a> <a href="mailto:another@one.de">another@one.de</a><br/>
 </body></html>
 "#
@@ -241,7 +241,7 @@ just an address: <a href="mailto:foo@bar.org">foo@bar.org</a> <a href="mailto:an
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto" style="unicode-bidi: plaintext">
 line still line<br/>
 <em>&gt;quote </em><br/>
 <em>&gt;still quote</em><br/>
@@ -265,7 +265,7 @@ line still line<br/>
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto" style="unicode-bidi: plaintext">
 linestill line<br/>
 <em>&gt;quote </em><br/>
 <em>&gt;still quote</em><br/>
@@ -289,7 +289,7 @@ linestill line<br/>
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto" style="unicode-bidi: plaintext">
 line <br/>
 still line<br/>
 <em>&gt;quote </em><br/>
@@ -314,7 +314,7 @@ still line<br/>
 <html><head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="color-scheme" content="light dark" />
-</head><body>
+</head><body dir="auto" style="unicode-bidi: plaintext">
 def foo():<br/>
 &nbsp;&nbsp;&nbsp;&nbsp;pass<br/>
 <br/>


### PR DESCRIPTION
This reapplies https://github.com/chatmail/core/pull/8227 but this time with fixed tests.

It turned out for desktop the style unicode-bidi: plaintext is needed. dir="auto" didn't work. The style only without dir attribute worked too but maybe it's better to have both. With this change https://github.com/deltachat/deltachat-desktop/issues/6345 is also solved for long messages that have a "Show full message" dialog

I hope there was no other reason for 6fb2f27831e95e5453 then the failing CI tests