### PR TITLE
fix: reconcile stale broadcast channel name from QR invite

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3633,6 +3633,16 @@ pub(crate) async fn create_out_broadcast_ex(
     }
 
     let timestamp = create_smeared_timestamp(context);
+
+    // Stamp the channel name with a timestamp right from creation so that every
+    // outgoing message carries a `Chat-Group-Name-Timestamp` header. Without it,
+    // a member that joined via a QR invite (and therefore took the channel name
+    // from the invite's `b=` parameter) could never reconcile a stale name with
+    // the actual channel name, see `apply_chat_name_avatar_and_description_changes()`.
+    let mut params = Params::new();
+    params.set_i64(Param::GroupNameTimestamp, timestamp);
+    let param = params.to_string();
+
     let trans_fn = |t: &mut rusqlite::Transaction| -> Result<ChatId> {
         let cnt: u32 = t.query_row(
             "SELECT COUNT(*) FROM chats WHERE grpid=?",
@@ -3643,13 +3653,14 @@ pub(crate) async fn create_out_broadcast_ex(
 
         t.execute(
             "INSERT INTO chats
-            (type, name, name_normalized, grpid, created_timestamp)
-            VALUES(?, ?, ?, ?, ?)",
+            (type, name, name_normalized, grpid, param, created_timestamp)
+            VALUES(?, ?, ?, ?, ?, ?)",
             (
                 Chattype::OutBroadcast,
                 &chat_name,
                 normalize_text(&chat_name),
                 &grpid,
+                &param,
                 timestamp,
             ),
         )?;

--- a/src/securejoin/securejoin_tests.rs
+++ b/src/securejoin/securejoin_tests.rs
@@ -710,6 +710,41 @@ async fn test_secure_join_broadcast_ex(v3: bool, remove_invite: bool) -> Result<
     Ok(())
 }
 
+/// Tests that a channel name taken from a stale QR invite (its `b=` parameter
+/// carries an outdated name) gets reconciled with the actual channel name once
+/// a regular channel message arrives, even though the channel was never renamed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_secure_join_broadcast_reconciles_stale_name() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = &tcm.alice().await;
+    let bob = &tcm.bob().await;
+
+    let alice_chat_id = chat::create_broadcast(alice, "Real Name".to_string()).await?;
+    let qr = get_securejoin_qr(alice, Some(alice_chat_id)).await?;
+
+    // Simulate a stale invite link: replace the `b=` parameter (always last in
+    // the QR) with an outdated channel name, as if the link was shared before
+    // the channel was renamed.
+    let stale_qr = Regex::new("&b=.*$")
+        .unwrap()
+        .replace(&qr, "&b=Stale%20Name");
+    assert!(stale_qr != *qr);
+    let qr = stale_qr.to_string();
+
+    let bob_chat_id = tcm.exec_securejoin_qr(bob, alice, &qr).await;
+
+    // A regular channel post, without any rename, must be enough for Bob to
+    // learn the actual channel name.
+    let sent = alice.send_text(alice_chat_id, "Hi channel").await;
+    let rcvd = bob.recv_msg(&sent).await;
+    assert_eq!(rcvd.chat_id, bob_chat_id);
+
+    let bob_chat = Chat::load_from_db(bob, bob_chat_id).await?;
+    assert_eq!(bob_chat.name, "Real Name");
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_setup_contact_compatibility_legacy() -> Result<()> {
     test_setup_contact_compatibility_ex(false, false).await

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -2385,6 +2385,24 @@ UPDATE msgs SET state=24 WHERE state=18; -- Change OutPreparing to OutFailed.
         .await?;
     }
 
+    inc_and_check(&mut migration_version, 153)?;
+    if dbversion < migration_version {
+        // Backfill `Param::GroupNameTimestamp` ('g') for existing outgoing broadcast
+        // channels (type 160 == `Chattype::OutBroadcast`). They were created without it,
+        // so their messages lacked a `Chat-Group-Name-Timestamp` header and joiners
+        // could not reconcile a channel name taken from a stale QR invite.
+        sql.execute_migration(
+            "UPDATE chats
+             SET param = CASE WHEN COALESCE(param, '') = '' THEN '' ELSE param || char(10) END
+                         || 'g=' || created_timestamp
+             WHERE type = 160
+               AND COALESCE(param, '') NOT LIKE 'g=%'
+               AND COALESCE(param, '') NOT LIKE '%' || char(10) || 'g=%'",
+            migration_version,
+        )
+        .await?;
+    }
+
     let new_version = sql
         .get_raw_config_int(VERSION_CFG)
         .await?


### PR DESCRIPTION
Closes #8250

## Problem

When a user joins a broadcast channel via a QR invite link
(`https://i.delta.chat/#...`), the joining device displays the channel
name taken from the link's `b=` parameter and **never reconciles it**
with the channel's actual name. If the two differ (e.g. the channel was
renamed after the link was generated, or an older link was shared), the
joining device shows the wrong name permanently — even after receiving
messages and membership events from the channel. Every other client
shows the correct name.

## Root cause

1. `check_qr` parses the link's `b=` parameter into
   `Qr::AskJoinBroadcast { name }`.
2. On join, `joining_chat_id()` creates the local `InBroadcast` chat
   with that name via `create_multiuser_record()`; the chat's
   `Param::GroupNameTimestamp` is left unset (`0`).
3. `create_out_broadcast_ex()` creates the owner's `OutBroadcast` chat
   **without** setting `Param::GroupNameTimestamp`. Channels are always
   promoted, so the first-message promotion path in `chat.rs` that sets
   the timestamp for `Group | OutBroadcast` is never reached.
4. Consequently `mimefactory` emits `Chat-Group-Name` but never
   `Chat-Group-Name-Timestamp` for channel messages.
5. `apply_chat_name_avatar_and_description_changes()` only enters the
   name-update block when the message carries a
   `Chat-Group-Name-Timestamp` (or `Chat-Group-Name-Changed`) header.
   With neither present, the QR-derived name is never overwritten.

## Fix

- `create_out_broadcast_ex()` now stamps `Param::GroupNameTimestamp` at
  channel creation, so every outgoing channel message advertises the
  name with a timestamp and joiners can reconcile a stale name.
- Migration 153 backfills `Param::GroupNameTimestamp` on existing
  outgoing broadcast channels.

This keeps the "broadcast channels are always promoted" invariant
intact (`Param::Unpromoted` is untouched).

## Testing

- New regression test `test_secure_join_broadcast_reconciles_stale_name`
  joins a channel with a manipulated (stale) `b=` parameter and asserts
  the name is reconciled after a regular channel post. It fails without
  the `chat.rs` change and passes with it.
- All existing broadcast tests pass, incl. `test_broadcasts_name_and_avatar`
  (which asserts channels are always promoted) and `test_broadcast_change_name`.
- `cargo fmt` clean.

## Disclosure

As my Rust knowledge is weak, I have created this patch with help of
Claude Code. Please take this under consideration when reviewing.