### PR TITLE
fix: Tombstone MDN before sending it (#8252)

### DIFF
--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -221,6 +221,30 @@ def test_account(acfactory) -> None:
     alice.stop_io()
 
 
+def test_mark_fresh_vs_self_mdn(acfactory) -> None:
+    alice, bob = acfactory.get_online_accounts(2)
+    bob.set_config("bcc_self", "1")
+
+    alice_contact_bob = alice.create_contact(bob)
+    alice_chat = alice_contact_bob.create_chat()
+    alice_chat.send_text("Hello!")
+
+    event = bob.wait_for_incoming_msg_event()
+    chat_id = event.chat_id
+    msg_id = event.msg_id
+
+    bob_chat = bob.get_chat_by_id(chat_id)
+    message = bob.get_message_by_id(msg_id)
+    bob_chat.accept()
+    bob.mark_seen_messages([message])
+    bob_chat.mark_fresh()
+    assert bob_chat.get_fresh_message_count() == 1
+    alice.wait_for_event(EventType.MSG_READ)
+    alice_chat.send_text("You've read 'Hello!'")
+    bob.wait_for_incoming_msg_event()
+    assert bob_chat.get_fresh_message_count() == 2
+
+
 def test_chat(acfactory) -> None:
     alice, bob = acfactory.get_online_accounts(2)
 

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -1374,6 +1374,18 @@ async fn test_markfresh_chat() -> Result<()> {
     assert_eq!(bob_chat_id.get_fresh_msg_cnt(bob).await?, 0);
     assert_eq!(bob.get_fresh_msgs().await?.len(), 0);
 
+    // Marking a message as seen results to sending an MDN to the contact and self.
+    message::markseen_msgs(bob, vec![bob_msg2.id]).await?;
+    assert_eq!(
+        bob.sql
+            .count(
+                "SELECT COUNT(*) FROM smtp_mdns WHERE from_id=?",
+                (bob_msg2.from_id,)
+            )
+            .await?,
+        1
+    );
+
     // bob marks the chat as fresh again, fresh count is 1 again
     markfresh_chat(bob, bob_chat_id).await?;
     let bob_msg1 = Message::load_from_db(bob, bob_msg1.id).await?;

--- a/src/smtp.rs
+++ b/src/smtp.rs
@@ -599,7 +599,7 @@ async fn send_mdn_rfc724_mid(
                 .ok()
         })
         .collect();
-
+    message::insert_tombstone(context, &rendered_msg.rfc724_mid).await?;
     match smtp_send(context, &recipients, &body, smtp, None).await {
         SendResult::Success => {
             if !recipients.is_empty() {


### PR DESCRIPTION
Otherwise, when it appears on IMAP, it will mark chat messages as seen/noticed even if
    markfresh_chat() is called meanwhile.

Fix #8252 