### PR TITLE
Remove fingerprint and addresses from the context info

### DIFF
--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -91,7 +91,15 @@ def test_lowercase_address(acfactory) -> None:
     assert account.list_transports()[0]["addr"] == addr
 
     param = account.get_info()["used_transport_settings"]
-    assert addr in param
+
+    domain = addr.rsplit("@")[-1]
+    domain_upper = addr_upper.rsplit("@")[-1]
+    assert domain in param
+    assert domain_upper not in param
+
+    # Whole address should not appear in the info,
+    # does not matter if uppercase or lowercase.
+    assert addr not in param
     assert addr_upper not in param
 
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -21,7 +21,6 @@ use crate::contact::{Contact, ContactId};
 use crate::debug_logging::DebugLogging;
 use crate::events::{Event, EventEmitter, EventType, Events};
 use crate::imap::{Imap, ServerMetadata};
-use crate::key::self_fingerprint;
 use crate::log::warn;
 use crate::logged_debug_assert;
 use crate::message::{self, MessageState, MsgId};
@@ -843,7 +842,6 @@ impl Context {
 
     /// Returns information about the context as key-value pairs.
     pub async fn get_info(&self) -> Result<BTreeMap<&'static str, String>> {
-        let all_self_addrs = self.get_all_self_addrs().await?.join(", ");
         let all_transports: Vec<String> = ConfiguredLoginParam::load_all(self)
             .await?
             .into_iter()
@@ -941,7 +939,6 @@ impl Context {
             }
         }
 
-        res.insert("all_self_addrs", all_self_addrs);
         res.insert(
             "who_can_call_me",
             self.get_config_int(Config::WhoCanCallMe).await?.to_string(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -880,10 +880,6 @@ impl Context {
             .sql
             .count("SELECT COUNT(*) FROM public_keys;", ())
             .await?;
-        let fingerprint_str = match self_fingerprint(self).await {
-            Ok(fp) => fp.to_string(),
-            Err(err) => format!("<key failure: {err}>"),
-        };
 
         let mut res = get_info();
 
@@ -962,7 +958,6 @@ impl Context {
         res.insert("disable_idle", disable_idle.to_string());
         res.insert("private_key_count", prv_key_cnt.to_string());
         res.insert("public_key_count", pub_key_cnt.to_string());
-        res.insert("fingerprint", fingerprint_str);
         res.insert(
             "media_quality",
             self.get_config_int(Config::MediaQuality).await?.to_string(),

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -131,7 +131,9 @@ pub(crate) struct ConfiguredServerLoginParam {
 
 impl fmt::Display for ConfiguredServerLoginParam {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", self.connection, self.user)?;
+        // Do not print the username,
+        // we do not want it to end up in the logs.
+        write!(f, "{}", self.connection)?;
         Ok(())
     }
 }
@@ -227,13 +229,21 @@ pub(crate) struct ConfiguredLoginParamJson {
 
 impl fmt::Display for ConfiguredLoginParam {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let addr = &self.addr;
         let provider_id = match self.provider {
             Some(provider) => provider.id,
             None => "none",
         };
         let certificate_checks = self.certificate_checks;
-        write!(f, "{addr} imap:[")?;
+        if let Ok(parsed_addr) = EmailAddress::new(&self.addr) {
+            // Only include the domain.
+            write!(f, "***@{}", parsed_addr.domain)?;
+        } else {
+            // Should not happen, but if the address
+            // does not have a distinct domain part,
+            // print it as is.
+            write!(f, "{}", self.addr)?;
+        };
+        write!(f, " imap:[")?;
         let mut first = true;
         for imap in &self.imap {
             if !first {


### PR DESCRIPTION
This info is printed at the top of the log, but is not necessary for debugging. It is enough to have just the domain names of the relays.