### PR TITLE
WIP: port to rpgp +1 while keeping the same decryption behavior for SEIPDv1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ num-derive = "0.4"
 num-traits = { workspace = true }
 parking_lot = "0.12.4"
 percent-encoding = "2.3"
-pgp = { version = "0.19.0", features = ["draft-pqc"], default-features = false }
+pgp = { git = "https://github.com/rpgp/rpgp/", features = ["draft-pqc"], default-features = false }
 pin-project = "1"
 qrcodegen = "1.7.0"
 quick-xml = { version = "0.39", features = ["escape-html"] }

--- a/src/decrypt.rs
+++ b/src/decrypt.rs
@@ -6,13 +6,16 @@ use std::io::Cursor;
 
 use anyhow::{Context as _, Result, bail};
 use mailparse::ParsedMail;
+use pgp::composed::DecryptionOptions;
 use pgp::composed::Esk;
 use pgp::composed::Message;
 use pgp::composed::PlainSessionKey;
 use pgp::composed::SignedSecretKey;
+use pgp::composed::TheRing;
 use pgp::composed::decrypt_session_key_with_password;
 use pgp::packet::SymKeyEncryptedSessionKey;
 use pgp::types::Password;
+use pgp::types::Seipdv1ReadMode;
 use pgp::types::StringToKey;
 
 use crate::chat::ChatId;
@@ -61,8 +64,14 @@ pub(crate) async fn decrypt(
         expected_sender_fingerprint = fingerprint;
 
         tokio::task::spawn_blocking(move || -> Result<Message<'_>> {
-            let plain = msg
-                .decrypt_with_session_key(psk)
+            let ring = TheRing {
+                session_keys: vec![psk],
+                decrypt_options: DecryptionOptions::new()
+                    .set_seipdv1_read_mode(Seipdv1ReadMode::Streaming),
+                ..Default::default()
+            };
+            let (plain, _) = msg
+                .decrypt_the_ring(ring, true)
                 .context("decrypt_with_session_key")?;
 
             let plain: Message<'static> = plain.decompress()?;


### PR DESCRIPTION
rPGP's default behavior while decrypting SEIPDv1 messages has changed from streaming to buffering the full plaintext in memory first: https://github.com/rpgp/rpgp/pull/662

This is more defensive, but may cause OOM problems for applications (which I believe has been a problem for Delta Chat in the past). When applications are able to safely deal with early release of unauthenticated plaintext during decryption, then (re-)opting in to streaming SEIPDv1 decryption is attractive.

The diff in PR shows how to keep the same rPGP decryption characteristics as before when using the (still unfinished) next release.