### PR TITLE
refactor: remove pre_encrypt_mime_hook

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -452,11 +452,6 @@ pub enum Config {
     /// storing the same token multiple times on the server.
     EncryptedDeviceToken,
 
-    /// Enables running test hooks, e.g. see `InnerContext::pre_encrypt_mime_hook`.
-    /// This way is better than conditional compilation, i.e. `#[cfg(test)]`, because tests not
-    /// using this still run unmodified code.
-    TestHooks,
-
     /// Return an error from `receive_imf_inner()`. For tests.
     SimulateReceiveImfError,
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -332,17 +332,6 @@ pub struct InnerContext {
     /// `Connectivity` values for mailboxes, unordered. Used to compute the aggregate connectivity,
     /// see [`Context::get_connectivity()`].
     pub(crate) connectivities: parking_lot::Mutex<Vec<ConnectivityStore>>,
-
-    #[expect(clippy::type_complexity)]
-    /// Transforms the root of the cryptographic payload before encryption.
-    pub(crate) pre_encrypt_mime_hook: parking_lot::Mutex<
-        Option<
-            for<'a> fn(
-                &Context,
-                mail_builder::mime::MimePart<'a>,
-            ) -> mail_builder::mime::MimePart<'a>,
-        >,
-    >,
 }
 
 /// The state of ongoing process.
@@ -522,7 +511,6 @@ impl Context {
             self_fingerprint: OnceLock::new(),
             self_public_key: Mutex::new(None),
             connectivities: parking_lot::Mutex::new(Vec::new()),
-            pre_encrypt_mime_hook: None.into(),
         };
 
         let ctx = Context {

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1168,12 +1168,6 @@ impl MimeFactory {
                 _ => None,
             };
 
-            if context.get_config_bool(Config::TestHooks).await?
-                && let Some(hook) = &*context.pre_encrypt_mime_hook.lock()
-            {
-                message = hook(context, message);
-            }
-
             let encrypted = if let Some(shared_secret) = shared_secret {
                 let sign = true;
                 encrypt_helper

--- a/src/mimeparser/mimeparser_tests.rs
+++ b/src/mimeparser/mimeparser_tests.rs
@@ -1790,35 +1790,27 @@ async fn test_time_in_future() -> Result<()> {
     Ok(())
 }
 
+/// Tests receiving a message with RFC 9788 header protection and legacy display element.
+///
+/// Legacy display elements should not be rendered:
+/// <https://www.rfc-editor.org/rfc/rfc9788.html#name-do-not-render-legacy-displa>
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_hp_legacy_display() -> Result<()> {
     let mut tcm = TestContextManager::new();
-    let alice = &tcm.alice().await;
     let bob = &tcm.bob().await;
 
-    let mut msg = Message::new_text(
-        "Subject: Dinner plans\n\
-        \n\
-        Let's eat"
-            .to_string(),
-    );
-    msg.set_subject("Dinner plans".to_string());
-    let chat_id = alice.create_chat(bob).await.id;
-    alice.set_config_bool(Config::TestHooks, true).await?;
-    *alice.pre_encrypt_mime_hook.lock() = Some(|_, mut mime| {
-        for (h, v) in &mut mime.headers {
-            if h == "Content-Type"
-                && let mail_builder::headers::HeaderType::ContentType(ct) = v
-            {
-                *ct = ct.clone().attribute("hp-legacy-display", "1");
-            }
-        }
-        mime
-    });
-    let sent_msg = alice.send_msg(chat_id, &mut msg).await;
-
-    let msg_bob = bob.recv_msg(&sent_msg).await;
+    let msg_id = receive_imf(
+        bob,
+        include_bytes!("../../test-data/message/hp_legacy_display.eml"),
+        false,
+    )
+    .await?
+    .unwrap()
+    .msg_ids[0];
+    let msg_bob = Message::load_from_db(bob, msg_id).await?;
     assert_eq!(msg_bob.subject, "Dinner plans");
+
+    // Legacy display element is removed from the text/plain body.
     assert_eq!(msg_bob.text, "Let's eat");
     Ok(())
 }

--- a/test-data/message/hp_legacy_display.eml
+++ b/test-data/message/hp_legacy_display.eml
@@ -1,0 +1,63 @@
+Content-Type: multipart/encrypted; protocol="application/pgp-encrypted";
+	boundary="18b255ee53144064_9da6abff99cb33df_3854fea559a18923"
+MIME-Version: 1.0
+From: <alice@example.org>
+To: "hidden-recipients": ;
+Subject: [...]
+Date: Fri, 22 May 2026 22:48:16 +0000
+Message-ID: <3a5ae0d2-be4b-4463-8011-ab4a354ee690@localhost>
+Chat-Version: 1.0
+
+
+--18b255ee53144064_9da6abff99cb33df_3854fea559a18923
+Content-Type: application/pgp-encrypted; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+Version: 1
+
+--18b255ee53144064_9da6abff99cb33df_3854fea559a18923
+Content-Type: application/octet-stream; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+-----BEGIN PGP MESSAGE-----
+
+wUcGABIBB0BNBleU/G9GwCpizow72+5GANtiX+F7y/gI45x7MJLpFiBi+7OqwdFk
+dmINorerXmnk1jR7TEppDYhjCBRWaCXHJsHARQYAAQf/Zj43ZUA3rtGS6Nq9vUcc
+0L6knU0ukLc3KGTExQXu4ktiPT0RIjQ11wtSGlS75Bj7tu3syDf2/oQXi7eUh35T
+IULpBQ5Pnpk6h26GX9WbRYR5zmBNnlyppqJcaYueQzPX1gvybJ4cwfOmnMdUqzFr
+D9BR/YeyrBETsGKR+UfH167xgGY8d0ev8Tt4X01muiyrwLVqfoGCRUwjQFUY+ClY
+9yuCrNDnu8fHY/WRTKXoDkA8Qn9/6TdJM7G41wOaJYbWn4R8WqjqoQNdUYwL2cBg
+Pj1SNgaTaLMMH8YEtlRUN3JHiiqaBVIJIKBduOXnVEovf8FVXlmqX8DARLvqFCk2
+LdLEjQIHAgdxw8asmmKOpatAEwFHuVwkWe/ZbRhu3D1V38BzZEuSLHzQ/nWbWWVP
+GRmcZPmpusvRGX5W4zC6ybr5jePkW1dEqpgFFeoywz5REQxnl2QDPMHbWRFmC+q5
+FSA/zacYGIKmU761xWc1raaosN4uzf8ujJA8H+TQT4AKu4K2nzSMFpUl05sNToGN
+FdCNAvsnM9/PAraE3pju6YK+l4Woo/MLVEkrDEcLYEC/TrbNCJ6cnx/3uU+9gZyp
+ntXzwOJIIQ5el2qcSQuzec931Lr4UuX4k0FUKeLS24EiYid4K59iPHgKJn6E7grb
+34bxbQXkIMug0nTBKuAOTv7MFF4/rzn5deAUXpKty5zYLjqGApo4o5nnEvY9inXP
+3489C77lCTLuXgkASrYhqTZcFT6ewaLNJxKRQgLB/V8BY4DrckA/If31z57EK2Ju
+5kXpUfZKw/qjnHELLLSmYqx0Sd6w37d0x4LxHIjnpBEmsjWagM9fhiBJyaitNfCz
+hBEUAQoO2DlqrZMwAhKxADH8WUbXOhgXcj68NM185A+/UzMbbdV0cmLKynH3tlLX
+d16ZyriiRcllSuISXYLTsUwlQeA0zIyuYItzk7bGkw/2k4AmxFAFZjZPvaHOrt98
+BapEkxYp8wyhXdloknJ687E5Oa4UTsMKzRTrXRiPhVNstYcYnde4fZs0cUX0JJqE
+bZrR+T8biflfGWidc0D0cSd2rx6RryvykFBzvZJH4zqNaHap3w5F0miZWfrePQ8Y
+ljPCb162x3SAHc5RzhHH7tq4YatWlnncSAuGkZA7XMqBgFbIRdY2z+Hv5AQLj563
+OHD0Dc0pXUZYcHVdJnY4svuiekjEYLaGzjklULBsQo4KQXb8i3SufS8JUwypwAT1
+BzMWYQrT6cv3IQHtF9Yys6Z3ngYs9UoCIyqPHYFZYV8Y64injpBFtiY6kd0zvm/3
+5D5c0DcmI6kq0LNNNzZg5F0oMoDvyny1pI5/IGxS1H3OyBNJlNZkftMadyvDydY7
+khCjWzB9mTStrmeYVqJof/NyfMWJMa0NtJrqW+730FYnld95cGzf3gnRsTYd/CgD
+vXVcj5F2/fxsDUekmMMAYBB3DCBv0yCJJfqaTgQKcwngOL0+kuGVnjT8qfjf0FQR
+yzImEPJFTQFe+mpRALBoMSDRpzja6ZkU/AIOTT/xy1ZkfpLU/TpNk7XS6InsIjdH
+wBzfPvDUV7hHWwgILE+DTlebZVEuVBuoKTM72paMomYzskTkCGnIkTxioA1SyJxJ
+eOsSlNC30Le6rcbvz+kl+H7cW2RGZuCUub/UtCMlcdjlzEVAjwXgQZgys2mAwLPx
+n61I6rO+eEphXr5F/S6/0NwomR/02FY5AmqeViKC0G6/bDJOO374vU3bix28xqeB
+yYYeO+ZymhjqA7tLTEjrkrCh0vo1WoKSAWbhVqM9YUzAeusqyndZ2uLbTgCEayER
+MviI27DrXTDpExV9qLyELpo0z18kwoFScJ5ULXDN4lpwfsCeg3ThvBJD86V+4faT
+4neKUwzasjYvuzKqSRV4j89I5Bs1g8ERaQr3VZ4BnyjKxQ91eLsMDD+LMx2QW2lB
+HPUTWc4qmSAItogwZRxGUj+dASjcuGwqVhabUxWpxPsVGdOp6D3au1M3k7EuvLLa
+NmnDDyNRSU8d7Mc/Tp9swfPKd2ItI4cREXTpyu53ayzSD5/7LaDtpHUASdaDLgDv
+2evlUTBRk2a8+trbhE0oy8zzRdbgiNrwcegGM+y5BYCdV5Gooerk4g8pnULtKT1R
+VgWMKvXvFduvQsfXW+PKChw=
+=EBeW
+-----END PGP MESSAGE-----
+
+--18b255ee53144064_9da6abff99cb33df_3854fea559a18923--


### PR DESCRIPTION
It is only used in a single test
and the test is more reliable by having a blob .eml that will not be accidentally modified
by mimefactory changes.