### PR TITLE
fix: sql syntax error in older migration

### DIFF
--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -2346,7 +2346,7 @@ ALTER TABLE contacts ADD COLUMN name_normalized TEXT;
                     transaction.execute(
                         "UPDATE transports
                          SET entered_param=json_set(entered_param, '$.imap.folder', ?1),
-                             configured_param=json_set(configured_param', '$.imap_folder', ?1)",
+                             configured_param=json_set(configured_param, '$.imap_folder', ?1)",
                         (mvbox_folder,),
                     )?;
                 }


### PR DESCRIPTION
reported by support account today ...

```
Updating Delta Chat failed. Please send this message to the Delta Chat developers, either at delta@merlinux.eu or at https://support.delta.chat.

failed to run migrations: execute_migration failed for version 150: near "', '": syntax error in UPDATE transports
SET entered_param=json_set(entered_param, '$.imap.folder', ?1),
configured_param=json_set(configured_param', '$.imap_folder', ?1) at offset 178: Error code 1: SQL error or missing database
```

probably only happens if only_fetch_mvbox is enabled and a user upgrades from a 2025 version or so.  Apparently there was no test touching that code. 