### PR TITLE
Fix nix build (remove naersk)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,15 +3,19 @@
     "android": {
       "inputs": {
         "devshell": "devshell",
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1731356359,
-        "narHash": "sha256-vYqJnu6jotmWpPT4DgzHVdvNIZcKZCIUqS8QaptsZA0=",
+        "lastModified": 1779918845,
+        "narHash": "sha256-FbpOOBg15L7X6NWWmTKbSdccnH59Jq53wWmAO37d2Q8=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "c028ead7e88edb2e94cd7c90ee37593f63ae494a",
+        "rev": "105c093afc8c8fbeea98f8e398403f93043eba17",
         "type": "github"
       },
       "original": {
@@ -28,11 +32,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728330715,
-        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
         "type": "github"
       },
       "original": {
@@ -43,15 +47,17 @@
     },
     "fenix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1763361733,
-        "narHash": "sha256-ka7dpwH3HIXCyD2wl5F7cPLeRbqZoY2ullALsvxdPt8=",
+        "lastModified": 1779876442,
+        "narHash": "sha256-O25HomVNmdROO13PEQ3Ran8Hq5EsyLmVn8Gb8JvJtJE=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "6c8d48e3b0ae371b19ac1485744687b788e80193",
+        "rev": "2eff81fc84390a35e1565395ae945d9394856824",
         "type": "github"
       },
       "original": {
@@ -65,29 +71,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -98,29 +86,35 @@
     },
     "naersk": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "fenix": [
+          "fenix"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1721727458,
-        "narHash": "sha256-r/xppY958gmZ4oTfLiHN0ZGuQ+RSTijDblVgVLFi1mw=",
+        "lastModified": 1779912356,
+        "narHash": "sha256-yj5O6vmAj+OfhTQMiUwhmQRP0HAII3BxEI6zuY6h/5k=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "3fb418eaf352498f6b6c30592e3beb63df42ef11",
+        "rev": "33eaf5c72a67db15073322d26cd342c443556214",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
+        "ref": "pull/391/head",
         "repo": "naersk",
         "type": "github"
       }
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1730207686,
-        "narHash": "sha256-SCHiL+1f7q9TAnxpasriP6fMarWE5H43t25F5/9e28I=",
+        "lastModified": 1757882181,
+        "narHash": "sha256-+cCxYIh2UNalTz364p+QYmWHs0P+6wDhiWR4jDIKQIU=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "776e68c1d014c3adde193a18db9d738458cd2ba4",
+        "rev": "59c44d1909c72441144b93cf0f054be7fe764de5",
         "type": "github"
       },
       "original": {
@@ -131,60 +125,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731139594,
-        "narHash": "sha256-IigrKK3vYRpUu+HEjPL/phrfh7Ox881er1UEsZvw9Q4=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "76612b17c0ce71689921ca12d9ffdc9c23ce40b2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1762977756,
-        "narHash": "sha256-4PqRErxfe+2toFJFgcRKZ0UI9NSIOJa+7RXVtBhy4KE=",
+        "lastModified": 1779931091,
+        "narHash": "sha256-gc8NEz7a++7OQPGvMv+zIjXCec1PO38XRXZRa3m97ew=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c5ae371f1a6a7fd27823bc500d9390b38c05fa55",
+        "rev": "3052ddf0614791c1869384a868248be5607a309f",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY=",
-        "path": "/nix/store/zq2axpgzd5kykk1v446rkffj3bxa2m2h-source",
-        "type": "path"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1747179050,
-        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "master",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -193,20 +143,20 @@
       "inputs": {
         "android": "android",
         "fenix": "fenix",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "naersk": "naersk",
         "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs"
       }
     },
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1762860488,
-        "narHash": "sha256-rMfWMCOo/pPefM2We0iMBLi2kLBAnYoB9thi4qS7uk4=",
+        "lastModified": 1779827300,
+        "narHash": "sha256-J6pHxKoZzWCrAvOVInwBcYYWix/NWwM10Ad+i29Qc5s=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "2efc80078029894eec0699f62ec8d5c1a56af763",
+        "rev": "c3af07ad84d68adc5e652e86f0c20009caa29014",
         "type": "github"
       },
       "original": {
@@ -217,21 +167,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -84,30 +84,6 @@
         "type": "github"
       }
     },
-    "naersk": {
-      "inputs": {
-        "fenix": [
-          "fenix"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1779912356,
-        "narHash": "sha256-yj5O6vmAj+OfhTQMiUwhmQRP0HAII3BxEI6zuY6h/5k=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "33eaf5c72a67db15073322d26cd342c443556214",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "pull/391/head",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
     "nix-filter": {
       "locked": {
         "lastModified": 1757882181,
@@ -144,7 +120,6 @@
         "android": "android",
         "fenix": "fenix",
         "flake-utils": "flake-utils",
-        "naersk": "naersk",
         "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,16 +4,13 @@
     fenix.url = "github:nix-community/fenix";
     fenix.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
-    naersk.url = "github:nix-community/naersk/pull/391/head";
-    naersk.inputs.nixpkgs.follows = "nixpkgs";
-    naersk.inputs.fenix.follows = "fenix";
     nix-filter.url = "github:numtide/nix-filter";
     nixpkgs.url = "github:nixos/nixpkgs/master";
     android.url = "github:tadfisher/android-nixpkgs";
     android.inputs.nixpkgs.follows = "nixpkgs";
     android.inputs.flake-utils.follows = "flake-utils";
   };
-  outputs = { self, nixpkgs, flake-utils, nix-filter, naersk, fenix, android }:
+  outputs = { self, nixpkgs, flake-utils, nix-filter, fenix, android }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
@@ -24,7 +21,7 @@
           fenixPkgs.stable.cargo
           fenixPkgs.stable.rust-std
         ];
-        naersk' = pkgs.callPackage naersk {
+        rustPlatform = pkgs.makeRustPlatform {
           cargo = fenixToolchain;
           rustc = fenixToolchain;
         };
@@ -102,86 +99,26 @@
           lockFile = ./Cargo.lock;
         };
         mkRustPackage = packageName:
-          naersk'.buildPackage {
+          rustPlatform.buildRustPackage {
             pname = packageName;
-            cargoBuildOptions = x: x ++ [ "--package" packageName ];
+            cargoDeps = rustPlatform.importCargoLock cargoLock;
+            cargoBuildFlags = [ "--package" packageName ];
             version = manifest.version;
             src = pkgs.lib.cleanSource ./.;
             nativeBuildInputs = [
               pkgs.perl # Needed to build vendored OpenSSL.
             ];
-            auditable = false; # Avoid cargo-auditable failures.
             doCheck = false; # Disable test as it requires network access.
           };
-        pkgsWin64 = pkgs.pkgsCross.mingwW64;
         mkWin64RustPackage = packageName:
           let
+            pkgsWinStatic = import nixpkgs {
+              inherit system;
+              crossSystem = { config = "x86_64-w64-mingw32"; isStatic = true; };
+            };
             rustTarget = "x86_64-pc-windows-gnu";
-            toolchainWin = fenixPkgs.combine [
-              fenixPkgs.stable.rustc
-              fenixPkgs.stable.cargo
-              fenixPkgs.targets.${rustTarget}.stable.rust-std
-            ];
-            naerskWin = pkgs.callPackage naersk {
-              cargo = toolchainWin;
-              rustc = toolchainWin;
-            };
-          in
-          naerskWin.buildPackage rec {
-            pname = packageName;
-            cargoBuildOptions = x: x ++ [ "--package" packageName ];
-            version = manifest.version;
-            strictDeps = true;
-            src = pkgs.lib.cleanSource ./.;
-            nativeBuildInputs = [
-              pkgs.perl # Needed to build vendored OpenSSL.
-            ];
-            depsBuildBuild = [
-              pkgsWin64.stdenv.cc
-            ];
-            buildInputs = [
-              pkgsWin64.windows.pthreads
-            ];
-            auditable = false; # Avoid cargo-auditable failures.
-            doCheck = false; # Disable test as it requires network access.
-
-            CARGO_BUILD_TARGET = rustTarget;
-            TARGET_CC = "${pkgsWin64.stdenv.cc}/bin/${pkgsWin64.stdenv.cc.targetPrefix}cc";
-            CARGO_BUILD_RUSTFLAGS = [
-              "-C"
-              "linker=${TARGET_CC}"
-              "-L"
-              "native=${pkgsWin64.windows.pthreads}/lib"
-            ];
-
-            CC = "${pkgsWin64.stdenv.cc}/bin/${pkgsWin64.stdenv.cc.targetPrefix}cc";
-            LD = "${pkgsWin64.stdenv.cc}/bin/${pkgsWin64.stdenv.cc.targetPrefix}cc";
-          };
-
-        pkgsWin32 = pkgs.pkgsCross.mingw32;
-        mkWin32RustPackage = packageName:
-          let
-            rustTarget = "i686-pc-windows-gnu";
-          in
-          let
-            toolchainWin = fenixPkgs.combine [
-              fenixPkgs.stable.rustc
-              fenixPkgs.stable.cargo
-              fenixPkgs.targets.${rustTarget}.stable.rust-std
-            ];
-            naerskWin = pkgs.callPackage naersk {
-              cargo = toolchainWin;
-              rustc = toolchainWin;
-            };
-
-            # Get rid of MCF Gthread library.
-            # See <https://github.com/NixOS/nixpkgs/issues/156343>
-            # and <https://discourse.nixos.org/t/statically-linked-mingw-binaries/38395>
-            # for details.
-            #
-            # Use DWARF-2 instead of SJLJ for exception handling.
-            winCC = pkgsWin32.buildPackages.wrapCC (
-              (pkgsWin32.buildPackages.gcc-unwrapped.override
+            winCC = pkgsWinStatic.buildPackages.wrapCC (
+              (pkgsWinStatic.buildPackages.gcc-unwrapped.override
                 ({
                   threadsCross = {
                     model = "win32";
@@ -189,15 +126,24 @@
                   };
                 })).overrideAttrs (oldAttr: {
                 configureFlags = oldAttr.configureFlags ++ [
-                  "--disable-sjlj-exceptions"
-                  "--with-dwarf2"
+                  "--enable-sjlj-exceptions"
                 ];
               })
             );
+            toolchainWin = fenixPkgs.combine [
+              fenixPkgs.stable.rustc
+              fenixPkgs.stable.cargo
+              fenixPkgs.targets.${rustTarget}.stable.rust-std
+            ];
+            winRustPlatform = pkgsWinStatic.makeRustPlatform {
+              cargo = toolchainWin;
+              rustc = toolchainWin;
+            };
           in
-          naerskWin.buildPackage rec {
+          winRustPlatform.buildRustPackage rec {
             pname = packageName;
-            cargoBuildOptions = x: x ++ [ "--package" packageName ];
+            cargoDeps = winRustPlatform.importCargoLock cargoLock;
+            cargoBuildFlags = [ "--package" packageName ];
             version = manifest.version;
             strictDeps = true;
             src = pkgs.lib.cleanSource ./.;
@@ -208,18 +154,85 @@
               winCC
             ];
             buildInputs = [
-              pkgsWin32.windows.pthreads
+              pkgsWinStatic.windows.pthreads
             ];
-            auditable = false; # Avoid cargo-auditable failures.
             doCheck = false; # Disable test as it requires network access.
 
-            CARGO_BUILD_TARGET = rustTarget;
+            cargoBuildTarget = rustTarget;
+            TARGET_CC = "${pkgsWinStatic.stdenv.cc}/bin/${pkgsWinStatic.stdenv.cc.targetPrefix}cc";
+            CARGO_BUILD_RUSTFLAGS = [
+              "-C"
+              "linker=${TARGET_CC}"
+              "-L"
+              "native=${pkgsWinStatic.windows.pthreads}/lib"
+            ];
+
+            CC = "${winCC}/bin/${winCC.targetPrefix}cc";
+            LD = "${winCC}/bin/${winCC.targetPrefix}cc";
+          };
+
+        mkWin32RustPackage = packageName:
+          let
+            pkgsWinStatic = import nixpkgs {
+              inherit system;
+              crossSystem = { config = "i686-w64-mingw32"; isStatic = true; };
+            };
+            rustTarget = "i686-pc-windows-gnu";
+            toolchainWin = fenixPkgs.combine [
+              fenixPkgs.stable.rustc
+              fenixPkgs.stable.cargo
+              fenixPkgs.targets.${rustTarget}.stable.rust-std
+            ];
+            winRustPlatform = pkgsWinStatic.makeRustPlatform {
+              cargo = toolchainWin;
+              rustc = toolchainWin;
+            };
+
+            # Get rid of MCF Gthread library.
+            # See <https://github.com/NixOS/nixpkgs/issues/156343>
+            # and <https://discourse.nixos.org/t/statically-linked-mingw-binaries/38395>
+            # for details.
+            #
+            # Use DWARF-2 instead of SJLJ for exception handling.
+            winCC = pkgsWinStatic.buildPackages.wrapCC (
+              (pkgsWinStatic.buildPackages.gcc-unwrapped.override
+                ({
+                  threadsCross = {
+                    model = "win32";
+                    package = null;
+                  };
+                })).overrideAttrs (oldAttr: {
+                configureFlags = oldAttr.configureFlags ++ [
+                  "--enable-sjlj-exceptions"
+                ];
+              })
+            );
+          in
+          winRustPlatform.buildRustPackage rec {
+            pname = packageName;
+            cargoDeps = winRustPlatform.importCargoLock cargoLock;
+            cargoBuildFlags = [ "--package" packageName ];
+            version = manifest.version;
+            strictDeps = true;
+            src = pkgs.lib.cleanSource ./.;
+            nativeBuildInputs = [
+              pkgs.perl # Needed to build vendored OpenSSL.
+            ];
+            depsBuildBuild = [
+              winCC
+            ];
+            buildInputs = [
+              pkgsWinStatic.windows.pthreads
+            ];
+            doCheck = false; # Disable test as it requires network access.
+
+            cargoBuildTarget = rustTarget;
             TARGET_CC = "${winCC}/bin/${winCC.targetPrefix}cc";
             CARGO_BUILD_RUSTFLAGS = [
               "-C"
               "linker=${TARGET_CC}"
               "-L"
-              "native=${pkgsWin32.windows.pthreads}/lib"
+              "native=${pkgsWinStatic.windows.pthreads}/lib"
             ];
 
             CC = "${winCC}/bin/${winCC.targetPrefix}cc";
@@ -234,6 +247,7 @@
               system = system;
               crossSystem.config = crossTarget;
             };
+            pkgsCrossStatic = pkgsCross.pkgsStatic;
           in
           let
             toolchain = fenixPkgs.combine [
@@ -241,35 +255,35 @@
               fenixPkgs.stable.cargo
               fenixPkgs.targets.${rustTarget}.stable.rust-std
             ];
-            naersk-lib = pkgs.callPackage naersk {
+            crossRustPlatform = pkgsCrossStatic.makeRustPlatform {
               cargo = toolchain;
               rustc = toolchain;
             };
           in
-          naersk-lib.buildPackage rec {
+          crossRustPlatform.buildRustPackage rec {
             pname = packageName;
-            cargoBuildOptions = x: x ++ [ "--package" packageName ];
+            cargoDeps = crossRustPlatform.importCargoLock cargoLock;
+            cargoBuildFlags = [ "--package" packageName ];
             version = manifest.version;
             strictDeps = true;
             src = rustSrc;
             nativeBuildInputs = [
               pkgs.perl # Needed to build vendored OpenSSL.
             ];
-            auditable = false; # Avoid cargo-auditable failures.
             doCheck = false; # Disable test as it requires network access.
 
-            CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS = "-Clink-args=-L${pkgsCross.libiconv}/lib";
-            CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS = "-Clink-args=-L${pkgsCross.libiconv}/lib";
+            CARGO_TARGET_X86_64_APPLE_DARWIN_RUSTFLAGS = "-Clink-args=-L${pkgsCrossStatic.libiconv}/lib";
+            CARGO_TARGET_AARCH64_APPLE_DARWIN_RUSTFLAGS = "-Clink-args=-L${pkgsCrossStatic.libiconv}/lib";
 
-            CARGO_BUILD_TARGET = rustTarget;
-            TARGET_CC = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
+            cargoBuildTarget = rustTarget;
+            TARGET_CC = "${pkgsCrossStatic.stdenv.cc}/bin/${pkgsCrossStatic.stdenv.cc.targetPrefix}cc";
             CARGO_BUILD_RUSTFLAGS = [
               "-C"
               "linker=${TARGET_CC}"
             ];
 
-            CC = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
-            LD = "${pkgsCross.stdenv.cc}/bin/${pkgsCross.stdenv.cc.targetPrefix}cc";
+            CC = "${pkgsCrossStatic.stdenv.cc}/bin/${pkgsCrossStatic.stdenv.cc.targetPrefix}cc";
+            LD = "${pkgsCrossStatic.stdenv.cc}/bin/${pkgsCrossStatic.stdenv.cc.targetPrefix}cc";
           };
 
         androidAttrs = {
@@ -299,7 +313,7 @@
               fenixPkgs.stable.cargo
               fenixPkgs.targets.${rustTarget}.stable.rust-std
             ];
-            naersk-lib = pkgs.callPackage naersk {
+            androidRustPlatform = pkgs.makeRustPlatform {
               cargo = toolchain;
               rustc = toolchain;
             };
@@ -307,19 +321,19 @@
             targetCcName = androidAttrs.${arch}.cc;
             targetCc = "${targetToolchain}/bin/${targetCcName}";
           in
-          naersk-lib.buildPackage rec {
+          androidRustPlatform.buildRustPackage rec {
             pname = packageName;
-            cargoBuildOptions = x: x ++ [ "--package" packageName ];
+            cargoDeps = androidRustPlatform.importCargoLock cargoLock;
+            cargoBuildFlags = [ "--package" packageName ];
             version = manifest.version;
-            strictDeps = true;
             src = rustSrc;
             nativeBuildInputs = [
               pkgs.perl # Needed to build vendored OpenSSL.
             ];
-            auditable = false; # Avoid cargo-auditable failures.
             doCheck = false; # Disable test as it requires network access.
 
-            CARGO_BUILD_TARGET = rustTarget;
+            cargoBuildTarget = rustTarget;
+            dontPatchelf = true;
             TARGET_CC = "${targetCc}";
             CARGO_BUILD_RUSTFLAGS = [
               "-C"

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,16 @@
   description = "Chatmail core";
   inputs = {
     fenix.url = "github:nix-community/fenix";
+    fenix.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
-    naersk.url = "github:nix-community/naersk";
+    naersk.url = "github:nix-community/naersk/pull/391/head";
+    naersk.inputs.nixpkgs.follows = "nixpkgs";
+    naersk.inputs.fenix.follows = "fenix";
     nix-filter.url = "github:numtide/nix-filter";
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/master";
     android.url = "github:tadfisher/android-nixpkgs";
+    android.inputs.nixpkgs.follows = "nixpkgs";
+    android.inputs.flake-utils.follows = "flake-utils";
   };
   outputs = { self, nixpkgs, flake-utils, nix-filter, naersk, fenix, android }:
     flake-utils.lib.eachDefaultSystem (system:
@@ -133,6 +138,8 @@
             ];
             depsBuildBuild = [
               pkgsWin64.stdenv.cc
+            ];
+            buildInputs = [
               pkgsWin64.windows.pthreads
             ];
             auditable = false; # Avoid cargo-auditable failures.
@@ -143,6 +150,8 @@
             CARGO_BUILD_RUSTFLAGS = [
               "-C"
               "linker=${TARGET_CC}"
+              "-L"
+              "native=${pkgsWin64.windows.pthreads}/lib"
             ];
 
             CC = "${pkgsWin64.stdenv.cc}/bin/${pkgsWin64.stdenv.cc.targetPrefix}cc";
@@ -180,7 +189,8 @@
                   };
                 })).overrideAttrs (oldAttr: {
                 configureFlags = oldAttr.configureFlags ++ [
-                  "--disable-sjlj-exceptions --with-dwarf2"
+                  "--disable-sjlj-exceptions"
+                  "--with-dwarf2"
                 ];
               })
             );
@@ -196,6 +206,8 @@
             ];
             depsBuildBuild = [
               winCC
+            ];
+            buildInputs = [
               pkgsWin32.windows.pthreads
             ];
             auditable = false; # Avoid cargo-auditable failures.
@@ -206,6 +218,8 @@
             CARGO_BUILD_RUSTFLAGS = [
               "-C"
               "linker=${TARGET_CC}"
+              "-L"
+              "native=${pkgsWin32.windows.pthreads}/lib"
             ];
 
             CC = "${winCC}/bin/${winCC.targetPrefix}cc";
@@ -562,7 +576,7 @@
                   deltachat-python
                   deltachat-rpc-client
                   pkgs.python3Packages.breathe
-                  pkgs.python3Packages.sphinx_rtd_theme
+                  pkgs.python3Packages.sphinx-rtd-theme
                 ];
                 nativeBuildInputs = [ pkgs.sphinx ];
                 buildPhase = ''sphinx-build -b html -a python/doc/ dist/html'';


### PR DESCRIPTION
Alternative to #8282, removing `naersk` dependency.

There is a larger refactoring at https://github.com/chatmail/core/pull/8272, in this PR i am just fixing the build so we can make releases again.