### PR TITLE
Delete encrypted messages from the server in single-device mode immediately

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -6,6 +6,7 @@ use anyhow::{Result, anyhow, bail, ensure};
 use deltachat_derive::{FromSql, ToSql};
 use serde::{Deserialize, Serialize};
 
+use crate::config::Config;
 use crate::context::Context;
 use crate::imap::session::Session;
 use crate::log::warn;
@@ -169,7 +170,8 @@ pub(crate) async fn download_msg(
     }
     Box::pin(session.fetch_single_msg(context, &server_folder, server_uid, rfc724_mid)).await?;
 
-    if ephemeral::should_delete_all_downloaded_messages(context, session.is_chatmail()).await? {
+    let bcc_self = context.get_config_bool(Config::BccSelf).await?;
+    if ephemeral::should_delete_all_downloaded_messages(bcc_self, session.is_chatmail()) {
         // Now that the message was downloaded, it likely needs to be deleted;
         // trigger a re-check by interrupting the inbox folder.
         // This is mainly needed to make the tests pass;

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -654,7 +654,7 @@ pub(crate) async fn ephemeral_loop(context: &Context, interrupt_receiver: Receiv
 
 /// Schedules expired IMAP messages for deletion on the server.
 ///
-/// Also see [`delete_expired_imap_messages`],
+/// Also see [`delete_expired_messages`],
 /// which locally deletes expired messages.
 pub(crate) async fn delete_expired_imap_messages(
     context: &Context,

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -663,7 +663,8 @@ pub(crate) async fn delete_expired_imap_messages(
 ) -> Result<()> {
     let now = time();
 
-    if should_delete_all_downloaded_messages(context, is_chatmail).await? {
+    let bcc_self = context.get_config_bool(Config::BccSelf).await?;
+    if should_delete_all_downloaded_messages(bcc_self, is_chatmail) {
         // This is the only device using this relay.
         // Mark all downloaded messages for deletion, because they are not needed anymore.
         //
@@ -716,11 +717,8 @@ pub(crate) async fn delete_expired_imap_messages(
     Ok(())
 }
 
-pub(crate) async fn should_delete_all_downloaded_messages(
-    context: &Context,
-    is_chatmail: bool,
-) -> Result<bool> {
-    Ok(!context.get_config_bool(Config::BccSelf).await? && is_chatmail)
+pub(crate) fn should_delete_all_downloaded_messages(bcc_self: bool, is_chatmail: bool) -> bool {
+    !bcc_self && is_chatmail
 }
 
 /// Start ephemeral timers for seen messages if they are not started

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -691,7 +691,7 @@ pub(crate) async fn delete_expired_imap_messages(
                 (transport_id, now, DownloadState::Done),
             )
             .await?;
-    } else {
+    } else if bcc_self {
         // There may be other devices using this relay,
         // either because there is multi-device or because this is a classical email server.
         // Only delete expired ephemeral messages.
@@ -710,6 +710,30 @@ pub(crate) async fn delete_expired_imap_messages(
                         AND ephemeral_timestamp!=0 AND ephemeral_timestamp<=?2 AND id>9
                 )",
                 (transport_id, now),
+            )
+            .await?;
+    } else {
+        // Single device.
+        // Delete all expired and encrypted messages.
+        context
+            .sql
+            .execute(
+                "UPDATE imap
+                 SET target=''
+                 WHERE transport_id=?1
+                 AND rfc724_mid IN (
+                    SELECT rfc724_mid FROM msgs
+                    WHERE id>9
+                      AND ((ephemeral_timestamp!=0 AND ephemeral_timestamp<=?2) OR
+                           ((param GLOB '*\nc=1*' OR param GLOB 'c=1*') AND download_state=?3))
+                    UNION
+                    SELECT pre_rfc724_mid FROM msgs
+                    WHERE pre_rfc724_mid!=''
+                      AND id>9
+                      AND ((ephemeral_timestamp!=0 AND ephemeral_timestamp<=?2) OR
+                           (param GLOB '*\nc=1*' OR param GLOB 'c=1*'))
+                )",
+                (transport_id, now, DownloadState::Done),
             )
             .await?;
     }

--- a/src/ephemeral/ephemeral_tests.rs
+++ b/src/ephemeral/ephemeral_tests.rs
@@ -554,12 +554,21 @@ async fn test_delete_expired_imap_messages() -> Result<()> {
             .await?;
     }
 
-    for (is_chatmail, other_transport) in
-        [(false, false), (false, true), (true, false), (true, true)]
-    {
+    for (is_chatmail, other_transport, bcc_self) in [
+        (false, false, false),
+        (false, false, true),
+        (false, true, false),
+        (false, true, true),
+        (true, false, false),
+        (true, false, true),
+        (true, true, false),
+        (true, true, true),
+    ] {
         println!(
-            "Testing combination is_chatmail={is_chatmail}, other_transport={other_transport}"
+            "Testing combination is_chatmail={is_chatmail}, other_transport={other_transport}, bcc_self={bcc_self}"
         );
+
+        t.set_config_bool(Config::BccSelf, bcc_self).await?;
 
         delete_expired_imap_messages(
             &t,
@@ -581,19 +590,34 @@ async fn test_delete_expired_imap_messages() -> Result<()> {
         }
 
         assert_eq!(is_deleted(&t, "expired@localhost").await?, true);
-        assert_eq!(is_deleted(&t, "no_expire@localhost").await?, is_chatmail);
-        assert_eq!(is_deleted(&t, "future@localhost").await?, is_chatmail);
+        assert_eq!(
+            is_deleted(&t, "no_expire@localhost").await?,
+            is_chatmail && !bcc_self
+        );
+        assert_eq!(
+            is_deleted(&t, "future@localhost").await?,
+            is_chatmail && !bcc_self
+        );
         assert_eq!(is_deleted(&t, "expired_post@localhost").await?, true);
         assert_eq!(is_deleted(&t, "expired_pre@localhost").await?, true);
         assert_eq!(is_deleted(&t, "no_expire_post@localhost").await?, false);
         assert_eq!(
             is_deleted(&t, "no_expire_pre@localhost").await?,
-            is_chatmail
+            is_chatmail && !bcc_self
         );
         assert_eq!(is_deleted(&t, "future_post@localhost").await?, false);
-        assert_eq!(is_deleted(&t, "future_pre@localhost").await?, is_chatmail);
-        assert_eq!(is_deleted(&t, "done_pre@localhost").await?, is_chatmail);
-        assert_eq!(is_deleted(&t, "done_post@localhost").await?, is_chatmail);
+        assert_eq!(
+            is_deleted(&t, "future_pre@localhost").await?,
+            is_chatmail && !bcc_self
+        );
+        assert_eq!(
+            is_deleted(&t, "done_pre@localhost").await?,
+            is_chatmail && !bcc_self
+        );
+        assert_eq!(
+            is_deleted(&t, "done_post@localhost").await?,
+            is_chatmail && !bcc_self
+        );
 
         reset_targets(&t).await;
     }

--- a/src/ephemeral/ephemeral_tests.rs
+++ b/src/ephemeral/ephemeral_tests.rs
@@ -478,9 +478,10 @@ async fn test_delete_expired_imap_messages() -> Result<()> {
 
     // Test messages:
     //
-    // Three messages that were not split into pre- and post- message:
+    // Four messages that were not split into pre- and post- message:
     //  "expired@localhost"     - expired ephemeral message
     //  "no_expire@localhost"   - non-ephemeral message
+    //  "no_expire_unencrypted@localhost"   - non-ephemeral message, not encrypted
     //  "future@localhost"      - will expire in the future, but not yet
     //
     // And four messages that were split into pre- and post-message.
@@ -489,57 +490,81 @@ async fn test_delete_expired_imap_messages() -> Result<()> {
     //  "future_*@localhost"    - has pre-msg, not expired yet, not downloaded yet
     //  "done_*@localhost"      - Fully downloaded -> post- message can be deleted
     //
-    // The tuple is (rfc724_mid, ephemeral_timestamp, download_state, pre_rfc724_mid)
-    let msgs: [(&str, i64, DownloadState, &str); 7] = [
-        ("expired@localhost", now - 1, DownloadState::Done, ""),
-        ("no_expire@localhost", 0, DownloadState::Done, ""),
+    // The tuple is (rfc724_mid, ephemeral_timestamp, download_state, pre_rfc724_mid, is_encrypted)
+    let msgs: [(&str, i64, DownloadState, &str, bool); 8] = [
+        ("expired@localhost", now - 1, DownloadState::Done, "", true),
+        ("no_expire@localhost", 0, DownloadState::Done, "", true),
+        (
+            "no_expire_unencrypted@localhost",
+            0,
+            DownloadState::Done,
+            "",
+            false,
+        ),
         // Use "now + 3600" rather than "now + 1", otherwise the test may be flaky
         // if it is slow and the message expires in a second
-        ("future@localhost", now + 3600, DownloadState::Done, ""),
+        (
+            "future@localhost",
+            now + 3600,
+            DownloadState::Done,
+            "",
+            true,
+        ),
         (
             "expired_post@localhost",
             now - 1,
             DownloadState::Available,
             "expired_pre@localhost",
+            true,
         ),
         (
             "no_expire_post@localhost",
             0,
             DownloadState::Available,
             "no_expire_pre@localhost",
+            true,
         ),
         (
             "future_post@localhost",
             now + 3600,
             DownloadState::Available,
             "future_pre@localhost",
+            true,
         ),
         (
             "done_post@localhost",
             0,
             DownloadState::Done,
             "done_pre@localhost",
+            true,
         ),
     ];
-    for (rfc724_mid, ephemeral_timestamp, download_state, pre_rfc724_mid) in msgs {
+    for (rfc724_mid, ephemeral_timestamp, download_state, pre_rfc724_mid, is_encrypted) in msgs {
         t.sql
             .execute(
                 "INSERT INTO msgs \
-                 (rfc724_mid, timestamp, ephemeral_timestamp, download_state, pre_rfc724_mid) \
-                 VALUES (?,?,?,?,?)",
+                 (rfc724_mid, timestamp, ephemeral_timestamp, download_state, pre_rfc724_mid, param) \
+                 VALUES (?,?,?,?,?,?)",
                 (
                     rfc724_mid,
                     now,
                     ephemeral_timestamp,
                     download_state,
                     pre_rfc724_mid,
+                    if is_encrypted {
+                        "c=1"
+                    } else {
+                        ""
+                    }
                 ),
             )
             .await?;
     }
     let rfc724_mids: Vec<&str> = msgs
         .iter()
-        .flat_map(|(rfc724_mid, _, _, pre_rfc724_mid)| [*rfc724_mid, *pre_rfc724_mid])
+        .flat_map(|(rfc724_mid, _, _, pre_rfc724_mid, _is_encrypted)| {
+            [*rfc724_mid, *pre_rfc724_mid]
+        })
         .filter(|s| !s.is_empty())
         .collect();
 
@@ -590,34 +615,20 @@ async fn test_delete_expired_imap_messages() -> Result<()> {
         }
 
         assert_eq!(is_deleted(&t, "expired@localhost").await?, true);
+        assert_eq!(is_deleted(&t, "no_expire@localhost").await?, !bcc_self);
         assert_eq!(
-            is_deleted(&t, "no_expire@localhost").await?,
+            is_deleted(&t, "no_expire_unencrypted@localhost").await?,
             is_chatmail && !bcc_self
         );
-        assert_eq!(
-            is_deleted(&t, "future@localhost").await?,
-            is_chatmail && !bcc_self
-        );
+        assert_eq!(is_deleted(&t, "future@localhost").await?, !bcc_self);
         assert_eq!(is_deleted(&t, "expired_post@localhost").await?, true);
         assert_eq!(is_deleted(&t, "expired_pre@localhost").await?, true);
         assert_eq!(is_deleted(&t, "no_expire_post@localhost").await?, false);
-        assert_eq!(
-            is_deleted(&t, "no_expire_pre@localhost").await?,
-            is_chatmail && !bcc_self
-        );
+        assert_eq!(is_deleted(&t, "no_expire_pre@localhost").await?, !bcc_self);
         assert_eq!(is_deleted(&t, "future_post@localhost").await?, false);
-        assert_eq!(
-            is_deleted(&t, "future_pre@localhost").await?,
-            is_chatmail && !bcc_self
-        );
-        assert_eq!(
-            is_deleted(&t, "done_pre@localhost").await?,
-            is_chatmail && !bcc_self
-        );
-        assert_eq!(
-            is_deleted(&t, "done_post@localhost").await?,
-            is_chatmail && !bcc_self
-        );
+        assert_eq!(is_deleted(&t, "future_pre@localhost").await?, !bcc_self);
+        assert_eq!(is_deleted(&t, "done_pre@localhost").await?, !bcc_self);
+        assert_eq!(is_deleted(&t, "done_post@localhost").await?, !bcc_self);
 
         reset_targets(&t).await;
     }


### PR DESCRIPTION
This is a partial replacement for removed `delete_server_after`. Users of non-chatmail servers with a single device will not run out of space easily this way as long as they don't disable `force_encryption` and only receive encrypted messages.

Closes #8277