### PR TITLE
feat: On Nauta, continue deleting messages immediately in single-device mode

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -171,7 +171,8 @@ pub(crate) async fn download_msg(
     Box::pin(session.fetch_single_msg(context, &server_folder, server_uid, rfc724_mid)).await?;
 
     let bcc_self = context.get_config_bool(Config::BccSelf).await?;
-    if ephemeral::should_delete_all_downloaded_messages(bcc_self, session.is_chatmail()) {
+    let is_nauta = ephemeral::is_nauta(context, transport_id).await?;
+    if ephemeral::should_delete_all_downloaded_messages(bcc_self, session.is_chatmail(), is_nauta) {
         // Now that the message was downloaded, it likely needs to be deleted;
         // trigger a re-check by interrupting the inbox folder.
         // This is mainly needed to make the tests pass;

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -664,7 +664,9 @@ pub(crate) async fn delete_expired_imap_messages(
     let now = time();
 
     let bcc_self = context.get_config_bool(Config::BccSelf).await?;
-    if should_delete_all_downloaded_messages(bcc_self, is_chatmail) {
+    let is_nauta = is_nauta(context, transport_id).await?;
+
+    if should_delete_all_downloaded_messages(bcc_self, is_chatmail, is_nauta) {
         // This is the only device using this relay.
         // Mark all downloaded messages for deletion, because they are not needed anymore.
         //
@@ -741,8 +743,23 @@ pub(crate) async fn delete_expired_imap_messages(
     Ok(())
 }
 
-pub(crate) fn should_delete_all_downloaded_messages(bcc_self: bool, is_chatmail: bool) -> bool {
-    !bcc_self && is_chatmail
+pub(crate) async fn is_nauta(context: &Context, transport_id: u32) -> Result<bool> {
+    let is_nauta = crate::transport::ConfiguredLoginParam::load_all(context)
+        .await?
+        .iter()
+        .filter(|(tid, _)| *tid == transport_id)
+        .filter_map(|(_, param)| param.provider)
+        .next()
+        .is_some_and(|provider| provider.id == "nauta.cu");
+    Ok(is_nauta)
+}
+
+pub(crate) fn should_delete_all_downloaded_messages(
+    bcc_self: bool,
+    is_chatmail: bool,
+    is_nauta: bool,
+) -> bool {
+    !bcc_self && (is_chatmail || is_nauta)
 }
 
 /// Start ephemeral timers for seen messages if they are not started

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -744,13 +744,20 @@ pub(crate) async fn delete_expired_imap_messages(
 }
 
 pub(crate) async fn is_nauta(context: &Context, transport_id: u32) -> Result<bool> {
+    let nauta_id = "nauta.cu";
+    debug_assert!({
+        // Check that the "nauta.cu" ID was spelled correctly:
+        let nauta = crate::provider::get_provider_by_id(nauta_id);
+        nauta.is_some_and(|p| p.id == nauta_id)
+    });
+
     let is_nauta = crate::transport::ConfiguredLoginParam::load_all(context)
         .await?
         .iter()
         .filter(|(tid, _)| *tid == transport_id)
         .filter_map(|(_, param)| param.provider)
         .next()
-        .is_some_and(|provider| provider.id == "nauta.cu");
+        .is_some_and(|provider| provider.id == nauta_id);
     Ok(is_nauta)
 }
 


### PR DESCRIPTION
This is a way to make sure that on Nauta, the old behavior of deleting messages immediately in single-device mode (because of the small storage) is restored.

Now, we can decide whether we merge this into Core, or only into ArcaneChat. CC @adbenitez.

TODO:
- [ ] Test on a real device whether this actually works

Optional TODOs: (not sure how big @adbenitez's code quality requirements are in ArcaneChat):
- [ ] Unit Tests
- [ ] Documentation