### PR TITLE
feat: Add IMAP folder to Context::get_info() (#8285)

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -252,7 +252,11 @@ impl fmt::Display for ConfiguredLoginParam {
             write!(f, "{imap}")?;
             first = false;
         }
-        write!(f, "] smtp:[")?;
+        write!(f, "]")?;
+        if let Some(folder) = &self.imap_folder {
+            write!(f, " folder:{folder:?}")?;
+        }
+        write!(f, " smtp:[")?;
         let mut first = true;
         for smtp in &self.smtp {
             if !first {

--- a/src/transport/transport_tests.rs
+++ b/src/transport/transport_tests.rs
@@ -34,7 +34,7 @@ async fn test_save_load_login_param() -> Result<()> {
             },
             user: "alice".to_string(),
         }],
-        imap_folder: None,
+        imap_folder: Some("Folder".to_string()),
         imap_user: "".to_string(),
         imap_password: "foo".to_string(),
         smtp: vec![ConfiguredServerLoginParam {
@@ -56,7 +56,7 @@ async fn test_save_load_login_param() -> Result<()> {
         .clone()
         .save_to_transports_table(&t, &EnteredLoginParam::default(), time())
         .await?;
-    let expected_param = r#"{"addr":"alice@example.org","imap":[{"connection":{"host":"imap.example.com","port":123,"security":"Starttls"},"user":"alice"}],"imap_user":"","imap_password":"foo","smtp":[{"connection":{"host":"smtp.example.com","port":456,"security":"Tls"},"user":"alice@example.org"}],"smtp_user":"","smtp_password":"bar","provider_id":null,"certificate_checks":"Strict","oauth2":false}"#;
+    let expected_param = r#"{"addr":"alice@example.org","imap":[{"connection":{"host":"imap.example.com","port":123,"security":"Starttls"},"user":"alice"}],"imap_folder":"Folder","imap_user":"","imap_password":"foo","smtp":[{"connection":{"host":"smtp.example.com","port":456,"security":"Tls"},"user":"alice@example.org"}],"smtp_user":"","smtp_password":"bar","provider_id":null,"certificate_checks":"Strict","oauth2":false}"#;
     assert_eq!(
         t.sql
             .query_get_value::<String>("SELECT configured_param FROM transports", ())
@@ -67,6 +67,14 @@ async fn test_save_load_login_param() -> Result<()> {
     assert_eq!(t.is_configured().await?, true);
     let (_transport_id, loaded) = ConfiguredLoginParam::load(&t).await?.unwrap();
     assert_eq!(param, loaded);
+
+    let formatted = format!(" {loaded}");
+    assert!(formatted.contains(" ***@example.org"));
+    assert!(formatted.contains(" imap:[imap.example.com:123:starttls]"));
+    assert!(formatted.contains(" folder:\"Folder\""));
+    assert!(formatted.contains(" smtp:[smtp.example.com:456:tls]"));
+    assert!(formatted.contains(" provider:none"));
+    assert!(formatted.contains(" cert_strict"));
 
     // Legacy ConfiguredImapCertificateChecks config is ignored
     t.set_config(Config::ConfiguredImapCertificateChecks, Some("999"))


### PR DESCRIPTION
Note that the default value "INBOX" isn't shown however.
Close #8285 
Tested manually with
```Diff
diff --git a/src/context/context_tests.rs b/src/context/context_tests.rs                                                                                                                                             
index dc8d031f1..43a431adc 100644                                                                                                                                                                                    
--- a/src/context/context_tests.rs                                                                                                                                                                                   
+++ b/src/context/context_tests.rs                                                                                                                                                                                   
@@ -322,6 +322,8 @@ async fn test_get_info_completeness() {                                                                                                                                                          
             );                                                                                                                                                                                                      
         }                                                                                                                                                                                                           
     }                                                                                                                                                                                                               
+    info!(&t, "used_transport_settings: {}", info["used_transport_settings"]);                                                                                                                                      
+    unreachable!();                                                                                                                                                                                                 
 }                                                                                                                                                                                                                   
                                                                                                                                                                                                                     
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]                                                                                                                                                         
diff --git a/src/sql/migrations.rs b/src/sql/migrations.rs                                                                                                                                                           
index 32275335e..8a1f14fe1 100644                                                                                                                                                                                    
--- a/src/sql/migrations.rs                                                                                                                                                                                          
+++ b/src/sql/migrations.rs                                                                                                                                                                                          
@@ -2313,6 +2313,9 @@ pub async fn run(context: &Context, sql: &Sql) -> Result<bool> {                                                                                                                               
         .await?;                                                                                                                                                                                                    
     }                                                                                                                                                                                                               
                                                                                                                                                                                                                     
+    crate::transport::add_pseudo_transport(context, "user@localhost").await?;                                                                                                                                       
+    sql.set_raw_config_bool("only_fetch_mvbox", true).await?;                                                                                                                                                       
+                                                                                                                                                                                                                    
     inc_and_check(&mut migration_version, 150)?;                                                                                                                                                                    
     if dbversion < migration_version {                                                                                                                                                                              
         sql.execute_migration_transaction(
```