### PR TITLE
fix: Make truncated edited messages have HTML for receivers (#8249)

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -3046,7 +3046,7 @@ pub async fn send_edit_request(context: &Context, msg_id: MsgId, new_text: Strin
         return Ok(());
     }
 
-    save_text_edit_to_db(context, &mut original_msg, &new_text).await?;
+    save_text_edit_to_db(context, &mut original_msg, &new_text, &[]).await?;
 
     let mut edit_msg = Message::new_text(EDITED_PREFIX.to_owned() + &new_text); // prefix only set for nicer display in Non-Delta-MUAs
     edit_msg.set_quote(context, Some(&original_msg)).await?; // quote only set for nicer display in Non-Delta-MUAs
@@ -3065,16 +3065,20 @@ pub(crate) async fn save_text_edit_to_db(
     context: &Context,
     original_msg: &mut Message,
     new_text: &str,
+    mime_headers: &[u8],
 ) -> Result<()> {
     original_msg.param.set_int(Param::IsEdited, 1);
     context
         .sql
         .execute(
-            "UPDATE msgs SET txt=?, txt_normalized=?, param=? WHERE id=?",
+            "
+UPDATE msgs SET txt=?, txt_normalized=?, param=?, mime_headers=?, mime_modified=? WHERE id=?",
             (
                 new_text,
                 normalize_text(new_text),
                 original_msg.param.to_string(),
+                mime_headers,
+                !mime_headers.is_empty(),
                 original_msg.id,
             ),
         )

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use super::*;
 use crate::Event;
 use crate::chatlist::get_archived_cnt;
-use crate::constants::{DC_GCL_ARCHIVED_ONLY, DC_GCL_NO_SPECIALS, N_MSGS_TO_NEW_BROADCAST_MEMBER};
+use crate::constants::{
+    self, DC_GCL_ARCHIVED_ONLY, DC_GCL_NO_SPECIALS, N_MSGS_TO_NEW_BROADCAST_MEMBER,
+};
 use crate::ephemeral::Timer;
 use crate::headerdef::HeaderDef;
 use crate::imex::{ImexMode, has_backup, imex};
@@ -5823,6 +5825,35 @@ async fn test_send_edit_request() -> Result<()> {
     forward_msgs(&alice2, &[test.id], test.chat_id).await?;
     let forwarded = alice2.get_last_msg().await;
     assert!(!forwarded.is_edited());
+
+    // If a message is too long after editing, it becomes an HTML message on the receiver side. On
+    // the sender side it's still text so that it can be edited again.
+    static REPEAT_TXT: &str = "this text with 42 chars is just repeated.\n";
+    static REPEAT_CNT: usize = constants::DC_DESIRED_TEXT_LEN / REPEAT_TXT.len() + 2;
+    let long_txt = REPEAT_TXT.repeat(REPEAT_CNT);
+    send_edit_request(alice, alice_msg.id, long_txt.clone()).await?;
+    let sent = alice.pop_sent_msg().await;
+    let test = Message::load_from_db(alice, alice_msg.id).await?;
+    assert!(!test.has_html());
+    assert_eq!(test.text, long_txt);
+    bob.recv_msg_opt(&sent).await;
+    let test = Message::load_from_db(bob, bob_msg.id).await?;
+    assert!(test.is_edited());
+    assert!(test.has_html());
+    let html = test.id.get_html(bob).await?.unwrap();
+    assert_eq!(html.matches("just repeated.<br/>").count(), REPEAT_CNT);
+    assert!(test.text.matches("just repeated.").count() > 0);
+
+    // Alice shortens the message back so it's not HTML for Bob anymore.
+    send_edit_request(alice, alice_msg.id, "Text me on Delta.Chat".to_string()).await?;
+    let sent = alice.pop_sent_msg().await;
+    let test = Message::load_from_db(alice, alice_msg.id).await?;
+    assert_eq!(test.text, "Text me on Delta.Chat");
+    bob.recv_msg_opt(&sent).await;
+    let test = Message::load_from_db(bob, bob_msg.id).await?;
+    assert!(test.is_edited());
+    assert!(!test.has_html());
+    assert_eq!(test.text, "Text me on Delta.Chat");
 
     Ok(())
 }

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2083,7 +2083,7 @@ async fn add_parts(
         }
     }
 
-    handle_edit_delete(context, mime_parser, from_id).await?;
+    handle_edit_delete(context, mime_parser, from_id, &mime_headers).await?;
     handle_post_message(context, mime_parser, from_id, state).await?;
 
     if mime_parser.is_system_message == SystemMessage::CallAccepted
@@ -2353,6 +2353,7 @@ async fn handle_edit_delete(
     context: &Context,
     mime_parser: &MimeMessage,
     from_id: ContactId,
+    mime_headers: &[u8],
 ) -> Result<()> {
     if let Some(rfc724_mid) = mime_parser.get_header(HeaderDef::ChatEdit) {
         let Some(original_msg_id) = rfc724_mid_exists(context, rfc724_mid).await? else {
@@ -2386,7 +2387,7 @@ async fn handle_edit_delete(
         }
 
         let new_text = part.msg.strip_prefix(EDITED_PREFIX).unwrap_or(&part.msg);
-        chat::save_text_edit_to_db(context, &mut original_msg, new_text).await?;
+        chat::save_text_edit_to_db(context, &mut original_msg, new_text, mime_headers).await?;
     } else if let Some(rfc724_mid_list) = mime_parser.get_header(HeaderDef::ChatDelete)
         && let Some(part) = mime_parser.parts.first()
     {


### PR DESCRIPTION
Otherwise it's not possible to see the full message text if it's too long in a received edit. On the sender side let it still be text so that the message can be edited again.
Fix #8249 

Decided not to complicate things on the sender side, anyway truncating long messages is reworked in #7749 , so this is just a minimal fix. Maybe it's even better that a message can always be edited again, even if only on the sending device.