### PR TITLE
fix: do not trash pre-messages without text but with a webxdc update

### DIFF
--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -1215,6 +1215,8 @@ async fn decide_chat_assignment(
         // Most mailboxes have a "Drafts" folder where constantly new emails appear but we don't actually want to show them
         info!(context, "Email is probably just a draft (TRASH).");
         true
+    } else if matches!(mime_parser.pre_message, PreMessageMode::Pre { .. }) {
+        false
     } else if mime_parser.webxdc_status_update.is_some() && mime_parser.parts.len() == 1 {
         if let Some(part) = mime_parser.parts.first() {
             if part.typ == Viewtype::Text && part.msg.is_empty() {

--- a/src/tests/pre_messages/receiving.rs
+++ b/src/tests/pre_messages/receiving.rs
@@ -565,6 +565,51 @@ async fn test_webxdc_updates_in_post_message_after_pre_message() -> Result<()> {
     Ok(())
 }
 
+/// Tests sending large webxdc without text.
+///
+/// This is a regression test, previously pre-message
+/// was trashed when it had no text.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_large_webxdc_without_text() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = &tcm.alice().await;
+    let bob = &tcm.bob().await;
+
+    tcm.section("Bob sends large webxdc without attached text message.");
+    let bob_chat_id = bob.create_chat_id(alice).await;
+    let big_webxdc_app = big_webxdc_app().await?;
+    let mut bob_instance = Message::new(Viewtype::Webxdc);
+    bob_instance.set_file_from_bytes(bob, "test.xdc", &big_webxdc_app, None)?;
+    bob_chat_id.set_draft(bob, Some(&mut bob_instance)).await?;
+    bob.send_webxdc_status_update(bob_instance.id, r#"{"payload":42, "info":"i"}"#)
+        .await?;
+
+    send_msg(bob, bob_chat_id, &mut bob_instance).await?;
+    let post_message = bob.pop_sent_msg().await;
+    let pre_message = bob.pop_sent_msg().await;
+
+    tcm.section("Alice receives a pre-message");
+    let alice_instance = alice.recv_msg(&pre_message).await;
+    assert_eq!(alice_instance.download_state, DownloadState::Available);
+
+    tcm.section("Alice receives a post-message");
+    alice.recv_msg_trash(&post_message).await;
+    let alice_instance = Message::load_from_db(alice, alice_instance.id).await?;
+    assert_eq!(alice_instance.download_state, DownloadState::Done);
+
+    let alice_file_path = alice_instance.get_file(alice).expect("No file");
+    tokio::fs::try_exists(alice_file_path).await?;
+
+    assert_eq!(
+        alice
+            .get_webxdc_status_updates(alice_instance.id, StatusUpdateSerial::new(0))
+            .await?,
+        r#"[{"payload":42,"info":"i","serial":1,"max_serial":1}]"#
+    );
+
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_webxdc_updates_in_post_message_after_deleted_pre_message() -> Result<()> {
     let mut tcm = TestContextManager::new();


### PR DESCRIPTION
This is related to https://github.com/chatmail/core/issues/8094 but does not fix all cases.

Webxdc updates go to pre-message (which is questionable, maybe should go to post-message instead, but on the other hand there will be updates sent as separate messages afterwards and if we change the sender now we still need to handle all cases on the receiver), and I noticed that when the message has no text, the whole pre-message is trashed if it has a webxdc update. The solution is not to trash pre-message in this case so preview is displayed.