### PR TITLE
fix: don't send or process webxdc status updates in pre-messages

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1813,14 +1813,15 @@ impl MimeFactory {
                 HeaderDef::IrohGossipTopic.get_headername(),
                 mail_builder::headers::raw::Raw::new(topic).into(),
             ));
-            if let (Some(json), _) = context
-                .render_webxdc_status_update_object(
-                    msg.id,
-                    StatusUpdateSerial::MIN,
-                    StatusUpdateSerial::MAX,
-                    None,
-                )
-                .await?
+            if !matches!(self.pre_message_mode, PreMessageMode::Pre { .. })
+                && let (Some(json), _) = context
+                    .render_webxdc_status_update_object(
+                        msg.id,
+                        StatusUpdateSerial::MIN,
+                        StatusUpdateSerial::MAX,
+                        None,
+                    )
+                    .await?
             {
                 parts.push(context.build_status_update_part(&json));
             }

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -826,7 +826,9 @@ UPDATE config SET value=? WHERE keyname='configured_addr' AND value!=?1
         }
     }
 
-    if let Some(ref status_update) = mime_parser.webxdc_status_update {
+    if let Some(ref status_update) = mime_parser.webxdc_status_update
+        && !matches!(mime_parser.pre_message, PreMessageMode::Pre { .. })
+    {
         let can_info_msg;
         let instance = if mime_parser
             .parts

--- a/src/tests/pre_messages/receiving.rs
+++ b/src/tests/pre_messages/receiving.rs
@@ -534,6 +534,17 @@ async fn test_webxdc_updates_in_post_message_after_pre_message() -> Result<()> {
 
     let alice_chat_id = alice.create_chat_id(bob).await;
 
+    // regression test where updates get assigned to an unrelated prior webxdc message
+    let mut unrelated_xdc = Message::new(Viewtype::Webxdc);
+    unrelated_xdc.set_file_from_bytes(
+        alice,
+        "first.xdc",
+        include_bytes!("../../../test-data/webxdc/minimal.xdc"),
+        None,
+    )?;
+    send_msg(alice, alice_chat_id, &mut unrelated_xdc).await?;
+    let bob_unrelated_webxdc = bob.recv_msg(&alice.pop_sent_msg().await).await;
+
     let big_webxdc_app = big_webxdc_app().await?;
 
     let mut alice_instance = Message::new(Viewtype::Webxdc);
@@ -552,6 +563,14 @@ async fn test_webxdc_updates_in_post_message_after_pre_message() -> Result<()> {
 
     let bob_instance = bob.recv_msg(&pre_message).await;
     assert_eq!(bob_instance.download_state, DownloadState::Available);
+
+    // don't accidentally assign updates from a pre-message to parent message
+    assert_eq!(
+        bob.get_webxdc_status_updates(bob_unrelated_webxdc.id, StatusUpdateSerial::new(0))
+            .await?,
+        "[]"
+    );
+
     bob.recv_msg_trash(&post_message).await;
     let bob_instance = Message::load_from_db(bob, bob_instance.id).await?;
     assert_eq!(bob_instance.download_state, DownloadState::Done);


### PR DESCRIPTION
it makes no sense to send or receive status updates in pre-messages for large webxdc attachments because they can't be processed anyway, and the full message also contains them. 
fixes #8094
technically, only not sending updates in pre-messages is enough to pass the test, but not processing them on the receiving side fixes the issue for anyone upgrading even if communicating with old clients which send webxdc-updates in pre-messages.  