### PR TITLE
test: fixup the tests after removing timesmearing

### DIFF
--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -2971,6 +2971,7 @@ async fn test_broadcast_change_name() -> Result<()> {
 
     {
         tcm.section("Alice changes the chat name");
+        SystemTime::shift(Duration::from_secs(1));
         set_chat_name(alice, broadcast_id, "My great broadcast").await?;
         let sent = alice.pop_sent_msg().await;
 
@@ -2989,6 +2990,7 @@ async fn test_broadcast_change_name() -> Result<()> {
 
     {
         tcm.section("Alice changes the chat name again, but the system message is lost somehow");
+        SystemTime::shift(Duration::from_secs(1));
         set_chat_name(alice, broadcast_id, "Broadcast channel").await?;
 
         let chat = Chat::load_from_db(alice, broadcast_id).await?;
@@ -3343,6 +3345,7 @@ async fn test_broadcasts_name_and_avatar() -> Result<()> {
     assert_eq!(bob_chat.get_profile_image(bob).await?, None);
 
     tcm.section("Change broadcast channel name, and check that receivers see it");
+    SystemTime::shift(Duration::from_secs(1));
     set_chat_name(alice, alice_chat_id, "New Channel name").await?;
     let sent = alice.pop_sent_msg().await;
     let rcvd = bob.recv_msg(&sent).await;


### PR DESCRIPTION
This is a fixup for CI after merging #8226.

`SystemTime::shift(Duration::from_secs(1));` is not a nice way to fix this and #8226 already has similar fixups, but the real problem is that merging group name changes depends on timestamps and may not apply if your clock appears to be in the past. For most users and groups that don't get the name changed every second it is fine, but for bots, e.g. bridge bots, might actually be a problem. Timesmearing was just hiding this problem for tests where all the changes are made by the same device in a short sequence and we already had time shifts in multi-device tests.