### PR TITLE
fix: do not abort IMAP connection if setting the push token fails

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -454,10 +454,12 @@ async fn inbox_fetch_idle(ctx: &Context, imap: &mut Imap, mut session: Session) 
         .update_metadata(ctx)
         .await
         .context("update_metadata")?;
-    session
-        .register_token(ctx)
-        .await
-        .context("Failed to register push token")?;
+    if let Err(err) = session.register_token(ctx).await {
+        warn!(
+            ctx,
+            "Transport {transport_id}: Failed to register push token: {err:#}."
+        );
+    }
 
     let session = fetch_idle(ctx, imap, session).await?;
     Ok(session)


### PR DESCRIPTION
With madmail 2.2.2 from https://github.com/themadorg/madmail/releases/download/v2.2.2/madmail-linux-amd64 using IMAP command SETMETADATA to set /private/devicetoken returns error "A0003 BAD command not supported".

With this change connection is not aborted anymore and the error is logged like this:
src/scheduler.rs:458: Transport 1: Failed to register push token: SETMETADATA command failed: bad response: code: None, info: Some("command not supported").

madmail 2.2.2 however fails to select the INBOX afterwards and the following command `A0004 SELECT "INBOX"`
results in `* BAD command not supported` response.

Fixes https://github.com/chatmail/core/issues/8334