### PR TITLE
fix: Hide synced chat if we only know its visibility

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -5230,9 +5230,11 @@ impl Context {
                     }
                     _ => (),
                 }
-                // Use `Request` so that even if the program crashes, the user doesn't have to look
-                // into the blocked contacts.
-                ChatIdBlocked::get_for_contact(self, contact_id, Blocked::Request)
+                // Newly created chat will be soon unblocked, `Blocked::Yes` here is just
+                // to hide it from chatlist, as at this point it is completely blank (no name etc.).
+                // Even if app crashes at this point, the chat will re-appear on e.g. any new
+                // message sent from other device.
+                ChatIdBlocked::get_for_contact(self, contact_id, Blocked::Yes)
                     .await?
                     .id
             }
@@ -5256,7 +5258,13 @@ impl Context {
                     }
                     _ => (),
                 }
-                ChatIdBlocked::get_for_contact(self, contact_id, Blocked::Request)
+                // Don't show a chat on other devices until securejoin completes.
+                // E.g. pinning a not-synced chat on device A shouldn't display it on device B yet.
+                //
+                // A pinned chat will appear on other devices only when the first
+                // message is sent from the device that read the invitation - which is the same
+                // behavior as with un-pinned chats.
+                ChatIdBlocked::get_for_contact(self, contact_id, Blocked::Yes)
                     .await?
                     .id
             }

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -5166,6 +5166,52 @@ async fn test_blocked_bob_cant_create_11_chat_via_securejoin() -> Result<()> {
     Ok(())
 }
 
+/// Regression test:
+///
+/// Pinning a chat that didn't complete securejoin on one device
+/// should not cause a blank chat to be displayed on other device.
+/// Such chat should be marked as blocked until the first message is sent.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_sync_no_blank_chat() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice1 = &tcm.alice().await;
+    let alice2 = &tcm.alice().await;
+    let bob = &tcm.bob().await;
+
+    for a in [alice1, alice2] {
+        a.set_config_bool(Config::SyncMsgs, true).await?;
+        a.set_config_bool(Config::BccSelf, true).await?;
+    }
+
+    let qr = get_securejoin_qr(bob, None).await?;
+
+    // Scan QR on alice1 and pin the resulting chat.
+    let chat_id = tcm.exec_securejoin_qr(alice1, bob, &qr).await;
+    chat_id
+        .set_visibility(&alice1.ctx, ChatVisibility::Pinned)
+        .await?;
+
+    // alice2 should receive a sync item about changing visibility of a chat it doesn't know about.
+    sync(alice1, alice2).await;
+
+    // Chat created on alice2 should be blocked (hidden)
+    let chat = Chat::load_from_db(&alice2.ctx, chat_id).await?;
+    assert_eq!(chat.blocked, Blocked::Yes);
+    assert_eq!(chat.get_name(), "");
+    assert_eq!(chat.visibility, ChatVisibility::Pinned);
+
+    // First message should unblock and fill missing data on other device.
+    let msg = alice1.send_text(chat_id, "meow").await;
+
+    alice2.recv_msg(&msg).await;
+    let chat = Chat::load_from_db(&alice2.ctx, chat_id).await?;
+    assert_eq!(chat.blocked, Blocked::Not);
+    assert_eq!(chat.get_name(), "bob@example.net");
+    assert_eq!(chat.visibility, ChatVisibility::Pinned);
+
+    Ok(())
+}
+
 /// Tests sending JPEG image with .png extension.
 ///
 /// This is a regression test, previously sending failed


### PR DESCRIPTION
Prevents showing "empty" chat on other devices,
when pinning a chat that did not complete securejoin yet.

Fixes: #7713