### PR TITLE
chore: deprecate unused SkipAutocrypt param

### DIFF
--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -618,9 +618,7 @@ impl MimeFactory {
 
     fn should_skip_autocrypt(&self) -> bool {
         match &self.loaded {
-            Loaded::Message { msg, .. } => {
-                msg.param.get_bool(Param::SkipAutocrypt).unwrap_or_default()
-            }
+            Loaded::Message { .. } => false,
             Loaded::Mdn { .. } => true,
         }
     }

--- a/src/param.rs
+++ b/src/param.rs
@@ -64,7 +64,8 @@ pub enum Param {
     ForcePlaintext = b'u',
 
     /// For Messages: do not include Autocrypt header.
-    SkipAutocrypt = b'o',
+    /// Deprecated on 2026-06-20
+    DeprecatedSkipAutocrypt = b'o',
 
     /// For Messages
     WantsMdn = b'r',


### PR DESCRIPTION
I renamed SkipAutocrypt into DeprecatedSkipAutocrypt instead of removing to make sure the letter is not reused.