### PR TITLE
refactor: move ensure_secret_key_exists into key.rs

### DIFF
--- a/src/e2ee.rs
+++ b/src/e2ee.rs
@@ -97,18 +97,6 @@ impl EncryptHelper {
     }
 }
 
-/// Ensures a private key exists for the configured user.
-///
-/// Normally the private key is generated when the first message is
-/// sent but in a few locations there are no such guarantees,
-/// e.g. when exporting keys, and calling this function ensures a
-/// private key will be present.
-// TODO, remove this once deltachat::key::Key no longer exists.
-pub async fn ensure_secret_key_exists(context: &Context) -> Result<()> {
-    load_self_public_key(context).await?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -118,23 +106,7 @@ mod tests {
     use crate::message::Message;
     use crate::mimeparser::SystemMessage;
     use crate::receive_imf::receive_imf;
-    use crate::test_utils::{TestContext, TestContextManager};
-
-    mod ensure_secret_key_exists {
-        use super::*;
-
-        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-        async fn test_prexisting() {
-            let t = TestContext::new_alice().await;
-            assert!(ensure_secret_key_exists(&t).await.is_ok());
-        }
-
-        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-        async fn test_not_configured() {
-            let t = TestContext::new().await;
-            assert!(ensure_secret_key_exists(&t).await.is_err());
-        }
-    }
+    use crate::test_utils::TestContextManager;
 
     #[test]
     fn test_mailmime_parse() {

--- a/src/imex.rs
+++ b/src/imex.rs
@@ -17,7 +17,6 @@ use crate::blob::BlobDirContents;
 use crate::chat::delete_and_reset_all_device_msgs;
 use crate::config::Config;
 use crate::context::Context;
-use crate::e2ee;
 use crate::events::EventType;
 use crate::key::{self, DcKey, SignedSecretKey};
 use crate::log::{LogExt, warn};
@@ -170,7 +169,7 @@ async fn imex_inner(
 
     if what == ImexMode::ExportBackup || what == ImexMode::ExportSelfKeys {
         // before we export anything, make sure the private key exists
-        e2ee::ensure_secret_key_exists(context)
+        key::ensure_secret_key_exists(context)
             .await
             .context("Cannot create private key or private key not available")?;
 

--- a/src/imex/transfer.rs
+++ b/src/imex/transfer.rs
@@ -38,15 +38,16 @@ use tokio::fs;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+use crate::EventType;
 use crate::chat::add_device_msg;
 use crate::context::Context;
 use crate::imex::BlobDirContents;
+use crate::key;
 use crate::log::warn;
 use crate::message::Message;
 use crate::qr::Qr;
 use crate::stock_str::backup_transfer_msg_body;
 use crate::tools::{TempPathGuard, create_id, time};
-use crate::{EventType, e2ee};
 
 use super::{DBFILE_BACKUP_NAME, export_backup_stream, export_database, import_backup_stream};
 
@@ -112,7 +113,7 @@ impl BackupProvider {
             .context("Context dir not found")?;
 
         // before we export, make sure the private key exists
-        e2ee::ensure_secret_key_exists(context)
+        key::ensure_secret_key_exists(context)
             .await
             .context("Cannot create private key or private key not available")?;
 

--- a/src/key.rs
+++ b/src/key.rs
@@ -320,6 +320,17 @@ pub(crate) async fn load_self_public_key(context: &Context) -> Result<SignedPubl
     }
 }
 
+/// Ensures a private key exists for the configured user.
+///
+/// Normally the private key is generated when the first message is
+/// sent but in a few locations there are no such guarantees,
+/// e.g. when exporting keys, and calling this function ensures a
+/// private key will be present.
+pub async fn ensure_secret_key_exists(context: &Context) -> Result<()> {
+    load_self_public_key(context).await?;
+    Ok(())
+}
+
 /// Returns our own public keyring.
 ///
 /// No keys are generated and at most one key is returned.
@@ -897,5 +908,21 @@ i8pcjGO+IZffvyZJVRWfVooBJmWWbPB1pueo3tx8w3+fcuzpxz+RLFKaPyqXO+dD
             fp.human_readable(),
             "0102 0408 1020 4080 FF01\n0204 0810 2040 80FF 1314"
         );
+    }
+
+    mod ensure_secret_key_exists {
+        use super::*;
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_prexisting() {
+            let t = TestContext::new_alice().await;
+            assert!(ensure_secret_key_exists(&t).await.is_ok());
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_not_configured() {
+            let t = TestContext::new().await;
+            assert!(ensure_secret_key_exists(&t).await.is_err());
+        }
     }
 }

--- a/src/securejoin.rs
+++ b/src/securejoin.rs
@@ -14,9 +14,9 @@ use crate::constants::{
 use crate::contact::mark_contact_id_as_verified;
 use crate::contact::{Contact, ContactId, Origin};
 use crate::context::Context;
-use crate::e2ee::ensure_secret_key_exists;
 use crate::events::EventType;
 use crate::headerdef::HeaderDef;
+use crate::key;
 use crate::key::{DcKey, Fingerprint, load_self_public_key, self_fingerprint};
 use crate::log::LogExt as _;
 use crate::log::warn;
@@ -92,7 +92,7 @@ pub async fn get_securejoin_qr(context: &Context, chat: Option<ChatId>) -> Resul
     ====   Step 1 in "Setup verified contact" protocol   ====
     =======================================================*/
 
-    ensure_secret_key_exists(context).await.ok();
+    key::ensure_secret_key_exists(context).await.ok();
 
     let chat = match chat {
         Some(id) => {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -232,9 +232,7 @@ impl TestContextManager {
 
         test_context.set_primary_self_addr(new_addr).await.unwrap();
         // ensure_secret_key_exists() is called during configure
-        crate::e2ee::ensure_secret_key_exists(test_context)
-            .await
-            .unwrap();
+        key::ensure_secret_key_exists(test_context).await.unwrap();
 
         assert_eq!(
             test_context.get_primary_self_addr().await.unwrap(),

--- a/src/tests/verified_chats.rs
+++ b/src/tests/verified_chats.rs
@@ -6,7 +6,9 @@ use crate::chat::{self, Chat, add_contact_to_chat, remove_contact_from_chat, sen
 use crate::config::Config;
 use crate::constants::Chattype;
 use crate::contact::{Contact, ContactId};
+use crate::key;
 use crate::key::self_fingerprint;
+use crate::message;
 use crate::message::{Message, Viewtype};
 use crate::mimefactory::MimeFactory;
 use crate::mimeparser::SystemMessage;
@@ -18,7 +20,6 @@ use crate::test_utils::{
     E2EE_INFO_MSGS, TestContext, TestContextManager, get_chat_msg, mark_as_verified,
 };
 use crate::tools::SystemTime;
-use crate::{e2ee, message};
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_verified_oneonone_chat_not_broken_by_classical() {
@@ -126,7 +127,7 @@ async fn test_create_verified_oneonone_chat() -> Result<()> {
 
     let fiona_new = tcm.unconfigured().await;
     fiona_new.configure_addr("fiona@example.net").await;
-    e2ee::ensure_secret_key_exists(&fiona_new).await?;
+    key::ensure_secret_key_exists(&fiona_new).await?;
 
     tcm.send_recv(&fiona_new, &alice, "I have a new device")
         .await;
@@ -428,7 +429,7 @@ async fn test_verify_then_verify_again() -> Result<()> {
     drop(bob);
     let bob_new = tcm.unconfigured().await;
     bob_new.configure_addr("bob@example.net").await;
-    e2ee::ensure_secret_key_exists(&bob_new).await?;
+    key::ensure_secret_key_exists(&bob_new).await?;
 
     tcm.execute_securejoin(&bob_new, &alice).await;
     assert_verified(&alice, &bob_new).await;


### PR DESCRIPTION
In #8345 i'm removing EncryptHelper so this function and the tests are the only things that remain in `e2ee` module. If we move the remaining tests somewhere then we can remove `e2ee` module completely.