### PR TITLE
api!: Deprecate `is_chatmail`

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -462,7 +462,10 @@ char*           dc_get_blobdir               (const dc_context_t* context);
  * - `gossip_period` = How often to gossip Autocrypt keys in chats with multiple recipients, in
  *                    seconds. 2 days by default.
  *                    This is not supposed to be changed by UIs and only used for testing.
- * - `is_chatmail` = 1 if the the server is a chatmail server, 0 otherwise.
+ * - `is_chatmail`  = (deprecated) 1 if the the server is a chatmail server, 0 otherwise.
+ *                    This is deprecated, UIs should not behave differently
+ *                    for chatmail relays and classical email servers.
+ *                    Most usages in UIs can be replaced by `force_encryption`.
  * - `is_muted`     = Whether a context is muted by the user.
  *                    Muted contexts should not sound, vibrate or show notifications.
  *                    In contrast to `dc_set_chat_mute_duration()`,

--- a/src/config.rs
+++ b/src/config.rs
@@ -319,6 +319,12 @@ pub enum Config {
     /// True if account is configured.
     Configured,
 
+    /// Deprecated, we are trying to get rid of this global setting.
+    /// It is possible to configure a profile with both chatmail relays
+    /// and classical email servers.
+    ///
+    /// Most usages in UIs can be replaced by `force_encryption`.
+    ///
     /// True if account is a chatmail account.
     IsChatmail,
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -566,6 +566,10 @@ impl Context {
         self.scheduler.maybe_network().await;
     }
 
+    /// Deprecated, we are trying to get rid of this global setting.
+    /// It is possible to configure a profile with both chatmail relays
+    /// and classical email servers.
+    ///
     /// Returns true if an account is on a chatmail server.
     pub async fn is_chatmail(&self) -> Result<bool> {
         self.get_config_bool(Config::IsChatmail).await

--- a/src/imap/session.rs
+++ b/src/imap/session.rs
@@ -111,7 +111,7 @@ impl Session {
     }
 
     // Returns true if IMAP server has `XCHATMAIL` capability.
-    pub fn is_chatmail(&self) -> bool {
+    pub(crate) fn is_chatmail(&self) -> bool {
         self.capabilities.is_chatmail
     }
 


### PR DESCRIPTION
BREAKING CHANGE: UIs should not behave differently for chatmail relays and classical email servers; most usages in UIs can be replaced by `force_encryption`.

After rebase-merging, this will appear like this in the changelog:

```
### API-Changes

- [**breaking**] Deprecate `is_chatmail`.
  - UIs should not behave differently for chatmail relays and classical email servers; most usages in UIs can be replaced by `force_encryption`
```