### PR TITLE
fix: Return early from receive_imf to not tombstone Iroh-Node-Addr message if webxdc instance isn't found (#8372)

### DIFF
--- a/deltachat-rpc-client/tests/test_something.py
+++ b/deltachat-rpc-client/tests/test_something.py
@@ -380,7 +380,7 @@ def test_receive_imf_failure(acfactory) -> None:
         snapshot.text == "❌ Failed to receive a message:"
         " Condition failed: `!context.get_config_bool(Config::SimulateReceiveImfError).await?`."
         f" Core version {version}."
-        " Please report this bug to delta@merlinux.eu or https://support.delta.chat/."
+        " Please report this bug to delta@merlinux.eu or https://support.delta.chat/"
     )
 
     # The failed message doesn't break the IMAP loop.

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1284,7 +1284,9 @@ impl Session {
                         warn!(context, "receive_imf error: {err:#}.");
 
                         let text = format!(
-                            "❌ Failed to receive a message: {err:#}. Core version v{DC_VERSION_STR}. Please report this bug to delta@merlinux.eu or https://support.delta.chat/.",
+                            // No trailing '.' to avoid from the Android UI treating it as a part of
+                            // URL.
+                            "❌ Failed to receive a message: {err:#}. Core version v{DC_VERSION_STR}. Please report this bug to delta@merlinux.eu or https://support.delta.chat/",
                         );
                         let mut msg = Message::new_text(text);
                         add_device_msg(context, None, Some(&mut msg)).await?;

--- a/src/peer_channels.rs
+++ b/src/peer_channels.rs
@@ -589,6 +589,7 @@ mod tests {
         EventType,
         chat::{self, ChatId, add_contact_to_chat, resend_msgs, send_msg},
         message::{Message, Viewtype},
+        receive_imf::receive_imf,
         test_utils::{TestContext, TestContextManager},
     };
 
@@ -757,6 +758,67 @@ mod tests {
         assert!(alice.iroh.read().await.is_some());
         alice.stop_io().await;
         assert!(alice.iroh.read().await.is_none());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_duplicated_out_of_order_advertisement() -> Result<()> {
+        let mut tcm = TestContextManager::new();
+        let alice = &mut tcm.alice().await;
+        let bob = &mut tcm.bob().await;
+
+        let alice_chat = alice.create_chat(bob).await;
+        let mut instance = Message::new(Viewtype::File);
+        instance.set_file_from_bytes(
+            alice,
+            "minimal.xdc",
+            include_bytes!("../test-data/webxdc/minimal.xdc"),
+            None,
+        )?;
+
+        send_msg(alice, alice_chat.id, &mut instance).await?;
+        let alice_webxdc = alice.get_last_msg().await;
+        assert_eq!(alice_webxdc.get_viewtype(), Viewtype::Webxdc);
+
+        let webxdc = alice.pop_sent_msg().await;
+        // Imagine that at this point Alice learns about Bob's new transport...
+        send_webxdc_realtime_advertisement(alice, alice_webxdc.id).await?;
+        let advertisement = alice.pop_sent_msg().await;
+
+        // Bob receives an out-of-order advertisement from his new transport.
+        receive_imf(bob, advertisement.payload().as_bytes(), false).await?;
+
+        let bob_webxdc = bob.recv_msg(&webxdc).await;
+        assert_eq!(bob_webxdc.get_viewtype(), Viewtype::Webxdc);
+
+        bob_webxdc.chat_id.accept(bob).await?;
+
+        bob.recv_msg_trash(&advertisement).await;
+        loop {
+            let event = bob.evtracker.recv().await.unwrap();
+            if let EventType::WebxdcRealtimeAdvertisementReceived { msg_id } = event.typ {
+                assert!(msg_id == bob_webxdc.id);
+                break;
+            }
+        }
+        let members = get_iroh_gossip_peers(bob, bob_webxdc.id)
+            .await?
+            .into_iter()
+            .map(|addr| addr.node_id)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            members,
+            vec![
+                alice
+                    .get_or_try_init_peer_channel()
+                    .await
+                    .unwrap()
+                    .get_node_addr()
+                    .await
+                    .unwrap()
+                    .node_id
+            ]
+        );
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -61,7 +61,7 @@ use crate::{logged_debug_assert, mimeparser};
 ///
 /// One email with multiple attachments can end up as multiple chat messages, but they
 /// all have the same chat_id, state and sort_timestamp.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct ReceivedMsg {
     /// Chat the message is assigned to.
     pub chat_id: ChatId,
@@ -2074,8 +2074,15 @@ async fn add_parts(
                 None => {
                     warn!(
                         context,
-                        "Cannot add iroh peer because WebXDC instance does not exist."
+                        "Cannot add iroh peer because WebXDC instance {in_reply_to} does not exist."
                     );
+                    return Ok(ReceivedMsg {
+                        chat_id,
+                        state,
+                        hidden: true,
+                        sort_timestamp,
+                        ..Default::default()
+                    });
                 }
             },
             None => {


### PR DESCRIPTION
An Iroh-Node-Addr message (realtime advertisement) may arrive earlier than the referenced webxdc in
    case of multi-transport. By not creating a tombstone we still can receive it later on another
    transport.
    
Fix (partially) #8372 