### PR TITLE
feat: accept messages from key contacts with forged From address

### DIFF
--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -525,8 +525,6 @@ impl MimeMessage {
             // let known protected headers from the decrypted
             // part override the unencrypted top-level
 
-            // Signature was checked for original From, so we
-            // do not allow overriding it.
             let mut inner_from = None;
 
             MimeMessage::merge_headers(
@@ -558,19 +556,22 @@ impl MimeMessage {
                     // This _might_ be because the sender's mail server
                     // replaced the sending address, e.g. in a mailing list.
                     // Or it's because someone is doing some replay attack.
-                    // Resending encrypted messages via mailing lists
-                    // without reencrypting is not useful anyway,
-                    // so we return an error below.
                     warn!(
                         context,
                         "From header in encrypted part doesn't match the outer one",
                     );
 
-                    // Return an error from the parser.
-                    // This will result in creating a tombstone
-                    // and no further message processing
-                    // as if the MIME structure is broken.
-                    bail!("From header is forged");
+                    // If there are no valid signatures,
+                    // possibly because we don't have the public key,
+                    // the message will be associated with the address-contact.
+                    // If the address is possibly forged, we trash the message.
+                    if signatures.is_empty() {
+                        // Return an error from the parser.
+                        // This will result in creating a tombstone
+                        // and no further message processing
+                        // as if the MIME structure is broken.
+                        bail!("From header is forged");
+                    }
                 }
                 from = inner_from;
             }

--- a/src/receive_imf/receive_imf_tests.rs
+++ b/src/receive_imf/receive_imf_tests.rs
@@ -3456,6 +3456,8 @@ async fn test_prefer_encrypt_mutual_if_encrypted() -> Result<()> {
     Ok(())
 }
 
+/// Tests reception of encrypted and signed message with forged From header
+/// when the signature cannot be checked because the public key is not available.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_forged_from_and_no_valid_signatures() -> Result<()> {
     let mut tcm = TestContextManager::new();
@@ -4718,6 +4720,10 @@ async fn test_no_op_member_added_is_trash() -> Result<()> {
     Ok(())
 }
 
+/// Tests reception of a message with a valid signature and forged From header.
+///
+/// The message is accepted because the sender contact is associated with the key
+/// rather than the address.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_forged_from() -> Result<()> {
     let mut tcm = TestContextManager::new();
@@ -4732,8 +4738,16 @@ async fn test_forged_from() -> Result<()> {
         .payload
         .replace("bob@example.net", "notbob@example.net");
 
-    let msg = alice.recv_msg_opt(&sent_msg).await;
-    assert!(msg.is_none());
+    let msg = alice.recv_msg(&sent_msg).await;
+    assert_eq!(msg.text, "hi!");
+    assert!(msg.get_showpadlock());
+    let contact = Contact::get_by_id(&alice, msg.from_id).await?;
+    assert!(contact.is_key_contact());
+
+    // We take the address from the encrypted part
+    // and send replies there.
+    assert_eq!(contact.get_addr(), "bob@example.net");
+
     Ok(())
 }
 


### PR DESCRIPTION
From address is not used for key contacts
other than as the address to send replies to.

___Edit by Hocuri:___

The reason for this pull request is because we want to keep open the opportunity to do sending failover without needing late encryption:

If we didn't manage to send a message via one of our relays, then we want to try another one. This is called 'sending failover'. It means that we need to change the From address after the first sending attempt. Changing the outer (unencrypted) From in the SMTP queue is easy, but changing the inner (encrypted) From is not possible anymore after the message has been encrypted. There are two possible solutions:
- Encrypt the message only at the time of sending it out, rather than at the time when the user presses "Send" ("late encryption"), so that the inner From can be adapted to match the outer From. https://github.com/chatmail/core/pull/8345 is a preparation PR for this.
- Make the receiving side accept it if the inner and outer From headers don't match. Then the sending side only needs to change the outer From. This means that any Delta Chat version with sending failover will be incompatible with older versions of DC that don't accept mismatching From headers.

Merging this PR here will allow us to choose the second solution once the PR has been released for a sufficient amount of time.