### PR TITLE
chore: update quick-xml to 0.41.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4785,9 +4785,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ percent-encoding = "2.3"
 pgp = { version = "0.20.0", features = ["draft-pqc"], default-features = false }
 pin-project = "1"
 qrcodegen = "1.7.0"
-quick-xml = { version = "0.39", features = ["escape-html"] }
+quick-xml = { version = "0.41", features = ["escape-html"] }
 rand-old = { package = "rand", version = "0.8" }
 rand = { workspace = true }
 regex = { workspace = true }

--- a/src/configure/auto_mozilla.rs
+++ b/src/configure/auto_mozilla.rs
@@ -5,6 +5,7 @@
 use std::io::BufRead;
 use std::str::FromStr;
 
+use quick_xml::XmlVersion;
 use quick_xml::events::{BytesStart, Event};
 
 use super::{Error, ServerParams};
@@ -71,7 +72,7 @@ fn parse_server<B: BufRead>(
             })
         })
         .map(|typ| {
-            typ.decode_and_unescape_value(reader.decoder())
+            typ.decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())
                 .unwrap_or_default()
                 .to_lowercase()
         })
@@ -101,7 +102,11 @@ fn parse_server<B: BufRead>(
                 }
             }
             Event::Text(ref event) => {
-                let val = event.xml_content().unwrap_or_default().trim().to_owned();
+                let val = event
+                    .xml_content(XmlVersion::Implicit1_0)
+                    .unwrap_or_default()
+                    .trim()
+                    .to_owned();
 
                 match tag_config {
                     MozConfigTag::Hostname => hostname = Some(val),

--- a/src/configure/auto_outlook.rs
+++ b/src/configure/auto_outlook.rs
@@ -5,6 +5,7 @@
 
 use std::io::BufRead;
 
+use quick_xml::XmlVersion;
 use quick_xml::events::Event;
 
 use super::{Error, ServerParams};
@@ -79,7 +80,7 @@ fn parse_protocol<B: BufRead>(
                 }
             }
             Event::Text(ref e) => {
-                let val = e.xml_content().unwrap_or_default();
+                let val = e.xml_content(XmlVersion::Implicit1_0).unwrap_or_default();
 
                 if let Some(ref tag) = current_tag {
                     match tag.as_str() {
@@ -123,7 +124,7 @@ fn parse_redirecturl<B: BufRead>(
     let mut buf = Vec::new();
     match reader.read_event_into(&mut buf)? {
         Event::Text(ref e) => {
-            let val = e.xml_content().unwrap_or_default();
+            let val = e.xml_content(XmlVersion::Implicit1_0).unwrap_or_default();
             Ok(val.trim().to_string())
         }
         _ => Ok("".to_string()),

--- a/src/dehtml.rs
+++ b/src/dehtml.rs
@@ -6,7 +6,7 @@ use std::io::BufRead;
 use std::sync::LazyLock;
 
 use quick_xml::{
-    Reader,
+    Reader, XmlVersion,
     errors::Error as QuickXmlError,
     events::{BytesEnd, BytesStart, BytesText},
 };
@@ -327,7 +327,7 @@ fn dehtml_starttag_cb<B: std::io::BufRead>(
                 })
             {
                 let href = href
-                    .decode_and_unescape_value(reader.decoder())
+                    .decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())
                     .unwrap_or_default()
                     .to_string();
 
@@ -374,7 +374,7 @@ fn maybe_push_tag(
 fn tag_contains_attr(event: &BytesStart, reader: &Reader<impl BufRead>, name: &str) -> bool {
     event.attributes().any(|r| {
         r.map(|a| {
-            a.decode_and_unescape_value(reader.decoder())
+            a.decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())
                 .map(|v| v == name)
                 .unwrap_or(false)
         })

--- a/src/location.rs
+++ b/src/location.rs
@@ -14,6 +14,7 @@ use std::time::Duration;
 
 use anyhow::{Context as _, Result, ensure};
 use async_channel::Receiver;
+use quick_xml::XmlVersion;
 use quick_xml::events::{BytesEnd, BytesStart, BytesText};
 use tokio::time::timeout;
 
@@ -140,8 +141,9 @@ impl Kml {
         if self.tag == KmlTag::PlacemarkTimestampWhen
             || self.tag == KmlTag::PlacemarkPointCoordinates
         {
-            let val = event.xml_content().unwrap_or_default();
-
+            let val = event
+                .xml_content(XmlVersion::Implicit1_0)
+                .unwrap_or_default();
             let val = val.replace(['\n', '\r', '\t', ' '], "");
 
             if self.tag == KmlTag::PlacemarkTimestampWhen && val.len() >= 19 {
@@ -227,7 +229,7 @@ impl Kml {
                     == "addr"
             }) {
                 self.addr = addr
-                    .decode_and_unescape_value(reader.decoder())
+                    .decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())
                     .ok()
                     .map(|a| a.into_owned());
             }
@@ -253,7 +255,7 @@ impl Kml {
                 })
             }) {
                 let v = acc
-                    .decode_and_unescape_value(reader.decoder())
+                    .decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())
                     .unwrap_or_default();
 
                 self.curr.accuracy = v.trim().parse().unwrap_or_default();


### PR DESCRIPTION
Fixes cargo-deny complaining about https://rustsec.org/advisories/RUSTSEC-2026-0194