### PR TITLE
feat: Remove hidden relays automatically

### DIFF
--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -590,7 +590,7 @@ impl CommandApi {
 
     /// Immediately deletes a transport, potentially causing messages not to arrive.
     /// This must ONLY be used by the automated tests.
-    /// UI implementations must use `set_transport_unpublished()` instead.
+    /// UI implementations must use [`Self::set_transport_unpublished`] instead.
     async fn delete_transport(&self, account_id: u32, addr: String) -> Result<()> {
         let ctx = self.get_context(account_id).await?;
         ctx.delete_transport(&addr).await
@@ -605,6 +605,11 @@ impl CommandApi {
     /// and self-sent messages are not sent there,
     /// so that we don't cause extra messages to the corresponding inbox,
     /// but can still receive messages from contacts who don't know our new transport addresses yet.
+    ///
+    /// Unpublished transports that are not used to receive any new messages for a time defined by
+    /// [`UNPUBLISHED_TRANSPORT_KEEP_TIME`] are automatically removed.
+    ///
+    /// [`UNPUBLISHED_TRANSPORT_KEEP_TIME`]: deltachat::sql::UNPUBLISHED_TRANSPORT_KEEP_TIME
     async fn set_transport_unpublished(
         &self,
         account_id: u32,

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -232,7 +232,7 @@ impl Context {
 
     /// Immediately deletes a transport, potentially causing messages not to arrive.
     /// This must ONLY be used by the automated tests.
-    /// UI implementations must use `set_transport_unpublished()` instead.
+    /// UI implementations must use [`Self::set_transport_unpublished`] instead.
     pub async fn delete_transport(&self, addr: &str) -> Result<()> {
         let now = time();
         let removed_transport_id = self
@@ -291,6 +291,9 @@ impl Context {
     /// and self-sent messages are not sent there,
     /// so that we don't cause extra messages to the corresponding inbox,
     /// but can still receive messages from contacts who don't know our new transport addresses yet.
+    ///
+    /// Unpublished transports that are not used to receive any new messages for a time defined by
+    /// `UNPUBLISHED_TRANSPORT_KEEP_TIME` are automatically removed.
     pub async fn set_transport_unpublished(&self, addr: &str, unpublished: bool) -> Result<()> {
         self.sql
             .transaction(|trans| {

--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1182,6 +1182,7 @@ impl Session {
 
         for (request_uids, set) in build_sequence_sets(&request_uids)? {
             info!(context, "Starting UID FETCH of message set \"{}\".", set);
+            let transport_id = self.transport_id();
             let mut fetch_responses = self
                 .uid_fetch(&set, BODY_FULL)
                 .await
@@ -1277,6 +1278,12 @@ impl Session {
                     "Passing message UID {} to receive_imf().", request_uid
                 );
                 let res = receive_imf_inner(context, rfc724_mid, body, is_seen).await;
+                crate::sql::update_transport_last_rcvd_timestamp(context, transport_id)
+                    .await
+                    .context(format!(
+                        "Failed to update last_rcvd_timestamp of transport {}",
+                        transport_id
+                    ))?;
 
                 // If there was an error receiving the message, show a device message:
                 let received_msg = match res {

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -47,6 +47,9 @@ mod pool;
 
 use pool::{Pool, WalCheckpointStats};
 
+/// How long a hidden and unused transport should be kept in the database before being deleted.
+pub const UNPUBLISHED_TRANSPORT_KEEP_TIME: i64 = 90 * 24 * 60 * 60;
+
 /// A wrapper around the underlying Sqlite3 object.
 #[derive(Debug)]
 pub struct Sql {
@@ -908,8 +911,51 @@ pub async fn housekeeping(context: &Context) -> Result<()> {
         .log_err(context)
         .ok();
 
+    remove_unused_hidden_transports(context)
+        .await
+        .context("Failed to remove unused hidden transports")
+        .log_err(context)
+        .ok();
+
     info!(context, "Housekeeping done.");
     Ok(())
+}
+
+/// Removes transports that are hidden (`is_published=0`),
+/// and haven't been used to receive new messages for [`UNPUBLISHED_TRANSPORT_KEEP_TIME`] seconds.
+pub(crate) async fn remove_unused_hidden_transports(context: &Context) -> Result<usize> {
+    let now = time();
+    let cutoff = now.saturating_sub(UNPUBLISHED_TRANSPORT_KEEP_TIME);
+    context
+        .sql
+        .execute(
+            "DELETE FROM transports
+            WHERE is_published=0
+            AND last_rcvd_timestamp<?1
+            AND add_timestamp<?1", // important, prevents immediate deletion in case of `last_rcvd_timestamp=0`
+            (cutoff,),
+        )
+        .await
+}
+
+/// Updates transport's `last_rcvd_timestamp`
+/// with the current time.
+///
+/// This is used to postpone deletion of hidden transport by [`remove_unused_hidden_transports`],
+/// if it is still used to receive messages.
+pub(crate) async fn update_transport_last_rcvd_timestamp(
+    context: &Context,
+    transport_id: u32,
+) -> Result<usize> {
+    context
+        .sql
+        .execute(
+            "UPDATE transports
+            SET last_rcvd_timestamp=?1
+            WHERE id=?2",
+            (time(), transport_id),
+        )
+        .await
 }
 
 /// Get the value of a column `idx` of the `row` as `Vec<u8>`.

--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -2456,6 +2456,27 @@ UPDATE msgs SET state=24 WHERE state=18; -- Change OutPreparing to OutFailed.
         .await?;
     }
 
+    inc_and_check(&mut migration_version, 155)?;
+    if dbversion < migration_version {
+        // last_rcvd_timestamp tracks timestamp of the last received message
+        // on the transport. This is used to remove hidden transports that
+        // were not used to receive messages for some predefined time.
+        //
+        // NOTE: ideally we would use `DEFAULT (unixepoch())`,
+        // but sqlite forbids non-constant default in ALTER TABLE.
+        // Instead, we need to remember to also check `add_timestamp`
+        // before removing transport
+        // (so it won't be immediately deleted if last_rcvd_timestamp=0).
+        sql.execute_migration(
+            "
+            ALTER TABLE transports
+            ADD last_rcvd_timestamp INTEGER NOT NULL DEFAULT 0
+            ",
+            migration_version,
+        )
+        .await?;
+    }
+
     let new_version = sql
         .get_raw_config_int(VERSION_CFG)
         .await?

--- a/src/sql/sql_tests.rs
+++ b/src/sql/sql_tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::message::Message;
+use crate::tools::SystemTime;
 use crate::{EventType, test_utils::TestContext};
 
 #[test]
@@ -364,6 +365,117 @@ async fn test_incremental_vacuum() -> Result<()> {
     let t = TestContext::new().await;
 
     incremental_vacuum(&t).await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_remove_unused_hidden_transports() -> Result<()> {
+    let t = TestContext::new().await;
+    let now = time();
+
+    let transport_id = t
+        .sql
+        .transaction(|t| {
+            // published transport
+            t.execute(
+                "INSERT INTO transports
+                (addr,
+                entered_param,
+                configured_param,
+                add_timestamp)
+                VALUES (?, ?, ?, ?)",
+                ("1", "", "", now),
+            )?;
+
+            // not published transport
+            let transport_id = t.query_row::<u32, _, _>(
+                "INSERT INTO transports
+                (addr,
+                entered_param,
+                configured_param,
+                is_published,
+                add_timestamp)
+                VALUES (?, ?, ?, ?, ?)
+                RETURNING id",
+                ("2", "", "", 0, now),
+                |row| row.get(0),
+            )?;
+
+            // this transport has add_timestamp in the future,
+            // and should not be removed at all, since we only shift time
+            // by 90 days and one second.
+            t.execute(
+                "INSERT INTO transports
+                (addr,
+                entered_param,
+                configured_param,
+                is_published,
+                add_timestamp)
+                VALUES (?, ?, ?, ?, ?)",
+                ("3", "", "", 0, now + 60),
+            )?;
+            Ok(transport_id)
+        })
+        .await?;
+
+    async fn assert_transport_removed(
+        context: &Context,
+        hidden_transport_id: u32,
+        should_be_removed: bool,
+    ) -> Result<()> {
+        let transports_count: u32 = context
+            .sql
+            .query_get_value("SELECT count(*) FROM transports", ())
+            .await?
+            .unwrap();
+        assert_eq!(transports_count, if should_be_removed { 2 } else { 3 });
+        let hidden_transport_present: bool = context
+            .sql
+            .query_get_value(
+                "SELECT count(*) FROM transports WHERE id=?",
+                (hidden_transport_id,),
+            )
+            .await?
+            .unwrap();
+        assert_eq!(hidden_transport_present, !should_be_removed);
+        Ok(())
+    }
+
+    assert_eq!(
+        t.sql
+            .query_get_value::<i64>(
+                "SELECT last_rcvd_timestamp FROM transports WHERE id=?",
+                (transport_id,)
+            )
+            .await?
+            .unwrap(),
+        0
+    );
+    update_transport_last_rcvd_timestamp(&t, transport_id).await?;
+    // last_rcvd_timestamp should update
+    assert!(
+        t.sql
+            .query_get_value::<i64>(
+                "SELECT last_rcvd_timestamp FROM transports WHERE id=?",
+                (transport_id,)
+            )
+            .await?
+            .unwrap()
+            >= now
+    );
+
+    assert_transport_removed(&t, transport_id, false).await?;
+    remove_unused_hidden_transports(&t).await?;
+    // it was recently used, so nothing is deleted
+    assert_transport_removed(&t, transport_id, false).await?;
+
+    SystemTime::shift(Duration::from_secs(
+        (UNPUBLISHED_TRANSPORT_KEEP_TIME + 1).try_into()?,
+    ));
+
+    remove_unused_hidden_transports(&t).await?;
+    assert_transport_removed(&t, transport_id, true).await?;
 
     Ok(())
 }


### PR DESCRIPTION
Automatically remove relays that are hidden (`is_published=0`) and haven't been used to receive new messages for over 90 days.

Closes: #8384