### PR TITLE
refactor: remove set_modseq() function

### DIFF
--- a/src/imap.rs
+++ b/src/imap.rs
@@ -1999,23 +1999,6 @@ async fn get_uidvalidity(context: &Context, transport_id: u32, folder: &str) -> 
         .unwrap_or(0))
 }
 
-pub(crate) async fn set_modseq(
-    context: &Context,
-    transport_id: u32,
-    folder: &str,
-    modseq: u64,
-) -> Result<()> {
-    context
-        .sql
-        .execute(
-            "INSERT INTO imap_sync (transport_id, folder, modseq) VALUES (?,?,?)
-                ON CONFLICT(transport_id, folder) DO UPDATE SET modseq=excluded.modseq",
-            (transport_id, folder, modseq),
-        )
-        .await?;
-    Ok(())
-}
-
 /// Builds a list of sequence/uid sets. The returned sets have each no more than around 1000
 /// characters because according to <https://tools.ietf.org/html/rfc2683#section-3.2.1.5>
 /// command lines should not be much more than 1000 chars (servers should allow at least 8000 chars)

--- a/src/imap/select_folder.rs
+++ b/src/imap/select_folder.rs
@@ -3,7 +3,7 @@
 use anyhow::Context as _;
 
 use super::session::Session as ImapSession;
-use super::{get_uid_next, get_uidvalidity, set_modseq, set_uid_next, set_uidvalidity};
+use super::{get_uid_next, get_uidvalidity, set_uid_next, set_uidvalidity};
 use crate::context::Context;
 use crate::ensure_and_debug_assert;
 use crate::log::warn;
@@ -199,9 +199,6 @@ impl ImapSession {
 
             return Ok(true);
         }
-
-        // UIDVALIDITY is modified, reset highest seen MODSEQ.
-        set_modseq(context, transport_id, folder, 0).await?;
 
         // ==============  uid_validity has changed or is being set the first time.  ==============
 


### PR DESCRIPTION
This is a follow-up to 8f51c7b9d5e9eb0abe4c1f367dc0e792b94d25e5 which removed sync_seen_flags().

MODSEQ is a message attribute related to
CONDSTORE IMAP extension and is not used anymore
since CONDSTORE is not used.