### PR TITLE
fix: Un-escape message footer marks in full messages (`get_html`)

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -21,6 +21,7 @@ use crate::message::{Message, MsgId};
 use crate::mimeparser::parse_message_id;
 use crate::param::{Param::SendHtml, Params};
 use crate::plaintext::PlainText;
+use crate::simplify::unescape_message_footer_marks;
 use crate::sql;
 use crate::tools::{buf_compress, buf_decompress};
 
@@ -174,14 +175,14 @@ impl HtmlMsgParser {
                     if self.html.is_empty()
                         && let Ok(decoded_data) = mail.get_body()
                     {
-                        self.html = decoded_data;
+                        self.html = unescape_message_footer_marks(&decoded_data);
                     }
                 } else if mimetype == mime::TEXT_PLAIN
                     && self.plain.is_none()
                     && let Ok(decoded_data) = mail.get_body()
                 {
                     self.plain = Some(PlainText {
-                        text: decoded_data,
+                        text: unescape_message_footer_marks(&decoded_data),
                         flowed: if let Some(format) = mail.ctype.params.get("format") {
                             format.as_str().eq_ignore_ascii_case("flowed")
                         } else {
@@ -412,6 +413,25 @@ and will be wrapped as usual.<br/>
 mime-modified should not be set set as there is no html and no special stuff;<br/>
 although not being a delta-message.<br/>
 test some special html-characters as &lt; &gt; and &amp; but also &quot; and &#x27; :)<br/>
+</body></html>
+"#
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_htmlparse_plain_escaped_footer() {
+        let t = TestContext::new().await;
+        let raw = include_bytes!("../test-data/message/text_plain_escaped_footer.eml");
+        let (parser, _) = HtmlMsgParser::from_bytes(&t.ctx, raw).unwrap();
+        assert_eq!(
+            parser.html,
+            r#"<!DOCTYPE html>
+<html><head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta name="color-scheme" content="light dark" />
+</head><body dir="auto" style="unicode-bidi: plaintext">
+-- escaped footer 1<br/>
+-- escaped footer 2<br/>
 </body></html>
 "#
         );

--- a/src/simplify.rs
+++ b/src/simplify.rs
@@ -1,7 +1,7 @@
 //! # Simplify incoming plaintext.
 use crate::tools::IsNoneOrEmpty;
 
-/// Protects lines starting with `--` against being treated as a footer.
+/// Protects lines starting with `-- ` against being treated as a footer.
 /// for that, we insert a ZERO WIDTH SPACE (ZWSP, 0x200B);
 /// this should be invisible on most systems and there is no need to unescape it again
 /// (which won't be done by non-deltas anyway).
@@ -10,10 +10,27 @@ use crate::tools::IsNoneOrEmpty;
 /// but for non-delta-compatibility, that seems to be better.
 /// (to be only compatible with delta, only "[\r\n|\n]-- {0,2}[\r\n|\n]" needs to be replaced)
 pub fn escape_message_footer_marks(text: &str) -> String {
-    if let Some(text) = text.strip_prefix("--") {
-        "-\u{200B}-".to_string() + &text.replace("\n--", "\n-\u{200B}-")
+    if let Some(text) = text.strip_prefix("-- ") {
+        "-\u{200B}- ".to_string() + &text.replace("\n-- ", "\n-\u{200B}- ")
     } else {
-        text.replace("\n--", "\n-\u{200B}-")
+        text.replace("\n-- ", "\n-\u{200B}- ")
+    }
+}
+
+/// Unapplies changes made by [`escape_message_footer_marks`].
+///
+/// This assumes original message doesn't contain `LF DASH ZWSP DASH` (`\n-\u{200B}-`)
+/// character sequence and doesn't start with `DASH ZWSP DASH` (`-\u{200B}-`)
+/// character sequence.
+/// Such sequences are unlikely to appear in normal text communication.
+///
+/// For backward compatibility, un-escaping as opposed to escaping
+/// doesn't require the final space to be present.
+pub fn unescape_message_footer_marks(text: &str) -> String {
+    if let Some(text) = text.strip_prefix("-\u{200B}-") {
+        "--".to_string() + &text.replace("\n-\u{200B}-", "\n--")
+    } else {
+        text.replace("\n-\u{200B}-", "\n--")
     }
 }
 
@@ -289,8 +306,7 @@ fn render_message(lines: &[&str], is_cut_at_end: bool) -> String {
     if is_cut_at_end && !ret.is_empty() {
         ret += " [...]";
     }
-    // redo escaping done by escape_message_footer_marks()
-    ret.replace('\u{200B}', "")
+    unescape_message_footer_marks(&ret)
 }
 
 /// Returns true if the line contains only whitespace.
@@ -467,12 +483,21 @@ mod tests {
     }
 
     #[test]
-    fn test_escape_message_footer_marks() {
-        let esc = escape_message_footer_marks("--\n--text --in line");
-        assert_eq!(esc, "-\u{200B}-\n-\u{200B}-text --in line");
+    fn test_escape_unescape_message_footer_marks() {
+        let original = "-- \n-- text -- in line";
+        let esc = escape_message_footer_marks(original);
+        assert_eq!(esc, "-\u{200B}- \n-\u{200B}- text -- in line");
+        let unesc = unescape_message_footer_marks(&esc);
+        assert_eq!(unesc, original);
+    }
 
-        let esc = escape_message_footer_marks("--\r\n--text");
-        assert_eq!(esc, "-\u{200B}-\r\n-\u{200B}-text");
+    #[test]
+    fn test_escape_unescape_message_footer_marks_crlf() {
+        let original = "-- \r\n-- text";
+        let esc = escape_message_footer_marks(original);
+        assert_eq!(esc, "-\u{200B}- \r\n-\u{200B}- text");
+        let unesc = unescape_message_footer_marks(&esc);
+        assert_eq!(unesc, original);
     }
 
     #[test]
@@ -515,7 +540,7 @@ mod tests {
         assert!(!is_cut);
         assert_eq!(footer.unwrap(), "footer");
 
-        let input = "text\n\n--\ntreated as footer when unescaped".to_string();
+        let input = "text\n\n-- \ntreated as footer when unescaped".to_string();
         let SimplifiedText {
             text,
             is_cut,
@@ -532,7 +557,7 @@ mod tests {
             footer,
             ..
         } = simplify(escaped, true);
-        assert_eq!(text, "text\n\n--\ntreated as footer when unescaped");
+        assert_eq!(text, "text\n\n-- \ntreated as footer when unescaped");
         assert!(!is_cut);
         assert_eq!(footer, None);
 
@@ -557,7 +582,7 @@ mod tests {
         assert!(!is_cut);
         assert_eq!(footer, None);
 
-        let input = "--\ntreated as footer when unescaped".to_string();
+        let input = "-- \ntreated as footer when unescaped".to_string();
         let SimplifiedText {
             text,
             is_cut,
@@ -575,7 +600,7 @@ mod tests {
             footer,
             ..
         } = simplify(escaped, true);
-        assert_eq!(text, "--\ntreated as footer when unescaped");
+        assert_eq!(text, "-- \ntreated as footer when unescaped");
         assert!(!is_cut);
         assert_eq!(footer, None);
     }

--- a/test-data/message/text_plain_escaped_footer.eml
+++ b/test-data/message/text_plain_escaped_footer.eml
@@ -1,0 +1,8 @@
+Message-Id: <lkjsdf01u@example.org>
+Date: Sat, 14 Sep 2019 19:00:13 +0200
+From: lmn <x@tux.org>
+To: abc <abc@bcd.com>
+Content-Type: text/plain; charset=utf-8
+
+-​- escaped footer 1
+-​- escaped footer 2


### PR DESCRIPTION
Un-escapes footer marks in long plain-text messages when retrieved with `get_message_html`/`dc_get_msg_html`.

Additionally, makes escaping stricter,
only matching lines starting with `-- ` instead of `--`.

Fixes: #8269