### PR TITLE
ci: update Node version to 24

### DIFF
--- a/.github/workflows/deltachat-rpc-server.yml
+++ b/.github/workflows/deltachat-rpc-server.yml
@@ -513,15 +513,12 @@ jobs:
             deltachat-rpc-server/npm-package/*.tgz
 
       # Configure Node.js for publishing.
+      # Check <https://docs.npmjs.com/trusted-publishers> for the version requirements.
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
-
-      # Ensure npm 11.5.1 or later is installed.
-      # It is needed for <https://docs.npmjs.com/trusted-publishers>
-      - name: Update npm
-        run: npm install -g npm@latest
+          package-manager-cache: false  # never use caching in release builds
 
       - name: Publish npm packets for prebuilds and `@deltachat/stdio-rpc-server`
         if: github.event_name == 'release'

--- a/.github/workflows/jsonrpc-client-npm-package.yml
+++ b/.github/workflows/jsonrpc-client-npm-package.yml
@@ -22,15 +22,13 @@ jobs:
           show-progress: false
           persist-credentials: false
 
+      # Configure Node.js for publishing.
+      # Check <https://docs.npmjs.com/trusted-publishers> for the version requirements.
       - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
-
-      # Ensure npm 11.5.1 or later is installed.
-      # It is needed for <https://docs.npmjs.com/trusted-publishers>
-      - name: Update npm
-        run: npm install -g npm@latest
+          package-manager-cache: false  # never use caching in release builds
 
       - name: Install dependencies without running scripts
         working-directory: deltachat-jsonrpc/typescript

--- a/.github/workflows/jsonrpc.yml
+++ b/.github/workflows/jsonrpc.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           show-progress: false
           persist-credentials: false
-      - name: Use Node.js 18.x
+      - name: Use Node.js 24
         uses: actions/setup-node@v6
         with:
-          node-version: 18.x
+          node-version: 24
       - name: Add Rust cache
         uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
         with:

--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          node-version: 24
       - name: npm install
         run: npm install
       - name: npm run build


### PR DESCRIPTION
https://docs.npmjs.com/trusted-publishers recommends node-version 24 and not updating npm separately, this change copies the recommended configuration.

Also update node version to 24 in non-release workflows, version 18 is EOL. There is a version 26 already, but 24 is LTS.

Also disable cache for release pipelines.

Closes #8435 