### PR TITLE
feat: enable TLS certificate compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5222,6 +5222,8 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "brotli",
+ "brotli-decompressor",
  "log",
  "once_cell",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ tagger = "4.3.4"
 textwrap = "0.16.2"
 thiserror = { workspace = true }
 tokio-io-timeout = "1.2.1"
-tokio-rustls = { version = "0.26.2", default-features = false }
+tokio-rustls = { version = "0.26.2", default-features = false, features = ["tls12", "brotli"] }
 tokio-stream = { version = "0.1.17", features = ["fs"] }
 astral-tokio-tar = { version = "0.6.3", default-features = false }
 tokio-util = { workspace = true }


### PR DESCRIPTION
Enabling brotli does not add new dependencies,
we have it already.
Documentation at <https://docs.rs/rustls/0.23.42/rustls/compress/> recommends enabling at least brotli.

zlib feature is not enabled as it pulls in duplicate zlib-rs 0.6.6 zlib was even never supported in Chromium (while brotli is). It might still be interesting to enable it in the future because it seems to be the only option supported by OpenSSL and there may be servers that support zlib but not brotli.

RFC 8879 specifies zstd as well, but there is no feature to enable it yet.

This also brings back explicit TLS 1.2 feature that was reverted. We don't want TLS 1.2 support to be accidentally dropped if no dependencies explicitly require it anymore.