### PR TITLE
build: update all crates to Rust 2024 edition

### DIFF
--- a/deltachat-contact-tools/Cargo.toml
+++ b/deltachat-contact-tools/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "deltachat-contact-tools"
 version = "0.0.0" # No semver-stable versioning
-edition = "2021"
+edition = "2024"
 description = "Contact-related tools, like parsing vcards and sanitizing name and address. Meant for internal use in the deltachat crate."
 license = "MPL-2.0"
 

--- a/deltachat-contact-tools/src/lib.rs
+++ b/deltachat-contact-tools/src/lib.rs
@@ -30,12 +30,12 @@
 use std::fmt;
 use std::ops::Deref;
 
-use anyhow::bail;
 use anyhow::Result;
+use anyhow::bail;
 use regex::regex;
 
 mod vcard;
-pub use vcard::{make_vcard, parse_vcard, VcardContact};
+pub use vcard::{VcardContact, make_vcard, parse_vcard};
 
 /// Valid contact address.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/deltachat-contact-tools/src/vcard/vcard_tests.rs
+++ b/deltachat-contact-tools/src/vcard/vcard_tests.rs
@@ -220,7 +220,10 @@ END:VCARD
         assert_eq!(contacts[0].addr, "bob@example.org".to_string());
         assert_eq!(contacts[0].authname, "Bob".to_string());
         assert_eq!(contacts[0].key, None);
-        assert_eq!(contacts[0].profile_image.as_deref().unwrap(), "/9j/4AAQSkZJRgABAQAAAQABAAD/4gIoSUNDX1BST0ZJTEUAAQEAAAIYAAAAAAQwAABtbnRyUkdCIFhZWiAAAAAAAAAAAAAAAABhY3NwAAAAAAAAAAAAAAAAL8bRuAJYoZUYrI4ZY3VWwxw4Ay28AAGBISScmf/2Q==");
+        assert_eq!(
+            contacts[0].profile_image.as_deref().unwrap(),
+            "/9j/4AAQSkZJRgABAQAAAQABAAD/4gIoSUNDX1BST0ZJTEUAAQEAAAIYAAAAAAQwAABtbnRyUkdCIFhZWiAAAAAAAAAAAAAAAABhY3NwAAAAAAAAAAAAAAAAL8bRuAJYoZUYrI4ZY3VWwxw4Ay28AAGBISScmf/2Q=="
+        );
     }
 }
 
@@ -244,7 +247,10 @@ END:VCARD",
     assert_eq!(contacts.len(), 1);
     assert_eq!(&contacts[0].addr, "alice@example.org");
     assert_eq!(&contacts[0].authname, "Alice Wonderland");
-    assert_eq!(contacts[0].key.as_ref().unwrap(), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    assert_eq!(
+        contacts[0].key.as_ref().unwrap(),
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
     assert!(contacts[0].timestamp.is_err());
     assert_eq!(contacts[0].profile_image, None);
 }
@@ -272,9 +278,15 @@ END:VCARD",
     assert_eq!(contacts.len(), 1);
     assert_eq!(&contacts[0].addr, "alice@example.org");
     assert_eq!(&contacts[0].authname, "Alice");
-    assert_eq!(contacts[0].key.as_ref().unwrap(), "xsaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==");
+    assert_eq!(
+        contacts[0].key.as_ref().unwrap(),
+        "xsaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa=="
+    );
     assert!(contacts[0].timestamp.is_err());
-    assert_eq!(contacts[0].profile_image.as_ref().unwrap(), "/9aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Z");
+    assert_eq!(
+        contacts[0].profile_image.as_ref().unwrap(),
+        "/9aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Z"
+    );
 }
 
 #[test]

--- a/deltachat-ffi/Cargo.toml
+++ b/deltachat-ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "deltachat_ffi"
 version = "2.58.0-dev"
 description = "Deltachat FFI"
-edition = "2018"
+edition = "2024"
 readme = "README.md"
 license = "MPL-2.0"
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -101,7 +101,7 @@ pub unsafe extern "C" fn dc_context_new(
         // generate random ID as this functionality is not yet available on the C-api.
         let id = rand::random();
         block_on(
-            ContextBuilder::new(as_path(dbfile).to_path_buf())
+            ContextBuilder::new(unsafe { as_path(dbfile) }.to_path_buf())
                 .with_id(id)
                 .open(),
         )
@@ -129,7 +129,7 @@ pub unsafe extern "C" fn dc_context_new_closed(dbfile: *const libc::c_char) -> *
 
     let id = rand::random();
     match block_on(
-        ContextBuilder::new(as_path(dbfile).to_path_buf())
+        ContextBuilder::new(unsafe { as_path(dbfile) }.to_path_buf())
             .with_id(id)
             .build(),
     ) {
@@ -3728,7 +3728,7 @@ pub unsafe extern "C" fn dc_msg_set_file_and_deduplicate(
         .message
         .set_file_and_deduplicate(
             ctx,
-            as_path(file),
+            unsafe { as_path(file) },
             to_opt_string_lossy(name).as_deref(),
             to_opt_string_lossy(filemime).as_deref(),
         )
@@ -4448,7 +4448,7 @@ pub unsafe extern "C" fn dc_accounts_new(
         return ptr::null_mut();
     }
 
-    let accs = block_on(Accounts::new(as_path(dir).into(), writable != 0));
+    let accs = block_on(Accounts::new(unsafe { as_path(dir) }.into(), writable != 0));
 
     match accs {
         Ok(accs) => Arc::into_raw(Arc::new(RwLock::new(accs))),
@@ -4542,7 +4542,7 @@ pub unsafe extern "C" fn dc_accounts_new_with_event_channel(
     };
 
     let accs = block_on(Accounts::new_with_events(
-        as_path(dir).into(),
+        unsafe { as_path(dir) }.into(),
         writable != 0,
         event_channel,
     ));

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -84,7 +84,7 @@ where
     RT.spawn(fut)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_context_new(
     _os_name: *const libc::c_char,
     dbfile: *const libc::c_char,
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn dc_context_new(
         return ptr::null_mut();
     }
 
-    let ctx = if blobdir.is_null() || *blobdir == 0 {
+    let ctx = if blobdir.is_null() || unsafe { *blobdir == 0 } {
         // generate random ID as this functionality is not yet available on the C-api.
         let id = rand::random();
         block_on(
@@ -118,7 +118,7 @@ pub unsafe extern "C" fn dc_context_new(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_context_new_closed(dbfile: *const libc::c_char) -> *mut dc_context_t {
     setup_panic!();
 
@@ -141,7 +141,7 @@ pub unsafe extern "C" fn dc_context_new_closed(dbfile: *const libc::c_char) -> *
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_context_open(
     context: *mut dc_context_t,
     passphrase: *const libc::c_char,
@@ -151,7 +151,7 @@ pub unsafe extern "C" fn dc_context_open(
         return 0;
     }
 
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let passphrase = to_string_lossy(passphrase);
     block_on(ctx.open(passphrase))
         .context("dc_context_open() failed")
@@ -160,7 +160,7 @@ pub unsafe extern "C" fn dc_context_open(
         .unwrap_or(0)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_context_change_passphrase(
     context: *mut dc_context_t,
     passphrase: *const libc::c_char,
@@ -170,7 +170,7 @@ pub unsafe extern "C" fn dc_context_change_passphrase(
         return 0;
     }
 
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let passphrase = to_string_lossy(passphrase);
     block_on(ctx.change_passphrase(passphrase))
         .context("dc_context_change_passphrase() failed")
@@ -178,40 +178,42 @@ pub unsafe extern "C" fn dc_context_change_passphrase(
         .is_ok() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_context_is_open(context: *mut dc_context_t) -> libc::c_int {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_context_is_open()");
         return 0;
     }
 
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     block_on(ctx.is_open()) as libc::c_int
 }
 
 /// Release the context structure.
 ///
 /// This function releases the memory of the `dc_context_t` structure.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_context_unref(context: *mut dc_context_t) {
-    if context.is_null() {
-        eprintln!("ignoring careless call to dc_context_unref()");
-        return;
+    unsafe {
+        if context.is_null() {
+            eprintln!("ignoring careless call to dc_context_unref()");
+            return;
+        }
+        drop(Box::from_raw(context));
     }
-    drop(Box::from_raw(context));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_blobdir(context: *mut dc_context_t) -> *mut libc::c_char {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_blobdir()");
         return "".strdup();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     ctx.get_blobdir().to_string_lossy().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_set_config(
     context: *mut dc_context_t,
     key: *const libc::c_char,
@@ -221,7 +223,7 @@ pub unsafe extern "C" fn dc_set_config(
         eprintln!("ignoring careless call to dc_set_config()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let key = to_string_lossy(key);
     let value = to_opt_string_lossy(value);
 
@@ -251,7 +253,7 @@ pub unsafe extern "C" fn dc_set_config(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_config(
     context: *mut dc_context_t,
     key: *const libc::c_char,
@@ -260,7 +262,7 @@ pub unsafe extern "C" fn dc_get_config(
         eprintln!("ignoring careless call to dc_get_config()");
         return "".strdup();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     let key = to_string_lossy(key);
 
@@ -292,7 +294,7 @@ pub unsafe extern "C" fn dc_get_config(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_set_stock_translation(
     context: *mut dc_context_t,
     stock_id: u32,
@@ -303,7 +305,7 @@ pub unsafe extern "C" fn dc_set_stock_translation(
         return 0;
     }
     let msg = to_string_lossy(stock_msg);
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     match StockMessage::from_u32(stock_id)
         .with_context(|| format!("Invalid stock message ID {stock_id}"))
@@ -318,7 +320,7 @@ pub unsafe extern "C" fn dc_set_stock_translation(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_set_config_from_qr(
     context: *mut dc_context_t,
     qr: *mut libc::c_char,
@@ -327,8 +329,9 @@ pub unsafe extern "C" fn dc_set_config_from_qr(
         eprintln!("ignoring careless call to dc_set_config_from_qr");
         return 0;
     }
+
     let qr = to_string_lossy(qr);
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(qr::set_config_from_qr(ctx, &qr))
         .context("Failed to create account from QR code")
@@ -336,18 +339,21 @@ pub unsafe extern "C" fn dc_set_config_from_qr(
         .is_ok() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_info(context: *const dc_context_t) -> *mut libc::c_char {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_info()");
         return "".strdup();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     match block_on(ctx.get_info())
         .context("Failed to get info")
         .log_err(ctx)
     {
-        Ok(info) => render_info(info).unwrap_or_default().strdup(),
+        Ok(info) => {
+            let info = render_info(info).unwrap_or_default();
+            info.strdup()
+        }
         Err(_) => "".strdup(),
     }
 }
@@ -363,17 +369,17 @@ fn render_info(
     Ok(res)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_connectivity(context: *const dc_context_t) -> libc::c_int {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_connectivity()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     ctx.get_connectivity() as u32 as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_connectivity_html(
     context: *const dc_context_t,
 ) -> *mut libc::c_char {
@@ -381,7 +387,7 @@ pub unsafe extern "C" fn dc_get_connectivity_html(
         eprintln!("ignoring careless call to dc_get_connectivity_html()");
         return "".strdup();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     match block_on(ctx.get_connectivity_html())
         .context("Failed to get connectivity html")
         .log_err(ctx)
@@ -391,13 +397,13 @@ pub unsafe extern "C" fn dc_get_connectivity_html(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_push_state(context: *const dc_context_t) -> libc::c_int {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_push_state()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     ctx.push_state() as libc::c_int
 }
 
@@ -410,24 +416,24 @@ fn spawn_configure(ctx: Context) {
     });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_configure(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_configure()");
         return;
     }
 
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     spawn_configure(ctx.clone());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_is_configured(context: *mut dc_context_t) -> libc::c_int {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_is_configured()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(async move {
         ctx.is_configured()
@@ -438,46 +444,46 @@ pub unsafe extern "C" fn dc_is_configured(context: *mut dc_context_t) -> libc::c
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_start_io(context: *mut dc_context_t) {
     if context.is_null() {
         return;
     }
-    let ctx = &mut *context;
+    let ctx = unsafe { &mut *context };
 
     block_on(ctx.start_io())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_id(context: *mut dc_context_t) -> libc::c_int {
     if context.is_null() {
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     ctx.get_id() as libc::c_int
 }
 
 pub type dc_event_t = Event;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_event_unref(a: *mut dc_event_t) {
     if a.is_null() {
         eprintln!("ignoring careless call to dc_event_unref()");
         return;
     }
 
-    drop(Box::from_raw(a));
+    drop(unsafe { Box::from_raw(a) });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_event_get_id(event: *mut dc_event_t) -> libc::c_int {
     if event.is_null() {
         eprintln!("ignoring careless call to dc_event_get_id()");
         return 0;
     }
 
-    let event = &*event;
+    let event = unsafe { &*event };
     match event.typ {
         EventType::Info(_) => 100,
         EventType::SmtpConnected(_) => 101,
@@ -537,14 +543,14 @@ pub unsafe extern "C" fn dc_event_get_id(event: *mut dc_event_t) -> libc::c_int 
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_event_get_data1_int(event: *mut dc_event_t) -> libc::c_int {
     if event.is_null() {
         eprintln!("ignoring careless call to dc_event_get_data1_int()");
         return 0;
     }
 
-    let event = &(*event).typ;
+    let event = unsafe { &(*event).typ };
     match event {
         EventType::Info(_)
         | EventType::SmtpConnected(_)
@@ -611,14 +617,14 @@ pub unsafe extern "C" fn dc_event_get_data1_int(event: *mut dc_event_t) -> libc:
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_event_get_data2_int(event: *mut dc_event_t) -> libc::c_int {
     if event.is_null() {
         eprintln!("ignoring careless call to dc_event_get_data2_int()");
         return 0;
     }
 
-    let event = &(*event).typ;
+    let event = unsafe { &(*event).typ };
 
     match event {
         EventType::Info(_)
@@ -685,14 +691,14 @@ pub unsafe extern "C" fn dc_event_get_data2_int(event: *mut dc_event_t) -> libc:
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_event_get_data1_str(event: *mut dc_event_t) -> *mut libc::c_char {
     if event.is_null() {
         eprintln!("ignoring careless call to dc_event_get_data1_str()");
         return ptr::null_mut();
     }
 
-    let event = &(*event).typ;
+    let event = unsafe { &(*event).typ };
 
     match event {
         EventType::IncomingWebxdcNotify { href, .. } => {
@@ -706,14 +712,14 @@ pub unsafe extern "C" fn dc_event_get_data1_str(event: *mut dc_event_t) -> *mut 
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_event_get_data2_str(event: *mut dc_event_t) -> *mut libc::c_char {
     if event.is_null() {
         eprintln!("ignoring careless call to dc_event_get_data2_str()");
         return ptr::null_mut();
     }
 
-    let event = &(*event).typ;
+    let event = unsafe { &(*event).typ };
 
     match event {
         EventType::Info(msg)
@@ -790,8 +796,8 @@ pub unsafe extern "C" fn dc_event_get_data2_str(event: *mut dc_event_t) -> *mut 
             data2.into_raw()
         }
         EventType::WebxdcRealtimeData { data, .. } => {
-            let ptr = libc::malloc(data.len());
-            libc::memcpy(ptr, data.as_ptr() as *mut libc::c_void, data.len());
+            let ptr = unsafe { libc::malloc(data.len()) };
+            unsafe { libc::memcpy(ptr, data.as_ptr() as *mut libc::c_void, data.len()) };
             ptr as *mut libc::c_char
         }
         EventType::IncomingReaction { reaction, .. } => reaction
@@ -808,19 +814,19 @@ pub unsafe extern "C" fn dc_event_get_data2_str(event: *mut dc_event_t) -> *mut 
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_event_get_account_id(event: *mut dc_event_t) -> u32 {
     if event.is_null() {
         eprintln!("ignoring careless call to dc_event_get_account_id()");
         return 0;
     }
 
-    (*event).id
+    unsafe { (*event).id }
 }
 
 pub type dc_event_emitter_t = EventEmitter;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_event_emitter(
     context: *mut dc_context_t,
 ) -> *mut dc_event_emitter_t {
@@ -828,27 +834,29 @@ pub unsafe extern "C" fn dc_get_event_emitter(
         eprintln!("ignoring careless call to dc_get_event_emitter()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
-    Box::into_raw(Box::new(ctx.get_event_emitter()))
+    unsafe {
+        let ctx = &*context;
+        Box::into_raw(Box::new(ctx.get_event_emitter()))
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_event_emitter_unref(emitter: *mut dc_event_emitter_t) {
     if emitter.is_null() {
         eprintln!("ignoring careless call to dc_event_emitter_unref()");
         return;
     }
 
-    drop(Box::from_raw(emitter));
+    drop(unsafe { Box::from_raw(emitter) });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_next_event(events: *mut dc_event_emitter_t) -> *mut dc_event_t {
     if events.is_null() {
         eprintln!("ignoring careless call to dc_get_next_event()");
         return ptr::null_mut();
     }
-    let events = &*events;
+    let events = unsafe { &*events };
 
     block_on(async move {
         events
@@ -859,31 +867,31 @@ pub unsafe extern "C" fn dc_get_next_event(events: *mut dc_event_emitter_t) -> *
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_stop_io(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_stop_io()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(async move {
         ctx.stop_io().await;
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_maybe_network(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_maybe_network()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(async move { ctx.maybe_network().await })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_preconfigure_keypair(
     context: *mut dc_context_t,
     secret_data: *const libc::c_char,
@@ -892,7 +900,7 @@ pub unsafe extern "C" fn dc_preconfigure_keypair(
         eprintln!("ignoring careless call to dc_preconfigure_keypair()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let secret_data = to_string_lossy(secret_data);
     block_on(preconfigure_keypair(ctx, &secret_data))
         .context("Failed to save keypair")
@@ -900,7 +908,7 @@ pub unsafe extern "C" fn dc_preconfigure_keypair(
         .is_ok() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_chatlist(
     context: *mut dc_context_t,
     flags: libc::c_int,
@@ -911,7 +919,7 @@ pub unsafe extern "C" fn dc_get_chatlist(
         eprintln!("ignoring careless call to dc_get_chatlist()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let qs = to_opt_string_lossy(query_str);
 
     let qi = if query_id == 0 {
@@ -920,22 +928,24 @@ pub unsafe extern "C" fn dc_get_chatlist(
         Some(ContactId::new(query_id))
     };
 
-    block_on(async move {
-        match chatlist::Chatlist::try_load(ctx, flags as usize, qs.as_deref(), qi)
-            .await
-            .context("Failed to get chatlist")
-            .log_err(ctx)
-        {
-            Ok(list) => {
-                let ffi_list = ChatlistWrapper { context, list };
-                Box::into_raw(Box::new(ffi_list))
-            }
-            Err(_) => ptr::null_mut(),
+    match block_on(chatlist::Chatlist::try_load(
+        ctx,
+        flags as usize,
+        qs.as_deref(),
+        qi,
+    ))
+    .context("Failed to get chatlist")
+    .log_err(ctx)
+    {
+        Ok(list) => {
+            let ffi_list = ChatlistWrapper { context, list };
+            Box::into_raw(Box::new(ffi_list))
         }
-    })
+        Err(_) => ptr::null_mut(),
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_create_chat_by_contact_id(
     context: *mut dc_context_t,
     contact_id: u32,
@@ -944,19 +954,16 @@ pub unsafe extern "C" fn dc_create_chat_by_contact_id(
         eprintln!("ignoring careless call to dc_create_chat_by_contact_id()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        ChatId::create_for_contact(ctx, ContactId::new(contact_id))
-            .await
-            .context("Failed to create chat from contact_id")
-            .log_err(ctx)
-            .map(|id| id.to_u32())
-            .unwrap_or(0)
-    })
+    block_on(ChatId::create_for_contact(ctx, ContactId::new(contact_id)))
+        .context("Failed to create chat from contact_id")
+        .log_err(ctx)
+        .map(|id| id.to_u32())
+        .unwrap_or(0)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_chat_id_by_contact_id(
     context: *mut dc_context_t,
     contact_id: u32,
@@ -965,20 +972,17 @@ pub unsafe extern "C" fn dc_get_chat_id_by_contact_id(
         eprintln!("ignoring careless call to dc_get_chat_id_by_contact_id()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        ChatId::lookup_by_contact(ctx, ContactId::new(contact_id))
-            .await
-            .context("Failed to get chat for contact_id")
-            .log_err(ctx)
-            .unwrap_or_default() // unwraps the Result
-            .map(|id| id.to_u32())
-            .unwrap_or(0) // unwraps the Option
-    })
+    block_on(ChatId::lookup_by_contact(ctx, ContactId::new(contact_id)))
+        .context("Failed to get chat for contact_id")
+        .log_err(ctx)
+        .unwrap_or_default() // unwraps the Result
+        .map(|id| id.to_u32())
+        .unwrap_or(0) // unwraps the Option
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_send_msg(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -988,18 +992,19 @@ pub unsafe extern "C" fn dc_send_msg(
         eprintln!("ignoring careless call to dc_send_msg()");
         return 0;
     }
-    let ctx = &mut *context;
-    let ffi_msg = &mut *msg;
+    let ctx = unsafe { &mut *context };
+    let ffi_msg = unsafe { &mut *msg };
 
-    block_on(async move {
-        chat::send_msg(ctx, ChatId::new(chat_id), &mut ffi_msg.message)
-            .await
-            .unwrap_or_log_default(ctx, "Failed to send message")
-    })
+    block_on(chat::send_msg(
+        ctx,
+        ChatId::new(chat_id),
+        &mut ffi_msg.message,
+    ))
+    .unwrap_or_log_default(ctx, "Failed to send message")
     .to_u32()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_send_msg_sync(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1009,18 +1014,19 @@ pub unsafe extern "C" fn dc_send_msg_sync(
         eprintln!("ignoring careless call to dc_send_msg_sync()");
         return 0;
     }
-    let ctx = &mut *context;
-    let ffi_msg = &mut *msg;
+    let ctx = unsafe { &mut *context };
+    let ffi_msg = unsafe { &mut *msg };
 
-    block_on(async move {
-        chat::send_msg_sync(ctx, ChatId::new(chat_id), &mut ffi_msg.message)
-            .await
-            .unwrap_or_log_default(ctx, "Failed to send message")
-    })
+    block_on(chat::send_msg_sync(
+        ctx,
+        ChatId::new(chat_id),
+        &mut ffi_msg.message,
+    ))
+    .unwrap_or_log_default(ctx, "Failed to send message")
     .to_u32()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_send_text_msg(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1030,18 +1036,15 @@ pub unsafe extern "C" fn dc_send_text_msg(
         eprintln!("ignoring careless call to dc_send_text_msg()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let text_to_send = to_string_lossy(text_to_send);
 
-    block_on(async move {
-        chat::send_text_msg(ctx, ChatId::new(chat_id), text_to_send)
-            .await
-            .map(|msg_id| msg_id.to_u32())
-            .unwrap_or_log_default(ctx, "Failed to send text message")
-    })
+    block_on(chat::send_text_msg(ctx, ChatId::new(chat_id), text_to_send))
+        .map(|msg_id| msg_id.to_u32())
+        .unwrap_or_log_default(ctx, "Failed to send text message")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_send_edit_request(
     context: *mut dc_context_t,
     msg_id: u32,
@@ -1051,14 +1054,14 @@ pub unsafe extern "C" fn dc_send_edit_request(
         eprintln!("ignoring careless call to dc_send_edit_request()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let new_text = to_string_lossy(new_text);
 
     block_on(chat::send_edit_request(ctx, MsgId::new(msg_id), new_text))
         .unwrap_or_log_default(ctx, "Failed to send text edit")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_send_delete_request(
     context: *mut dc_context_t,
     msg_ids: *const u32,
@@ -1068,7 +1071,7 @@ pub unsafe extern "C" fn dc_send_delete_request(
         eprintln!("ignoring careless call to dc_send_delete_request()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let msg_ids = convert_and_prune_message_ids(msg_ids, msg_cnt);
 
     block_on(message::delete_msgs_ex(ctx, &msg_ids, true))
@@ -1077,7 +1080,7 @@ pub unsafe extern "C" fn dc_send_delete_request(
         .ok();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_send_webxdc_status_update(
     context: *mut dc_context_t,
     msg_id: u32,
@@ -1088,7 +1091,7 @@ pub unsafe extern "C" fn dc_send_webxdc_status_update(
         eprintln!("ignoring careless call to dc_send_webxdc_status_update()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(ctx.send_webxdc_status_update(MsgId::new(msg_id), &to_string_lossy(json)))
         .context("Failed to send webxdc update")
@@ -1096,7 +1099,7 @@ pub unsafe extern "C" fn dc_send_webxdc_status_update(
         .is_ok() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_webxdc_status_updates(
     context: *mut dc_context_t,
     msg_id: u32,
@@ -1106,7 +1109,7 @@ pub unsafe extern "C" fn dc_get_webxdc_status_updates(
         eprintln!("ignoring careless call to dc_get_webxdc_status_updates()");
         return "".strdup();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(ctx.get_webxdc_status_updates(
         MsgId::new(msg_id),
@@ -1116,7 +1119,7 @@ pub unsafe extern "C" fn dc_get_webxdc_status_updates(
     .strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_set_webxdc_integration(
     context: *mut dc_context_t,
     file: *const libc::c_char,
@@ -1125,13 +1128,13 @@ pub unsafe extern "C" fn dc_set_webxdc_integration(
         eprintln!("ignoring careless call to dc_set_webxdc_integration()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     block_on(ctx.set_webxdc_integration(&to_string_lossy(file)))
         .log_err(ctx)
         .unwrap_or_default();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_init_webxdc_integration(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1140,7 +1143,7 @@ pub unsafe extern "C" fn dc_init_webxdc_integration(
         eprintln!("ignoring careless call to dc_init_webxdc_integration()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let chat_id = if chat_id == 0 {
         None
     } else {
@@ -1153,7 +1156,7 @@ pub unsafe extern "C" fn dc_init_webxdc_integration(
         .unwrap_or(0)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_place_outgoing_call(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1164,7 +1167,7 @@ pub unsafe extern "C" fn dc_place_outgoing_call(
         eprintln!("ignoring careless call to dc_place_outgoing_call()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let chat_id = ChatId::new(chat_id);
     let place_call_info = to_string_lossy(place_call_info);
 
@@ -1175,7 +1178,7 @@ pub unsafe extern "C" fn dc_place_outgoing_call(
         .unwrap_or_log_default(ctx, "Failed to place call")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accept_incoming_call(
     context: *mut dc_context_t,
     msg_id: u32,
@@ -1185,7 +1188,7 @@ pub unsafe extern "C" fn dc_accept_incoming_call(
         eprintln!("ignoring careless call to dc_accept_incoming_call()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let msg_id = MsgId::new(msg_id);
     let accept_call_info = to_string_lossy(accept_call_info);
 
@@ -1194,13 +1197,13 @@ pub unsafe extern "C" fn dc_accept_incoming_call(
         .is_ok() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_end_call(context: *mut dc_context_t, msg_id: u32) -> libc::c_int {
     if context.is_null() || msg_id == 0 {
         eprintln!("ignoring careless call to dc_end_call()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let msg_id = MsgId::new(msg_id);
 
     block_on(ctx.end_call(msg_id))
@@ -1209,7 +1212,7 @@ pub unsafe extern "C" fn dc_end_call(context: *mut dc_context_t, msg_id: u32) ->
         .is_ok() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_set_draft(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1219,23 +1222,19 @@ pub unsafe extern "C" fn dc_set_draft(
         eprintln!("ignoring careless call to dc_set_draft()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let msg = if msg.is_null() {
         None
     } else {
-        let ffi_msg: &mut MessageWrapper = &mut *msg;
+        let ffi_msg: &mut MessageWrapper = unsafe { &mut *msg };
         Some(&mut ffi_msg.message)
     };
 
-    block_on(async move {
-        ChatId::new(chat_id)
-            .set_draft(ctx, msg)
-            .await
-            .unwrap_or_log_default(ctx, "failed to set draft");
-    });
+    block_on(ChatId::new(chat_id).set_draft(ctx, msg))
+        .unwrap_or_log_default(ctx, "failed to set draft");
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_add_device_msg(
     context: *mut dc_context_t,
     label: *const libc::c_char,
@@ -1245,23 +1244,24 @@ pub unsafe extern "C" fn dc_add_device_msg(
         eprintln!("ignoring careless call to dc_add_device_msg()");
         return 0;
     }
-    let ctx = &mut *context;
+    let ctx = unsafe { &mut *context };
     let msg = if msg.is_null() {
         None
     } else {
-        let ffi_msg: &mut MessageWrapper = &mut *msg;
+        let ffi_msg: &mut MessageWrapper = unsafe { &mut *msg };
         Some(&mut ffi_msg.message)
     };
 
-    block_on(async move {
-        chat::add_device_msg(ctx, to_opt_string_lossy(label).as_deref(), msg)
-            .await
-            .unwrap_or_log_default(ctx, "Failed to add device message")
-    })
+    block_on(chat::add_device_msg(
+        ctx,
+        to_opt_string_lossy(label).as_deref(),
+        msg,
+    ))
+    .unwrap_or_log_default(ctx, "Failed to add device message")
     .to_u32()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_was_device_msg_ever_added(
     context: *mut dc_context_t,
     label: *const libc::c_char,
@@ -1270,22 +1270,22 @@ pub unsafe extern "C" fn dc_was_device_msg_ever_added(
         eprintln!("ignoring careless call to dc_was_device_msg_ever_added()");
         return 0;
     }
-    let ctx = &mut *context;
+    let ctx = unsafe { &mut *context };
 
-    block_on(async move {
-        chat::was_device_msg_ever_added(ctx, &to_string_lossy(label))
-            .await
-            .unwrap_or(false) as libc::c_int
-    })
+    block_on(chat::was_device_msg_ever_added(
+        ctx,
+        &to_string_lossy(label),
+    ))
+    .unwrap_or(false) as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_draft(context: *mut dc_context_t, chat_id: u32) -> *mut dc_msg_t {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_draft()");
         return ptr::null_mut(); // NULL explicitly defined as "no draft"
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     match block_on(ChatId::new(chat_id).get_draft(ctx))
         .with_context(|| format!("Failed to get draft for chat #{chat_id}"))
@@ -1302,7 +1302,7 @@ pub unsafe extern "C" fn dc_get_draft(context: *mut dc_context_t, chat_id: u32) 
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_chat_msgs(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1313,40 +1313,33 @@ pub unsafe extern "C" fn dc_get_chat_msgs(
         eprintln!("ignoring careless call to dc_get_chat_msgs()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     let add_daymarker = (flags & DC_GCM_ADDDAYMARKER) != 0;
-    block_on(async move {
-        Box::into_raw(Box::new(
-            chat::get_chat_msgs_ex(
-                ctx,
-                ChatId::new(chat_id),
-                MessageListOptions { add_daymarker },
-            )
-            .await
-            .unwrap_or_log_default(ctx, "failed to get chat msgs")
-            .into(),
+    Box::into_raw(Box::new(
+        block_on(chat::get_chat_msgs_ex(
+            ctx,
+            ChatId::new(chat_id),
+            MessageListOptions { add_daymarker },
         ))
-    })
+        .unwrap_or_log_default(ctx, "failed to get chat msgs")
+        .into(),
+    ))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_msg_cnt(context: *mut dc_context_t, chat_id: u32) -> libc::c_int {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_msg_cnt()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        ChatId::new(chat_id)
-            .get_msg_cnt(ctx)
-            .await
-            .unwrap_or_log_default(ctx, "failed to get msg count") as libc::c_int
-    })
+    block_on(ChatId::new(chat_id).get_msg_cnt(ctx))
+        .unwrap_or_log_default(ctx, "failed to get msg count") as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_fresh_msg_cnt(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1355,17 +1348,13 @@ pub unsafe extern "C" fn dc_get_fresh_msg_cnt(
         eprintln!("ignoring careless call to dc_get_fresh_msg_cnt()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        ChatId::new(chat_id)
-            .get_fresh_msg_cnt(ctx)
-            .await
-            .unwrap_or_log_default(ctx, "failed to get fresh msg cnt") as libc::c_int
-    })
+    block_on(ChatId::new(chat_id).get_fresh_msg_cnt(ctx))
+        .unwrap_or_log_default(ctx, "failed to get fresh msg cnt") as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_similar_chatlist(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1374,7 +1363,7 @@ pub unsafe extern "C" fn dc_get_similar_chatlist(
         eprintln!("ignoring careless call to dc_get_similar_chatlist()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     let chat_id = ChatId::new(chat_id);
     match block_on(chat_id.get_similar_chatlist(ctx))
@@ -1389,7 +1378,7 @@ pub unsafe extern "C" fn dc_get_similar_chatlist(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_estimate_deletion_cnt(
     context: *mut dc_context_t,
     from_server: libc::c_int,
@@ -1399,15 +1388,16 @@ pub unsafe extern "C" fn dc_estimate_deletion_cnt(
         eprintln!("ignoring careless call to dc_estimate_deletion_cnt()");
         return 0;
     }
-    let ctx = &*context;
-    block_on(async move {
-        message::estimate_deletion_cnt(ctx, from_server != 0, seconds)
-            .await
-            .unwrap_or(0) as libc::c_int
-    })
+    let ctx = unsafe { &*context };
+    block_on(message::estimate_deletion_cnt(
+        ctx,
+        from_server != 0,
+        seconds,
+    ))
+    .unwrap_or(0) as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_fresh_msgs(
     context: *mut dc_context_t,
 ) -> *mut dc_array::dc_array_t {
@@ -1415,30 +1405,27 @@ pub unsafe extern "C" fn dc_get_fresh_msgs(
         eprintln!("ignoring careless call to dc_get_fresh_msgs()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        let arr = dc_array_t::from(
-            ctx.get_fresh_msgs()
-                .await
-                .context("Failed to get fresh messages")
-                .log_err(ctx)
-                .unwrap_or_default()
-                .iter()
-                .map(|msg_id| msg_id.to_u32())
-                .collect::<Vec<u32>>(),
-        );
-        Box::into_raw(Box::new(arr))
-    })
+    let arr = dc_array_t::from(
+        block_on(ctx.get_fresh_msgs())
+            .context("Failed to get fresh messages")
+            .log_err(ctx)
+            .unwrap_or_default()
+            .iter()
+            .map(|msg_id| msg_id.to_u32())
+            .collect::<Vec<u32>>(),
+    );
+    Box::into_raw(Box::new(arr))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_next_msgs(context: *mut dc_context_t) -> *mut dc_array::dc_array_t {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_next_msgs()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     let msg_ids = block_on(ctx.get_next_msgs())
         .context("failed to get next messages")
@@ -1453,7 +1440,7 @@ pub unsafe extern "C" fn dc_get_next_msgs(context: *mut dc_context_t) -> *mut dc
     Box::into_raw(Box::new(arr))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_wait_next_msgs(
     context: *mut dc_context_t,
 ) -> *mut dc_array::dc_array_t {
@@ -1461,7 +1448,7 @@ pub unsafe extern "C" fn dc_wait_next_msgs(
         eprintln!("ignoring careless call to dc_wait_next_msgs()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     let msg_ids = block_on(ctx.wait_next_msgs())
         .context("failed to wait for next messages")
@@ -1476,38 +1463,32 @@ pub unsafe extern "C" fn dc_wait_next_msgs(
     Box::into_raw(Box::new(arr))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_marknoticed_chat(context: *mut dc_context_t, chat_id: u32) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_marknoticed_chat()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        chat::marknoticed_chat(ctx, ChatId::new(chat_id))
-            .await
-            .context("Failed marknoticed chat")
-            .log_err(ctx)
-            .unwrap_or(())
-    })
+    block_on(chat::marknoticed_chat(ctx, ChatId::new(chat_id)))
+        .context("Failed marknoticed chat")
+        .log_err(ctx)
+        .unwrap_or(())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_markfresh_chat(context: *mut dc_context_t, chat_id: u32) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_markfresh_chat()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        chat::markfresh_chat(ctx, ChatId::new(chat_id))
-            .await
-            .context("Failed markfresh chat")
-            .log_err(ctx)
-            .unwrap_or(())
-    })
+    block_on(chat::markfresh_chat(ctx, ChatId::new(chat_id)))
+        .context("Failed markfresh chat")
+        .log_err(ctx)
+        .unwrap_or(())
 }
 
 fn from_prim<S, T>(s: S) -> Option<T>
@@ -1518,7 +1499,7 @@ where
     FromPrimitive::from_i64(s.into())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_chat_media(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1530,7 +1511,7 @@ pub unsafe extern "C" fn dc_get_chat_media(
         eprintln!("ignoring careless call to dc_get_chat_media()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let chat_id = if chat_id == 0 {
         None
     } else {
@@ -1542,17 +1523,20 @@ pub unsafe extern "C" fn dc_get_chat_media(
     let or_msg_type3 =
         from_prim(or_msg_type3).expect(&format!("incorrect or_msg_type3 = {or_msg_type3}"));
 
-    block_on(async move {
-        Box::into_raw(Box::new(
-            chat::get_chat_media(ctx, chat_id, msg_type, or_msg_type2, or_msg_type3)
-                .await
-                .unwrap_or_log_default(ctx, "Failed get_chat_media")
-                .into(),
+    Box::into_raw(Box::new(
+        block_on(chat::get_chat_media(
+            ctx,
+            chat_id,
+            msg_type,
+            or_msg_type2,
+            or_msg_type3,
         ))
-    })
+        .unwrap_or_log_default(ctx, "Failed get_chat_media")
+        .into(),
+    ))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_set_chat_visibility(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1562,7 +1546,7 @@ pub unsafe extern "C" fn dc_set_chat_visibility(
         eprintln!("ignoring careless call to dc_set_chat_visibility()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let visibility = match archive {
         0 => ChatVisibility::Normal,
         1 => ChatVisibility::Archived,
@@ -1573,71 +1557,55 @@ pub unsafe extern "C" fn dc_set_chat_visibility(
         }
     };
 
-    block_on(async move {
-        ChatId::new(chat_id)
-            .set_visibility(ctx, visibility)
-            .await
-            .context("Failed setting chat visibility")
-            .log_err(ctx)
-            .unwrap_or(())
-    })
+    block_on(ChatId::new(chat_id).set_visibility(ctx, visibility))
+        .context("Failed setting chat visibility")
+        .log_err(ctx)
+        .unwrap_or(())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_delete_chat(context: *mut dc_context_t, chat_id: u32) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_delete_chat()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        ChatId::new(chat_id)
-            .delete(ctx)
-            .await
-            .context("Failed chat delete")
-            .log_err(ctx)
-            .ok();
-    })
+    block_on(ChatId::new(chat_id).delete(ctx))
+        .context("Failed chat delete")
+        .log_err(ctx)
+        .ok();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_block_chat(context: *mut dc_context_t, chat_id: u32) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_block_chat()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        ChatId::new(chat_id)
-            .block(ctx)
-            .await
-            .context("Failed chat block")
-            .log_err(ctx)
-            .ok();
-    })
+    block_on(ChatId::new(chat_id).block(ctx))
+        .context("Failed chat block")
+        .log_err(ctx)
+        .ok();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accept_chat(context: *mut dc_context_t, chat_id: u32) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_accept_chat()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        ChatId::new(chat_id)
-            .accept(ctx)
-            .await
-            .context("Failed chat accept")
-            .log_err(ctx)
-            .ok();
-    })
+    block_on(ChatId::new(chat_id).accept(ctx))
+        .context("Failed chat accept")
+        .log_err(ctx)
+        .ok();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_chat_contacts(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1646,22 +1614,19 @@ pub unsafe extern "C" fn dc_get_chat_contacts(
         eprintln!("ignoring careless call to dc_get_chat_contacts()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        let arr = dc_array_t::from(
-            chat::get_chat_contacts(ctx, ChatId::new(chat_id))
-                .await
-                .unwrap_or_log_default(ctx, "Failed get_chat_contacts")
-                .iter()
-                .map(|id| id.to_u32())
-                .collect::<Vec<u32>>(),
-        );
-        Box::into_raw(Box::new(arr))
-    })
+    let arr = dc_array_t::from(
+        block_on(chat::get_chat_contacts(ctx, ChatId::new(chat_id)))
+            .unwrap_or_log_default(ctx, "Failed get_chat_contacts")
+            .iter()
+            .map(|id| id.to_u32())
+            .collect::<Vec<u32>>(),
+    );
+    Box::into_raw(Box::new(arr))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_search_msgs(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1671,47 +1636,44 @@ pub unsafe extern "C" fn dc_search_msgs(
         eprintln!("ignoring careless call to dc_search_msgs()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let chat_id = if chat_id == 0 {
         None
     } else {
         Some(ChatId::new(chat_id))
     };
 
-    block_on(async move {
-        let arr = dc_array_t::from(
-            ctx.search_msgs(chat_id, &to_string_lossy(query))
-                .await
-                .unwrap_or_log_default(ctx, "Failed search_msgs")
-                .iter()
-                .map(|msg_id| msg_id.to_u32())
-                .collect::<Vec<u32>>(),
-        );
-        Box::into_raw(Box::new(arr))
-    })
+    let arr = dc_array_t::from(
+        block_on(ctx.search_msgs(chat_id, &to_string_lossy(query)))
+            .unwrap_or_log_default(ctx, "Failed search_msgs")
+            .iter()
+            .map(|msg_id| msg_id.to_u32())
+            .collect::<Vec<u32>>(),
+    );
+    Box::into_raw(Box::new(arr))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_chat(context: *mut dc_context_t, chat_id: u32) -> *mut dc_chat_t {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_chat()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
-    let context: Context = ctx.clone();
+    let context = unsafe { &*context };
 
-    block_on(async move {
-        match chat::Chat::load_from_db(ctx, ChatId::new(chat_id)).await {
-            Ok(chat) => {
-                let ffi_chat = ChatWrapper { context, chat };
-                Box::into_raw(Box::new(ffi_chat))
-            }
-            Err(_) => ptr::null_mut(),
+    match block_on(chat::Chat::load_from_db(context, ChatId::new(chat_id))) {
+        Ok(chat) => {
+            let ffi_chat = ChatWrapper {
+                context: context.clone(),
+                chat,
+            };
+            Box::into_raw(Box::new(ffi_chat))
         }
-    })
+        Err(_) => ptr::null_mut(),
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_create_group_chat(
     context: *mut dc_context_t,
     _protect: libc::c_int,
@@ -1721,7 +1683,7 @@ pub unsafe extern "C" fn dc_create_group_chat(
         eprintln!("ignoring careless call to dc_create_group_chat()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(chat::create_group(ctx, &to_string_lossy(name)))
         .context("Failed to create group chat")
@@ -1730,21 +1692,23 @@ pub unsafe extern "C" fn dc_create_group_chat(
         .unwrap_or(0)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_create_broadcast_list(context: *mut dc_context_t) -> u32 {
-    if context.is_null() {
-        eprintln!("ignoring careless call to dc_create_broadcast_list()");
-        return 0;
+    unsafe {
+        if context.is_null() {
+            eprintln!("ignoring careless call to dc_create_broadcast_list()");
+            return 0;
+        }
+        let ctx = &*context;
+        block_on(chat::create_broadcast(ctx, "Channel".to_string()))
+            .context("Failed to create broadcast channel")
+            .log_err(ctx)
+            .map(|id| id.to_u32())
+            .unwrap_or(0)
     }
-    let ctx = &*context;
-    block_on(chat::create_broadcast(ctx, "Channel".to_string()))
-        .context("Failed to create broadcast channel")
-        .log_err(ctx)
-        .map(|id| id.to_u32())
-        .unwrap_or(0)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_is_contact_in_chat(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1754,7 +1718,7 @@ pub unsafe extern "C" fn dc_is_contact_in_chat(
         eprintln!("ignoring careless call to dc_is_contact_in_chat()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(chat::is_contact_in_chat(
         ctx,
@@ -1766,7 +1730,7 @@ pub unsafe extern "C" fn dc_is_contact_in_chat(
     .unwrap_or_default() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_add_contact_to_chat(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1776,7 +1740,7 @@ pub unsafe extern "C" fn dc_add_contact_to_chat(
         eprintln!("ignoring careless call to dc_add_contact_to_chat()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(chat::add_contact_to_chat(
         ctx,
@@ -1788,7 +1752,7 @@ pub unsafe extern "C" fn dc_add_contact_to_chat(
     .is_ok() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_remove_contact_from_chat(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1798,7 +1762,7 @@ pub unsafe extern "C" fn dc_remove_contact_from_chat(
         eprintln!("ignoring careless call to dc_remove_contact_from_chat()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(chat::remove_contact_from_chat(
         ctx,
@@ -1810,7 +1774,7 @@ pub unsafe extern "C" fn dc_remove_contact_from_chat(
     .is_ok() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_set_chat_name(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1821,17 +1785,18 @@ pub unsafe extern "C" fn dc_set_chat_name(
         eprintln!("ignoring careless call to dc_set_chat_name()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        chat::set_chat_name(ctx, ChatId::new(chat_id), &to_string_lossy(name))
-            .await
-            .map(|_| 1)
-            .unwrap_or_log_default(ctx, "Failed to set chat name")
-    })
+    block_on(chat::set_chat_name(
+        ctx,
+        ChatId::new(chat_id),
+        &to_string_lossy(name),
+    ))
+    .map(|_| 1)
+    .unwrap_or_log_default(ctx, "Failed to set chat name")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_set_chat_profile_image(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1841,17 +1806,18 @@ pub unsafe extern "C" fn dc_set_chat_profile_image(
         eprintln!("ignoring careless call to dc_set_chat_profile_image()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        chat::set_chat_profile_image(ctx, ChatId::new(chat_id), &to_string_lossy(image))
-            .await
-            .map(|_| 1)
-            .unwrap_or_log_default(ctx, "Failed to set profile image")
-    })
+    block_on(chat::set_chat_profile_image(
+        ctx,
+        ChatId::new(chat_id),
+        &to_string_lossy(image),
+    ))
+    .map(|_| 1)
+    .unwrap_or_log_default(ctx, "Failed to set profile image")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_set_chat_mute_duration(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1861,7 +1827,7 @@ pub unsafe extern "C" fn dc_set_chat_mute_duration(
         eprintln!("ignoring careless call to dc_set_chat_mute_duration()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let mute_duration = match duration {
         0 => MuteDuration::NotMuted,
         -1 => MuteDuration::Forever,
@@ -1874,15 +1840,12 @@ pub unsafe extern "C" fn dc_set_chat_mute_duration(
         }
     };
 
-    block_on(async move {
-        chat::set_muted(ctx, ChatId::new(chat_id), mute_duration)
-            .await
-            .map(|_| 1)
-            .unwrap_or_log_default(ctx, "Failed to set mute duration")
-    })
+    block_on(chat::set_muted(ctx, ChatId::new(chat_id), mute_duration))
+        .map(|_| 1)
+        .unwrap_or_log_default(ctx, "Failed to set mute duration")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_chat_encrinfo(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1891,7 +1854,7 @@ pub unsafe extern "C" fn dc_get_chat_encrinfo(
         eprintln!("ignoring careless call to dc_get_chat_encrinfo()");
         return "".strdup();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(ChatId::new(chat_id).get_encryption_info(ctx))
         .map(|s| s.strdup())
@@ -1899,7 +1862,7 @@ pub unsafe extern "C" fn dc_get_chat_encrinfo(
         .unwrap_or(ptr::null_mut())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_chat_ephemeral_timer(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1908,21 +1871,21 @@ pub unsafe extern "C" fn dc_get_chat_ephemeral_timer(
         eprintln!("ignoring careless call to dc_get_chat_ephemeral_timer()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     // Timer value 0 is returned in the rare case of a database error,
     // but it is not dangerous since it is only meant to be used as a
     // default when changing the value. Such errors should not be
     // ignored when ephemeral timer value is used to construct
     // message headers.
-    block_on(async move { ChatId::new(chat_id).get_ephemeral_timer(ctx).await })
+    block_on(ChatId::new(chat_id).get_ephemeral_timer(ctx))
         .context("Failed to get ephemeral timer")
         .log_err(ctx)
         .unwrap_or_default()
         .to_u32()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_set_chat_ephemeral_timer(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -1932,19 +1895,15 @@ pub unsafe extern "C" fn dc_set_chat_ephemeral_timer(
         eprintln!("ignoring careless call to dc_set_chat_ephemeral_timer()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        ChatId::new(chat_id)
-            .set_ephemeral_timer(ctx, EphemeralTimer::from_u32(timer))
-            .await
-            .context("Failed to set ephemeral timer")
-            .log_err(ctx)
-            .is_ok() as libc::c_int
-    })
+    block_on(ChatId::new(chat_id).set_ephemeral_timer(ctx, EphemeralTimer::from_u32(timer)))
+        .context("Failed to set ephemeral timer")
+        .log_err(ctx)
+        .is_ok() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_msg_info(
     context: *mut dc_context_t,
     msg_id: u32,
@@ -1953,14 +1912,14 @@ pub unsafe extern "C" fn dc_get_msg_info(
         eprintln!("ignoring careless call to dc_get_msg_info()");
         return "".strdup();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let msg_id = MsgId::new(msg_id);
     block_on(msg_id.get_info(ctx))
         .unwrap_or_log_default(ctx, "failed to get msg id")
         .strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_msg_html(
     context: *mut dc_context_t,
     msg_id: u32,
@@ -1969,14 +1928,14 @@ pub unsafe extern "C" fn dc_get_msg_html(
         eprintln!("ignoring careless call to dc_get_msg_html()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(MsgId::new(msg_id).get_html(ctx))
         .unwrap_or_log_default(ctx, "Failed get_msg_html")
         .strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_delete_msgs(
     context: *mut dc_context_t,
     msg_ids: *const u32,
@@ -1986,7 +1945,7 @@ pub unsafe extern "C" fn dc_delete_msgs(
         eprintln!("ignoring careless call to dc_delete_msgs()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let msg_ids = convert_and_prune_message_ids(msg_ids, msg_cnt);
 
     block_on(message::delete_msgs(ctx, &msg_ids))
@@ -1995,7 +1954,7 @@ pub unsafe extern "C" fn dc_delete_msgs(
         .ok();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_forward_msgs(
     context: *mut dc_context_t,
     msg_ids: *const u32,
@@ -2011,16 +1970,13 @@ pub unsafe extern "C" fn dc_forward_msgs(
         return;
     }
     let msg_ids = convert_and_prune_message_ids(msg_ids, msg_cnt);
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        chat::forward_msgs(ctx, &msg_ids[..], ChatId::new(chat_id))
-            .await
-            .unwrap_or_log_default(ctx, "Failed to forward message")
-    })
+    block_on(chat::forward_msgs(ctx, &msg_ids[..], ChatId::new(chat_id)))
+        .unwrap_or_log_default(ctx, "Failed to forward message")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_save_msgs(
     context: *mut dc_context_t,
     msg_ids: *const u32,
@@ -2031,16 +1987,13 @@ pub unsafe extern "C" fn dc_save_msgs(
         return;
     }
     let msg_ids = convert_and_prune_message_ids(msg_ids, msg_cnt);
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        chat::save_msgs(ctx, &msg_ids[..])
-            .await
-            .unwrap_or_log_default(ctx, "Failed to save message")
-    })
+    block_on(chat::save_msgs(ctx, &msg_ids[..]))
+        .unwrap_or_log_default(ctx, "Failed to save message")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_resend_msgs(
     context: *mut dc_context_t,
     msg_ids: *const u32,
@@ -2050,7 +2003,7 @@ pub unsafe extern "C" fn dc_resend_msgs(
         eprintln!("ignoring careless call to dc_resend_msgs()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let msg_ids = convert_and_prune_message_ids(msg_ids, msg_cnt);
 
     block_on(chat::resend_msgs(ctx, &msg_ids))
@@ -2059,7 +2012,7 @@ pub unsafe extern "C" fn dc_resend_msgs(
         .is_ok() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_markseen_msgs(
     context: *mut dc_context_t,
     msg_ids: *const u32,
@@ -2070,7 +2023,7 @@ pub unsafe extern "C" fn dc_markseen_msgs(
         return;
     }
     let msg_ids = convert_and_prune_message_ids(msg_ids, msg_cnt);
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(message::markseen_msgs(ctx, msg_ids))
         .context("failed dc_markseen_msgs() call")
@@ -2078,13 +2031,13 @@ pub unsafe extern "C" fn dc_markseen_msgs(
         .ok();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_msg(context: *mut dc_context_t, msg_id: u32) -> *mut dc_msg_t {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_msg()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     let message = match block_on(message::Message::load_from_db(ctx, MsgId::new(msg_id)))
         .with_context(|| format!("dc_get_msg could not rectieve msg_id {msg_id}"))
@@ -2104,20 +2057,20 @@ pub unsafe extern "C" fn dc_get_msg(context: *mut dc_context_t, msg_id: u32) -> 
     Box::into_raw(Box::new(ffi_msg))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_download_full_msg(context: *mut dc_context_t, msg_id: u32) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_download_full_msg()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     block_on(MsgId::new(msg_id).download_full(ctx))
         .context("Failed to download message fully.")
         .log_err(ctx)
         .ok();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_may_be_valid_addr(addr: *const libc::c_char) -> libc::c_int {
     if addr.is_null() {
         eprintln!("ignoring careless call to dc_may_be_valid_addr()");
@@ -2127,7 +2080,7 @@ pub unsafe extern "C" fn dc_may_be_valid_addr(addr: *const libc::c_char) -> libc
     contact::may_be_valid_addr(&to_string_lossy(addr)) as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_lookup_contact_id_by_addr(
     context: *mut dc_context_t,
     addr: *const libc::c_char,
@@ -2136,18 +2089,19 @@ pub unsafe extern "C" fn dc_lookup_contact_id_by_addr(
         eprintln!("ignoring careless call to dc_lookup_contact_id_by_addr()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        Contact::lookup_id_by_addr(ctx, &to_string_lossy(addr), Origin::IncomingReplyTo)
-            .await
-            .unwrap_or_log_default(ctx, "failed to lookup id")
-            .map(|id| id.to_u32())
-            .unwrap_or_default()
-    })
+    block_on(Contact::lookup_id_by_addr(
+        ctx,
+        &to_string_lossy(addr),
+        Origin::IncomingReplyTo,
+    ))
+    .unwrap_or_log_default(ctx, "failed to lookup id")
+    .map(|id| id.to_u32())
+    .unwrap_or_default()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_create_contact(
     context: *mut dc_context_t,
     name: *const libc::c_char,
@@ -2157,7 +2111,7 @@ pub unsafe extern "C" fn dc_create_contact(
         eprintln!("ignoring careless call to dc_create_contact()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let name = to_string_lossy(name);
 
     block_on(Contact::create(ctx, &name, &to_string_lossy(addr)))
@@ -2167,7 +2121,7 @@ pub unsafe extern "C" fn dc_create_contact(
         .unwrap_or(0)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_add_address_book(
     context: *mut dc_context_t,
     addr_book: *const libc::c_char,
@@ -2176,17 +2130,15 @@ pub unsafe extern "C" fn dc_add_address_book(
         eprintln!("ignoring careless call to dc_add_address_book()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        match Contact::add_address_book(ctx, &to_string_lossy(addr_book)).await {
-            Ok(cnt) => cnt as libc::c_int,
-            Err(_) => 0,
-        }
-    })
+    match block_on(Contact::add_address_book(ctx, &to_string_lossy(addr_book))) {
+        Ok(cnt) => cnt as libc::c_int,
+        Err(_) => 0,
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_make_vcard(
     context: *mut dc_context_t,
     contact_id: u32,
@@ -2195,7 +2147,7 @@ pub unsafe extern "C" fn dc_make_vcard(
         eprintln!("ignoring careless call to dc_make_vcard()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let contact_id = ContactId::new(contact_id);
 
     block_on(contact::make_vcard(ctx, &[contact_id]))
@@ -2203,7 +2155,7 @@ pub unsafe extern "C" fn dc_make_vcard(
         .strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_import_vcard(
     context: *mut dc_context_t,
     vcard: *const libc::c_char,
@@ -2212,7 +2164,7 @@ pub unsafe extern "C" fn dc_import_vcard(
         eprintln!("ignoring careless call to dc_import_vcard()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     match block_on(contact::import_vcard(ctx, &to_string_lossy(vcard)))
         .context("dc_import_vcard failed")
@@ -2228,7 +2180,7 @@ pub unsafe extern "C" fn dc_import_vcard(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_contacts(
     context: *mut dc_context_t,
     flags: u32,
@@ -2238,20 +2190,18 @@ pub unsafe extern "C" fn dc_get_contacts(
         eprintln!("ignoring careless call to dc_get_contacts()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let query = to_opt_string_lossy(query);
 
-    block_on(async move {
-        match Contact::get_all(ctx, flags, query.as_deref()).await {
-            Ok(contacts) => Box::into_raw(Box::new(dc_array_t::from(
-                contacts.iter().map(|id| id.to_u32()).collect::<Vec<u32>>(),
-            ))),
-            Err(_) => ptr::null_mut(),
-        }
-    })
+    match block_on(Contact::get_all(ctx, flags, query.as_deref())) {
+        Ok(contacts) => Box::into_raw(Box::new(dc_array_t::from(
+            contacts.iter().map(|id| id.to_u32()).collect::<Vec<u32>>(),
+        ))),
+        Err(_) => ptr::null_mut(),
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_blocked_contacts(
     context: *mut dc_context_t,
 ) -> *mut dc_array::dc_array_t {
@@ -2259,23 +2209,20 @@ pub unsafe extern "C" fn dc_get_blocked_contacts(
         eprintln!("ignoring careless call to dc_get_blocked_contacts()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        Box::into_raw(Box::new(dc_array_t::from(
-            Contact::get_all_blocked(ctx)
-                .await
-                .context("Can't get blocked contacts")
-                .log_err(ctx)
-                .unwrap_or_default()
-                .iter()
-                .map(|id| id.to_u32())
-                .collect::<Vec<u32>>(),
-        )))
-    })
+    Box::into_raw(Box::new(dc_array_t::from(
+        block_on(Contact::get_all_blocked(ctx))
+            .context("Can't get blocked contacts")
+            .log_err(ctx)
+            .unwrap_or_default()
+            .iter()
+            .map(|id| id.to_u32())
+            .collect::<Vec<u32>>(),
+    )))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_block_contact(
     context: *mut dc_context_t,
     contact_id: u32,
@@ -2286,7 +2233,7 @@ pub unsafe extern "C" fn dc_block_contact(
         eprintln!("ignoring careless call to dc_block_contact()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     block_on(async move {
         if block == 0 {
             Contact::unblock(ctx, contact_id)
@@ -2304,7 +2251,7 @@ pub unsafe extern "C" fn dc_block_contact(
     });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_contact_encrinfo(
     context: *mut dc_context_t,
     contact_id: u32,
@@ -2313,7 +2260,7 @@ pub unsafe extern "C" fn dc_get_contact_encrinfo(
         eprintln!("ignoring careless call to dc_get_contact_encrinfo()");
         return "".strdup();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(Contact::get_encrinfo(ctx, ContactId::new(contact_id)))
         .map(|s| s.strdup())
@@ -2321,7 +2268,7 @@ pub unsafe extern "C" fn dc_get_contact_encrinfo(
         .unwrap_or(ptr::null_mut())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_delete_contact(
     context: *mut dc_context_t,
     contact_id: u32,
@@ -2331,7 +2278,7 @@ pub unsafe extern "C" fn dc_delete_contact(
         eprintln!("ignoring careless call to dc_delete_contact()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(Contact::delete(ctx, contact_id))
         .context("Cannot delete contact")
@@ -2339,7 +2286,7 @@ pub unsafe extern "C" fn dc_delete_contact(
         .is_ok() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_contact(
     context: *mut dc_context_t,
     contact_id: u32,
@@ -2348,7 +2295,7 @@ pub unsafe extern "C" fn dc_get_contact(
         eprintln!("ignoring careless call to dc_get_contact()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(async move {
         Contact::get_by_id(ctx, ContactId::new(contact_id))
@@ -2367,7 +2314,7 @@ fn spawn_imex(ctx: Context, what: imex::ImexMode, param1: String, passphrase: Op
     });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_imex(
     context: *mut dc_context_t,
     what_raw: libc::c_int,
@@ -2387,7 +2334,7 @@ pub unsafe extern "C" fn dc_imex(
     };
     let passphrase = to_opt_string_lossy(param2);
 
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     if let Some(param1) = to_opt_string_lossy(param1) {
         spawn_imex(ctx.clone(), what, param1, passphrase);
@@ -2396,7 +2343,7 @@ pub unsafe extern "C" fn dc_imex(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_imex_has_backup(
     context: *mut dc_context_t,
     dir: *const libc::c_char,
@@ -2405,7 +2352,7 @@ pub unsafe extern "C" fn dc_imex_has_backup(
         eprintln!("ignoring careless call to dc_imex_has_backup()");
         return ptr::null_mut(); // NULL explicitly defined as "has no backup"
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     match block_on(imex::has_backup(ctx, to_string_lossy(dir).as_ref()))
         .context("dc_imex_has_backup")
@@ -2416,17 +2363,17 @@ pub unsafe extern "C" fn dc_imex_has_backup(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_stop_ongoing_process(context: *mut dc_context_t) {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_stop_ongoing_process()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     block_on(ctx.stop_ongoing());
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_check_qr(
     context: *mut dc_context_t,
     qr: *const libc::c_char,
@@ -2435,7 +2382,7 @@ pub unsafe extern "C" fn dc_check_qr(
         eprintln!("ignoring careless call to dc_check_qr()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     let lot = match block_on(qr::check_qr(ctx, &to_string_lossy(qr))) {
         Ok(qr) => qr.into(),
@@ -2444,7 +2391,7 @@ pub unsafe extern "C" fn dc_check_qr(
     Box::into_raw(Box::new(lot))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_securejoin_qr(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -2453,7 +2400,7 @@ pub unsafe extern "C" fn dc_get_securejoin_qr(
         eprintln!("ignoring careless call to dc_get_securejoin_qr()");
         return "".strdup();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let chat_id = if chat_id == 0 {
         None
     } else {
@@ -2465,7 +2412,7 @@ pub unsafe extern "C" fn dc_get_securejoin_qr(
         .strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_securejoin_qr_svg(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -2474,7 +2421,7 @@ pub unsafe extern "C" fn dc_get_securejoin_qr_svg(
         eprintln!("ignoring careless call to generate_verification_qr()");
         return "".strdup();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let chat_id = if chat_id == 0 {
         None
     } else {
@@ -2486,7 +2433,7 @@ pub unsafe extern "C" fn dc_get_securejoin_qr_svg(
         .strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_join_securejoin(
     context: *mut dc_context_t,
     qr: *const libc::c_char,
@@ -2495,7 +2442,7 @@ pub unsafe extern "C" fn dc_join_securejoin(
         eprintln!("ignoring careless call to dc_join_securejoin()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(async move {
         securejoin::join_securejoin(ctx, &to_string_lossy(qr))
@@ -2507,7 +2454,7 @@ pub unsafe extern "C" fn dc_join_securejoin(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_send_locations_to_chat(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -2517,7 +2464,7 @@ pub unsafe extern "C" fn dc_send_locations_to_chat(
         eprintln!("ignoring careless call to dc_send_locations_to_chat()");
         return;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(location::send_to_chat(
         ctx,
@@ -2529,7 +2476,7 @@ pub unsafe extern "C" fn dc_send_locations_to_chat(
     .ok();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_is_sending_locations_to_chat(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -2538,7 +2485,7 @@ pub unsafe extern "C" fn dc_is_sending_locations_to_chat(
         eprintln!("ignoring careless call to dc_is_sending_locations_to_chat()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     if chat_id == 0 {
         block_on(location::is_sending(ctx))
             .unwrap_or_log_default(ctx, "Failed is_sending_locations()") as libc::c_int
@@ -2549,7 +2496,7 @@ pub unsafe extern "C" fn dc_is_sending_locations_to_chat(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_set_location(
     context: *mut dc_context_t,
     latitude: libc::c_double,
@@ -2560,14 +2507,14 @@ pub unsafe extern "C" fn dc_set_location(
         eprintln!("ignoring careless call to dc_set_location()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
     block_on(location::set(ctx, latitude, longitude, accuracy))
         .log_err(ctx)
         .unwrap_or_default() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_locations(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -2579,7 +2526,7 @@ pub unsafe extern "C" fn dc_get_locations(
         eprintln!("ignoring careless call to dc_get_locations()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let chat_id = if chat_id == 0 {
         None
     } else {
@@ -2591,15 +2538,18 @@ pub unsafe extern "C" fn dc_get_locations(
         Some(contact_id)
     };
 
-    block_on(async move {
-        let res = location::get_range(ctx, chat_id, contact_id, timestamp_begin, timestamp_end)
-            .await
-            .unwrap_or_log_default(ctx, "Failed get_locations");
-        Box::into_raw(Box::new(dc_array_t::from(res)))
-    })
+    let res = block_on(location::get_range(
+        ctx,
+        chat_id,
+        contact_id,
+        timestamp_begin,
+        timestamp_end,
+    ))
+    .unwrap_or_log_default(ctx, "Failed get_locations");
+    Box::into_raw(Box::new(dc_array_t::from(res)))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_create_qr_svg(payload: *const libc::c_char) -> *mut libc::c_char {
     if payload.is_null() {
         eprintln!("ignoring careless call to dc_create_qr_svg()");
@@ -2611,13 +2561,13 @@ pub unsafe extern "C" fn dc_create_qr_svg(payload: *const libc::c_char) -> *mut 
         .strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_get_last_error(context: *mut dc_context_t) -> *mut libc::c_char {
     if context.is_null() {
         eprintln!("ignoring careless call to dc_get_last_error()");
         return "".strdup();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     ctx.get_last_error().strdup()
 }
 
@@ -2625,35 +2575,35 @@ pub unsafe extern "C" fn dc_get_last_error(context: *mut dc_context_t) -> *mut l
 
 pub type dc_array_t = dc_array::dc_array_t;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_array_unref(a: *mut dc_array::dc_array_t) {
     if a.is_null() {
         eprintln!("ignoring careless call to dc_array_unref()");
         return;
     }
 
-    drop(Box::from_raw(a));
+    drop(unsafe { Box::from_raw(a) });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_array_get_cnt(array: *const dc_array_t) -> libc::size_t {
     if array.is_null() {
         eprintln!("ignoring careless call to dc_array_get_cnt()");
         return 0;
     }
 
-    (*array).len()
+    unsafe { (*array).len() }
 }
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_array_get_id(array: *const dc_array_t, index: libc::size_t) -> u32 {
     if array.is_null() {
         eprintln!("ignoring careless call to dc_array_get_id()");
         return 0;
     }
 
-    (*array).get_id(index)
+    unsafe { (*array).get_id(index) }
 }
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_array_get_latitude(
     array: *const dc_array_t,
     index: libc::size_t,
@@ -2663,9 +2613,9 @@ pub unsafe extern "C" fn dc_array_get_latitude(
         return 0.0;
     }
 
-    (*array).get_location(index).latitude
+    unsafe { (*array).get_location(index).latitude }
 }
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_array_get_longitude(
     array: *const dc_array_t,
     index: libc::size_t,
@@ -2675,9 +2625,9 @@ pub unsafe extern "C" fn dc_array_get_longitude(
         return 0.0;
     }
 
-    (*array).get_location(index).longitude
+    unsafe { (*array).get_location(index).longitude }
 }
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_array_get_accuracy(
     array: *const dc_array_t,
     index: libc::size_t,
@@ -2687,9 +2637,9 @@ pub unsafe extern "C" fn dc_array_get_accuracy(
         return 0.0;
     }
 
-    (*array).get_location(index).accuracy
+    unsafe { (*array).get_location(index).accuracy }
 }
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_array_get_timestamp(
     array: *const dc_array_t,
     index: libc::size_t,
@@ -2699,9 +2649,9 @@ pub unsafe extern "C" fn dc_array_get_timestamp(
         return 0;
     }
 
-    (*array).get_timestamp(index).unwrap_or_default()
+    unsafe { (*array).get_timestamp(index).unwrap_or_default() }
 }
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_array_get_chat_id(
     array: *const dc_array_t,
     index: libc::size_t,
@@ -2710,9 +2660,10 @@ pub unsafe extern "C" fn dc_array_get_chat_id(
         eprintln!("ignoring careless call to dc_array_get_chat_id()");
         return 0;
     }
-    (*array).get_location(index).chat_id.to_u32()
+
+    unsafe { (*array).get_location(index).chat_id.to_u32() }
 }
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_array_get_contact_id(
     array: *const dc_array_t,
     index: libc::size_t,
@@ -2722,9 +2673,9 @@ pub unsafe extern "C" fn dc_array_get_contact_id(
         return 0;
     }
 
-    (*array).get_location(index).contact_id.to_u32()
+    unsafe { (*array).get_location(index).contact_id.to_u32() }
 }
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_array_get_msg_id(
     array: *const dc_array_t,
     index: libc::size_t,
@@ -2734,9 +2685,9 @@ pub unsafe extern "C" fn dc_array_get_msg_id(
         return 0;
     }
 
-    (*array).get_location(index).msg_id
+    unsafe { (*array).get_location(index).msg_id }
 }
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_array_get_marker(
     array: *const dc_array_t,
     index: libc::size_t,
@@ -2746,14 +2697,14 @@ pub unsafe extern "C" fn dc_array_get_marker(
         return std::ptr::null_mut(); // NULL explicitly defined as "no markers"
     }
 
-    if let Some(s) = (*array).get_marker(index) {
+    if let Some(s) = unsafe { (*array).get_marker(index) } {
         s.strdup()
     } else {
         std::ptr::null_mut()
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_array_search_id(
     array: *const dc_array_t,
     needle: libc::c_uint,
@@ -2764,9 +2715,9 @@ pub unsafe extern "C" fn dc_array_search_id(
         return 0;
     }
 
-    if let Some(i) = (*array).search_id(needle) {
+    if let Some(i) = unsafe { (*array).search_id(needle) } {
         if !ret_index.is_null() {
-            *ret_index = i
+            unsafe { *ret_index = i }
         }
         1
     } else {
@@ -2778,7 +2729,7 @@ pub unsafe extern "C" fn dc_array_search_id(
 // Independent locations do not belong to the track of the user.
 // Returns 1 if location belongs to the track of the user,
 // 0 if location was reported independently.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_array_is_independent(
     array: *const dc_array_t,
     index: libc::size_t,
@@ -2788,7 +2739,7 @@ pub unsafe extern "C" fn dc_array_is_independent(
         return 0;
     }
 
-    (*array).get_location(index).independent as libc::c_int
+    unsafe { (*array).get_location(index).independent as libc::c_int }
 }
 
 // dc_chatlist_t
@@ -2807,26 +2758,27 @@ pub struct ChatlistWrapper {
 
 pub type dc_chatlist_t = ChatlistWrapper;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chatlist_unref(chatlist: *mut dc_chatlist_t) {
     if chatlist.is_null() {
         eprintln!("ignoring careless call to dc_chatlist_unref()");
         return;
     }
-    drop(Box::from_raw(chatlist));
+
+    drop(unsafe { Box::from_raw(chatlist) });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chatlist_get_cnt(chatlist: *mut dc_chatlist_t) -> libc::size_t {
     if chatlist.is_null() {
         eprintln!("ignoring careless call to dc_chatlist_get_cnt()");
         return 0;
     }
-    let ffi_list = &*chatlist;
+    let ffi_list = unsafe { &*chatlist };
     ffi_list.list.len() as libc::size_t
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chatlist_get_chat_id(
     chatlist: *mut dc_chatlist_t,
     index: libc::size_t,
@@ -2835,8 +2787,8 @@ pub unsafe extern "C" fn dc_chatlist_get_chat_id(
         eprintln!("ignoring careless call to dc_chatlist_get_chat_id()");
         return 0;
     }
-    let ffi_list = &*chatlist;
-    let ctx = &*ffi_list.context;
+    let ffi_list = unsafe { &*chatlist };
+    let ctx = unsafe { &*ffi_list.context };
     match ffi_list
         .list
         .get_chat_id(index)
@@ -2848,7 +2800,7 @@ pub unsafe extern "C" fn dc_chatlist_get_chat_id(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chatlist_get_msg_id(
     chatlist: *mut dc_chatlist_t,
     index: libc::size_t,
@@ -2857,8 +2809,8 @@ pub unsafe extern "C" fn dc_chatlist_get_msg_id(
         eprintln!("ignoring careless call to dc_chatlist_get_msg_id()");
         return 0;
     }
-    let ffi_list = &*chatlist;
-    let ctx = &*ffi_list.context;
+    let ffi_list = unsafe { &*chatlist };
+    let ctx = unsafe { &*ffi_list.context };
     match ffi_list
         .list
         .get_msg_id(index)
@@ -2870,7 +2822,7 @@ pub unsafe extern "C" fn dc_chatlist_get_msg_id(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chatlist_get_summary(
     chatlist: *mut dc_chatlist_t,
     index: libc::size_t,
@@ -2883,25 +2835,20 @@ pub unsafe extern "C" fn dc_chatlist_get_summary(
     let maybe_chat = if chat.is_null() {
         None
     } else {
-        let ffi_chat = &*chat;
+        let ffi_chat = unsafe { &*chat };
         Some(&ffi_chat.chat)
     };
-    let ffi_list = &*chatlist;
-    let ctx = &*ffi_list.context;
+    let ffi_list = unsafe { &*chatlist };
+    let ctx = unsafe { &*ffi_list.context };
 
-    block_on(async move {
-        let summary = ffi_list
-            .list
-            .get_summary(ctx, index, maybe_chat)
-            .await
-            .context("get_summary failed")
-            .log_err(ctx)
-            .unwrap_or_default();
-        Box::into_raw(Box::new(summary.into()))
-    })
+    let summary = block_on(ffi_list.list.get_summary(ctx, index, maybe_chat))
+        .context("get_summary failed")
+        .log_err(ctx)
+        .unwrap_or_default();
+    Box::into_raw(Box::new(summary.into()))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chatlist_get_summary2(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -2911,7 +2858,7 @@ pub unsafe extern "C" fn dc_chatlist_get_summary2(
         eprintln!("ignoring careless call to dc_chatlist_get_summary2()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let msg_id = if msg_id == 0 {
         None
     } else {
@@ -2929,7 +2876,7 @@ pub unsafe extern "C" fn dc_chatlist_get_summary2(
     Box::into_raw(Box::new(summary.into()))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chatlist_get_context(
     chatlist: *mut dc_chatlist_t,
 ) -> *const dc_context_t {
@@ -2937,7 +2884,7 @@ pub unsafe extern "C" fn dc_chatlist_get_context(
         eprintln!("ignoring careless call to dc_chatlist_get_context()");
         return ptr::null_mut();
     }
-    let ffi_list = &*chatlist;
+    let ffi_list = unsafe { &*chatlist };
     ffi_list.context
 }
 
@@ -2957,53 +2904,53 @@ pub struct ChatWrapper {
 
 pub type dc_chat_t = ChatWrapper;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_unref(chat: *mut dc_chat_t) {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_unref()");
         return;
     }
 
-    drop(Box::from_raw(chat));
+    drop(unsafe { Box::from_raw(chat) })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_get_id(chat: *mut dc_chat_t) -> u32 {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_get_id()");
         return 0;
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
     ffi_chat.chat.get_id().to_u32()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_get_type(chat: *mut dc_chat_t) -> libc::c_int {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_get_type()");
         return 0;
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
     ffi_chat.chat.get_type() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_get_name(chat: *mut dc_chat_t) -> *mut libc::c_char {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_get_name()");
         return "".strdup();
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
     ffi_chat.chat.get_name().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_get_mailinglist_addr(chat: *mut dc_chat_t) -> *mut libc::c_char {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_get_mailinglist_addr()");
         return "".strdup();
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
     ffi_chat
         .chat
         .get_mailinglist_addr()
@@ -3011,48 +2958,43 @@ pub unsafe extern "C" fn dc_chat_get_mailinglist_addr(chat: *mut dc_chat_t) -> *
         .strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_get_profile_image(chat: *mut dc_chat_t) -> *mut libc::c_char {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_get_profile_image()");
         return ptr::null_mut(); // NULL explicitly defined as "no image"
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
 
-    block_on(async move {
-        match ffi_chat
-            .chat
-            .get_profile_image(&ffi_chat.context)
-            .await
-            .context("Failed to get profile image")
-            .log_err(&ffi_chat.context)
-            .unwrap_or_default()
-        {
-            Some(p) => p.to_string_lossy().strdup(),
-            None => ptr::null_mut(),
-        }
-    })
+    match block_on(ffi_chat.chat.get_profile_image(&ffi_chat.context))
+        .context("Failed to get profile image")
+        .log_err(&ffi_chat.context)
+        .unwrap_or_default()
+    {
+        Some(p) => p.to_string_lossy().strdup(),
+        None => ptr::null_mut(),
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_get_color(chat: *mut dc_chat_t) -> u32 {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_get_color()");
         return 0;
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
 
     block_on(ffi_chat.chat.get_color(&ffi_chat.context))
         .unwrap_or_log_default(&ffi_chat.context, "Failed get_color")
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_get_visibility(chat: *mut dc_chat_t) -> libc::c_int {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_get_visibility()");
         return 0;
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
     match ffi_chat.chat.visibility {
         ChatVisibility::Normal => 0,
         ChatVisibility::Archived => 1,
@@ -3060,103 +3002,103 @@ pub unsafe extern "C" fn dc_chat_get_visibility(chat: *mut dc_chat_t) -> libc::c
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_is_contact_request(chat: *mut dc_chat_t) -> libc::c_int {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_is_contact_request()");
         return 0;
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
     ffi_chat.chat.is_contact_request() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_is_unpromoted(chat: *mut dc_chat_t) -> libc::c_int {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_is_unpromoted()");
         return 0;
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
     ffi_chat.chat.is_unpromoted() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_is_self_talk(chat: *mut dc_chat_t) -> libc::c_int {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_is_self_talk()");
         return 0;
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
     ffi_chat.chat.is_self_talk() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_is_device_talk(chat: *mut dc_chat_t) -> libc::c_int {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_is_device_talk()");
         return 0;
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
     ffi_chat.chat.is_device_talk() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_can_send(chat: *mut dc_chat_t) -> libc::c_int {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_can_send()");
         return 0;
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
     block_on(ffi_chat.chat.can_send(&ffi_chat.context))
         .context("can_send failed")
         .log_err(&ffi_chat.context)
         .unwrap_or_default() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn dc_chat_is_protected(_chat: *mut dc_chat_t) -> libc::c_int {
     0
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_is_encrypted(chat: *mut dc_chat_t) -> libc::c_int {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_is_encrypted()");
         return 0;
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
 
     block_on(ffi_chat.chat.is_encrypted(&ffi_chat.context))
         .unwrap_or_log_default(&ffi_chat.context, "Failed dc_chat_is_encrypted") as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_is_sending_locations(chat: *mut dc_chat_t) -> libc::c_int {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_is_sending_locations()");
         return 0;
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
     ffi_chat.chat.is_sending_locations() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_is_muted(chat: *mut dc_chat_t) -> libc::c_int {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_is_muted()");
         return 0;
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
     ffi_chat.chat.is_muted() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_get_remaining_mute_duration(chat: *mut dc_chat_t) -> i64 {
     if chat.is_null() {
         eprintln!("ignoring careless call to dc_chat_get_remaining_mute_duration()");
         return 0;
     }
-    let ffi_chat = &*chat;
+    let ffi_chat = unsafe { &*chat };
     if !ffi_chat.chat.is_muted() {
         return 0;
     }
@@ -3171,7 +3113,7 @@ pub unsafe extern "C" fn dc_chat_get_remaining_mute_duration(chat: *mut dc_chat_
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_chat_get_info_json(
     context: *mut dc_context_t,
     chat_id: u32,
@@ -3180,28 +3122,23 @@ pub unsafe extern "C" fn dc_chat_get_info_json(
         eprintln!("ignoring careless call to dc_chat_get_info_json()");
         return "".strdup();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
 
-    block_on(async move {
-        let Ok(chat) = chat::Chat::load_from_db(ctx, ChatId::new(chat_id))
-            .await
-            .context("dc_get_chat_info_json() failed to load chat")
-            .log_err(ctx)
-        else {
-            return "".strdup();
-        };
-        let Ok(info) = chat
-            .get_info(ctx)
-            .await
-            .context("dc_get_chat_info_json() failed to get chat info")
-            .log_err(ctx)
-        else {
-            return "".strdup();
-        };
-        serde_json::to_string(&info)
-            .unwrap_or_log_default(ctx, "dc_get_chat_info_json() failed to serialise to json")
-            .strdup()
-    })
+    let Ok(chat) = block_on(chat::Chat::load_from_db(ctx, ChatId::new(chat_id)))
+        .context("dc_get_chat_info_json() failed to load chat")
+        .log_err(ctx)
+    else {
+        return "".strdup();
+    };
+    let Ok(info) = block_on(chat.get_info(ctx))
+        .context("dc_get_chat_info_json() failed to get chat info")
+        .log_err(ctx)
+    else {
+        return "".strdup();
+    };
+    serde_json::to_string(&info)
+        .unwrap_or_log_default(ctx, "dc_get_chat_info_json() failed to serialise to json")
+        .strdup()
 }
 
 // dc_msg_t
@@ -3220,7 +3157,7 @@ pub struct MessageWrapper {
 
 pub type dc_msg_t = MessageWrapper;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_new(
     context: *mut dc_context_t,
     viewtype: libc::c_int,
@@ -3229,7 +3166,7 @@ pub unsafe extern "C" fn dc_msg_new(
         eprintln!("ignoring careless call to dc_msg_new()");
         return ptr::null_mut();
     }
-    let context = &*context;
+    let context = unsafe { &*context };
     let viewtype = from_prim(viewtype).expect(&format!("invalid viewtype = {viewtype}"));
     let msg = MessageWrapper {
         context,
@@ -3238,53 +3175,53 @@ pub unsafe extern "C" fn dc_msg_new(
     Box::into_raw(Box::new(msg))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_unref(msg: *mut dc_msg_t) {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_unref()");
         return;
     }
 
-    drop(Box::from_raw(msg));
+    drop(unsafe { Box::from_raw(msg) });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_id(msg: *mut dc_msg_t) -> u32 {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_id()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_id().to_u32()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_from_id(msg: *mut dc_msg_t) -> u32 {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_from_id()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_from_id().to_u32()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_chat_id(msg: *mut dc_msg_t) -> u32 {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_chat_id()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_chat_id().to_u32()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_viewtype(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_viewtype()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg
         .message
         .get_viewtype()
@@ -3292,84 +3229,84 @@ pub unsafe extern "C" fn dc_msg_get_viewtype(msg: *mut dc_msg_t) -> libc::c_int 
         .expect("impossible: Viewtype -> i64 conversion failed") as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_state(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_state()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_state() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_download_state(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_download_state()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.download_state() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_timestamp(msg: *mut dc_msg_t) -> i64 {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_received_timestamp()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_timestamp()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_received_timestamp(msg: *mut dc_msg_t) -> i64 {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_received_timestamp()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_received_timestamp()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_sort_timestamp(msg: *mut dc_msg_t) -> i64 {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_sort_timestamp()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_sort_timestamp()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_text(msg: *mut dc_msg_t) -> *mut libc::c_char {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_text()");
         return "".strdup();
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_text().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_subject(msg: *mut dc_msg_t) -> *mut libc::c_char {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_subject()");
         return "".strdup();
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_subject().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_file(msg: *mut dc_msg_t) -> *mut libc::c_char {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_file()");
         return "".strdup();
     }
-    let ffi_msg = &*msg;
-    let ctx = &*ffi_msg.context;
+    let ffi_msg = unsafe { &*msg };
+    let ctx = unsafe { &*ffi_msg.context };
     ffi_msg
         .message
         .get_file(ctx)
@@ -3377,7 +3314,7 @@ pub unsafe extern "C" fn dc_msg_get_file(msg: *mut dc_msg_t) -> *mut libc::c_cha
         .unwrap_or_else(|| "".strdup())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_save_file(
     msg: *mut dc_msg_t,
     path: *const libc::c_char,
@@ -3386,8 +3323,8 @@ pub unsafe extern "C" fn dc_msg_save_file(
         eprintln!("ignoring careless call to dc_msg_save_file()");
         return 0;
     }
-    let ffi_msg = &*msg;
-    let ctx = &*ffi_msg.context;
+    let ffi_msg = unsafe { &*msg };
+    let ctx = unsafe { &*ffi_msg.context };
     let path = to_string_lossy(path);
     let r = block_on(
         ffi_msg
@@ -3405,17 +3342,17 @@ pub unsafe extern "C" fn dc_msg_save_file(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_filename(msg: *mut dc_msg_t) -> *mut libc::c_char {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_filename()");
         return "".strdup();
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_filename().unwrap_or_default().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_webxdc_blob(
     msg: *mut dc_msg_t,
     filename: *const libc::c_char,
@@ -3425,8 +3362,8 @@ pub unsafe extern "C" fn dc_msg_get_webxdc_blob(
         eprintln!("ignoring careless call to dc_msg_get_webxdc_blob()");
         return ptr::null_mut();
     }
-    let ffi_msg = &*msg;
-    let ctx = &*ffi_msg.context;
+    let ffi_msg = unsafe { &*msg };
+    let ctx = unsafe { &*ffi_msg.context };
     let blob = block_on(async move {
         ffi_msg
             .message
@@ -3434,12 +3371,12 @@ pub unsafe extern "C" fn dc_msg_get_webxdc_blob(
             .await
     });
     match blob {
-        Ok(blob) => {
+        Ok(blob) => unsafe {
             *ret_bytes = blob.len();
             let ptr = libc::malloc(*ret_bytes);
             libc::memcpy(ptr, blob.as_ptr() as *mut libc::c_void, *ret_bytes);
             ptr as *mut libc::c_char
-        }
+        },
         Err(err) => {
             eprintln!("failed read blob from archive: {err}");
             ptr::null_mut()
@@ -3447,14 +3384,14 @@ pub unsafe extern "C" fn dc_msg_get_webxdc_blob(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_webxdc_info(msg: *mut dc_msg_t) -> *mut libc::c_char {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_webxdc_info()");
         return "".strdup();
     }
-    let ffi_msg = &*msg;
-    let ctx = &*ffi_msg.context;
+    let ffi_msg = unsafe { &*msg };
+    let ctx = unsafe { &*ffi_msg.context };
 
     let Ok(info) = block_on(ffi_msg.message.get_webxdc_info(ctx))
         .context("dc_msg_get_webxdc_info() failed to get info")
@@ -3467,13 +3404,13 @@ pub unsafe extern "C" fn dc_msg_get_webxdc_info(msg: *mut dc_msg_t) -> *mut libc
         .strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_filemime(msg: *mut dc_msg_t) -> *mut libc::c_char {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_filemime()");
         return "".strdup();
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     if let Some(x) = ffi_msg.message.get_filemime() {
         x.strdup()
     } else {
@@ -3481,91 +3418,91 @@ pub unsafe extern "C" fn dc_msg_get_filemime(msg: *mut dc_msg_t) -> *mut libc::c
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_filebytes(msg: *mut dc_msg_t) -> u64 {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_filebytes()");
         return 0;
     }
-    let ffi_msg = &*msg;
-    let ctx = &*ffi_msg.context;
+    let ffi_msg = unsafe { &*msg };
+    let ctx = unsafe { &*ffi_msg.context };
 
     block_on(ffi_msg.message.get_filebytes(ctx))
         .unwrap_or_log_default(ctx, "Cannot get file size")
         .unwrap_or_default()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_width(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_width()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_width()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_height(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_height()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_height()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_duration(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_duration()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_duration()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_showpadlock(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_showpadlock()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_showpadlock() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_is_bot(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_is_bot()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.is_bot() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_ephemeral_timer(msg: *mut dc_msg_t) -> u32 {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_ephemeral_timer()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_ephemeral_timer().to_u32()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_ephemeral_timestamp(msg: *mut dc_msg_t) -> i64 {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_ephemeral_timer()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_ephemeral_timestamp()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_summary(
     msg: *mut dc_msg_t,
     chat: *mut dc_chat_t,
@@ -3577,11 +3514,11 @@ pub unsafe extern "C" fn dc_msg_get_summary(
     let maybe_chat = if chat.is_null() {
         None
     } else {
-        let ffi_chat = &*chat;
+        let ffi_chat = unsafe { &*chat };
         Some(&ffi_chat.chat)
     };
-    let ffi_msg = &mut *msg;
-    let ctx = &*ffi_msg.context;
+    let ffi_msg = unsafe { &mut *msg };
+    let ctx = unsafe { &*ffi_msg.context };
 
     let summary = block_on(ffi_msg.message.get_summary(ctx, maybe_chat))
         .context("dc_msg_get_summary failed")
@@ -3590,7 +3527,7 @@ pub unsafe extern "C" fn dc_msg_get_summary(
     Box::into_raw(Box::new(summary.into()))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_summarytext(
     msg: *mut dc_msg_t,
     approx_characters: libc::c_int,
@@ -3599,8 +3536,8 @@ pub unsafe extern "C" fn dc_msg_get_summarytext(
         eprintln!("ignoring careless call to dc_msg_get_summarytext()");
         return "".strdup();
     }
-    let ffi_msg = &mut *msg;
-    let ctx = &*ffi_msg.context;
+    let ffi_msg = unsafe { &mut *msg };
+    let ctx = unsafe { &*ffi_msg.context };
 
     let summary = block_on(ffi_msg.message.get_summary(ctx, None))
         .context("dc_msg_get_summarytext failed")
@@ -3612,153 +3549,153 @@ pub unsafe extern "C" fn dc_msg_get_summarytext(
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_override_sender_name(msg: *mut dc_msg_t) -> *mut libc::c_char {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_override_sender_name()");
         return "".strdup();
     }
-    let ffi_msg = &mut *msg;
+    let ffi_msg = unsafe { &mut *msg };
 
     ffi_msg.message.get_override_sender_name().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_has_deviating_timestamp(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_has_deviating_timestamp()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.has_deviating_timestamp().into()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_has_location(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_has_location()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.has_location() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_is_sent(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_is_sent()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.is_sent().into()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_is_forwarded(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_is_forwarded()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.is_forwarded().into()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_is_edited(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_is_edited()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.is_edited().into()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_is_info(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_is_info()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.is_info().into()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_info_type(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_info_type()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_info_type() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_info_contact_id(msg: *mut dc_msg_t) -> u32 {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_info_contact_id()");
         return 0;
     }
-    let ffi_msg = &*msg;
-    let context = &*ffi_msg.context;
+    let ffi_msg = unsafe { &*msg };
+    let context = unsafe { &*ffi_msg.context };
     block_on(ffi_msg.message.get_info_contact_id(context))
         .unwrap_or_default()
         .map(|id| id.to_u32())
         .unwrap_or_default()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_webxdc_href(msg: *mut dc_msg_t) -> *mut libc::c_char {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_webxdc_href()");
         return "".strdup();
     }
 
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.get_webxdc_href().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_has_html(msg: *mut dc_msg_t) -> libc::c_int {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_has_html()");
         return 0;
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     ffi_msg.message.has_html().into()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_set_text(msg: *mut dc_msg_t, text: *const libc::c_char) {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_set_text()");
         return;
     }
-    let ffi_msg = &mut *msg;
+    let ffi_msg = unsafe { &mut *msg };
     ffi_msg.message.set_text(to_string_lossy(text))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_set_html(msg: *mut dc_msg_t, html: *const libc::c_char) {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_set_html()");
         return;
     }
-    let ffi_msg = &mut *msg;
+    let ffi_msg = unsafe { &mut *msg };
     ffi_msg.message.set_html(to_opt_string_lossy(html))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_set_subject(msg: *mut dc_msg_t, subject: *const libc::c_char) {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_subject()");
         return;
     }
-    let ffi_msg = &mut *msg;
+    let ffi_msg = unsafe { &mut *msg };
     ffi_msg.message.set_subject(to_string_lossy(subject));
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_set_override_sender_name(
     msg: *mut dc_msg_t,
     name: *const libc::c_char,
@@ -3767,13 +3704,13 @@ pub unsafe extern "C" fn dc_msg_set_override_sender_name(
         eprintln!("ignoring careless call to dc_msg_set_override_sender_name()");
         return;
     }
-    let ffi_msg = &mut *msg;
+    let ffi_msg = unsafe { &mut *msg };
     ffi_msg
         .message
         .set_override_sender_name(to_opt_string_lossy(name))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_set_file_and_deduplicate(
     msg: *mut dc_msg_t,
     file: *const libc::c_char,
@@ -3784,8 +3721,8 @@ pub unsafe extern "C" fn dc_msg_set_file_and_deduplicate(
         eprintln!("ignoring careless call to dc_msg_set_file_and_deduplicate()");
         return;
     }
-    let ffi_msg = &mut *msg;
-    let ctx = &*ffi_msg.context;
+    let ffi_msg = unsafe { &mut *msg };
+    let ctx = unsafe { &*ffi_msg.context };
 
     ffi_msg
         .message
@@ -3796,11 +3733,11 @@ pub unsafe extern "C" fn dc_msg_set_file_and_deduplicate(
             to_opt_string_lossy(filemime).as_deref(),
         )
         .context("Failed to set file")
-        .log_err(&*ffi_msg.context)
+        .log_err(ctx)
         .ok();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_set_dimension(
     msg: *mut dc_msg_t,
     width: libc::c_int,
@@ -3810,21 +3747,21 @@ pub unsafe extern "C" fn dc_msg_set_dimension(
         eprintln!("ignoring careless call to dc_msg_set_dimension()");
         return;
     }
-    let ffi_msg = &mut *msg;
+    let ffi_msg = unsafe { &mut *msg };
     ffi_msg.message.set_dimension(width, height)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_set_duration(msg: *mut dc_msg_t, duration: libc::c_int) {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_set_duration()");
         return;
     }
-    let ffi_msg = &mut *msg;
+    let ffi_msg = unsafe { &mut *msg };
     ffi_msg.message.set_duration(duration)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_set_location(
     msg: *mut dc_msg_t,
     latitude: libc::c_double,
@@ -3834,11 +3771,11 @@ pub unsafe extern "C" fn dc_msg_set_location(
         eprintln!("ignoring careless call to dc_msg_set_location()");
         return;
     }
-    let ffi_msg = &mut *msg;
+    let ffi_msg = unsafe { &mut *msg };
     ffi_msg.message.set_location(latitude, longitude)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_latefiling_mediasize(
     msg: *mut dc_msg_t,
     width: libc::c_int,
@@ -3849,8 +3786,8 @@ pub unsafe extern "C" fn dc_msg_latefiling_mediasize(
         eprintln!("ignoring careless call to dc_msg_latefiling_mediasize()");
         return;
     }
-    let ffi_msg = &mut *msg;
-    let ctx = &*ffi_msg.context;
+    let ffi_msg = unsafe { &mut *msg };
+    let ctx = unsafe { &*ffi_msg.context };
 
     block_on({
         ffi_msg
@@ -3862,30 +3799,30 @@ pub unsafe extern "C" fn dc_msg_latefiling_mediasize(
     .ok();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_error(msg: *mut dc_msg_t) -> *mut libc::c_char {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_error()");
         return ptr::null_mut();
     }
-    let ffi_msg = &*msg;
+    let ffi_msg = unsafe { &*msg };
     match ffi_msg.message.error() {
         Some(error) => error.strdup(),
         None => ptr::null_mut(),
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_set_quote(msg: *mut dc_msg_t, quote: *const dc_msg_t) {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_set_quote()");
         return;
     }
-    let ffi_msg = &mut *msg;
+    let ffi_msg = unsafe { &mut *msg };
     let quote_msg = if quote.is_null() {
         None
     } else {
-        let ffi_quote = &*quote;
+        let ffi_quote = unsafe { &*quote };
         if ffi_msg.context != ffi_quote.context {
             eprintln!("ignoring attempt to quote message from a different context");
             return;
@@ -3893,47 +3830,38 @@ pub unsafe extern "C" fn dc_msg_set_quote(msg: *mut dc_msg_t, quote: *const dc_m
         Some(&ffi_quote.message)
     };
 
-    block_on(async move {
-        ffi_msg
-            .message
-            .set_quote(&*ffi_msg.context, quote_msg)
-            .await
-            .context("failed to set quote")
-            .log_err(&*ffi_msg.context)
-            .ok();
-    });
+    let context = unsafe { &*ffi_msg.context };
+    block_on(ffi_msg.message.set_quote(context, quote_msg))
+        .context("failed to set quote")
+        .log_err(context)
+        .ok();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_quoted_text(msg: *const dc_msg_t) -> *mut libc::c_char {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_quoted_text()");
         return ptr::null_mut();
     }
-    let ffi_msg: &MessageWrapper = &*msg;
+    let ffi_msg: &MessageWrapper = unsafe { &*msg };
     ffi_msg
         .message
         .quoted_text()
         .map_or_else(ptr::null_mut, |s| s.strdup())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_quoted_msg(msg: *const dc_msg_t) -> *mut dc_msg_t {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_get_quoted_msg()");
         return ptr::null_mut();
     }
-    let ffi_msg: &MessageWrapper = &*msg;
-    let context = &*ffi_msg.context;
-    let res = block_on(async move {
-        ffi_msg
-            .message
-            .quoted_message(context)
-            .await
-            .context("failed to get quoted message")
-            .log_err(context)
-            .unwrap_or(None)
-    });
+    let ffi_msg: &MessageWrapper = unsafe { &*msg };
+    let context = unsafe { &*ffi_msg.context };
+    let res = block_on(ffi_msg.message.quoted_message(context))
+        .context("failed to get quoted message")
+        .log_err(context)
+        .unwrap_or(None);
 
     match res {
         Some(message) => Box::into_raw(Box::new(MessageWrapper { context, message })),
@@ -3941,23 +3869,18 @@ pub unsafe extern "C" fn dc_msg_get_quoted_msg(msg: *const dc_msg_t) -> *mut dc_
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_parent(msg: *const dc_msg_t) -> *mut dc_msg_t {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_parent()");
         return ptr::null_mut();
     }
-    let ffi_msg: &MessageWrapper = &*msg;
-    let context = &*ffi_msg.context;
-    let res = block_on(async move {
-        ffi_msg
-            .message
-            .parent(context)
-            .await
-            .context("failed to get parent message")
-            .log_err(context)
-            .unwrap_or(None)
-    });
+    let ffi_msg: &MessageWrapper = unsafe { &*msg };
+    let context = unsafe { &*ffi_msg.context };
+    let res = block_on(ffi_msg.message.parent(context))
+        .context("failed to get parent message")
+        .log_err(context)
+        .unwrap_or(None);
 
     match res {
         Some(message) => Box::into_raw(Box::new(MessageWrapper { context, message })),
@@ -3965,46 +3888,36 @@ pub unsafe extern "C" fn dc_msg_get_parent(msg: *const dc_msg_t) -> *mut dc_msg_
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_original_msg_id(msg: *const dc_msg_t) -> u32 {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_original_msg_id()");
         return 0;
     }
-    let ffi_msg: &MessageWrapper = &*msg;
-    let context = &*ffi_msg.context;
-    block_on(async move {
-        ffi_msg
-            .message
-            .get_original_msg_id(context)
-            .await
-            .context("failed to get original message")
-            .log_err(context)
-            .unwrap_or_default()
-            .map(|id| id.to_u32())
-            .unwrap_or(0)
-    })
+    let ffi_msg: &MessageWrapper = unsafe { &*msg };
+    let context = unsafe { &*ffi_msg.context };
+    block_on(ffi_msg.message.get_original_msg_id(context))
+        .context("failed to get original message")
+        .log_err(context)
+        .unwrap_or_default()
+        .map(|id| id.to_u32())
+        .unwrap_or(0)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_msg_get_saved_msg_id(msg: *const dc_msg_t) -> u32 {
     if msg.is_null() {
         eprintln!("ignoring careless call to dc_msg_get_saved_msg_id()");
         return 0;
     }
-    let ffi_msg: &MessageWrapper = &*msg;
-    let context = &*ffi_msg.context;
-    block_on(async move {
-        ffi_msg
-            .message
-            .get_saved_msg_id(context)
-            .await
-            .context("failed to get original message")
-            .log_err(context)
-            .unwrap_or_default()
-            .map(|id| id.to_u32())
-            .unwrap_or(0)
-    })
+    let ffi_msg: &MessageWrapper = unsafe { &*msg };
+    let context = unsafe { &*ffi_msg.context };
+    block_on(ffi_msg.message.get_saved_msg_id(context))
+        .context("failed to get original message")
+        .log_err(context)
+        .unwrap_or_default()
+        .map(|id| id.to_u32())
+        .unwrap_or(0)
 }
 
 // dc_contact_t
@@ -4023,56 +3936,56 @@ pub struct ContactWrapper {
 
 pub type dc_contact_t = ContactWrapper;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_unref(contact: *mut dc_contact_t) {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_unref()");
         return;
     }
-    drop(Box::from_raw(contact));
+    drop(unsafe { Box::from_raw(contact) });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_get_id(contact: *mut dc_contact_t) -> u32 {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_get_id()");
         return 0;
     }
-    let ffi_contact = &*contact;
+    let ffi_contact = unsafe { &*contact };
     ffi_contact.contact.get_id().to_u32()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_get_addr(contact: *mut dc_contact_t) -> *mut libc::c_char {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_get_addr()");
         return "".strdup();
     }
-    let ffi_contact = &*contact;
+    let ffi_contact = unsafe { &*contact };
     ffi_contact.contact.get_addr().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_get_name(contact: *mut dc_contact_t) -> *mut libc::c_char {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_get_name()");
         return "".strdup();
     }
-    let ffi_contact = &*contact;
+    let ffi_contact = unsafe { &*contact };
     ffi_contact.contact.get_name().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_get_auth_name(contact: *mut dc_contact_t) -> *mut libc::c_char {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_get_auth_name()");
         return "".strdup();
     }
-    let ffi_contact = &*contact;
+    let ffi_contact = unsafe { &*contact };
     ffi_contact.contact.get_authname().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_get_display_name(
     contact: *mut dc_contact_t,
 ) -> *mut libc::c_char {
@@ -4080,11 +3993,11 @@ pub unsafe extern "C" fn dc_contact_get_display_name(
         eprintln!("ignoring careless call to dc_contact_get_display_name()");
         return "".strdup();
     }
-    let ffi_contact = &*contact;
+    let ffi_contact = unsafe { &*contact };
     ffi_contact.contact.get_display_name().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_get_name_n_addr(
     contact: *mut dc_contact_t,
 ) -> *mut libc::c_char {
@@ -4092,11 +4005,11 @@ pub unsafe extern "C" fn dc_contact_get_name_n_addr(
         eprintln!("ignoring careless call to dc_contact_get_name_n_addr()");
         return "".strdup();
     }
-    let ffi_contact = &*contact;
+    let ffi_contact = unsafe { &*contact };
     ffi_contact.contact.get_name_n_addr().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_get_profile_image(
     contact: *mut dc_contact_t,
 ) -> *mut libc::c_char {
@@ -4104,88 +4017,82 @@ pub unsafe extern "C" fn dc_contact_get_profile_image(
         eprintln!("ignoring careless call to dc_contact_get_profile_image()");
         return ptr::null_mut(); // NULL explicitly defined as "no profile image"
     }
-    let ffi_contact = &*contact;
-    let ctx = &*ffi_contact.context;
+    let ffi_contact = unsafe { &*contact };
+    let ctx = unsafe { &*ffi_contact.context };
 
-    block_on(async move {
-        ffi_contact
-            .contact
-            .get_profile_image(ctx)
-            .await
-            .unwrap_or_log_default(ctx, "failed to get profile image")
-            .map(|p| p.to_string_lossy().strdup())
-            .unwrap_or_else(std::ptr::null_mut)
-    })
+    block_on(ffi_contact.contact.get_profile_image(ctx))
+        .unwrap_or_log_default(ctx, "failed to get profile image")
+        .map(|p| p.to_string_lossy().strdup())
+        .unwrap_or_else(std::ptr::null_mut)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_get_color(contact: *mut dc_contact_t) -> u32 {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_get_color()");
         return 0;
     }
-    let ffi_contact = &*contact;
-    let ctx = &*ffi_contact.context;
-    block_on(async move {
+    let ffi_contact = unsafe { &*contact };
+    let ctx = unsafe { &*ffi_contact.context };
+    block_on(
         ffi_contact
             .contact
             // We don't want any UIs displaying gray self-color.
-            .get_or_gen_color(ctx)
-            .await
-            .context("Contact::get_color()")
-            .log_err(ctx)
-            .unwrap_or(0)
-    })
+            .get_or_gen_color(ctx),
+    )
+    .context("Contact::get_color()")
+    .log_err(ctx)
+    .unwrap_or(0)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_get_status(contact: *mut dc_contact_t) -> *mut libc::c_char {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_get_status()");
         return "".strdup();
     }
-    let ffi_contact = &*contact;
+    let ffi_contact = unsafe { &*contact };
     ffi_contact.contact.get_status().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_get_last_seen(contact: *mut dc_contact_t) -> i64 {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_get_last_seen()");
         return 0;
     }
-    let ffi_contact = &*contact;
+    let ffi_contact = unsafe { &*contact };
     ffi_contact.contact.last_seen()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_was_seen_recently(contact: *mut dc_contact_t) -> libc::c_int {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_was_seen_recently()");
         return 0;
     }
-    let ffi_contact = &*contact;
+    let ffi_contact = unsafe { &*contact };
     ffi_contact.contact.was_seen_recently() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_is_blocked(contact: *mut dc_contact_t) -> libc::c_int {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_is_blocked()");
         return 0;
     }
-    let ffi_contact = &*contact;
+    let ffi_contact = unsafe { &*contact };
     ffi_contact.contact.is_blocked() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_is_verified(contact: *mut dc_contact_t) -> libc::c_int {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_is_verified()");
         return 0;
     }
-    let ffi_contact = &*contact;
-    let ctx = &*ffi_contact.context;
+    let ffi_contact = unsafe { &*contact };
+    let ctx = unsafe { &*ffi_contact.context };
 
     if block_on(ffi_contact.contact.is_verified(ctx))
         .context("is_verified failed")
@@ -4200,32 +4107,32 @@ pub unsafe extern "C" fn dc_contact_is_verified(contact: *mut dc_contact_t) -> l
     }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_is_bot(contact: *mut dc_contact_t) -> libc::c_int {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_is_bot()");
         return 0;
     }
-    (*contact).contact.is_bot() as libc::c_int
+    unsafe { (*contact).contact.is_bot() as libc::c_int }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_is_key_contact(contact: *mut dc_contact_t) -> libc::c_int {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_is_key_contact()");
         return 0;
     }
-    (*contact).contact.is_key_contact() as libc::c_int
+    unsafe { (*contact).contact.is_key_contact() as libc::c_int }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_contact_get_verifier_id(contact: *mut dc_contact_t) -> u32 {
     if contact.is_null() {
         eprintln!("ignoring careless call to dc_contact_get_verifier_id()");
         return 0;
     }
-    let ffi_contact = &*contact;
-    let ctx = &*ffi_contact.context;
+    let ffi_contact = unsafe { &*contact };
+    let ctx = unsafe { &*ffi_contact.context };
     let verifier_contact_id = block_on(ffi_contact.contact.get_verifier_id(ctx))
         .context("failed to get verifier")
         .log_err(ctx)
@@ -4239,85 +4146,85 @@ pub unsafe extern "C" fn dc_contact_get_verifier_id(contact: *mut dc_contact_t) 
 
 pub type dc_lot_t = lot::Lot;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_lot_unref(lot: *mut dc_lot_t) {
     if lot.is_null() {
         eprintln!("ignoring careless call to dc_lot_unref()");
         return;
     }
 
-    drop(Box::from_raw(lot));
+    drop(unsafe { Box::from_raw(lot) });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_lot_get_text1(lot: *mut dc_lot_t) -> *mut libc::c_char {
     if lot.is_null() {
         eprintln!("ignoring careless call to dc_lot_get_text1()");
         return ptr::null_mut(); // NULL explicitly defined as "there is no such text"
     }
 
-    let lot = &*lot;
+    let lot = unsafe { &*lot };
     lot.get_text1().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_lot_get_text2(lot: *mut dc_lot_t) -> *mut libc::c_char {
     if lot.is_null() {
         eprintln!("ignoring careless call to dc_lot_get_text2()");
         return ptr::null_mut(); // NULL explicitly defined as "there is no such text"
     }
 
-    let lot = &*lot;
+    let lot = unsafe { &*lot };
     lot.get_text2().strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_lot_get_text1_meaning(lot: *mut dc_lot_t) -> libc::c_int {
     if lot.is_null() {
         eprintln!("ignoring careless call to dc_lot_get_text1_meaning()");
         return 0;
     }
 
-    let lot = &*lot;
+    let lot = unsafe { &*lot };
     lot.get_text1_meaning() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_lot_get_state(lot: *mut dc_lot_t) -> libc::c_int {
     if lot.is_null() {
         eprintln!("ignoring careless call to dc_lot_get_state()");
         return 0;
     }
 
-    let lot = &*lot;
+    let lot = unsafe { &*lot };
     lot.get_state() as libc::c_int
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_lot_get_id(lot: *mut dc_lot_t) -> u32 {
     if lot.is_null() {
         eprintln!("ignoring careless call to dc_lot_get_id()");
         return 0;
     }
 
-    let lot = &*lot;
+    let lot = unsafe { &*lot };
     lot.get_id()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_lot_get_timestamp(lot: *mut dc_lot_t) -> i64 {
     if lot.is_null() {
         eprintln!("ignoring careless call to dc_lot_get_timestamp()");
         return 0;
     }
 
-    let lot = &*lot;
+    let lot = unsafe { &*lot };
     lot.get_timestamp()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_str_unref(s: *mut libc::c_char) {
-    libc::free(s as *mut _)
+    unsafe { libc::free(s as *mut _) }
 }
 
 pub struct BackupProviderWrapper {
@@ -4327,7 +4234,7 @@ pub struct BackupProviderWrapper {
 
 pub type dc_backup_provider_t = BackupProviderWrapper;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_backup_provider_new(
     context: *mut dc_context_t,
 ) -> *mut dc_backup_provider_t {
@@ -4335,7 +4242,7 @@ pub unsafe extern "C" fn dc_backup_provider_new(
         eprintln!("ignoring careless call to dc_backup_provider_new()");
         return ptr::null_mut();
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     block_on(BackupProvider::prepare(ctx))
         .map(|provider| BackupProviderWrapper {
             context: ctx,
@@ -4348,7 +4255,7 @@ pub unsafe extern "C" fn dc_backup_provider_new(
         .unwrap_or(ptr::null_mut())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_backup_provider_get_qr(
     provider: *const dc_backup_provider_t,
 ) -> *mut libc::c_char {
@@ -4356,8 +4263,8 @@ pub unsafe extern "C" fn dc_backup_provider_get_qr(
         eprintln!("ignoring careless call to dc_backup_provider_qr");
         return "".strdup();
     }
-    let ffi_provider = &*provider;
-    let ctx = &*ffi_provider.context;
+    let ffi_provider = unsafe { &*provider };
+    let ctx = unsafe { &*ffi_provider.context };
     deltachat::qr::format_backup(&ffi_provider.provider.qr())
         .context("BackupProvider get_qr failed")
         .log_err(ctx)
@@ -4366,7 +4273,7 @@ pub unsafe extern "C" fn dc_backup_provider_get_qr(
         .strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_backup_provider_get_qr_svg(
     provider: *const dc_backup_provider_t,
 ) -> *mut libc::c_char {
@@ -4374,8 +4281,8 @@ pub unsafe extern "C" fn dc_backup_provider_get_qr_svg(
         eprintln!("ignoring careless call to dc_backup_provider_qr_svg()");
         return "".strdup();
     }
-    let ffi_provider = &*provider;
-    let ctx = &*ffi_provider.context;
+    let ffi_provider = unsafe { &*provider };
+    let ctx = unsafe { &*ffi_provider.context };
     let provider = &ffi_provider.provider;
     block_on(generate_backup_qr(ctx, &provider.qr()))
         .context("BackupProvider get_qr_svg failed")
@@ -4385,14 +4292,14 @@ pub unsafe extern "C" fn dc_backup_provider_get_qr_svg(
         .strdup()
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_backup_provider_wait(provider: *mut dc_backup_provider_t) {
     if provider.is_null() {
         eprintln!("ignoring careless call to dc_backup_provider_wait()");
         return;
     }
-    let ffi_provider = &mut *provider;
-    let ctx = &*ffi_provider.context;
+    let ffi_provider = unsafe { &mut *provider };
+    let ctx = unsafe { &*ffi_provider.context };
     let provider = &mut ffi_provider.provider;
     block_on(provider)
         .context("Failed to await backup provider")
@@ -4401,16 +4308,16 @@ pub unsafe extern "C" fn dc_backup_provider_wait(provider: *mut dc_backup_provid
         .ok();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_backup_provider_unref(provider: *mut dc_backup_provider_t) {
     if provider.is_null() {
         eprintln!("ignoring careless call to dc_backup_provider_unref()");
         return;
     }
-    drop(Box::from_raw(provider));
+    drop(unsafe { Box::from_raw(provider) });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_receive_backup(
     context: *mut dc_context_t,
     qr: *const libc::c_char,
@@ -4419,7 +4326,7 @@ pub unsafe extern "C" fn dc_receive_backup(
         eprintln!("ignoring careless call to dc_receive_backup()");
         return 0;
     }
-    let ctx = &*context;
+    let ctx = unsafe { &*context };
     let qr_text = to_string_lossy(qr);
     receive_backup(ctx.clone(), qr_text)
 }
@@ -4529,7 +4436,7 @@ fn convert_and_prune_message_ids(msg_ids: *const u32, msg_cnt: libc::c_int) -> V
 /// `dc_accounts_t` in multiple threads at once.
 pub type dc_accounts_t = RwLock<Accounts>;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_new(
     dir: *const libc::c_char,
     writable: libc::c_int,
@@ -4555,7 +4462,7 @@ pub unsafe extern "C" fn dc_accounts_new(
 
 pub type dc_event_channel_t = Mutex<Option<Events>>;
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_event_channel_new() -> *mut dc_event_channel_t {
     Box::into_raw(Box::new(Mutex::new(Some(Events::new()))))
 }
@@ -4566,16 +4473,16 @@ pub unsafe extern "C" fn dc_event_channel_new() -> *mut dc_event_channel_t {
 ///
 /// you can call it after calling dc_accounts_new_with_event_channel,
 /// which took the events channel out of it already, so this just frees the underlying option.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_event_channel_unref(event_channel: *mut dc_event_channel_t) {
     if event_channel.is_null() {
         eprintln!("ignoring careless call to dc_event_channel_unref()");
         return;
     }
-    drop(Box::from_raw(event_channel))
+    drop(unsafe { Box::from_raw(event_channel) })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_event_channel_get_event_emitter(
     event_channel: *mut dc_event_channel_t,
 ) -> *mut dc_event_emitter_t {
@@ -4584,23 +4491,25 @@ pub unsafe extern "C" fn dc_event_channel_get_event_emitter(
         return ptr::null_mut();
     }
 
-    let Some(event_channel) = &*(*event_channel)
-        .lock()
-        .expect("call to dc_event_channel_get_event_emitter() failed: mutex is poisoned")
-    else {
-        eprintln!(
+    unsafe {
+        let Some(event_channel) = &*(*event_channel)
+            .lock()
+            .expect("call to dc_event_channel_get_event_emitter() failed: mutex is poisoned")
+        else {
+            eprintln!(
             "ignoring careless call to dc_event_channel_get_event_emitter() 
             -> channel was already consumed, make sure you call this before dc_accounts_new_with_event_channel"
         );
-        return ptr::null_mut();
-    };
+            return ptr::null_mut();
+        };
 
-    let emitter = event_channel.get_emitter();
+        let emitter = event_channel.get_emitter();
 
-    Box::into_raw(Box::new(emitter))
+        Box::into_raw(Box::new(emitter))
+    }
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_new_with_event_channel(
     dir: *const libc::c_char,
     writable: libc::c_int,
@@ -4617,16 +4526,19 @@ pub unsafe extern "C" fn dc_accounts_new_with_event_channel(
     // before initializing the account manager,
     // so that you don't miss events/errors during initialisation.
     // It also prevents you from using the same channel on multiple account managers.
-    let Some(event_channel) = (*event_channel)
-        .lock()
-        .expect("call to dc_event_channel_get_event_emitter() failed: mutex is poisoned")
-        .take()
-    else {
-        eprintln!(
-            "ignoring careless call to dc_accounts_new_with_event_channel()
+    let event_channel = unsafe {
+        let Some(event_channel) = (*event_channel)
+            .lock()
+            .expect("call to dc_event_channel_get_event_emitter() failed: mutex is poisoned")
+            .take()
+        else {
+            eprintln!(
+                "ignoring careless call to dc_accounts_new_with_event_channel()
             -> channel was already consumed"
-        );
-        return ptr::null_mut();
+            );
+            return ptr::null_mut();
+        };
+        event_channel
     };
 
     let accs = block_on(Accounts::new_with_events(
@@ -4648,16 +4560,16 @@ pub unsafe extern "C" fn dc_accounts_new_with_event_channel(
 /// Release the accounts structure.
 ///
 /// This function releases the memory of the `dc_accounts_t` structure.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_unref(accounts: *const dc_accounts_t) {
     if accounts.is_null() {
         eprintln!("ignoring careless call to dc_accounts_unref()");
         return;
     }
-    drop(Arc::from_raw(accounts));
+    drop(unsafe { Arc::from_raw(accounts) });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_get_account(
     accounts: *const dc_accounts_t,
     id: u32,
@@ -4667,14 +4579,14 @@ pub unsafe extern "C" fn dc_accounts_get_account(
         return ptr::null_mut();
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
     block_on(accounts.read())
         .get_account(id)
         .map(|ctx| Box::into_raw(Box::new(ctx)))
         .unwrap_or_else(std::ptr::null_mut)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_get_selected_account(
     accounts: *const dc_accounts_t,
 ) -> *mut dc_context_t {
@@ -4683,14 +4595,14 @@ pub unsafe extern "C" fn dc_accounts_get_selected_account(
         return ptr::null_mut();
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
     block_on(accounts.read())
         .get_selected_account()
         .map(|ctx| Box::into_raw(Box::new(ctx)))
         .unwrap_or_else(std::ptr::null_mut)
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_select_account(
     accounts: *const dc_accounts_t,
     id: u32,
@@ -4700,7 +4612,7 @@ pub unsafe extern "C" fn dc_accounts_select_account(
         return 0;
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
     block_on(async move {
         let mut accounts = accounts.write().await;
         match accounts.select_account(id).await {
@@ -4715,14 +4627,14 @@ pub unsafe extern "C" fn dc_accounts_select_account(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_add_account(accounts: *const dc_accounts_t) -> u32 {
     if accounts.is_null() {
         eprintln!("ignoring careless call to dc_accounts_add_account()");
         return 0;
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
 
     block_on(async move {
         let mut accounts = accounts.write().await;
@@ -4736,14 +4648,14 @@ pub unsafe extern "C" fn dc_accounts_add_account(accounts: *const dc_accounts_t)
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_add_closed_account(accounts: *const dc_accounts_t) -> u32 {
     if accounts.is_null() {
         eprintln!("ignoring careless call to dc_accounts_add_closed_account()");
         return 0;
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
 
     block_on(async move {
         let mut accounts = accounts.write().await;
@@ -4757,7 +4669,7 @@ pub unsafe extern "C" fn dc_accounts_add_closed_account(accounts: *const dc_acco
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_remove_account(
     accounts: *const dc_accounts_t,
     id: u32,
@@ -4767,7 +4679,7 @@ pub unsafe extern "C" fn dc_accounts_remove_account(
         return 0;
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
 
     block_on(async move {
         let mut accounts = accounts.write().await;
@@ -4783,7 +4695,7 @@ pub unsafe extern "C" fn dc_accounts_remove_account(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_migrate_account(
     accounts: *const dc_accounts_t,
     dbfile: *const libc::c_char,
@@ -4793,7 +4705,7 @@ pub unsafe extern "C" fn dc_accounts_migrate_account(
         return 0;
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
     let dbfile = to_string_lossy(dbfile);
 
     block_on(async move {
@@ -4813,65 +4725,65 @@ pub unsafe extern "C" fn dc_accounts_migrate_account(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_get_all(accounts: *const dc_accounts_t) -> *mut dc_array_t {
     if accounts.is_null() {
         eprintln!("ignoring careless call to dc_accounts_get_all()");
         return ptr::null_mut();
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
     let list = block_on(accounts.read()).get_all();
     let array: dc_array_t = list.into();
 
     Box::into_raw(Box::new(array))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_start_io(accounts: *const dc_accounts_t) {
     if accounts.is_null() {
         eprintln!("ignoring careless call to dc_accounts_start_io()");
         return;
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
     block_on(async move { accounts.write().await.start_io().await });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_stop_io(accounts: *const dc_accounts_t) {
     if accounts.is_null() {
         eprintln!("ignoring careless call to dc_accounts_stop_io()");
         return;
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
     block_on(async move { accounts.read().await.stop_io().await });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_maybe_network(accounts: *const dc_accounts_t) {
     if accounts.is_null() {
         eprintln!("ignoring careless call to dc_accounts_maybe_network()");
         return;
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
     block_on(async move { accounts.read().await.maybe_network().await });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_maybe_network_lost(accounts: *const dc_accounts_t) {
     if accounts.is_null() {
         eprintln!("ignoring careless call to dc_accounts_maybe_network_lost()");
         return;
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
     block_on(async move { accounts.read().await.maybe_network_lost().await });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_background_fetch(
     accounts: *const dc_accounts_t,
     timeout_in_seconds: u64,
@@ -4881,7 +4793,7 @@ pub unsafe extern "C" fn dc_accounts_background_fetch(
         return 0;
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
     let background_fetch_future = {
         let lock = block_on(accounts.read());
         lock.background_fetch(Duration::from_secs(timeout_in_seconds))
@@ -4891,18 +4803,18 @@ pub unsafe extern "C" fn dc_accounts_background_fetch(
     1
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_stop_background_fetch(accounts: *const dc_accounts_t) {
     if accounts.is_null() {
         eprintln!("ignoring careless call to dc_accounts_stop_background_fetch()");
         return;
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
     block_on(accounts.read()).stop_background_fetch();
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_set_push_device_token(
     accounts: *const dc_accounts_t,
     token: *const libc::c_char,
@@ -4912,7 +4824,7 @@ pub unsafe extern "C" fn dc_accounts_set_push_device_token(
         return;
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
     let token = to_string_lossy(token);
 
     block_on(async move {
@@ -4925,7 +4837,7 @@ pub unsafe extern "C" fn dc_accounts_set_push_device_token(
     })
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_accounts_get_event_emitter(
     accounts: *const dc_accounts_t,
 ) -> *mut dc_event_emitter_t {
@@ -4934,7 +4846,7 @@ pub unsafe extern "C" fn dc_accounts_get_event_emitter(
         return ptr::null_mut();
     }
 
-    let accounts = &*accounts;
+    let accounts = unsafe { &*accounts };
     let emitter = block_on(accounts.read()).get_event_emitter();
 
     Box::into_raw(Box::new(emitter))
@@ -4945,7 +4857,7 @@ pub struct dc_jsonrpc_instance_t {
     handle: RpcSession<CommandApi>,
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_jsonrpc_init(
     account_manager: *const dc_accounts_t,
 ) -> *mut dc_jsonrpc_instance_t {
@@ -4954,7 +4866,7 @@ pub unsafe extern "C" fn dc_jsonrpc_init(
         return ptr::null_mut();
     }
 
-    let account_manager = ManuallyDrop::new(Arc::from_raw(account_manager));
+    let account_manager = ManuallyDrop::new(unsafe { Arc::from_raw(account_manager) });
     let cmd_api = block_on(deltachat_jsonrpc::api::CommandApi::from_arc(Arc::clone(
         &account_manager,
     )));
@@ -4967,13 +4879,13 @@ pub unsafe extern "C" fn dc_jsonrpc_init(
     Box::into_raw(Box::new(instance))
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_jsonrpc_unref(jsonrpc_instance: *mut dc_jsonrpc_instance_t) {
     if jsonrpc_instance.is_null() {
         eprintln!("ignoring careless call to dc_jsonrpc_unref()");
         return;
     }
-    drop(Box::from_raw(jsonrpc_instance));
+    drop(unsafe { Box::from_raw(jsonrpc_instance) });
 }
 
 fn spawn_handle_jsonrpc_request(handle: RpcSession<CommandApi>, request: String) {
@@ -4982,7 +4894,7 @@ fn spawn_handle_jsonrpc_request(handle: RpcSession<CommandApi>, request: String)
     });
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_jsonrpc_request(
     jsonrpc_instance: *mut dc_jsonrpc_instance_t,
     request: *const libc::c_char,
@@ -4992,12 +4904,12 @@ pub unsafe extern "C" fn dc_jsonrpc_request(
         return;
     }
 
-    let handle = &(*jsonrpc_instance).handle;
+    let handle = unsafe { &(*jsonrpc_instance).handle };
     let request = to_string_lossy(request);
     spawn_handle_jsonrpc_request(handle.clone(), request);
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_jsonrpc_next_response(
     jsonrpc_instance: *mut dc_jsonrpc_instance_t,
 ) -> *mut libc::c_char {
@@ -5005,13 +4917,13 @@ pub unsafe extern "C" fn dc_jsonrpc_next_response(
         eprintln!("ignoring careless call to dc_jsonrpc_next_response()");
         return ptr::null_mut();
     }
-    let api = &*jsonrpc_instance;
+    let api = unsafe { &*jsonrpc_instance };
     block_on(api.receiver.recv())
         .map(|result| serde_json::to_string(&result).unwrap_or_default().strdup())
         .unwrap_or(ptr::null_mut())
 }
 
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dc_jsonrpc_blocking_call(
     jsonrpc_instance: *mut dc_jsonrpc_instance_t,
     input: *const libc::c_char,
@@ -5020,7 +4932,7 @@ pub unsafe extern "C" fn dc_jsonrpc_blocking_call(
         eprintln!("ignoring careless call to dc_jsonrpc_blocking_call()");
         return ptr::null_mut();
     }
-    let api = &*jsonrpc_instance;
+    let api = unsafe { &*jsonrpc_instance };
     let input = to_string_lossy(input);
     let res = block_on(api.handle.process_incoming(&input));
     match res {

--- a/deltachat-ffi/src/string.rs
+++ b/deltachat-ffi/src/string.rs
@@ -17,13 +17,15 @@ use std::ptr;
 /// }
 /// ```
 unsafe fn dc_strdup(s: *const libc::c_char) -> *mut libc::c_char {
-    let ret: *mut libc::c_char = if !s.is_null() {
-        libc::strdup(s)
-    } else {
-        libc::calloc(1, 1) as *mut libc::c_char
-    };
-    assert!(!ret.is_null());
-    ret
+    unsafe {
+        let ret: *mut libc::c_char = if !s.is_null() {
+            libc::strdup(s)
+        } else {
+            libc::calloc(1, 1) as *mut libc::c_char
+        };
+        assert!(!ret.is_null());
+        ret
+    }
 }
 
 /// Error type for the [OsStrExt] trait
@@ -164,34 +166,40 @@ pub(crate) trait Strdup {
     /// This function will panic when the original string contains an
     /// interior null byte as this can not be represented in raw C
     /// strings.
-    unsafe fn strdup(&self) -> *mut libc::c_char;
+    fn strdup(&self) -> *mut libc::c_char;
 }
 
 impl Strdup for str {
-    unsafe fn strdup(&self) -> *mut libc::c_char {
-        let tmp = CString::new_lossy(self);
-        dc_strdup(tmp.as_ptr())
+    fn strdup(&self) -> *mut libc::c_char {
+        unsafe {
+            let tmp = CString::new_lossy(self);
+            dc_strdup(tmp.as_ptr())
+        }
     }
 }
 
 impl Strdup for String {
-    unsafe fn strdup(&self) -> *mut libc::c_char {
+    fn strdup(&self) -> *mut libc::c_char {
         let s: &str = self;
         s.strdup()
     }
 }
 
 impl Strdup for std::path::Path {
-    unsafe fn strdup(&self) -> *mut libc::c_char {
-        let tmp = self.to_c_string().unwrap_or_else(|_| CString::default());
-        dc_strdup(tmp.as_ptr())
+    fn strdup(&self) -> *mut libc::c_char {
+        unsafe {
+            let tmp = self.to_c_string().unwrap_or_else(|_| CString::default());
+            dc_strdup(tmp.as_ptr())
+        }
     }
 }
 
 impl Strdup for [u8] {
-    unsafe fn strdup(&self) -> *mut libc::c_char {
-        let tmp = CString::new_lossy(self);
-        dc_strdup(tmp.as_ptr())
+    fn strdup(&self) -> *mut libc::c_char {
+        unsafe {
+            let tmp = CString::new_lossy(self);
+            dc_strdup(tmp.as_ptr())
+        }
     }
 }
 
@@ -209,15 +217,15 @@ pub(crate) trait OptStrdup {
     /// Allocate a new raw C `*char` version of this string, or NULL.
     ///
     /// See [Strdup::strdup] for details.
-    unsafe fn strdup(&self) -> *mut libc::c_char;
+    fn strdup(&self) -> *mut libc::c_char;
 }
 
 impl<T: AsRef<str>> OptStrdup for Option<T> {
-    unsafe fn strdup(&self) -> *mut libc::c_char {
+    fn strdup(&self) -> *mut libc::c_char {
         match self {
             Some(s) => {
                 let tmp = CString::new_lossy(s.as_ref());
-                dc_strdup(tmp.as_ptr())
+                unsafe { dc_strdup(tmp.as_ptr()) }
             }
             None => ptr::null_mut(),
         }
@@ -258,11 +266,9 @@ pub(crate) fn to_opt_string_lossy(s: *const libc::c_char) -> Option<String> {
 pub(crate) fn as_path<'a>(s: *const libc::c_char) -> &'a std::path::Path {
     assert!(!s.is_null(), "cannot be used on null pointers");
     use std::os::unix::ffi::OsStrExt;
-    unsafe {
-        let c_str = std::ffi::CStr::from_ptr(s).to_bytes();
-        let os_str = std::ffi::OsStr::from_bytes(c_str);
-        std::path::Path::new(os_str)
-    }
+    let c_str = unsafe { std::ffi::CStr::from_ptr(s) }.to_bytes();
+    let os_str = std::ffi::OsStr::from_bytes(c_str);
+    std::path::Path::new(os_str)
 }
 
 // as_path() implementation for windows, documented above.

--- a/deltachat-ffi/src/string.rs
+++ b/deltachat-ffi/src/string.rs
@@ -263,7 +263,7 @@ pub(crate) fn to_opt_string_lossy(s: *const libc::c_char) -> Option<String> {
 ///
 /// [Path]: std::path::Path
 #[cfg(not(target_os = "windows"))]
-pub(crate) fn as_path<'a>(s: *const libc::c_char) -> &'a std::path::Path {
+pub(crate) unsafe fn as_path<'a>(s: *const libc::c_char) -> &'a std::path::Path {
     assert!(!s.is_null(), "cannot be used on null pointers");
     use std::os::unix::ffi::OsStrExt;
     let c_str = unsafe { std::ffi::CStr::from_ptr(s) }.to_bytes();
@@ -273,8 +273,8 @@ pub(crate) fn as_path<'a>(s: *const libc::c_char) -> &'a std::path::Path {
 
 // as_path() implementation for windows, documented above.
 #[cfg(target_os = "windows")]
-pub(crate) fn as_path<'a>(s: *const libc::c_char) -> &'a std::path::Path {
-    as_path_unicode(s)
+pub(crate) unsafe fn as_path<'a>(s: *const libc::c_char) -> &'a std::path::Path {
+    unsafe { as_path_unicode(s) }
 }
 
 // Implementation for as_path() on Windows.
@@ -282,7 +282,7 @@ pub(crate) fn as_path<'a>(s: *const libc::c_char) -> &'a std::path::Path {
 // Having this as a separate function means it can be tested on unix
 // too.
 #[allow(dead_code)]
-fn as_path_unicode<'a>(s: *const libc::c_char) -> &'a std::path::Path {
+unsafe fn as_path_unicode<'a>(s: *const libc::c_char) -> &'a std::path::Path {
     assert!(!s.is_null(), "cannot be used on null pointers");
 
     let cstr = unsafe { CStr::from_ptr(s) };
@@ -370,14 +370,20 @@ mod tests {
     fn test_as_path() {
         let some_path = CString::new("/some/path").unwrap();
         let ptr = some_path.as_ptr();
-        assert_eq!(as_path(ptr), std::ffi::OsString::from("/some/path"))
+        assert_eq!(
+            unsafe { as_path(ptr) },
+            std::ffi::OsString::from("/some/path")
+        )
     }
 
     #[test]
     fn test_as_path_unicode_fn() {
         let some_path = CString::new("/some/path").unwrap();
         let ptr = some_path.as_ptr();
-        assert_eq!(as_path_unicode(ptr), std::ffi::OsString::from("/some/path"));
+        assert_eq!(
+            unsafe { as_path_unicode(ptr) },
+            std::ffi::OsString::from("/some/path")
+        );
     }
 
     #[test]

--- a/deltachat-jsonrpc/Cargo.toml
+++ b/deltachat-jsonrpc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "deltachat-jsonrpc"
 version = "2.58.0-dev"
 description = "DeltaChat JSON-RPC API"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 repository = "https://github.com/chatmail/core"
 

--- a/deltachat-jsonrpc/src/api.rs
+++ b/deltachat-jsonrpc/src/api.rs
@@ -5,26 +5,27 @@ use std::sync::Arc;
 use std::time::Duration;
 use std::{collections::HashMap, str::FromStr};
 
-use anyhow::{anyhow, bail, ensure, Context, Result};
+use anyhow::{Context, Result, anyhow, bail, ensure};
+use deltachat::EventEmitter;
 pub use deltachat::accounts::Accounts;
 use deltachat::blob::BlobObject;
 use deltachat::calls::ice_servers;
 use deltachat::chat::{
-    self, add_contact_to_chat, forward_msgs, forward_msgs_2ctx, get_chat_media, get_chat_msgs,
-    get_chat_msgs_ex, markfresh_chat, marknoticed_all_chats, marknoticed_chat,
-    remove_contact_from_chat, Chat, ChatId, ChatItem, MessageListOptions,
+    self, Chat, ChatId, ChatItem, MessageListOptions, add_contact_to_chat, forward_msgs,
+    forward_msgs_2ctx, get_chat_media, get_chat_msgs, get_chat_msgs_ex, markfresh_chat,
+    marknoticed_all_chats, marknoticed_chat, remove_contact_from_chat,
 };
 use deltachat::chatlist::Chatlist;
-use deltachat::config::{get_all_ui_config_keys, Config};
+use deltachat::config::{Config, get_all_ui_config_keys};
 use deltachat::constants::DC_MSG_ID_DAYMARKER;
-use deltachat::contact::{may_be_valid_addr, Contact, ContactId, Origin};
+use deltachat::contact::{Contact, ContactId, Origin, may_be_valid_addr};
 use deltachat::context::get_info;
 use deltachat::ephemeral::Timer;
 use deltachat::imex;
 use deltachat::location;
 use deltachat::message::{
-    self, delete_msgs_ex, get_existing_msg_ids, get_msg_read_receipt_count, get_msg_read_receipts,
-    markseen_msgs, Message, MessageState, MsgId, Viewtype,
+    self, Message, MessageState, MsgId, Viewtype, delete_msgs_ex, get_existing_msg_ids,
+    get_msg_read_receipt_count, get_msg_read_receipts, markseen_msgs,
 };
 use deltachat::peer_channels::{
     leave_webxdc_realtime, send_webxdc_realtime_advertisement, send_webxdc_realtime_data,
@@ -36,10 +37,9 @@ use deltachat::securejoin;
 use deltachat::stock_str::StockMessage;
 use deltachat::storage_usage::{get_blobdir_storage_usage, get_storage_usage};
 use deltachat::webxdc::StatusUpdateSerial;
-use deltachat::EventEmitter;
 use sanitize_filename::is_sanitized;
 use tokio::fs;
-use tokio::sync::{watch, Mutex, RwLock};
+use tokio::sync::{Mutex, RwLock, watch};
 use types::login_param::EnteredLoginParam;
 use yerpc::rpc;
 
@@ -65,7 +65,7 @@ use self::types::{
         JsonrpcMessageListItem, MessageNotificationInfo, MessageSearchResult, MessageViewtype,
     },
 };
-use crate::api::types::chat_list::{get_chat_list_item_by_id, ChatListItemFetchResult};
+use crate::api::types::chat_list::{ChatListItemFetchResult, get_chat_list_item_by_id};
 use crate::api::types::login_param::TransportListEntry;
 use crate::api::types::qr::{QrObject, SecurejoinSource, SecurejoinUiPath};
 
@@ -2278,7 +2278,7 @@ impl CommandApi {
         let message = Message::load_from_db(&ctx, MsgId::new(instance_msg_id)).await?;
         let blob = message.get_webxdc_blob(&ctx, &path).await?;
 
-        use base64::{engine::general_purpose, Engine as _};
+        use base64::{Engine as _, engine::general_purpose};
         Ok(general_purpose::STANDARD_NO_PAD.encode(blob))
     }
 

--- a/deltachat-jsonrpc/src/api/types/calls.rs
+++ b/deltachat-jsonrpc/src/api/types/calls.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context as _, Result};
 
-use deltachat::calls::{call_state, CallState};
+use deltachat::calls::{CallState, call_state};
 use deltachat::context::Context;
 use deltachat::message::MsgId;
 use serde::Serialize;

--- a/deltachat-jsonrpc/src/api/types/chat.rs
+++ b/deltachat-jsonrpc/src/api/types/chat.rs
@@ -1,7 +1,7 @@
 use std::time::{Duration, SystemTime};
 
-use anyhow::{bail, Context as _, Result};
-use deltachat::chat::{self, get_chat_contacts, get_past_chat_contacts, ChatVisibility};
+use anyhow::{Context as _, Result, bail};
+use deltachat::chat::{self, ChatVisibility, get_chat_contacts, get_past_chat_contacts};
 use deltachat::chat::{Chat, ChatId};
 use deltachat::constants::Chattype;
 use deltachat::contact::{Contact, ContactId};

--- a/deltachat-jsonrpc/src/api/types/chat_list.rs
+++ b/deltachat-jsonrpc/src/api/types/chat_list.rs
@@ -4,7 +4,7 @@ use deltachat::chatlist::get_last_message_for_chat;
 use deltachat::constants::*;
 use deltachat::contact::Contact;
 use deltachat::{
-    chat::{get_chat_contacts, ChatVisibility},
+    chat::{ChatVisibility, get_chat_contacts},
     chatlist::Chatlist,
 };
 use num_traits::cast::ToPrimitive;

--- a/deltachat-jsonrpc/src/api/types/http.rs
+++ b/deltachat-jsonrpc/src/api/types/http.rs
@@ -16,7 +16,7 @@ pub struct HttpResponse {
 
 impl From<CoreHttpResponse> for HttpResponse {
     fn from(response: CoreHttpResponse) -> Self {
-        use base64::{engine::general_purpose, Engine as _};
+        use base64::{Engine as _, engine::general_purpose};
         let blob = general_purpose::STANDARD_NO_PAD.encode(response.blob);
         let mimetype = response.mimetype;
         let encoding = response.encoding;

--- a/deltachat-ratelimit/Cargo.toml
+++ b/deltachat-ratelimit/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ratelimit"
 version = "1.0.0"
 description = "Token bucket implementation"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
 [dependencies]

--- a/deltachat-repl/Cargo.toml
+++ b/deltachat-repl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "deltachat-repl"
 version = "2.58.0-dev"
 license = "MPL-2.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/chatmail/core"
 
 [dependencies]

--- a/deltachat-repl/src/cmdline.rs
+++ b/deltachat-repl/src/cmdline.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use std::str::FromStr;
 use std::time::Duration;
 
-use anyhow::{bail, ensure, Result};
+use anyhow::{Result, bail, ensure};
 use deltachat::chat::{self, Chat, ChatId, ChatItem, ChatVisibility, MuteDuration};
 use deltachat::chatlist::*;
 use deltachat::config;
@@ -1206,12 +1206,11 @@ pub async fn cmdline(context: Context, line: &str, chat_id: &mut ChatId) -> Resu
         "fileinfo" => {
             ensure!(!arg1.is_empty(), "Argument <file> missing.");
 
-            if let Ok(buf) = read_file(&context, Path::new(arg1)).await {
-                let (width, height) = get_filemeta(&buf)?;
-                println!("width={width}, height={height}");
-            } else {
+            let Ok(buf) = read_file(&context, Path::new(arg1)).await else {
                 bail!("Command failed.");
-            }
+            };
+            let (width, height) = get_filemeta(&buf)?;
+            println!("width={width}, height={height}");
         }
         "estimatedeletion" => {
             ensure!(!arg1.is_empty(), "Argument <seconds> missing");

--- a/deltachat-repl/src/main.rs
+++ b/deltachat-repl/src/main.rs
@@ -9,12 +9,12 @@ extern crate deltachat;
 
 use std::borrow::Cow::{self, Borrowed, Owned};
 
-use anyhow::{bail, Error};
+use anyhow::{Error, bail};
+use deltachat::EventType;
 use deltachat::chat::ChatId;
 use deltachat::context::*;
 use deltachat::qr_code_generator::get_securejoin_qr_svg;
 use deltachat::securejoin::*;
-use deltachat::EventType;
 use log::{error, info, warn};
 use nu_ansi_term::Color;
 use rustyline::completion::{Completer, FilenameCompleter, Pair};
@@ -266,10 +266,11 @@ impl Hinter for DcHelper {
                 &CONTACT_COMMANDS[..],
                 &MISC_COMMANDS[..],
             ] {
-                if let Some(entry) = cmds.iter().find(|el| el.starts_with(&line[..pos])) {
-                    if *entry != line && *entry != &line[..pos] {
-                        return Some(entry[pos..].to_owned());
-                    }
+                if let Some(entry) = cmds.iter().find(|el| el.starts_with(&line[..pos]))
+                    && *entry != line
+                    && *entry != &line[..pos]
+                {
+                    return Some(entry[pos..].to_owned());
                 }
             }
         }

--- a/deltachat-rpc-server/Cargo.toml
+++ b/deltachat-rpc-server/Cargo.toml
@@ -2,7 +2,7 @@
 name = "deltachat-rpc-server"
 version = "2.58.0-dev"
 description = "DeltaChat JSON-RPC server"
-edition = "2021"
+edition = "2024"
 readme = "README.md"
 license = "MPL-2.0"
 

--- a/deltachat-rpc-server/src/main.rs
+++ b/deltachat-rpc-server/src/main.rs
@@ -6,7 +6,7 @@ use std::env;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context as _, Result};
+use anyhow::{Context as _, Result, anyhow};
 use deltachat::constants::DC_VERSION_STR;
 use deltachat_jsonrpc::api::{Accounts, CommandApi};
 use futures_lite::stream::StreamExt;

--- a/deltachat-time/Cargo.toml
+++ b/deltachat-time/Cargo.toml
@@ -2,7 +2,7 @@
 name = "deltachat-time"
 version = "1.0.0"
 description = "Time-related tools"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
 [dependencies]

--- a/deltachat_derive/Cargo.toml
+++ b/deltachat_derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "deltachat_derive"
 version = "2.0.0"
-edition = "2018"
+edition = "2024"
 license = "MPL-2.0"
 
 [lib]

--- a/deltachat_derive/src/lib.rs
+++ b/deltachat_derive/src/lib.rs
@@ -14,7 +14,7 @@ pub fn to_sql_derive(input: TokenStream) -> TokenStream {
     let ast: syn::DeriveInput = syn::parse(input).unwrap();
     let name = &ast.ident;
 
-    let gen = quote! {
+    let q = quote! {
         impl rusqlite::types::ToSql for #name {
             fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput> {
                 let num = *self as i64;
@@ -24,7 +24,7 @@ pub fn to_sql_derive(input: TokenStream) -> TokenStream {
             }
         }
     };
-    gen.into()
+    q.into()
 }
 
 #[proc_macro_derive(FromSql)]
@@ -32,7 +32,7 @@ pub fn from_sql_derive(input: TokenStream) -> TokenStream {
     let ast: syn::DeriveInput = syn::parse(input).unwrap();
     let name = &ast.ident;
 
-    let gen = quote! {
+    let q = quote! {
         impl rusqlite::types::FromSql for #name {
             fn column_result(col: rusqlite::types::ValueRef) -> rusqlite::types::FromSqlResult<Self> {
                 let inner = rusqlite::types::FromSql::column_result(col)?;
@@ -44,5 +44,5 @@ pub fn from_sql_derive(input: TokenStream) -> TokenStream {
             }
         }
     };
-    gen.into()
+    q.into()
 }

--- a/format-flowed/Cargo.toml
+++ b/format-flowed/Cargo.toml
@@ -2,7 +2,7 @@
 name = "format-flowed"
 version = "1.0.0"
 description = "format=flowed support"
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
 keywords = ["email"]

--- a/format-flowed/src/lib.rs
+++ b/format-flowed/src/lib.rs
@@ -78,11 +78,11 @@ pub fn format_flowed(text: &str) -> String {
 
         let mut prefix = prefix.to_string();
 
-        if quote_depth > 0 {
-            if let Some(s) = line.strip_prefix(' ') {
-                line = s;
-                prefix += " ";
-            }
+        if quote_depth > 0
+            && let Some(s) = line.strip_prefix(' ')
+        {
+            line = s;
+            prefix += " ";
         }
 
         result += &format_line_flowed(line, &prefix);
@@ -224,8 +224,7 @@ mod tests {
     fn test_unformat_flowed() {
         let text = "this is a very long message that should be wrapped using format=flowed and \n\
             unwrapped on the receiver";
-        let expected =
-            "this is a very long message that should be wrapped using format=flowed and \
+        let expected = "this is a very long message that should be wrapped using format=flowed and \
                         unwrapped on the receiver";
         assert_eq!(unformat_flowed(text, false), expected);
 
@@ -255,8 +254,7 @@ mod tests {
         assert_eq!(format_flowed_quote(quote), expected);
 
         let quote = "this is a very long quote that should be wrapped using format=flowed and unwrapped on the receiver";
-        let expected =
-            "> this is a very long quote that should be wrapped using format=flowed and \r\n\
+        let expected = "> this is a very long quote that should be wrapped using format=flowed and \r\n\
             > unwrapped on the receiver";
         assert_eq!(format_flowed_quote(quote), expected);
     }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "deltachat-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 license = "MPL-2.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Largest change in the FFI crate.
With 2024 (but not 2021) edition unsafe code
inside unsafe functions should be marked separately so we can mark exactly the code that is unsafe.
Some CFFI functions even have no unsafe code inside.

Most interesting change is that .strdup()
functions are not marked as unsafe anymore.
They are allocating memory and return raw pointers, but there is nothing unsafe about it.
Only using the returned raw pointers is unsafe.
This way calls to .strdup() don't have to be marked with unsafe{} blocks.