### PR TITLE
docs: remove oauth2 from standards

### DIFF
--- a/standards.md
+++ b/standards.md
@@ -14,7 +14,6 @@ Identify server folders          | IMAP LIST Extension ([RFC 6154][])
 Push                             | IMAP IDLE ([RFC 2177][])
 Quota                            | IMAP QUOTA extension ([RFC 2087][])
 Client/server identification     | IMAP ID extension ([RFC 2971][])
-Authorization                    | OAuth2 ([RFC 6749][])
 End-to-end encryption            | [Autocrypt Level 1][], OpenPGP ([RFC 4880][]), Security Multiparts for MIME ([RFC 1847][]) and [“Mixed Up” Encryption repairing](https://datatracker.ietf.org/doc/html/draft-dkg-openpgp-pgpmime-message-mangling-00)
 Detect/prevent active attacks    | [securejoin][] protocols
 Compare public keys              | [openpgp4fpr][] URI Scheme


### PR DESCRIPTION
this PR updates the docs to the recent removal of oauth2 support at https://github.com/chatmail/core/pull/8431