### PR TITLE
fix: Re-add oauth2 to serialized structs

### DIFF
--- a/deltachat-jsonrpc/src/api/types/login_param.rs
+++ b/deltachat-jsonrpc/src/api/types/login_param.rs
@@ -122,6 +122,7 @@ impl TryFrom<EnteredLoginParam> for dc::EnteredLoginParam {
                 password: param.smtp_password.unwrap_or_default(),
             },
             certificate_checks: param.certificate_checks.unwrap_or_default().into(),
+            oauth2: false,
         })
     }
 }

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -140,6 +140,10 @@ pub struct EnteredLoginParam {
     /// TLS options: whether to allow invalid certificates and/or
     /// invalid hostnames
     pub certificate_checks: EnteredCertificateChecks,
+
+    /// Deprecated, always false
+    #[serde(default)]
+    pub oauth2: bool,
 }
 
 impl EnteredLoginParam {
@@ -235,6 +239,7 @@ impl EnteredLoginParam {
                 password: send_pw,
             },
             certificate_checks,
+            oauth2: false,
         })
     }
 
@@ -396,6 +401,7 @@ mod tests {
                 password: "".to_string(),
             },
             certificate_checks: Default::default(),
+            oauth2: false,
         };
         param.save_legacy(&t).await?;
         assert_eq!(

--- a/src/login_param.rs
+++ b/src/login_param.rs
@@ -141,7 +141,7 @@ pub struct EnteredLoginParam {
     /// invalid hostnames
     pub certificate_checks: EnteredCertificateChecks,
 
-    /// Deprecated, always false
+    /// Deprecated 2026-07, always false
     #[serde(default)]
     pub oauth2: bool,
 }

--- a/src/qr.rs
+++ b/src/qr.rs
@@ -841,6 +841,7 @@ pub(crate) async fn login_param_from_account_qr(
             },
             smtp: Default::default(),
             certificate_checks: EnteredCertificateChecks::Strict,
+            oauth2: false,
         };
         return Ok(param);
     }
@@ -860,6 +861,7 @@ pub(crate) async fn login_param_from_account_qr(
             },
             smtp: Default::default(),
             certificate_checks: EnteredCertificateChecks::Strict,
+            oauth2: false,
         };
 
         Ok(param)

--- a/src/qr/dclogin_scheme.rs
+++ b/src/qr/dclogin_scheme.rs
@@ -196,6 +196,7 @@ pub(crate) fn login_param_from_login_qr(
                     password: smtp_password.unwrap_or_default(),
                 },
                 certificate_checks: certificate_checks.unwrap_or_default(),
+                oauth2: false,
             };
             Ok(param)
         }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -212,6 +212,9 @@ pub(crate) struct ConfiguredLoginParamJson {
     pub smtp_password: String,
 
     pub certificate_checks: ConfiguredCertificateChecks,
+
+    #[serde(default)]
+    pub oauth2: bool,
 }
 
 impl fmt::Display for ConfiguredLoginParam {
@@ -488,6 +491,7 @@ impl From<ConfiguredLoginParam> for ConfiguredLoginParamJson {
             smtp_password: configured_login_param.smtp_password,
 
             certificate_checks: configured_login_param.certificate_checks,
+            oauth2: false,
         }
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -213,6 +213,7 @@ pub(crate) struct ConfiguredLoginParamJson {
 
     pub certificate_checks: ConfiguredCertificateChecks,
 
+    /// Deprecated 2026-07, always false
     #[serde(default)]
     pub oauth2: bool,
 }

--- a/src/transport/transport_tests.rs
+++ b/src/transport/transport_tests.rs
@@ -52,7 +52,7 @@ async fn test_save_load_login_param() -> Result<()> {
         .clone()
         .save_to_transports_table(&t, &EnteredLoginParam::default(), time())
         .await?;
-    let expected_param = r#"{"addr":"alice@example.org","imap":[{"connection":{"host":"imap.example.com","port":123,"security":"Starttls"},"user":"alice"}],"imap_folder":"Folder","imap_user":"","imap_password":"foo","smtp":[{"connection":{"host":"smtp.example.com","port":456,"security":"Tls"},"user":"alice@example.org"}],"smtp_user":"","smtp_password":"bar","certificate_checks":"Strict"}"#;
+    let expected_param = r#"{"addr":"alice@example.org","imap":[{"connection":{"host":"imap.example.com","port":123,"security":"Starttls"},"user":"alice"}],"imap_folder":"Folder","imap_user":"","imap_password":"foo","smtp":[{"connection":{"host":"smtp.example.com","port":456,"security":"Tls"},"user":"alice@example.org"}],"smtp_user":"","smtp_password":"bar","certificate_checks":"Strict","oauth2":false}"#;
     assert_eq!(
         t.sql
             .query_get_value::<String>("SELECT configured_param FROM transports", ())


### PR DESCRIPTION
fix https://github.com/chatmail/core/issues/8463

Followup to https://github.com/chatmail/core/pull/8431: Re-dd `oauth2` to the two structs that serialized and sent over the wire. This solves an incompatibility problem where transports could not be synced to older versions of DC, and profiles could not be transferred, because the deserializer expected the field to be present.

I now added `#[serde(default)]`, so that with this PR, Delta Chat will be compatible with both v2.56 and with older versions.

Not tested yet.