### PR TITLE
fix: migrate transports configured on 2.56 to also have a oauth:false flag

### DIFF
--- a/src/sql/migrations.rs
+++ b/src/sql/migrations.rs
@@ -2506,6 +2506,20 @@ UPDATE msgs SET state=24 WHERE state=18; -- Change OutPreparing to OutFailed.
         .await?;
     }
 
+    inc_and_check(&mut migration_version, 159)?;
+    if dbversion < migration_version {
+        // Core 2.56.0 stored login parameters without the `oauth2` field,
+        // but older cores require it when deserializing.
+        // Set it to false as OAuth2 is not supported anymore.
+        sql.execute_migration(
+            "UPDATE transports
+             SET entered_param=json_set(entered_param, '$.oauth2', json('false')),
+                 configured_param=json_set(configured_param, '$.oauth2', json('false'))",
+            migration_version,
+        )
+        .await?;
+    }
+
     let new_version = sql
         .get_raw_config_int(VERSION_CFG)
         .await?

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -686,7 +686,7 @@ pub(crate) async fn add_pseudo_transport(context: &Context, addr: &str) -> Resul
             (
                 addr,
                 serde_json::to_string(&EnteredLoginParam{addr: addr.to_string(), ..Default::default()})?,
-                format!(r#"{{"addr":"{addr}","imap":[],"imap_user":"","imap_password":"","smtp":[],"smtp_user":"","smtp_password":"","certificate_checks":"Automatic"}}"#)
+                format!(r#"{{"addr":"{addr}","imap":[],"imap_user":"","imap_password":"","smtp":[],"smtp_user":"","smtp_password":"","certificate_checks":"Automatic","oauth2":false}}"#)
             ),
         )
         .await?;


### PR DESCRIPTION
also fix test setup to include the oauth:false flag

for json sqlite functions https://sqlite.org/json1.html#the_json_insert_json_replace_and_json_set_functions