### PR TITLE
fix(deltachat-rpc-client): don't depend on execnet for importing pytest plugin

### DIFF
--- a/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
+++ b/deltachat-rpc-client/src/deltachat_rpc_client/pytestplugin.py
@@ -11,8 +11,6 @@ import subprocess
 import sys
 from typing import AsyncGenerator, Optional
 
-import execnet
-import py
 import pytest
 
 from . import Account, AttrDict, Bot, Chat, Client, DeltaChat, EventType, Message
@@ -176,9 +174,9 @@ def data():
 
     class Data:
         def __init__(self) -> None:
-            for path in reversed(py.path.local(__file__).parts()):
-                datadir = path.join("test-data")
-                if datadir.isdir():
+            for path in pathlib.Path(__file__).parents:
+                datadir = path / "test-data"
+                if datadir.is_dir():
                     self.path = datadir
                     return
             raise Exception("Data path cannot be found")
@@ -274,10 +272,11 @@ def alice_and_remote_bob(tmp_path, acfactory, get_core_python_env):
     The 'eval' function allows to remote-execute arbitrary expressions
     that can use the `bob` online account, and the `bob_contact_alice`.
     """
+    from execnet import makegateway
 
     def factory(core_version):
         python, rpc_server_path = get_core_python_env(core_version)
-        gw = execnet.makegateway(f"popen//python={python}")
+        gw = makegateway(f"popen//python={python}")
 
         accounts_dir = str(tmp_path.joinpath("account1_venv1"))
         channel = gw.remote_exec(remote_bob_loop)


### PR DESCRIPTION
unsuspecting consumers will otherwise require execnet to run pytest with deltachat-rpc-client installed.
EDIT: also strike the minor last "import py" usage in the plugin (a library i once authored, and from which py.test came, the first version -- times they are changing) 