### PR TITLE
chore: disable "large futures" lint again

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
     clippy::cloned_instead_of_copied,
     clippy::manual_is_variant_and
 )]
-#![cfg_attr(not(test), warn(clippy::large_futures))]
 #![cfg_attr(not(test), warn(clippy::arithmetic_side_effects))]
 #![cfg_attr(not(test), forbid(clippy::indexing_slicing))]
 #![cfg_attr(not(test), forbid(clippy::string_slice))]


### PR DESCRIPTION
The lint is reasonable, but without some work
to bring the future sizes way below the limit,
this lint is frequently triggered in unrelated PRs that just add some local variables to async functions or extend some structure that is passed on the stack.