### PR TITLE
refactor: do not clean imap_send table on transport change

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -792,13 +792,12 @@ impl Context {
                                     "Failed to update add_timestamp for the new primary transport",
                                 )?;
 
-                            // Clean up SMTP and IMAP APPEND queue.
+                            // Clean up SMTP queue.
                             //
                             // The messages in the queue have a different
                             // From address so we cannot send them over
                             // the new SMTP transport.
                             transaction.execute("DELETE FROM smtp", ())?;
-                            transaction.execute("DELETE FROM imap_send", ())?;
 
                             Ok(())
                         })


### PR DESCRIPTION
imap_send table is not unused anymore
and should eventually be deleted.
It only exists for compatibility
and no other SQL statements use it anymore.