### PR TITLE
refactor: mark enabled ephemeral timer duration as NonZero

### DIFF
--- a/deltachat-jsonrpc/src/api/types/message.rs
+++ b/deltachat-jsonrpc/src/api/types/message.rs
@@ -726,9 +726,9 @@ impl From<deltachat::ephemeral::Timer> for EphemeralTimer {
     fn from(value: deltachat::ephemeral::Timer) -> Self {
         match value {
             deltachat::ephemeral::Timer::Disabled => EphemeralTimer::Disabled,
-            deltachat::ephemeral::Timer::Enabled { duration } => {
-                EphemeralTimer::Enabled { duration }
-            }
+            deltachat::ephemeral::Timer::Enabled { duration } => EphemeralTimer::Enabled {
+                duration: duration.get(),
+            },
         }
     }
 }

--- a/src/chat.rs
+++ b/src/chat.rs
@@ -1899,7 +1899,7 @@ impl Chat {
         };
         let ephemeral_timestamp = match ephemeral_timer {
             EphemeralTimer::Disabled => 0,
-            EphemeralTimer::Enabled { duration } => time().saturating_add(duration.into()),
+            EphemeralTimer::Enabled { duration } => time().saturating_add(duration.get().into()),
         };
 
         let (msg_text, was_truncated) = truncate_msg_text(context, msg.text.clone()).await?;

--- a/src/chat/chat_tests.rs
+++ b/src/chat/chat_tests.rs
@@ -1,4 +1,6 @@
+use std::num::NonZero;
 use std::sync::Arc;
+use std::time::Duration;
 
 use super::*;
 use crate::Event;
@@ -21,7 +23,6 @@ use crate::test_utils::{
 };
 use crate::tools::SystemTime;
 use pretty_assertions::assert_eq;
-use std::time::Duration;
 use strum::IntoEnumIterator;
 use tokio::fs;
 
@@ -5417,7 +5418,12 @@ async fn test_info_contact_id() -> Result<()> {
     .await?;
 
     alice_chat_id
-        .set_ephemeral_timer(alice, Timer::Enabled { duration: 60 })
+        .set_ephemeral_timer(
+            alice,
+            Timer::Enabled {
+                duration: NonZero::new(60).unwrap(),
+            },
+        )
         .await?;
     pop_recv_and_check(
         alice,

--- a/src/ephemeral.rs
+++ b/src/ephemeral.rs
@@ -63,7 +63,7 @@
 
 use std::collections::BTreeSet;
 use std::fmt;
-use std::num::ParseIntError;
+use std::num::{NonZero, ParseIntError};
 use std::str::FromStr;
 use std::time::{Duration, UNIX_EPOCH};
 
@@ -96,9 +96,7 @@ pub enum Timer {
     /// Timer is enabled.
     Enabled {
         /// Timer duration in seconds.
-        ///
-        /// The value cannot be 0.
-        duration: u32,
+        duration: NonZero<u32>,
     },
 }
 
@@ -109,7 +107,7 @@ impl Timer {
     pub fn to_u32(self) -> u32 {
         match self {
             Self::Disabled => 0,
-            Self::Enabled { duration } => duration,
+            Self::Enabled { duration } => duration.get(),
         }
     }
 
@@ -117,10 +115,10 @@ impl Timer {
     ///
     /// 0 value is treated as disabled timer.
     pub fn from_u32(duration: u32) -> Self {
-        if duration == 0 {
-            Self::Disabled
-        } else {
+        if let Some(duration) = NonZero::<u32>::new(duration) {
             Self::Enabled { duration }
+        } else {
+            Self::Disabled
         }
     }
 }
@@ -143,7 +141,7 @@ impl rusqlite::types::ToSql for Timer {
     fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
         let val = rusqlite::types::Value::Integer(match self {
             Self::Disabled => 0,
-            Self::Enabled { duration } => i64::from(*duration),
+            Self::Enabled { duration } => i64::from(duration.get()),
         });
         let out = rusqlite::types::ToSqlOutput::Owned(val);
         Ok(out)
@@ -152,15 +150,7 @@ impl rusqlite::types::ToSql for Timer {
 
 impl rusqlite::types::FromSql for Timer {
     fn column_result(value: rusqlite::types::ValueRef) -> rusqlite::types::FromSqlResult<Self> {
-        i64::column_result(value).and_then(|value| {
-            if value == 0 {
-                Ok(Self::Disabled)
-            } else if let Ok(duration) = u32::try_from(value) {
-                Ok(Self::Enabled { duration })
-            } else {
-                Err(rusqlite::types::FromSqlError::OutOfRange(value))
-            }
-        })
+        u32::column_result(value).map(Self::from_u32)
     }
 }
 
@@ -239,47 +229,53 @@ pub(crate) async fn stock_ephemeral_timer_changed(
 ) -> String {
     match timer {
         Timer::Disabled => stock_str::msg_ephemeral_timer_disabled(context, from_id).await,
-        Timer::Enabled { duration } => match duration {
-            0..=60 => {
-                stock_str::msg_ephemeral_timer_enabled(context, &timer.to_string(), from_id).await
+        Timer::Enabled { duration } => {
+            let duration = duration.get();
+            match duration {
+                1..=60 => {
+                    stock_str::msg_ephemeral_timer_enabled(context, &timer.to_string(), from_id)
+                        .await
+                }
+                61..=3599 => {
+                    stock_str::msg_ephemeral_timer_minutes(
+                        context,
+                        &format!("{}", (f64::from(duration) / 6.0).round() / 10.0),
+                        from_id,
+                    )
+                    .await
+                }
+                3600 => stock_str::msg_ephemeral_timer_hour(context, from_id).await,
+                3601..=86399 => {
+                    stock_str::msg_ephemeral_timer_hours(
+                        context,
+                        &format!("{}", (f64::from(duration) / 360.0).round() / 10.0),
+                        from_id,
+                    )
+                    .await
+                }
+                86400 => stock_str::msg_ephemeral_timer_day(context, from_id).await,
+                86401..=604_799 => {
+                    stock_str::msg_ephemeral_timer_days(
+                        context,
+                        &format!("{}", (f64::from(duration) / 8640.0).round() / 10.0),
+                        from_id,
+                    )
+                    .await
+                }
+                604_800 => stock_str::msg_ephemeral_timer_week(context, from_id).await,
+                31_536_000..=31_708_800 => {
+                    stock_str::msg_ephemeral_timer_year(context, from_id).await
+                }
+                _ => {
+                    stock_str::msg_ephemeral_timer_weeks(
+                        context,
+                        &format!("{}", (f64::from(duration) / 60480.0).round() / 10.0),
+                        from_id,
+                    )
+                    .await
+                }
             }
-            61..=3599 => {
-                stock_str::msg_ephemeral_timer_minutes(
-                    context,
-                    &format!("{}", (f64::from(duration) / 6.0).round() / 10.0),
-                    from_id,
-                )
-                .await
-            }
-            3600 => stock_str::msg_ephemeral_timer_hour(context, from_id).await,
-            3601..=86399 => {
-                stock_str::msg_ephemeral_timer_hours(
-                    context,
-                    &format!("{}", (f64::from(duration) / 360.0).round() / 10.0),
-                    from_id,
-                )
-                .await
-            }
-            86400 => stock_str::msg_ephemeral_timer_day(context, from_id).await,
-            86401..=604_799 => {
-                stock_str::msg_ephemeral_timer_days(
-                    context,
-                    &format!("{}", (f64::from(duration) / 8640.0).round() / 10.0),
-                    from_id,
-                )
-                .await
-            }
-            604_800 => stock_str::msg_ephemeral_timer_week(context, from_id).await,
-            31_536_000..=31_708_800 => stock_str::msg_ephemeral_timer_year(context, from_id).await,
-            _ => {
-                stock_str::msg_ephemeral_timer_weeks(
-                    context,
-                    &format!("{}", (f64::from(duration) / 60480.0).round() / 10.0),
-                    from_id,
-                )
-                .await
-            }
-        },
+        }
     }
 }
 
@@ -291,8 +287,8 @@ impl MsgId {
             .query_get_value("SELECT ephemeral_timer FROM msgs WHERE id=?", (self,))
             .await?
         {
-            None | Some(0) => Timer::Disabled,
-            Some(duration) => Timer::Enabled { duration },
+            None => Timer::Disabled,
+            Some(duration) => Timer::from_u32(duration),
         };
         Ok(res)
     }
@@ -300,7 +296,7 @@ impl MsgId {
     /// Starts ephemeral message timer for the message if it is not started yet.
     pub(crate) async fn start_ephemeral_timer(self, context: &Context) -> Result<()> {
         if let Timer::Enabled { duration } = self.ephemeral_timer(context).await? {
-            let ephemeral_timestamp = time().saturating_add(duration.into());
+            let ephemeral_timestamp = time().saturating_add(duration.get().into());
 
             context
                 .sql

--- a/src/ephemeral/ephemeral_tests.rs
+++ b/src/ephemeral/ephemeral_tests.rs
@@ -16,6 +16,15 @@ use crate::{
     tools::IsNoneOrEmpty,
 };
 
+/// Test helper to construct `Timer::Enabled`.
+///
+/// Panics if the value is zero as `Timer::Disabled` should be used instead.
+fn enabled(value: u32) -> Timer {
+    Timer::Enabled {
+        duration: NonZero::new(value).expect("Timer value cannot be zero"),
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_stock_ephemeral_messages() {
     let context = TestContext::new().await;
@@ -26,101 +35,52 @@ async fn test_stock_ephemeral_messages() {
     );
 
     assert_eq!(
-        stock_ephemeral_timer_changed(&context, Timer::Enabled { duration: 1 }, ContactId::SELF)
-            .await,
+        stock_ephemeral_timer_changed(&context, enabled(1), ContactId::SELF).await,
         "You set message deletion timer to 1 s."
     );
     assert_eq!(
-        stock_ephemeral_timer_changed(&context, Timer::Enabled { duration: 30 }, ContactId::SELF)
-            .await,
+        stock_ephemeral_timer_changed(&context, enabled(30), ContactId::SELF).await,
         "You set message deletion timer to 30 s."
     );
     assert_eq!(
-        stock_ephemeral_timer_changed(&context, Timer::Enabled { duration: 60 }, ContactId::SELF)
-            .await,
+        stock_ephemeral_timer_changed(&context, enabled(60), ContactId::SELF).await,
         "You set message deletion timer to 60 s."
     );
     assert_eq!(
-        stock_ephemeral_timer_changed(&context, Timer::Enabled { duration: 90 }, ContactId::SELF)
-            .await,
+        stock_ephemeral_timer_changed(&context, enabled(90), ContactId::SELF).await,
         "You set message deletion timer to 1.5 minutes."
     );
     assert_eq!(
-        stock_ephemeral_timer_changed(
-            &context,
-            Timer::Enabled { duration: 30 * 60 },
-            ContactId::SELF
-        )
-        .await,
+        stock_ephemeral_timer_changed(&context, enabled(30 * 60), ContactId::SELF).await,
         "You set message deletion timer to 30 minutes."
     );
     assert_eq!(
-        stock_ephemeral_timer_changed(
-            &context,
-            Timer::Enabled { duration: 60 * 60 },
-            ContactId::SELF
-        )
-        .await,
+        stock_ephemeral_timer_changed(&context, enabled(60 * 60), ContactId::SELF).await,
         "You set message deletion timer to 1 hour."
     );
     assert_eq!(
-        stock_ephemeral_timer_changed(&context, Timer::Enabled { duration: 5400 }, ContactId::SELF)
-            .await,
+        stock_ephemeral_timer_changed(&context, enabled(5400), ContactId::SELF).await,
         "You set message deletion timer to 1.5 hours."
     );
     assert_eq!(
-        stock_ephemeral_timer_changed(
-            &context,
-            Timer::Enabled {
-                duration: 2 * 60 * 60
-            },
-            ContactId::SELF
-        )
-        .await,
+        stock_ephemeral_timer_changed(&context, enabled(2 * 60 * 60), ContactId::SELF).await,
         "You set message deletion timer to 2 hours."
     );
     assert_eq!(
-        stock_ephemeral_timer_changed(
-            &context,
-            Timer::Enabled {
-                duration: 24 * 60 * 60
-            },
-            ContactId::SELF
-        )
-        .await,
+        stock_ephemeral_timer_changed(&context, enabled(24 * 60 * 60), ContactId::SELF).await,
         "You set message deletion timer to 1 day."
     );
     assert_eq!(
-        stock_ephemeral_timer_changed(
-            &context,
-            Timer::Enabled {
-                duration: 2 * 24 * 60 * 60
-            },
-            ContactId::SELF
-        )
-        .await,
+        stock_ephemeral_timer_changed(&context, enabled(2 * 24 * 60 * 60), ContactId::SELF).await,
         "You set message deletion timer to 2 days."
     );
     assert_eq!(
-        stock_ephemeral_timer_changed(
-            &context,
-            Timer::Enabled {
-                duration: 7 * 24 * 60 * 60
-            },
-            ContactId::SELF
-        )
-        .await,
+        stock_ephemeral_timer_changed(&context, enabled(7 * 24 * 60 * 60), ContactId::SELF).await,
         "You set message deletion timer to 1 week."
     );
     assert_eq!(
-        stock_ephemeral_timer_changed(
-            &context,
-            Timer::Enabled {
-                duration: 4 * 7 * 24 * 60 * 60
-            },
-            ContactId::SELF
-        )
-        .await,
+        stock_ephemeral_timer_changed(&context, enabled(4 * 7 * 24 * 60 * 60), ContactId::SELF)
+            .await,
         "You set message deletion timer to 4 weeks."
     );
 }
@@ -135,19 +95,14 @@ async fn test_ephemeral_enable_disable() -> Result<()> {
     let chat_alice = alice.create_chat(bob).await.id;
     let chat_bob = bob.create_chat(alice).await.id;
 
-    chat_alice
-        .set_ephemeral_timer(alice, Timer::Enabled { duration: 60 })
-        .await?;
+    chat_alice.set_ephemeral_timer(alice, enabled(60)).await?;
     let sent = alice.pop_sent_msg().await;
     let bob_received_message = bob.recv_msg(&sent).await;
     assert_eq!(
         bob_received_message.text,
         "Message deletion timer is set to 60 s by alice@example.org."
     );
-    assert_eq!(
-        chat_bob.get_ephemeral_timer(bob).await?,
-        Timer::Enabled { duration: 60 }
-    );
+    assert_eq!(chat_bob.get_ephemeral_timer(bob).await?, enabled(60));
 
     chat_alice
         .set_ephemeral_timer(alice, Timer::Disabled)
@@ -168,15 +123,10 @@ async fn test_ephemeral_unpromoted() -> Result<()> {
 
     // Group is unpromoted, the timer can be changed without sending a message.
     assert!(chat_id.is_unpromoted(&alice).await?);
-    chat_id
-        .set_ephemeral_timer(&alice, Timer::Enabled { duration: 60 })
-        .await?;
+    chat_id.set_ephemeral_timer(&alice, enabled(60)).await?;
     let sent = alice.pop_sent_msg_opt().await;
     assert!(sent.is_none());
-    assert_eq!(
-        chat_id.get_ephemeral_timer(&alice).await?,
-        Timer::Enabled { duration: 60 }
-    );
+    assert_eq!(chat_id.get_ephemeral_timer(&alice).await?, enabled(60));
 
     // Promote the group.
     send_text_msg(&alice, chat_id, "hi!".to_string()).await?;
@@ -205,11 +155,11 @@ async fn test_ephemeral_enable_lost() -> Result<()> {
 
     // Alice enables the timer.
     chat_alice
-        .set_ephemeral_timer(&alice.ctx, Timer::Enabled { duration: 60 })
+        .set_ephemeral_timer(&alice.ctx, enabled(60))
         .await?;
     assert_eq!(
         chat_alice.get_ephemeral_timer(&alice.ctx).await?,
-        Timer::Enabled { duration: 60 }
+        enabled(60)
     );
     // The message enabling the timer is lost.
     let _sent = alice.pop_sent_msg().await;
@@ -226,10 +176,7 @@ async fn test_ephemeral_enable_lost() -> Result<()> {
     // Bob receives text message and enables the timer, even though explicit timer update was
     // lost previously.
     bob.recv_msg(&sent).await;
-    assert_eq!(
-        chat_bob.get_ephemeral_timer(&bob.ctx).await?,
-        Timer::Enabled { duration: 60 }
-    );
+    assert_eq!(chat_bob.get_ephemeral_timer(&bob.ctx).await?, enabled(60));
 
     Ok(())
 }
@@ -261,15 +208,10 @@ async fn test_ephemeral_timer_rollback() -> Result<()> {
     );
 
     // Bob sets ephemeral timer and sends a message about timer change
-    chat_bob
-        .set_ephemeral_timer(&bob.ctx, Timer::Enabled { duration: 60 })
-        .await?;
+    chat_bob.set_ephemeral_timer(&bob.ctx, enabled(60)).await?;
     let sent_timer_change = bob.pop_sent_msg().await;
 
-    assert_eq!(
-        chat_bob.get_ephemeral_timer(&bob.ctx).await?,
-        Timer::Enabled { duration: 60 }
-    );
+    assert_eq!(chat_bob.get_ephemeral_timer(&bob.ctx).await?, enabled(60));
 
     // Bob receives message from Alice.
     // Alice message has no timer. However, Bob should not disable timer,
@@ -280,17 +222,14 @@ async fn test_ephemeral_timer_rollback() -> Result<()> {
         chat_alice.get_ephemeral_timer(&alice.ctx).await?,
         Timer::Disabled
     );
-    assert_eq!(
-        chat_bob.get_ephemeral_timer(&bob.ctx).await?,
-        Timer::Enabled { duration: 60 }
-    );
+    assert_eq!(chat_bob.get_ephemeral_timer(&bob.ctx).await?, enabled(60));
 
     // Alice receives message from Bob
     alice.recv_msg(&sent_timer_change).await;
 
     assert_eq!(
         chat_alice.get_ephemeral_timer(&alice.ctx).await?,
-        Timer::Enabled { duration: 60 }
+        enabled(60)
     );
 
     // Bob disables the chat timer.
@@ -325,7 +264,7 @@ async fn test_ephemeral_delete_msgs() -> Result<()> {
 
     self_chat
         .id
-        .set_ephemeral_timer(t, Timer::Enabled { duration: 3600 })
+        .set_ephemeral_timer(t, enabled(3600))
         .await
         .unwrap();
 
@@ -360,10 +299,7 @@ async fn test_ephemeral_delete_msgs() -> Result<()> {
 
     // Enable ephemeral messages with Bob -> message will be deleted after 60s.
     // This tests that the message is deleted at min(ephemeral deletion time, DeleteDeviceAfter deletion time).
-    bob_chat
-        .id
-        .set_ephemeral_timer(t, Timer::Enabled { duration: 60 })
-        .await?;
+    bob_chat.id.set_ephemeral_timer(t, enabled(60)).await?;
 
     let now = time();
     let msg = t.send_text(bob_chat.id, "Message text").await;
@@ -678,10 +614,7 @@ async fn test_ephemeral_timer_references() -> Result<()> {
     )
     .await?;
     receive_imf(alice, encrypted_msg.as_bytes(), false).await?;
-    assert_eq!(
-        chat_id.get_ephemeral_timer(alice).await?,
-        Timer::Enabled { duration: 60 }
-    );
+    assert_eq!(chat_id.get_ephemeral_timer(alice).await?, enabled(60));
     let msg = alice.get_last_msg().await;
 
     // Message is deleted when its timer expires.
@@ -736,7 +669,7 @@ async fn test_ephemeral_msg_offline() -> Result<()> {
     let chat = alice.create_chat(bob).await;
     let duration = 60;
     chat.id
-        .set_ephemeral_timer(alice, Timer::Enabled { duration })
+        .set_ephemeral_timer(alice, enabled(duration))
         .await?;
     let mut msg = Message::new_text("hi".to_string());
     assert!(chat::send_msg_sync(alice, chat.id, &mut msg).await.is_err());
@@ -760,7 +693,7 @@ async fn test_ephemeral_poi_location() -> Result<()> {
 
     let duration = 60;
     chat.id
-        .set_ephemeral_timer(alice, Timer::Enabled { duration })
+        .set_ephemeral_timer(alice, enabled(duration))
         .await?;
     let sent = alice.pop_sent_msg().await;
     bob.recv_msg(&sent).await;
@@ -808,7 +741,7 @@ async fn test_noticed_ephemeral_timer() -> Result<()> {
     let chat = alice.create_chat(bob).await;
     let duration = 60;
     chat.id
-        .set_ephemeral_timer(alice, Timer::Enabled { duration })
+        .set_ephemeral_timer(alice, enabled(duration))
         .await?;
     let bob_received_message = tcm.send_recv(alice, bob, "Hello!").await;
 
@@ -835,7 +768,7 @@ async fn test_archived_ephemeral_timer() -> Result<()> {
     let chat = alice.create_chat(bob).await;
     let duration = 60;
     chat.id
-        .set_ephemeral_timer(alice, Timer::Enabled { duration })
+        .set_ephemeral_timer(alice, enabled(duration))
         .await?;
     let bob_received_message = tcm.send_recv(alice, bob, "Hello!").await;
 
@@ -892,9 +825,7 @@ async fn test_ephemeral_timer_non_member() -> Result<()> {
 
     // Bob wants to modify the timer.
     bob_chat_id.accept(bob).await?;
-    bob_chat_id
-        .set_ephemeral_timer(bob, Timer::Enabled { duration: 60 })
-        .await?;
+    bob_chat_id.set_ephemeral_timer(bob, enabled(60)).await?;
     let sent_ephemeral_timer_change = bob.pop_sent_msg().await;
 
     // Alice removes Bob before receiving the timer change.
@@ -922,7 +853,7 @@ async fn test_disappearing_unknown_viewtype() -> Result<()> {
 
     let duration = 60;
     chat.id
-        .set_ephemeral_timer(alice, Timer::Enabled { duration })
+        .set_ephemeral_timer(alice, enabled(duration))
         .await?;
 
     let mut msg = Message::new_text("Expiring message".to_string());

--- a/src/events/chatlist_events.rs
+++ b/src/events/chatlist_events.rs
@@ -58,11 +58,9 @@ pub(crate) fn emit_chatlist_items_changed_for_contact(context: &Context, _contac
 /// does not check for excess/too-many events
 #[cfg(test)]
 mod test_chatlist_events {
-
-    use std::{
-        sync::atomic::{AtomicBool, Ordering},
-        time::Duration,
-    };
+    use std::num::NonZero;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
 
     use crate::{
         EventType,
@@ -500,8 +498,13 @@ mod test_chatlist_events {
         let mut tcm = TestContextManager::new();
         let alice = tcm.alice().await;
         let chat = create_group(&alice, "My Group").await?;
-        chat.set_ephemeral_timer(&alice, crate::ephemeral::Timer::Enabled { duration: 60 })
-            .await?;
+        chat.set_ephemeral_timer(
+            &alice,
+            crate::ephemeral::Timer::Enabled {
+                duration: NonZero::new(60).unwrap(),
+            },
+        )
+        .await?;
         alice
             .evtracker
             .get_matching(|evt| matches!(evt, EventType::ChatEphemeralTimerModified { .. }))

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -2169,9 +2169,9 @@ async fn add_parts(
         } else {
             match ephemeral_timer {
                 EphemeralTimer::Disabled => 0,
-                EphemeralTimer::Enabled { duration } => {
-                    mime_parser.timestamp_rcvd.saturating_add(duration.into())
-                }
+                EphemeralTimer::Enabled { duration } => mime_parser
+                    .timestamp_rcvd
+                    .saturating_add(duration.get().into()),
             }
         };
 


### PR DESCRIPTION
Now the type system ensures that Timer::Enabled
never stores 0 value inside accidentally,
it is impossible to put 0 there without unsafe code.