### PR TITLE
api(ffi): store reference-counted Context in dc_msg_t, dc_contact_t and dc_chatlist_t

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3559,16 +3559,6 @@ dc_lot_t*        dc_chatlist_get_summary2    (dc_context_t* context, uint32_t ch
 
 
 /**
- * Helper function to get the associated context object.
- *
- * @memberof dc_chatlist_t
- * @param chatlist The chatlist object to empty.
- * @return The context object associated with the chatlist. NULL if none or on errors.
- */
-dc_context_t*    dc_chatlist_get_context     (dc_chatlist_t* chatlist);
-
-
-/**
  * Get info summary for a chat, in JSON format.
  *
  * The returned JSON string has the following key/values:

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -909,7 +909,7 @@ pub unsafe extern "C" fn dc_get_chatlist(
         eprintln!("ignoring careless call to dc_get_chatlist()");
         return ptr::null_mut();
     }
-    let ctx = unsafe { &*context };
+    let context = unsafe { &*context };
     let qs = to_opt_string_lossy(query_str);
 
     let qi = if query_id == 0 {
@@ -919,16 +919,19 @@ pub unsafe extern "C" fn dc_get_chatlist(
     };
 
     match block_on(chatlist::Chatlist::try_load(
-        ctx,
+        context,
         flags as usize,
         qs.as_deref(),
         qi,
     ))
     .context("Failed to get chatlist")
-    .log_err(ctx)
+    .log_err(context)
     {
         Ok(list) => {
-            let ffi_list = ChatlistWrapper { context, list };
+            let ffi_list = ChatlistWrapper {
+                context: context.clone(),
+                list,
+            };
             Box::into_raw(Box::new(ffi_list))
         }
         Err(_) => ptr::null_mut(),
@@ -1353,15 +1356,18 @@ pub unsafe extern "C" fn dc_get_similar_chatlist(
         eprintln!("ignoring careless call to dc_get_similar_chatlist()");
         return ptr::null_mut();
     }
-    let ctx = unsafe { &*context };
+    let context = unsafe { &*context };
 
     let chat_id = ChatId::new(chat_id);
-    match block_on(chat_id.get_similar_chatlist(ctx))
+    match block_on(chat_id.get_similar_chatlist(context))
         .context("failed to get similar chatlist")
-        .log_err(ctx)
+        .log_err(context)
     {
         Ok(list) => {
-            let ffi_list = ChatlistWrapper { context, list };
+            let ffi_list = ChatlistWrapper {
+                context: context.clone(),
+                list,
+            };
             Box::into_raw(Box::new(ffi_list))
         }
         Err(_) => ptr::null_mut(),
@@ -2750,7 +2756,7 @@ pub unsafe extern "C" fn dc_array_is_independent(
 /// context, but the Rust API does not, so the FFI layer needs to glue
 /// these together.
 pub struct ChatlistWrapper {
-    context: *const dc_context_t,
+    context: Context,
     list: chatlist::Chatlist,
 }
 
@@ -2786,12 +2792,11 @@ pub unsafe extern "C" fn dc_chatlist_get_chat_id(
         return 0;
     }
     let ffi_list = unsafe { &*chatlist };
-    let ctx = unsafe { &*ffi_list.context };
     match ffi_list
         .list
         .get_chat_id(index)
         .context("get_chat_id failed")
-        .log_err(ctx)
+        .log_err(&ffi_list.context)
     {
         Ok(chat_id) => chat_id.to_u32(),
         Err(_) => 0,
@@ -2808,12 +2813,11 @@ pub unsafe extern "C" fn dc_chatlist_get_msg_id(
         return 0;
     }
     let ffi_list = unsafe { &*chatlist };
-    let ctx = unsafe { &*ffi_list.context };
     match ffi_list
         .list
         .get_msg_id(index)
         .context("get_msg_id failed")
-        .log_err(ctx)
+        .log_err(&ffi_list.context)
     {
         Ok(msg_id) => msg_id.map_or(0, |msg_id| msg_id.to_u32()),
         Err(_) => 0,
@@ -2837,12 +2841,15 @@ pub unsafe extern "C" fn dc_chatlist_get_summary(
         Some(&ffi_chat.chat)
     };
     let ffi_list = unsafe { &*chatlist };
-    let ctx = unsafe { &*ffi_list.context };
 
-    let summary = block_on(ffi_list.list.get_summary(ctx, index, maybe_chat))
-        .context("get_summary failed")
-        .log_err(ctx)
-        .unwrap_or_default();
+    let summary = block_on(
+        ffi_list
+            .list
+            .get_summary(&ffi_list.context, index, maybe_chat),
+    )
+    .context("get_summary failed")
+    .log_err(&ffi_list.context)
+    .unwrap_or_default();
     Box::into_raw(Box::new(summary.into()))
 }
 

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -1216,7 +1216,7 @@ pub unsafe extern "C" fn dc_set_draft(
     let msg = if msg.is_null() {
         None
     } else {
-        let ffi_msg: &mut MessageWrapper = unsafe { &mut *msg };
+        let ffi_msg = unsafe { &mut *msg };
         Some(&mut ffi_msg.message)
     };
 
@@ -1238,7 +1238,7 @@ pub unsafe extern "C" fn dc_add_device_msg(
     let msg = if msg.is_null() {
         None
     } else {
-        let ffi_msg: &mut MessageWrapper = unsafe { &mut *msg };
+        let ffi_msg = unsafe { &mut *msg };
         Some(&mut ffi_msg.message)
     };
 
@@ -1275,15 +1275,15 @@ pub unsafe extern "C" fn dc_get_draft(context: *mut dc_context_t, chat_id: u32) 
         eprintln!("ignoring careless call to dc_get_draft()");
         return ptr::null_mut(); // NULL explicitly defined as "no draft"
     }
-    let ctx = unsafe { &*context };
+    let context = unsafe { &*context };
 
-    match block_on(ChatId::new(chat_id).get_draft(ctx))
+    match block_on(ChatId::new(chat_id).get_draft(context))
         .with_context(|| format!("Failed to get draft for chat #{chat_id}"))
         .unwrap_or_default()
     {
         Some(draft) => {
             let ffi_msg = MessageWrapper {
-                context,
+                context: context.clone(),
                 message: draft,
             };
             Box::into_raw(Box::new(ffi_msg))
@@ -2027,11 +2027,11 @@ pub unsafe extern "C" fn dc_get_msg(context: *mut dc_context_t, msg_id: u32) -> 
         eprintln!("ignoring careless call to dc_get_msg()");
         return ptr::null_mut();
     }
-    let ctx = unsafe { &*context };
+    let context = unsafe { &*context };
 
-    let message = match block_on(message::Message::load_from_db(ctx, MsgId::new(msg_id)))
+    let message = match block_on(message::Message::load_from_db(context, MsgId::new(msg_id)))
         .with_context(|| format!("dc_get_msg could not rectieve msg_id {msg_id}"))
-        .log_err(ctx)
+        .log_err(context)
     {
         Ok(msg) => msg,
         Err(_) => {
@@ -2043,7 +2043,10 @@ pub unsafe extern "C" fn dc_get_msg(context: *mut dc_context_t, msg_id: u32) -> 
             }
         }
     };
-    let ffi_msg = MessageWrapper { context, message };
+    let ffi_msg = MessageWrapper {
+        context: context.clone(),
+        message,
+    };
     Box::into_raw(Box::new(ffi_msg))
 }
 
@@ -3141,7 +3144,7 @@ pub unsafe extern "C" fn dc_chat_get_info_json(
 /// context, but the Rust API does not, so the FFI layer needs to glue
 /// these together.
 pub struct MessageWrapper {
-    context: *const dc_context_t,
+    context: Context,
     message: message::Message,
 }
 
@@ -3159,7 +3162,7 @@ pub unsafe extern "C" fn dc_msg_new(
     let context = unsafe { &*context };
     let viewtype = from_prim(viewtype).expect(&format!("invalid viewtype = {viewtype}"));
     let msg = MessageWrapper {
-        context,
+        context: context.clone(),
         message: message::Message::new(viewtype),
     };
     Box::into_raw(Box::new(msg))
@@ -3296,10 +3299,9 @@ pub unsafe extern "C" fn dc_msg_get_file(msg: *mut dc_msg_t) -> *mut libc::c_cha
         return "".strdup();
     }
     let ffi_msg = unsafe { &*msg };
-    let ctx = unsafe { &*ffi_msg.context };
     ffi_msg
         .message
-        .get_file(ctx)
+        .get_file(&ffi_msg.context)
         .map(|p| p.to_string_lossy().strdup())
         .unwrap_or_else(|| "".strdup())
 }
@@ -3314,18 +3316,17 @@ pub unsafe extern "C" fn dc_msg_save_file(
         return 0;
     }
     let ffi_msg = unsafe { &*msg };
-    let ctx = unsafe { &*ffi_msg.context };
     let path = to_string_lossy(path);
     let r = block_on(
         ffi_msg
             .message
-            .save_file(ctx, &std::path::PathBuf::from(path)),
+            .save_file(&ffi_msg.context, &std::path::PathBuf::from(path)),
     );
     match r {
         Ok(()) => 1,
         Err(_) => {
             r.context("Failed to save file from message")
-                .log_err(ctx)
+                .log_err(&ffi_msg.context)
                 .unwrap_or_default();
             0
         }
@@ -3353,13 +3354,11 @@ pub unsafe extern "C" fn dc_msg_get_webxdc_blob(
         return ptr::null_mut();
     }
     let ffi_msg = unsafe { &*msg };
-    let ctx = unsafe { &*ffi_msg.context };
-    let blob = block_on(async move {
+    let blob = block_on(
         ffi_msg
             .message
-            .get_webxdc_blob(ctx, &to_string_lossy(filename))
-            .await
-    });
+            .get_webxdc_blob(&ffi_msg.context, &to_string_lossy(filename)),
+    );
     match blob {
         Ok(blob) => unsafe {
             *ret_bytes = blob.len();
@@ -3381,16 +3380,18 @@ pub unsafe extern "C" fn dc_msg_get_webxdc_info(msg: *mut dc_msg_t) -> *mut libc
         return "".strdup();
     }
     let ffi_msg = unsafe { &*msg };
-    let ctx = unsafe { &*ffi_msg.context };
 
-    let Ok(info) = block_on(ffi_msg.message.get_webxdc_info(ctx))
+    let Ok(info) = block_on(ffi_msg.message.get_webxdc_info(&ffi_msg.context))
         .context("dc_msg_get_webxdc_info() failed to get info")
-        .log_err(ctx)
+        .log_err(&ffi_msg.context)
     else {
         return "".strdup();
     };
     serde_json::to_string(&info)
-        .unwrap_or_log_default(ctx, "dc_msg_get_webxdc_info() failed to serialise to json")
+        .unwrap_or_log_default(
+            &ffi_msg.context,
+            "dc_msg_get_webxdc_info() failed to serialise to json",
+        )
         .strdup()
 }
 
@@ -3415,10 +3416,9 @@ pub unsafe extern "C" fn dc_msg_get_filebytes(msg: *mut dc_msg_t) -> u64 {
         return 0;
     }
     let ffi_msg = unsafe { &*msg };
-    let ctx = unsafe { &*ffi_msg.context };
 
-    block_on(ffi_msg.message.get_filebytes(ctx))
-        .unwrap_or_log_default(ctx, "Cannot get file size")
+    block_on(ffi_msg.message.get_filebytes(&ffi_msg.context))
+        .unwrap_or_log_default(&ffi_msg.context, "Cannot get file size")
         .unwrap_or_default()
 }
 
@@ -3508,11 +3508,10 @@ pub unsafe extern "C" fn dc_msg_get_summary(
         Some(&ffi_chat.chat)
     };
     let ffi_msg = unsafe { &mut *msg };
-    let ctx = unsafe { &*ffi_msg.context };
 
-    let summary = block_on(ffi_msg.message.get_summary(ctx, maybe_chat))
+    let summary = block_on(ffi_msg.message.get_summary(&ffi_msg.context, maybe_chat))
         .context("dc_msg_get_summary failed")
-        .log_err(ctx)
+        .log_err(&ffi_msg.context)
         .unwrap_or_default();
     Box::into_raw(Box::new(summary.into()))
 }
@@ -3527,11 +3526,10 @@ pub unsafe extern "C" fn dc_msg_get_summarytext(
         return "".strdup();
     }
     let ffi_msg = unsafe { &mut *msg };
-    let ctx = unsafe { &*ffi_msg.context };
 
-    let summary = block_on(ffi_msg.message.get_summary(ctx, None))
+    let summary = block_on(ffi_msg.message.get_summary(&ffi_msg.context, None))
         .context("dc_msg_get_summarytext failed")
-        .log_err(ctx)
+        .log_err(&ffi_msg.context)
         .unwrap_or_default();
     match usize::try_from(approx_characters) {
         Ok(chars) => summary.truncated_text(chars).strdup(),
@@ -3627,8 +3625,7 @@ pub unsafe extern "C" fn dc_msg_get_info_contact_id(msg: *mut dc_msg_t) -> u32 {
         return 0;
     }
     let ffi_msg = unsafe { &*msg };
-    let context = unsafe { &*ffi_msg.context };
-    block_on(ffi_msg.message.get_info_contact_id(context))
+    block_on(ffi_msg.message.get_info_contact_id(&ffi_msg.context))
         .unwrap_or_default()
         .map(|id| id.to_u32())
         .unwrap_or_default()
@@ -3712,18 +3709,17 @@ pub unsafe extern "C" fn dc_msg_set_file_and_deduplicate(
         return;
     }
     let ffi_msg = unsafe { &mut *msg };
-    let ctx = unsafe { &*ffi_msg.context };
 
     ffi_msg
         .message
         .set_file_and_deduplicate(
-            ctx,
+            &ffi_msg.context,
             unsafe { as_path(file) },
             to_opt_string_lossy(name).as_deref(),
             to_opt_string_lossy(filemime).as_deref(),
         )
         .context("Failed to set file")
-        .log_err(ctx)
+        .log_err(&ffi_msg.context)
         .ok();
 }
 
@@ -3777,15 +3773,14 @@ pub unsafe extern "C" fn dc_msg_latefiling_mediasize(
         return;
     }
     let ffi_msg = unsafe { &mut *msg };
-    let ctx = unsafe { &*ffi_msg.context };
 
     block_on({
         ffi_msg
             .message
-            .latefiling_mediasize(ctx, width, height, duration)
+            .latefiling_mediasize(&ffi_msg.context, width, height, duration)
     })
     .context("Cannot set media size")
-    .log_err(ctx)
+    .log_err(&ffi_msg.context)
     .ok();
 }
 
@@ -3813,17 +3808,16 @@ pub unsafe extern "C" fn dc_msg_set_quote(msg: *mut dc_msg_t, quote: *const dc_m
         None
     } else {
         let ffi_quote = unsafe { &*quote };
-        if ffi_msg.context != ffi_quote.context {
+        if ffi_msg.context.get_id() != ffi_quote.context.get_id() {
             eprintln!("ignoring attempt to quote message from a different context");
             return;
         }
         Some(&ffi_quote.message)
     };
 
-    let context = unsafe { &*ffi_msg.context };
-    block_on(ffi_msg.message.set_quote(context, quote_msg))
+    block_on(ffi_msg.message.set_quote(&ffi_msg.context, quote_msg))
         .context("failed to set quote")
-        .log_err(context)
+        .log_err(&ffi_msg.context)
         .ok();
 }
 
@@ -3833,7 +3827,7 @@ pub unsafe extern "C" fn dc_msg_get_quoted_text(msg: *const dc_msg_t) -> *mut li
         eprintln!("ignoring careless call to dc_msg_get_quoted_text()");
         return ptr::null_mut();
     }
-    let ffi_msg: &MessageWrapper = unsafe { &*msg };
+    let ffi_msg = unsafe { &*msg };
     ffi_msg
         .message
         .quoted_text()
@@ -3846,15 +3840,17 @@ pub unsafe extern "C" fn dc_msg_get_quoted_msg(msg: *const dc_msg_t) -> *mut dc_
         eprintln!("ignoring careless call to dc_get_quoted_msg()");
         return ptr::null_mut();
     }
-    let ffi_msg: &MessageWrapper = unsafe { &*msg };
-    let context = unsafe { &*ffi_msg.context };
-    let res = block_on(ffi_msg.message.quoted_message(context))
+    let ffi_msg = unsafe { &*msg };
+    let res = block_on(ffi_msg.message.quoted_message(&ffi_msg.context))
         .context("failed to get quoted message")
-        .log_err(context)
+        .log_err(&ffi_msg.context)
         .unwrap_or(None);
 
     match res {
-        Some(message) => Box::into_raw(Box::new(MessageWrapper { context, message })),
+        Some(message) => Box::into_raw(Box::new(MessageWrapper {
+            context: ffi_msg.context.clone(),
+            message,
+        })),
         None => ptr::null_mut(),
     }
 }
@@ -3865,15 +3861,17 @@ pub unsafe extern "C" fn dc_msg_get_parent(msg: *const dc_msg_t) -> *mut dc_msg_
         eprintln!("ignoring careless call to dc_msg_get_parent()");
         return ptr::null_mut();
     }
-    let ffi_msg: &MessageWrapper = unsafe { &*msg };
-    let context = unsafe { &*ffi_msg.context };
-    let res = block_on(ffi_msg.message.parent(context))
+    let ffi_msg = unsafe { &*msg };
+    let res = block_on(ffi_msg.message.parent(&ffi_msg.context))
         .context("failed to get parent message")
-        .log_err(context)
+        .log_err(&ffi_msg.context)
         .unwrap_or(None);
 
     match res {
-        Some(message) => Box::into_raw(Box::new(MessageWrapper { context, message })),
+        Some(message) => Box::into_raw(Box::new(MessageWrapper {
+            context: ffi_msg.context.clone(),
+            message,
+        })),
         None => ptr::null_mut(),
     }
 }
@@ -3884,11 +3882,10 @@ pub unsafe extern "C" fn dc_msg_get_original_msg_id(msg: *const dc_msg_t) -> u32
         eprintln!("ignoring careless call to dc_msg_get_original_msg_id()");
         return 0;
     }
-    let ffi_msg: &MessageWrapper = unsafe { &*msg };
-    let context = unsafe { &*ffi_msg.context };
-    block_on(ffi_msg.message.get_original_msg_id(context))
+    let ffi_msg = unsafe { &*msg };
+    block_on(ffi_msg.message.get_original_msg_id(&ffi_msg.context))
         .context("failed to get original message")
-        .log_err(context)
+        .log_err(&ffi_msg.context)
         .unwrap_or_default()
         .map(|id| id.to_u32())
         .unwrap_or(0)
@@ -3900,11 +3897,10 @@ pub unsafe extern "C" fn dc_msg_get_saved_msg_id(msg: *const dc_msg_t) -> u32 {
         eprintln!("ignoring careless call to dc_msg_get_saved_msg_id()");
         return 0;
     }
-    let ffi_msg: &MessageWrapper = unsafe { &*msg };
-    let context = unsafe { &*ffi_msg.context };
-    block_on(ffi_msg.message.get_saved_msg_id(context))
+    let ffi_msg = unsafe { &*msg };
+    block_on(ffi_msg.message.get_saved_msg_id(&ffi_msg.context))
         .context("failed to get original message")
-        .log_err(context)
+        .log_err(&ffi_msg.context)
         .unwrap_or_default()
         .map(|id| id.to_u32())
         .unwrap_or(0)

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2288,12 +2288,17 @@ pub unsafe extern "C" fn dc_get_contact(
         eprintln!("ignoring careless call to dc_get_contact()");
         return ptr::null_mut();
     }
-    let ctx = unsafe { &*context };
+    let context = unsafe { &*context };
 
     block_on(async move {
-        Contact::get_by_id(ctx, ContactId::new(contact_id))
+        Contact::get_by_id(context, ContactId::new(contact_id))
             .await
-            .map(|contact| Box::into_raw(Box::new(ContactWrapper { context, contact })))
+            .map(|contact| {
+                Box::into_raw(Box::new(ContactWrapper {
+                    context: context.clone(),
+                    contact,
+                }))
+            })
             .unwrap_or_else(|_| ptr::null_mut())
     })
 }
@@ -3916,7 +3921,7 @@ pub unsafe extern "C" fn dc_msg_get_saved_msg_id(msg: *const dc_msg_t) -> u32 {
 /// context, but the Rust API does not, so the FFI layer needs to glue
 /// these together.
 pub struct ContactWrapper {
-    context: *const dc_context_t,
+    context: Context,
     contact: contact::Contact,
 }
 
@@ -4004,10 +4009,9 @@ pub unsafe extern "C" fn dc_contact_get_profile_image(
         return ptr::null_mut(); // NULL explicitly defined as "no profile image"
     }
     let ffi_contact = unsafe { &*contact };
-    let ctx = unsafe { &*ffi_contact.context };
 
-    block_on(ffi_contact.contact.get_profile_image(ctx))
-        .unwrap_or_log_default(ctx, "failed to get profile image")
+    block_on(ffi_contact.contact.get_profile_image(&ffi_contact.context))
+        .unwrap_or_log_default(&ffi_contact.context, "failed to get profile image")
         .map(|p| p.to_string_lossy().strdup())
         .unwrap_or_else(std::ptr::null_mut)
 }
@@ -4019,15 +4023,14 @@ pub unsafe extern "C" fn dc_contact_get_color(contact: *mut dc_contact_t) -> u32
         return 0;
     }
     let ffi_contact = unsafe { &*contact };
-    let ctx = unsafe { &*ffi_contact.context };
     block_on(
         ffi_contact
             .contact
             // We don't want any UIs displaying gray self-color.
-            .get_or_gen_color(ctx),
+            .get_or_gen_color(&ffi_contact.context),
     )
     .context("Contact::get_color()")
-    .log_err(ctx)
+    .log_err(&ffi_contact.context)
     .unwrap_or(0)
 }
 
@@ -4078,11 +4081,10 @@ pub unsafe extern "C" fn dc_contact_is_verified(contact: *mut dc_contact_t) -> l
         return 0;
     }
     let ffi_contact = unsafe { &*contact };
-    let ctx = unsafe { &*ffi_contact.context };
 
-    if block_on(ffi_contact.contact.is_verified(ctx))
+    if block_on(ffi_contact.contact.is_verified(&ffi_contact.context))
         .context("is_verified failed")
-        .log_err(ctx)
+        .log_err(&ffi_contact.context)
         .unwrap_or_default()
     {
         // Return value is essentially a boolean,
@@ -4118,10 +4120,9 @@ pub unsafe extern "C" fn dc_contact_get_verifier_id(contact: *mut dc_contact_t) 
         return 0;
     }
     let ffi_contact = unsafe { &*contact };
-    let ctx = unsafe { &*ffi_contact.context };
-    let verifier_contact_id = block_on(ffi_contact.contact.get_verifier_id(ctx))
+    let verifier_contact_id = block_on(ffi_contact.contact.get_verifier_id(&ffi_contact.context))
         .context("failed to get verifier")
-        .log_err(ctx)
+        .log_err(&ffi_contact.context)
         .unwrap_or_default()
         .unwrap_or_default()
         .unwrap_or_default();

--- a/deltachat-ffi/src/lib.rs
+++ b/deltachat-ffi/src/lib.rs
@@ -2874,18 +2874,6 @@ pub unsafe extern "C" fn dc_chatlist_get_summary2(
     Box::into_raw(Box::new(summary.into()))
 }
 
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn dc_chatlist_get_context(
-    chatlist: *mut dc_chatlist_t,
-) -> *const dc_context_t {
-    if chatlist.is_null() {
-        eprintln!("ignoring careless call to dc_chatlist_get_context()");
-        return ptr::null_mut();
-    }
-    let ffi_list = unsafe { &*chatlist };
-    ffi_list.context
-}
-
 // dc_chat_t
 
 /// FFI struct for [dc_chat_t]


### PR DESCRIPTION
The change is similar to the change done to dc_chat_t in b5acbaa31c8de9f9bc8814a628c0717900e1750f

One commit is removing dangerous API dc_chatlist_get_context(), last call to which is removed in https://github.com/deltachat/deltachat-android/pull/4577

Closes #8502 (hopefully; there is no way to reproduce the issue, but better reopen it or open another issue later if the problem appears after this change)