### PR TITLE
docs: dc_chatlist_get_context() return value must not be freed

### DIFF
--- a/deltachat-ffi/deltachat.h
+++ b/deltachat-ffi/deltachat.h
@@ -3564,6 +3564,7 @@ dc_lot_t*        dc_chatlist_get_summary2    (dc_context_t* context, uint32_t ch
  * @memberof dc_chatlist_t
  * @param chatlist The chatlist object to empty.
  * @return The context object associated with the chatlist. NULL if none or on errors.
+ *     This pointer MUST NOT be freed with dc_context_unref().
  */
 dc_context_t*    dc_chatlist_get_context     (dc_chatlist_t* chatlist);
 


### PR DESCRIPTION
dc_chatlist_get_context() is a bad API,
but it is already used in Android
to quickly get access to the context pointer
when only the chatlist pointer is available:
`dc_get_msg(dc_chatlist_get_context(chatlist), dc_chatlist_get_msg_id(chatlist, index))`.

We cannot start cloning the Context
and increase reference count now
because existing code will then start leaking memory.