### PR TITLE
make primary transport (`configured_addr`) a per-device choice

### DIFF
--- a/deltachat-rpc-client/tests/test_multitransport.py
+++ b/deltachat-rpc-client/tests/test_multitransport.py
@@ -193,6 +193,7 @@ def test_transport_sync_new_as_primary(acfactory, log) -> None:
     ac1.set_config("configured_addr", transport2["addr"])
 
     ac1_clone.wait_for_event(EventType.TRANSPORTS_MODIFIED)
+    ac1_clone.wait_for_event(EventType.TRANSPORTS_MODIFIED)
     assert ac1_clone.get_config("configured_addr") == transport2["addr"]
 
     log.section("ac1_clone receives a message via the new primary transport")

--- a/deltachat-rpc-client/tests/test_multitransport.py
+++ b/deltachat-rpc-client/tests/test_multitransport.py
@@ -150,12 +150,9 @@ def test_transport_synchronization(acfactory, log) -> None:
     log.section("ac1 changes the primary transport")
     ac1.set_config("configured_addr", transport3["addr"])
 
-    # One event for updated `add_timestamp` of the new primary transport,
-    # one event for the `configured_addr` update.
-    ac1_clone.wait_for_event(EventType.TRANSPORTS_MODIFIED)
     ac1_clone.wait_for_event(EventType.TRANSPORTS_MODIFIED)
     [transport1, transport3] = ac1_clone.list_transports()
-    assert ac1_clone.get_config("configured_addr") == addr3
+    assert ac1_clone.get_config("configured_addr") == transport1["addr"]
 
     log.section("ac1 removes the first transport")
     ac1.delete_transport(transport1["addr"])
@@ -174,7 +171,7 @@ def test_transport_synchronization(acfactory, log) -> None:
 
 
 def test_transport_sync_new_as_primary(acfactory, log) -> None:
-    """Test synchronization of new transport as primary between devices."""
+    """Test that a transport promoted on one device is usable on other devices."""
     ac1, bob = acfactory.get_online_accounts(2)
     ac1_clone = ac1.clone()
     ac1_clone.bring_online()
@@ -193,10 +190,9 @@ def test_transport_sync_new_as_primary(acfactory, log) -> None:
     ac1.set_config("configured_addr", transport2["addr"])
 
     ac1_clone.wait_for_event(EventType.TRANSPORTS_MODIFIED)
-    ac1_clone.wait_for_event(EventType.TRANSPORTS_MODIFIED)
-    assert ac1_clone.get_config("configured_addr") == transport2["addr"]
+    assert ac1_clone.get_config("configured_addr") == transport1["addr"]
 
-    log.section("ac1_clone receives a message via the new primary transport")
+    log.section("ac1_clone receives a message via the new transport")
     ac1_chat = ac1.create_chat(bob)
     ac1_chat.send_text("Hello!")
     bob_chat_id = bob.wait_for_incoming_msg_event().chat_id

--- a/src/config.rs
+++ b/src/config.rs
@@ -785,16 +785,19 @@ impl Context {
                                 (addr,),
                             )?;
 
-                            // Update the timestamp for the primary transport
-                            // so it becomes the first in `get_all_self_addrs()` list
-                            // and the list of relays distributed in the public key.
-                            // This ensures that messages will be sent
-                            // to the primary relay by the contacts
-                            // and will be fetched in background_fetch()
-                            // which only fetches from the primary transport.
+                            // `is_published=1`: an unpublished primary would be missing
+                            // from the relay list in the public key, so contacts would
+                            // never send to it.
+                            //
+                            // The timestamp must strictly increase because
+                            // other devices ignore the row update otherwise,
+                            // and contacts only adopt the re-signed key
+                            // if its signature timestamp increases.
                             transaction
                                 .execute(
-                                    "UPDATE transports SET add_timestamp=?, is_published=1 WHERE addr=?",
+                                    "UPDATE transports
+                                     SET add_timestamp=MAX(?, add_timestamp+1), is_published=1
+                                     WHERE addr=?",
                                     (time(), addr),
                                 )
                                 .context(

--- a/src/config.rs
+++ b/src/config.rs
@@ -192,7 +192,9 @@ pub enum Config {
     #[strum(props(default = "0"))]
     DeleteDeviceAfter,
 
-    /// The primary email address.
+    /// The primary email address, used for sending and background fetch.
+    ///
+    /// Device-local, other devices keep their own primary transport.
     ConfiguredAddr,
 
     /// Deprecated(2026-04).

--- a/src/config.rs
+++ b/src/config.rs
@@ -814,8 +814,9 @@ impl Context {
                             Ok(())
                         })
                         .await?;
-                    send_sync_transports(self).await?;
+                    // Invalidate the cache so the sync message cannot read a stale primary address.
                     self.sql.uncache_raw_config("configured_addr").await;
+                    send_sync_transports(self).await?;
                 }
             }
             _ => {

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::ffi::OsString;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, OnceLock, Weak};
 use std::time::Duration;
 
@@ -258,6 +259,14 @@ pub struct InnerContext {
     /// This causes [`Context::wait_next_msgs`] to wake up.
     pub(crate) new_msgs_notify: Notify,
 
+    /// Whether IO should be restarted after the current fetch cycle completed.
+    ///
+    /// Set when a fetched transport sync message modified the transports.
+    /// Restarting from within the inbox loop would cancel it,
+    /// losing the remaining processing of the sync message
+    /// which is already stored and is never fetched again.
+    pub(crate) restart_io_after_fetch: AtomicBool,
+
     /// Server ID response if ID capability is supported
     /// and the server returned non-NIL on the inbox connection.
     /// <https://datatracker.ietf.org/doc/html/rfc2971>
@@ -486,6 +495,7 @@ impl Context {
             ratelimit: RwLock::new(Ratelimit::new(Duration::new(3, 0), 3.0)), // Allow at least 1 message every second + a burst of 3.
             quota: RwLock::new(BTreeMap::new()),
             new_msgs_notify,
+            restart_io_after_fetch: AtomicBool::new(false),
             server_id: RwLock::new(None),
             metadata: RwLock::new(BTreeMap::new()),
             creation_time: tools::Time::now(),

--- a/src/receive_imf.rs
+++ b/src/receive_imf.rs
@@ -795,46 +795,6 @@ pub(crate) async fn receive_imf_inner(
                 context
                     .execute_sync_items(sync_items, mime_parser.timestamp_sent)
                     .await;
-
-                // Receiving encrypted message from self updates primary transport.
-                let from_addr = &mime_parser.from.addr;
-
-                let transport_changed = context
-                    .sql
-                    .transaction(|transaction| {
-                        let transport_exists = transaction.query_row(
-                            "SELECT COUNT(*) FROM transports WHERE addr=?",
-                            (from_addr,),
-                            |row| {
-                                let count: i64 = row.get(0)?;
-                                Ok(count > 0)
-                            },
-                        )?;
-
-                        let transport_changed = if transport_exists {
-                            transaction.execute(
-                                "
-UPDATE config SET value=? WHERE keyname='configured_addr' AND value!=?1
-                                ",
-                                (from_addr,),
-                            )? > 0
-                        } else {
-                            warn!(
-                                context,
-                                "Received sync message from unknown address {from_addr:?}."
-                            );
-                            false
-                        };
-                        Ok(transport_changed)
-                    })
-                    .await?;
-                if transport_changed {
-                    info!(context, "Primary transport changed to {from_addr:?}.");
-                    context.sql.uncache_raw_config("configured_addr").await;
-                    context.self_public_key.lock().await.take();
-
-                    context.emit_event(EventType::TransportsModified);
-                }
             } else {
                 warn!(context, "Sync items are not encrypted.");
             }

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,5 +1,8 @@
 use std::cmp;
+use std::future::Future;
 use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::sync::atomic::Ordering;
 
 use anyhow::{Context as _, Error, Result, bail};
 use async_channel::{self as channel, Receiver, Sender};
@@ -407,6 +410,12 @@ async fn inbox_loop(
         .await;
 }
 
+/// Same as `context.restart_io_if_running()`, but `Box::pin`ed and with a `+ Send` bound
+/// to break the async type cycle with the IMAP loop it restarts.
+fn restart_io_if_running_boxed(context: Context) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+    Box::pin(async move { context.restart_io_if_running().await })
+}
+
 async fn inbox_fetch_idle(ctx: &Context, imap: &mut Imap, mut session: Session) -> Result<Session> {
     let transport_id = session.transport_id();
 
@@ -490,6 +499,11 @@ async fn fetch_idle(ctx: &Context, connection: &mut Imap, mut session: Session) 
     download_msgs(ctx, &mut session)
         .await
         .context("download_msgs")?;
+
+    if ctx.restart_io_after_fetch.swap(false, Ordering::Relaxed) {
+        // Stopping IO from within the inbox loop would cancel it.
+        task::spawn(restart_io_if_running_boxed(ctx.clone()));
+    }
 
     connection.connectivity.set_idle(ctx);
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -9,7 +9,7 @@
 //! and configured list of connection candidates.
 
 use std::fmt;
-use std::pin::Pin;
+use std::sync::atomic::Ordering;
 
 use anyhow::{Context as _, Result, bail, format_err};
 use deltachat_contact_tools::{EmailAddress, addr_normalize};
@@ -666,16 +666,12 @@ pub(crate) async fn sync_transports(
 
     if modified {
         context.self_public_key.lock().await.take();
-        tokio::task::spawn(restart_io_if_running_boxed(context.clone()));
+        context
+            .restart_io_after_fetch
+            .store(true, Ordering::Relaxed);
         context.emit_event(EventType::TransportsModified);
     }
     Ok(())
-}
-
-/// Same as `context.restart_io_if_running()`, but `Box::pin`ed and with a `+ Send` bound,
-/// so that it can be called recursively.
-fn restart_io_if_running_boxed(context: Context) -> Pin<Box<dyn Future<Output = ()> + Send>> {
-    Box::pin(async move { context.restart_io_if_running().await })
 }
 
 /// Adds transport entry to the `transports` table with empty configuration.

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -631,20 +631,16 @@ pub(crate) async fn sync_transports(
         modified |= save_transport(context, entered, configured, *timestamp, *is_published).await?;
     }
 
-    context
+    let reelected = context
         .sql
         .transaction(|transaction| {
-            let configured_addr = transaction.query_row(
-                "SELECT value FROM config WHERE keyname='configured_addr'",
-                (),
-                |row| {
-                    let addr: String = row.get(0)?;
-                    Ok(addr)
-                },
-            )?;
             for RemovedTransportData { addr, timestamp } in removed_transports {
-                if *addr == configured_addr {
-                    continue;
+                let count: i64 =
+                    transaction
+                        .query_row("SELECT COUNT(*) FROM transports", (), |row| row.get(0))?;
+                if count <= 1 {
+                    // Removing the last transport would unconfigure the account.
+                    break;
                 }
                 modified |= transaction.execute(
                     "DELETE FROM transports
@@ -660,9 +656,16 @@ pub(crate) async fn sync_transports(
                     (addr, timestamp),
                 )?;
             }
-            Ok(())
+
+            maybe_reelect_local_primary(transaction)
         })
         .await?;
+
+    if let Some(new_addr) = reelected {
+        info!(context, "Re-elected primary transport {new_addr:?}.");
+        context.sql.uncache_raw_config("configured_addr").await;
+        modified = true;
+    }
 
     if modified {
         context.self_public_key.lock().await.take();
@@ -672,6 +675,48 @@ pub(crate) async fn sync_transports(
         context.emit_event(EventType::TransportsModified);
     }
     Ok(())
+}
+
+/// Elects a new primary transport for the device if the current one
+/// is not published or vanished, and there is a better candidate.
+///
+/// Returns the newly elected address if the primary transport changed.
+fn maybe_reelect_local_primary(transaction: &mut rusqlite::Transaction) -> Result<Option<String>> {
+    let configured_addr: String = transaction.query_row(
+        "SELECT value FROM config WHERE keyname='configured_addr'",
+        (),
+        |row| row.get(0),
+    )?;
+    // Newest transports first, they are the most likely to work.
+    let transports: Vec<(String, bool)> = transaction
+        .prepare(
+            "SELECT addr, is_published FROM transports
+             ORDER BY add_timestamp DESC, id DESC",
+        )?
+        .query_map((), |row| Ok((row.get(0)?, row.get(1)?)))?
+        .collect::<rusqlite::Result<_>>()?;
+
+    // A published primary transport is still a valid choice.
+    if transports
+        .iter()
+        .any(|(addr, is_published)| *is_published && *addr == configured_addr)
+    {
+        return Ok(None);
+    }
+    // Take an unpublished transport only if nothing is published.
+    let published = transports.iter().find(|(_, is_published)| *is_published);
+    let Some((new_addr, _)) = published.or_else(|| transports.first()) else {
+        return Ok(None);
+    };
+    if *new_addr == configured_addr {
+        // The primary transport may be the only remaining one.
+        return Ok(None);
+    }
+    transaction.execute(
+        "UPDATE config SET value=? WHERE keyname='configured_addr'",
+        (new_addr,),
+    )?;
+    Ok(Some(new_addr.clone()))
 }
 
 /// Adds transport entry to the `transports` table with empty configuration.

--- a/src/transport/transport_tests.rs
+++ b/src/transport/transport_tests.rs
@@ -115,6 +115,18 @@ fn dummy_configured_login_param(addr: &str) -> ConfiguredLoginParam {
     }
 }
 
+fn dummy_transport_data(addr: &str, is_published: bool) -> TransportData {
+    TransportData {
+        configured: dummy_configured_login_param(addr).into(),
+        entered: EnteredLoginParam {
+            addr: addr.to_string(),
+            ..Default::default()
+        },
+        timestamp: time(),
+        is_published,
+    }
+}
+
 async fn add_dummy_transport(t: &TestContext, addr: &str) -> Result<()> {
     dummy_configured_login_param(addr)
         .save_to_transports_table(
@@ -199,7 +211,11 @@ async fn test_is_published_flag() -> Result<()> {
 
     SystemTime::shift(Duration::from_secs(2));
 
-    promote_transport_and_check_success(alice, alice2, "alice@otherprovider.com").await?;
+    promote_transport_and_sync(alice, alice2, "alice@otherprovider.com").await?;
+
+    alice2
+        .set_config(Config::ConfiguredAddr, Some("alice@otherprovider.com"))
+        .await?;
 
     check_addrs(
         alice,
@@ -232,7 +248,7 @@ async fn test_promote_transport_same_second() -> Result<()> {
     send_sync_transports(alice).await?;
     sync_and_check_recipients(alice, alice2, "alice@otherprovider.com alice@example.org").await;
 
-    promote_transport_and_check_success(alice, alice2, "alice@otherprovider.com").await
+    promote_transport_and_sync(alice, alice2, "alice@otherprovider.com").await
 }
 
 /// Tests that `sync_transports()` requests an IO restart
@@ -241,15 +257,7 @@ async fn test_promote_transport_same_second() -> Result<()> {
 async fn test_sync_transports_requests_io_restart() -> Result<()> {
     let alice = &TestContext::new_alice().await;
 
-    let data = TransportData {
-        configured: dummy_configured_login_param("alice@otherprovider.com").into(),
-        entered: EnteredLoginParam {
-            addr: "alice@otherprovider.com".to_string(),
-            ..Default::default()
-        },
-        timestamp: time(),
-        is_published: true,
-    };
+    let data = dummy_transport_data("alice@otherprovider.com", true);
     let data = std::slice::from_ref(&data);
     sync_transports(alice, data, &[]).await?;
     assert!(alice.restart_io_after_fetch.swap(false, Ordering::Relaxed));
@@ -261,21 +269,21 @@ async fn test_sync_transports_requests_io_restart() -> Result<()> {
     Ok(())
 }
 
-/// Promotes `addr` to primary on `alice` and checks the change syncs to `alice2`.
-async fn promote_transport_and_check_success(
+/// Promotes `addr` on `alice` and syncs the transport update to `alice2`,
+/// whose own primary transport must stay unchanged.
+async fn promote_transport_and_sync(
     alice: &TestContext,
     alice2: &TestContext,
     addr: &str,
 ) -> Result<()> {
     let old_timestamp = add_timestamp(alice2, addr).await;
+    let alice2_primary = alice2.get_config(Config::ConfiguredAddr).await?;
     alice.set_config(Config::ConfiguredAddr, Some(addr)).await?;
     assert!(add_timestamp(alice, addr).await > old_timestamp);
 
     alice.send_sync_msg().await?.unwrap();
     let sync_msg = alice.pop_sent_msg().await;
     assert_eq!(sync_msg.recipients, format!("alice@example.org {addr}"));
-    // Other devices switch their primary transport
-    // based on the From address of the sync message.
     assert!(sync_msg.payload.contains(&format!("From: <{addr}>")));
     alice2.recv_msg_trash(&sync_msg).await;
 
@@ -283,8 +291,8 @@ async fn promote_transport_and_check_success(
     // other devices ignore the change otherwise.
     assert!(add_timestamp(alice2, addr).await > old_timestamp);
     assert_eq!(
-        alice2.get_config(Config::ConfiguredAddr).await?.as_deref(),
-        Some(addr)
+        alice2.get_config(Config::ConfiguredAddr).await?,
+        alice2_primary
     );
     Ok(())
 }
@@ -295,6 +303,71 @@ async fn add_timestamp(t: &TestContext, addr: &str) -> i64 {
         .await
         .unwrap()
         .unwrap()
+}
+
+/// Tests that the local primary transport is re-elected
+/// if a synced change unpublished or removed it.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_reelect_local_primary() -> Result<()> {
+    let alice = &TestContext::new_alice().await;
+    add_dummy_transport(alice, "alice@otherprovider.com").await?;
+
+    // Another device unpublished the primary transport.
+    let unpublished = dummy_transport_data("alice@example.org", false);
+    sync_transports(alice, std::slice::from_ref(&unpublished), &[]).await?;
+    assert_eq!(
+        alice.get_config(Config::ConfiguredAddr).await?.as_deref(),
+        Some("alice@otherprovider.com")
+    );
+
+    // Another device removed the new primary transport.
+    let removed = RemovedTransportData {
+        addr: "alice@otherprovider.com".to_string(),
+        timestamp: time(),
+    };
+    sync_transports(alice, &[], std::slice::from_ref(&removed)).await?;
+    assert_eq!(
+        alice.get_config(Config::ConfiguredAddr).await?.as_deref(),
+        Some("alice@example.org")
+    );
+    Ok(())
+}
+
+/// Tests which transport is elected as the local primary one.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_maybe_reelect_local_primary() -> Result<()> {
+    let t = &TestContext::new_alice().await;
+
+    // The only transport is kept even if it is unpublished.
+    t.sql
+        .execute("UPDATE transports SET is_published=0", ())
+        .await?;
+    assert_eq!(t.sql.transaction(maybe_reelect_local_primary).await?, None);
+
+    // A published primary transport is kept even if newer transports exist.
+    t.sql
+        .execute("UPDATE transports SET is_published=1", ())
+        .await?;
+    add_dummy_transport(t, "alice@one.com").await?;
+    assert_eq!(t.sql.transaction(maybe_reelect_local_primary).await?, None);
+
+    // The most recently added published transport is elected.
+    SystemTime::shift(Duration::from_secs(2));
+    add_dummy_transport(t, "alice@two.com").await?;
+    t.sql
+        .execute(
+            "UPDATE transports SET is_published=0 WHERE addr=?",
+            ("alice@example.org",),
+        )
+        .await?;
+    assert_eq!(
+        t.sql
+            .transaction(maybe_reelect_local_primary)
+            .await?
+            .as_deref(),
+        Some("alice@two.com")
+    );
+    Ok(())
 }
 
 struct Addresses {

--- a/src/transport/transport_tests.rs
+++ b/src/transport/transport_tests.rs
@@ -235,6 +235,32 @@ async fn test_promote_transport_same_second() -> Result<()> {
     promote_transport_and_check_success(alice, alice2, "alice@otherprovider.com").await
 }
 
+/// Tests that `sync_transports()` requests an IO restart
+/// if and only if it modified anything.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_sync_transports_requests_io_restart() -> Result<()> {
+    let alice = &TestContext::new_alice().await;
+
+    let data = TransportData {
+        configured: dummy_configured_login_param("alice@otherprovider.com").into(),
+        entered: EnteredLoginParam {
+            addr: "alice@otherprovider.com".to_string(),
+            ..Default::default()
+        },
+        timestamp: time(),
+        is_published: true,
+    };
+    let data = std::slice::from_ref(&data);
+    sync_transports(alice, data, &[]).await?;
+    assert!(alice.restart_io_after_fetch.swap(false, Ordering::Relaxed));
+
+    // Applying the same data again modifies nothing.
+    sync_transports(alice, data, &[]).await?;
+    assert!(!alice.restart_io_after_fetch.load(Ordering::Relaxed));
+
+    Ok(())
+}
+
 /// Promotes `addr` to primary on `alice` and checks the change syncs to `alice2`.
 async fn promote_transport_and_check_success(
     alice: &TestContext,

--- a/src/transport/transport_tests.rs
+++ b/src/transport/transport_tests.rs
@@ -115,6 +115,19 @@ fn dummy_configured_login_param(addr: &str) -> ConfiguredLoginParam {
     }
 }
 
+async fn add_dummy_transport(t: &TestContext, addr: &str) -> Result<()> {
+    dummy_configured_login_param(addr)
+        .save_to_transports_table(
+            t,
+            &EnteredLoginParam {
+                addr: addr.to_string(),
+                ..Default::default()
+            },
+            time(),
+        )
+        .await
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_is_published_flag() -> Result<()> {
     let mut tcm = TestContextManager::new();
@@ -138,16 +151,7 @@ async fn test_is_published_flag() -> Result<()> {
     )
     .await;
 
-    dummy_configured_login_param("alice@otherprovider.com")
-        .save_to_transports_table(
-            alice,
-            &EnteredLoginParam {
-                addr: "alice@otherprovider.com".to_string(),
-                ..Default::default()
-            },
-            time(),
-        )
-        .await?;
+    add_dummy_transport(alice, "alice@otherprovider.com").await?;
     send_sync_transports(alice).await?;
     sync_and_check_recipients(alice, alice2, "alice@otherprovider.com alice@example.org").await;
 
@@ -195,10 +199,7 @@ async fn test_is_published_flag() -> Result<()> {
 
     SystemTime::shift(Duration::from_secs(2));
 
-    alice
-        .set_config(Config::ConfiguredAddr, Some("alice@otherprovider.com"))
-        .await?;
-    sync_and_check_recipients(alice, alice2, "alice@example.org alice@otherprovider.com").await;
+    promote_transport_and_check_success(alice, alice2, "alice@otherprovider.com").await?;
 
     check_addrs(
         alice,
@@ -213,6 +214,61 @@ async fn test_is_published_flag() -> Result<()> {
     .await;
 
     Ok(())
+}
+
+/// Tests that changing the primary transport propagates to other devices
+/// even if the promoted transport was added within the same second.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_promote_transport_same_second() -> Result<()> {
+    let mut tcm = TestContextManager::new();
+    let alice = &tcm.alice().await;
+    let alice2 = &tcm.alice().await;
+    for a in [alice, alice2] {
+        a.set_config_bool(Config::SyncMsgs, true).await?;
+        a.set_config_bool(Config::BccSelf, true).await?;
+    }
+
+    add_dummy_transport(alice, "alice@otherprovider.com").await?;
+    send_sync_transports(alice).await?;
+    sync_and_check_recipients(alice, alice2, "alice@otherprovider.com alice@example.org").await;
+
+    promote_transport_and_check_success(alice, alice2, "alice@otherprovider.com").await
+}
+
+/// Promotes `addr` to primary on `alice` and checks the change syncs to `alice2`.
+async fn promote_transport_and_check_success(
+    alice: &TestContext,
+    alice2: &TestContext,
+    addr: &str,
+) -> Result<()> {
+    let old_timestamp = add_timestamp(alice2, addr).await;
+    alice.set_config(Config::ConfiguredAddr, Some(addr)).await?;
+    assert!(add_timestamp(alice, addr).await > old_timestamp);
+
+    alice.send_sync_msg().await?.unwrap();
+    let sync_msg = alice.pop_sent_msg().await;
+    assert_eq!(sync_msg.recipients, format!("alice@example.org {addr}"));
+    // Other devices switch their primary transport
+    // based on the From address of the sync message.
+    assert!(sync_msg.payload.contains(&format!("From: <{addr}>")));
+    alice2.recv_msg_trash(&sync_msg).await;
+
+    // add_timestamp must monotonically increase because
+    // other devices ignore the change otherwise.
+    assert!(add_timestamp(alice2, addr).await > old_timestamp);
+    assert_eq!(
+        alice2.get_config(Config::ConfiguredAddr).await?.as_deref(),
+        Some(addr)
+    );
+    Ok(())
+}
+
+async fn add_timestamp(t: &TestContext, addr: &str) -> i64 {
+    t.sql
+        .query_get_value("SELECT add_timestamp FROM transports WHERE addr=?", (addr,))
+        .await
+        .unwrap()
+        .unwrap()
 }
 
 struct Addresses {


### PR DESCRIPTION
`configured_addr`  now just carries a local device's current primary relay choice.  If another device removes the underlying transport, or unpublishes is, the device selects the next best from available transports. Devices no longer implicitly use the `From` address of sync messages to determine their primary transport. 

Note that this PR, just as main, does nothing to prevent SMTP queued outgoing messages from failing/vanishing when the primary changes.  But the PR may well cause less trouble as on main any `From` change of a sync message corrupts pending messages.  In any case, the eventual real fix is in finalizing and merging https://github.com/chatmail/core/pull/8345 and letting send-failover freely choose a "next primary" for sending if the current primary fails, without any multi-device synchronization repercussions. 

Users may notice the change in that changing a relay as "used for sending"  in settings/advanced/relays will not synchronize to other devices anymore. On the positive side, devices may anyway have different connectivity (VPN, different networks etc.) and letting them make per-device primary relay choices (used for sending and iOS background-fetch)  is better compared to them constantly disagreeing over what is a working primary transport. 