### PR TITLE
add a CI-failing check that documented sql schema matches real one

### DIFF
--- a/deltachat-rpc-client/tests/test_sql_schema_docs.py
+++ b/deltachat-rpc-client/tests/test_sql_schema_docs.py
@@ -1,0 +1,96 @@
+"""Test that docs/schema.sql matches the actual database schema."""
+
+import re
+import sqlite3
+from pathlib import Path
+
+DOC_PATH = Path(__file__).resolve().parents[2] / "docs" / "schema.sql"
+
+
+def strip_comments(sql):
+    return re.sub(r"--[^\n]*", "", sql)
+
+
+def normalize(stmt):
+    stmt = re.sub(r"\s+", " ", stmt).strip()
+    stmt = stmt.replace("CREATE TABLE IF NOT EXISTS ", "CREATE TABLE ")
+    return re.sub(r'"(\w+)"', r"\1", stmt)
+
+
+def split_table(body):
+    items = []
+    depth = 0
+    current = ""
+    for char in body:
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+        if char == "," and depth == 0:
+            items.append(current.strip())
+            current = ""
+        else:
+            current += char
+    if current.strip():
+        items.append(current.strip())
+    return items
+
+
+def parse_schema(sql):
+    objects = {}
+    for raw_stmt in strip_comments(sql).split(";"):
+        stmt = normalize(raw_stmt)
+        if not stmt:
+            continue
+        match = re.match(r"CREATE TABLE (\w+) ?\((.*)\)( STRICT)?$", stmt)
+        if match:
+            name, body, strict = match.groups()
+            objects[f"table {name}"] = {
+                "items": sorted(split_table(body)),
+                "strict": bool(strict),
+            }
+            continue
+        match = re.match(r"CREATE (?:UNIQUE )?INDEX (\w+)", stmt)
+        if match:
+            objects[f"index {match.group(1)}"] = {"sql": stmt}
+            continue
+        objects[stmt[:60]] = {"sql": stmt}
+    return objects
+
+
+def format_diff(documented, real):
+    if "items" in documented and "items" in real:
+        lines = []
+        # disregards order
+        for item in sorted(set(documented["items"]) - set(real["items"])):
+            lines.append(f"    documented but not in the database: {item}")
+        for item in sorted(set(real["items"]) - set(documented["items"])):
+            lines.append(f"    in the database but not documented: {item}")
+        if documented["strict"] != real["strict"]:
+            lines.append(f"    STRICT: documented={documented['strict']} actual={real['strict']}")
+        return "\n".join(lines)
+    return f"    documented: {documented}\n    actual:     {real}"
+
+
+def read_database_schema(dbfile):
+    with sqlite3.connect(f"file:{dbfile}?mode=ro", uri=True) as conn:
+        rows = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE sql IS NOT NULL AND name NOT LIKE 'sqlite_%'",
+        ).fetchall()
+    return ";\n".join(row[0] for row in rows)
+
+
+def test_documented_schema_matches_database(acfactory):
+    account = acfactory.get_unconfigured_account()
+    real = parse_schema(read_database_schema(account.get_info()["database_dir"]))
+    documented = parse_schema(DOC_PATH.read_text())
+
+    problems = []
+    for name in sorted(real.keys() - documented.keys()):
+        problems.append(f"{name} exists in the database but is not documented")
+    for name in sorted(documented.keys() - real.keys()):
+        problems.append(f"{name} is documented but does not exist in the database")
+    for name in sorted(documented.keys() & real.keys()):
+        if documented[name] != real[name]:
+            problems.append(f"{name} differs:\n{format_diff(documented[name], real[name])}")
+    assert not problems, "documented schema deviates from the database:\n" + "\n".join(problems)

--- a/docs/schema.sql
+++ b/docs/schema.sql
@@ -8,7 +8,7 @@
 -- Raw dump of the database schema does not have comments
 -- for deprecated columns and columns added by migrations.
 --
--- This is based on the version 160 of the database.
+-- This is based on the version 161 of the database.
 -- There may be new migrations added afterwards.
 
 CREATE TABLE config (
@@ -67,11 +67,16 @@ CREATE TABLE chats (
     type INTEGER DEFAULT 0,
     name TEXT DEFAULT '',
 
+    -- Unused columns, drafts are now tracked as separate
+    -- messages with a special msgs.state value.
+    draft_timestamp INTEGER DEFAULT 0,
+    draft_txt TEXT DEFAULT '',
+
     blocked INTEGER DEFAULT 0,
     grpid TEXT DEFAULT '',
     param TEXT DEFAULT '',
     archived INTEGER DEFAULT 0,
-    gossiped_timestamp INTEGER DEFAULT 0, -- deprecated 2025-04-08, replaced with gossiped_timestamp table
+    gossiped_timestamp INTEGER DEFAULT 0, -- deprecated 2025-04-08, replaced with gossip_timestamp table
     locations_send_begin INTEGER DEFAULT 0,
     locations_send_until INTEGER DEFAULT 0,
     locations_last_sent INTEGER DEFAULT 0,
@@ -199,11 +204,6 @@ CREATE TABLE msgs (
     server_folder TEXT DEFAULT '', -- Deprecated column that was used before "imap" table, replaced by imap.folder
     server_uid INTEGER DEFAULT 0, -- Deprecated column that was used before "imap" table, replaced by imap.uid
 
-    -- Drafts are now tracked as separate messages
-    -- with a special msgs.state value.
-    draft_timestamp INTEGER DEFAULT 0,
-    draft_txt TEXT DEFAULT '',
-
     -- Unused column formely used to mark the messages
     -- that should be moved to the dedicated IMAP folder.
     -- It was replaced with imap.target, which is also now
@@ -310,7 +310,7 @@ CREATE TABLE multi_device_sync (
 CREATE TABLE reactions (
     msg_id INTEGER NOT NULL, -- id of the message reacted to
     contact_id INTEGER NOT NULL, -- id of the contact reacting to the message
-    reaction TEXT DEFAULT '' NOT NULL -- a sequence of emojis separated by spaces
+    reaction TEXT DEFAULT '' NOT NULL, -- a sequence of emojis separated by spaces
     PRIMARY KEY(msg_id, contact_id),
     FOREIGN KEY(msg_id) REFERENCES msgs(id) ON DELETE CASCADE -- delete reactions when message is deleted
     FOREIGN KEY(contact_id) REFERENCES contacts(id) ON DELETE CASCADE -- delete reactions when contact is deleted
@@ -447,6 +447,12 @@ CREATE TABLE broadcast_secrets(
     secret TEXT NOT NULL
 ) STRICT;
 
+
+-- Candidate chatmail relays for automatic relay management.
+CREATE TABLE relay_candidates(
+    host TEXT PRIMARY KEY NOT NULL,
+    last_tried INTEGER NOT NULL DEFAULT 0 -- Timestamp of the last connection attempt.
+) STRICT;
 
 CREATE TABLE transports (
     id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
The PR goes against `link2xt/sql-schema-docs` branch.   
First commit adds the test, second the fixes 
If you roughly agree it makes sense, please just merge and adapt/refine to your liking.  

<img width="1491" height="1470" alt="image" src="https://github.com/user-attachments/assets/281d6881-7da4-41eb-9c91-8d427967f9df" />
