### PR TITLE
use `Chat-Broadcast-States:` header instead of `-Reactions:`

### DIFF
--- a/src/headerdef.rs
+++ b/src/headerdef.rs
@@ -124,7 +124,7 @@ pub enum HeaderDef {
 
     /// Broadcasted reactions for this or other chat messages.
     /// See broadcast_reactions.rs for the wire format.
-    ChatBroadcastReactions,
+    ChatBroadcastStates,
 
     /// [Autocrypt](https://autocrypt.org/) header.
     Autocrypt,

--- a/src/mimefactory.rs
+++ b/src/mimefactory.rs
@@ -1988,7 +1988,7 @@ impl MimeFactory {
 
         if let Some(broadcast_reactions) = msg.param.get(Param::BroadcastReactions) {
             headers.push((
-                "Chat-Broadcast-Reactions",
+                "Chat-Broadcast-States",
                 mail_builder::headers::raw::Raw::new(b_encode(broadcast_reactions)).into(),
             ));
         }

--- a/src/mimeparser.rs
+++ b/src/mimeparser.rs
@@ -116,7 +116,7 @@ pub(crate) struct MimeMessage {
     pub(crate) mdn_reports: Vec<Report>,
     pub(crate) delivery_report: Option<DeliveryReport>,
 
-    /// Parsed `Chat-Broadcast-Reactions` header, if any:
+    /// Parsed `Chat-Broadcast-States` header, if any:
     /// accumulated reaction updates sent by a broadcast channel owner.
     pub(crate) broadcast_reactions: Option<String>,
 
@@ -800,7 +800,7 @@ impl MimeMessage {
 
     fn parse_broadcast_reactions_header(&mut self) {
         self.broadcast_reactions = self
-            .get_header(HeaderDef::ChatBroadcastReactions)
+            .get_header(HeaderDef::ChatBroadcastStates)
             .map(|s| s.to_string());
     }
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -73,7 +73,7 @@ pub enum Param {
     /// For Messages: Render message as a RFC 9078 reaction.
     Reaction = b'x',
 
-    /// For Messages: Additional reactions that go to the `Chat-Broadcast-Reactions:` header
+    /// For Messages: Additional reactions that go to the `Chat-Broadcast-States:` header
     BroadcastReactions = b'X',
 
     /// For Chats: the timestamp of the last reaction.

--- a/src/reaction/broadcast_reactions.rs
+++ b/src/reaction/broadcast_reactions.rs
@@ -21,7 +21,7 @@ use crate::tools::time;
 use crate::{EventType, chatlist_events};
 
 /// Wire format for accumulated broadcast reactions
-/// (sent as JSON from broadcast channel owner to subscriber in `Chat-Broadcast-Reactions:` header)
+/// (sent as JSON from broadcast channel owner to subscriber in `Chat-Broadcast-States:` header)
 #[derive(Debug, Serialize, Deserialize)]
 struct WirePayload {
     messages: Vec<WireMessage>,
@@ -40,7 +40,7 @@ struct WireEntry {
     count: usize,
 }
 
-/// Renders one or more message's reactions as a JSON string, ready to be sent in `Broadcast-Reactions:` header.
+/// Renders one or more message's reactions as a JSON string, ready to be sent in `Chat-Broadcast-States:` header.
 ///
 /// The returned reaction array for a message may be empty,
 /// allowing to broadcast reaction removal.
@@ -166,7 +166,7 @@ async fn broadcast_reactions_for_one_chat(context: &Context, chat_id: ChatId) ->
     Ok(())
 }
 
-/// Applies incoming, accumulated reactions received via the `Chat-Broadcast-Reactions:` header
+/// Applies incoming, accumulated reactions received via the `Chat-Broadcast-States:` header
 /// to the `broadcasted_reactions` table.
 pub(crate) async fn receive_broadcast_reactions(context: &Context, json: &str) -> Result<()> {
     let payload: WirePayload = serde_json::from_str(json)?;
@@ -613,7 +613,7 @@ mod tests {
 
         // Alice broadcasts recent reaction changes to Bob and Claire.
         // On the wire, the hidden message has a header like
-        // `Chat-Broadcast-Reactions: {"messages":[{"id":"123@adc","reactions":[{"emoji":"❤️","count":1}]}]}`
+        // `Chat-Broadcast-States: {"messages":[{"id":"123@adc","reactions":[{"emoji":"❤️","count":1}]}]}`
         maybe_broadcast_reactions(alice).await?;
         let sent_msg = alice.pop_sent_msg().await;
         bob.recv_msg_hidden(&sent_msg).await;


### PR DESCRIPTION
the wire format is already prepared to carry information additionally to reactions, so let the header name reflect that as well.

> the old header name is not yet used in any release, so a rename now is cheap

in practise, we might want to use a `pinned` flag very soon in case pinned messages got resent in channels.
it makes sense if that flag goes to the message as such, and not to an extra message.
and then it makes sense to not introduce a new things.

ftr, this is about resending state to other members, it is not about syncing across devices for the same user.

the code as such is not changed by this PR,
it is only a wording preparation, of a header that is not even visible. if we semantically put things other than reactions to the wire format, we may want to move it out of `broadcast_reactions.rs`

